### PR TITLE
Email date and attachments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -31,6 +31,8 @@ src/sandstorm/legacy-bridge.c++
     Copyright: Kenton Varda
     License: BSD 2-clause
     License text: See below
+    Note: Uses public domain code from libb64
+          (http://libb64.sourceforge.net/)
 
 All files not explicitly mentioned above or below
     What: Sandstorm implementation

--- a/shell/packages/simplesmtp/.npm/package/npm-shrinkwrap.json
+++ b/shell/packages/simplesmtp/.npm/package/npm-shrinkwrap.json
@@ -1,5 +1,46 @@
 {
   "dependencies": {
+    "mailcomposer": {
+      "version": "0.2.11",
+      "dependencies": {
+        "mimelib": {
+          "version": "0.2.16",
+          "dependencies": {
+            "encoding": {
+              "version": "0.1.7",
+              "dependencies": {
+                "iconv-lite": {
+                  "version": "0.2.11"
+                }
+              }
+            },
+            "addressparser": {
+              "version": "0.2.1"
+            }
+          }
+        },
+        "mime": {
+          "version": "1.2.11"
+        },
+        "he": {
+          "version": "0.3.6"
+        },
+        "punycode": {
+          "version": "1.2.4"
+        },
+        "follow-redirects": {
+          "version": "0.0.3",
+          "dependencies": {
+            "underscore": {
+              "version": "1.6.0"
+            }
+          }
+        },
+        "dkim-signer": {
+          "version": "0.1.2"
+        }
+      }
+    },
     "mailparser": {
       "version": "0.4.2",
       "dependencies": {

--- a/shell/packages/simplesmtp/import.js
+++ b/shell/packages/simplesmtp/import.js
@@ -1,3 +1,4 @@
 this.simplesmtp = Npm.require("simplesmtp");
 this.MailParser = Npm.require("mailparser").MailParser;
 this.mimelib = Npm.require("mimelib");
+this.MailComposer = Npm.require("mailcomposer").MailComposer;

--- a/shell/packages/simplesmtp/package.js
+++ b/shell/packages/simplesmtp/package.js
@@ -1,7 +1,8 @@
 Npm.depends({
     'simplesmtp': '0.3.24',
     'mailparser': '0.4.2',
-    'mimelib': '0.2.14'
+    'mimelib': '0.2.14',
+    'mailcomposer': '0.2.11'
 });
 
 Package.on_use(function (api) {

--- a/shell/server/mail.js
+++ b/shell/server/mail.js
@@ -19,6 +19,7 @@
 // <http://www.gnu.org/licenses/>.
 
 var Http = Npm.require("http");
+var Future = Npm.require("fibers/future");
 
 var EmailRpc = Capnp.importSystem("sandstorm/email.capnp");
 var HackSessionContext = Capnp.importSystem("sandstorm/hack-session.capnp").HackSessionContext;
@@ -64,6 +65,20 @@ Meteor.startup(function() {
           from = { address: req.from, name: false };
         }
 
+        var attachments = [];
+        if (mail.attachments) {
+          attachments = mail.attachments.map(function (attachment) {
+            var disposition = attachment.contentDisposition || "attachment";
+            disposition += ';\n\tfilename="' + (attachment.fileName || attachment.generatedFileName) + '"';
+            return {
+              contentType: attachment.contentType,
+              contentDisposition: disposition,
+              contentId: attachment.contentId,
+              content: attachment.content
+            };
+          });
+        }
+
         var mailMessage = {
           // Date should be ok represented as a javascript float, since its mantissa has a maximum
           // value of 2^53, which equates to about the year 2255 in microseconds since the epoch
@@ -78,7 +93,8 @@ Meteor.startup(function() {
           inReplyTo: mail.inReplyTo || [],
           subject: mail.subject || '',
           text: mail.text || null,
-          html: mail.html || null
+          html: mail.html || null,
+          attachments: attachments
         };
 
         // Get list of grain IDs.
@@ -210,6 +226,51 @@ HackSessionContextImpl.prototype._getAddress = function () {
   return this._getPublicId() + '@' + HOSTNAME;
 }
 
+// makePool and getPool are lifted from the Meteor email package
+var makePool = function (mailUrlString) {
+  var mailUrl = Url.parse(mailUrlString);
+  if (mailUrl.protocol !== 'smtp:')
+    throw new Error("Email protocol in $MAIL_URL (" +
+                    mailUrlString + ") must be 'smtp'");
+
+  var port = +(mailUrl.port);
+  var auth = false;
+  if (mailUrl.auth) {
+    var parts = mailUrl.auth.split(':', 2);
+    auth = {user: parts[0] && decodeURIComponent(parts[0]),
+            pass: parts[1] && decodeURIComponent(parts[1])};
+  }
+
+  var pool = simplesmtp.createClientPool(
+    port,  // Defaults to 25
+    mailUrl.hostname,  // Defaults to "localhost"
+    { secureConnection: (port === 465),
+      // XXX allow maxConnections to be configured?
+      auth: auth });
+
+  pool._future_wrapped_sendMail = _.bind(Future.wrap(pool.sendMail), pool);
+  return pool;
+};
+
+// We construct smtpPool at the first call to Email.send, so that
+// Meteor.startup code can set $MAIL_URL.
+var smtpPoolFuture = new Future();
+var configured = false;
+
+var getPool = function () {
+  // We check MAIL_URL in case someone else set it in Meteor.startup code.
+  if (!configured) {
+    configured = true;
+    var url = process.env.MAIL_URL;
+    var pool = null;
+    if (url)
+      pool = makePool(url);
+    smtpPoolFuture.return(pool);
+  }
+
+  return smtpPoolFuture.wait();
+};
+
 HackSessionContextImpl.prototype.send = function (email) {
   return inMeteor((function() {
     var recipientCount = 0;
@@ -237,7 +298,9 @@ HackSessionContextImpl.prototype.send = function (email) {
 
     email.from.address = grainAddress;
 
-    var newEmail = {
+    var mc = new MailComposer();
+
+    mc.setMessageOption({
       from:     formatAddress(email.from),
       to:       formatAddress(email.to),
       cc:       formatAddress(email.cc),
@@ -246,22 +309,31 @@ HackSessionContextImpl.prototype.send = function (email) {
       subject:  email.subject,
       text:     email.text,
       html:     email.html
-    };
+    });
 
     var headers = {};
     if (email.messageId)
-      headers['message-id'] = email.messageId;
+      mc.addHeader('message-id', email.messageId);
     if (email.references)
-      headers['references'] = email.references;
+      mc.addHeader('references', email.references);
     if (email.messageId)
-      headers['in-reply-to'] = email.inReplyTo;
+      mc.addHeader('in-reply-to', email.inReplyTo);
     if (email.date) {
       var date = new Date(email.date / 1000);
       if (!isNaN(date.getTime())) // Check to make sure date is valid
-        headers['date'] = date.toUTCString();
+        mc.addHeader('date', date.toUTCString());
     }
 
-    newEmail['headers'] = headers;
+    if (email.attachments) {
+      email.attachments.forEach(function (attachment) {
+        mc.addAttachment({
+          cid: attachment.contentId,
+          contentType: attachment.contentType,
+          contentDisposition: attachment.contentDisposition,
+          contents: attachment.content
+        });
+      });
+    }
 
     if (!(this.userId in dailySendCounts)) {
       dailySendCounts[this.userId] = 0;
@@ -274,7 +346,7 @@ HackSessionContextImpl.prototype.send = function (email) {
           "Please feel free to contact us if this is a problem.");
     }
 
-    Email.send(newEmail);
+    getPool()._future_wrapped_sendMail(mc).wait();
   }).bind(this)).catch(function (err) {
     console.error("Error sending e-mail:", err.stack);
     throw err;

--- a/src/sandstorm/email.capnp
+++ b/src/sandstorm/email.capnp
@@ -38,6 +38,14 @@ struct EmailAddress {
   name @1 :Text;
 }
 
+struct EmailAttachment {
+  contentType @0 :Text; # header is actually content-type
+  contentDisposition @1 :Text; # header is actually content-disposition
+  contentId @2 :Text; # header is actually content-id
+
+  content @3 :Data;
+}
+
 struct EmailMessage {
   date @0 :Int64; # Micro-seconds since unix epoch.
 
@@ -47,7 +55,6 @@ struct EmailMessage {
   bcc @4 :List(EmailAddress);
   replyTo @5 :EmailAddress; # header is actually reply-to
 
-  # Not sure about these 3, but they can be pretty useful for mail clients
   messageId @6 :Text; # header is actually message-id
   references @7 :List(Text);
   inReplyTo @8 :List(Text); # header is actually in-reply-to
@@ -58,8 +65,7 @@ struct EmailMessage {
   # Any other content-types will be in the attachments field.
   text @10 :Text;
   html @11 :Text;
-  # TODO(someday): attachments @14 :List(Text);
-  #   Probably should add an Attachment struct with at least Content-Type split out
+  attachments @12 :List(EmailAttachment);
 }
 
 interface EmailSendPort @0xec831dbf4cc9bcca {

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -138,6 +138,145 @@ struct HttpStatusInfo {
   };
 };
 
+// This code is taken from libb64 which has been placed in the public domain.
+// For details, see http://sourceforge.net/projects/libb64
+typedef enum {
+  step_A, step_B, step_C
+} base64_encodestep;
+
+typedef struct {
+  base64_encodestep step;
+  char result;
+  int stepcount;
+} base64_encodestate;
+
+const int CHARS_PER_LINE = 72;
+
+void base64_init_encodestate(base64_encodestate* state_in) {
+  state_in->step = step_A;
+  state_in->result = 0;
+  state_in->stepcount = 0;
+}
+
+char base64_encode_value(char value_in) {
+  static const char* encoding = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  if (value_in > 63) return '=';
+  return encoding[(int)value_in];
+}
+
+int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in) {
+  const char* plainchar = plaintext_in;
+  const char* const plaintextend = plaintext_in + length_in;
+  char* codechar = code_out;
+  char result;
+  char fragment;
+
+  result = state_in->result;
+
+  switch (state_in->step) {
+    while (1) {
+  case step_A:
+      if (plainchar == plaintextend) {
+        state_in->result = result;
+        state_in->step = step_A;
+        return codechar - code_out;
+      }
+      fragment = *plainchar++;
+      result = (fragment & 0x0fc) >> 2;
+      *codechar++ = base64_encode_value(result);
+      result = (fragment & 0x003) << 4;
+  case step_B:
+      if (plainchar == plaintextend) {
+        state_in->result = result;
+        state_in->step = step_B;
+        return codechar - code_out;
+      }
+      fragment = *plainchar++;
+      result |= (fragment & 0x0f0) >> 4;
+      *codechar++ = base64_encode_value(result);
+      result = (fragment & 0x00f) << 2;
+  case step_C:
+      if (plainchar == plaintextend) {
+        state_in->result = result;
+        state_in->step = step_C;
+        return codechar - code_out;
+      }
+      fragment = *plainchar++;
+      result |= (fragment & 0x0c0) >> 6;
+      *codechar++ = base64_encode_value(result);
+      result  = (fragment & 0x03f) >> 0;
+      *codechar++ = base64_encode_value(result);
+
+      ++(state_in->stepcount);
+      if (state_in->stepcount == CHARS_PER_LINE/4) {
+        *codechar++ = '\n';
+        state_in->stepcount = 0;
+      }
+    }
+  }
+  /* control should not reach here */
+  return codechar - code_out;
+}
+
+int base64_encode_blockend(char* code_out, base64_encodestate* state_in) {
+  char* codechar = code_out;
+
+  switch (state_in->step) {
+  case step_B:
+    *codechar++ = base64_encode_value(state_in->result);
+    *codechar++ = '=';
+    *codechar++ = '=';
+    break;
+  case step_C:
+    *codechar++ = base64_encode_value(state_in->result);
+    *codechar++ = '=';
+    break;
+  case step_A:
+    break;
+  }
+  *codechar++ = '\n';
+
+  return codechar - code_out;
+}
+
+kj::String base64_encode(const kj::ArrayPtr<const byte> input) {
+  /* set up a destination buffer large enough to hold the encoded data */
+  // equivalent to ceil(input.size() / 3) * 4
+  auto numChars = (input.size() + 2) / 3 * 4;
+  auto output = kj::heapString(numChars + numChars / CHARS_PER_LINE + 1);
+  /* keep track of our encoded position */
+  char* c = output.begin();
+  /* store the number of bytes encoded by a single call */
+  int cnt = 0;
+  size_t total = 0;
+  /* we need an encoder state */
+  base64_encodestate s;
+
+  /*---------- START ENCODING ----------*/
+  /* initialise the encoder state */
+  base64_init_encodestate(&s);
+  /* gather data from the input and send it to the output */
+  cnt = base64_encode_block((const char *)input.begin(), input.size(), c, &s);
+  c += cnt;
+  total += cnt;
+
+  /* since we have encoded the entire input string, we know that 
+     there is no more input data; finalise the encoding */
+  cnt = base64_encode_blockend(c, &s);
+  c += cnt;
+  total += cnt;
+  /*---------- STOP ENCODING  ----------*/
+
+  // For the edge case, where the last line is 72+ characters, we will
+  // print 1 less newline than usual
+  while (total < output.size()) {
+    *c++ = '\n';  // Add newlines to the end, since they will be ignored safely
+    ++total;
+  }
+
+  return output;
+}
+
 HttpStatusInfo noContentInfo(bool shouldResetForm) {
   HttpStatusInfo result;
   result.type = WebSession::Response::NO_CONTENT;
@@ -866,15 +1005,20 @@ public:
 
     lines.add(nullptr);  // blank line starts body.
 
-    if(email.hasText()) {
+    if (email.hasText()) {
       lines.add(kj::str("--", id));
       addHeader(lines, "Content-Type", kj::str("text/plain; charset=UTF-8"));
+      lines.add(nullptr);
       lines.add(kj::str(email.getText()));
     }
-    if(email.hasHtml()) {
+    if (email.hasHtml()) {
       lines.add(kj::str("--", id));
       addHeader(lines, "Content-Type", kj::str("text/html; charset=UTF-8"));
+      lines.add(nullptr);
       lines.add(kj::str(email.getHtml()));
+    }
+    for (auto attachment : email.getAttachments()) {
+      addAttachment(lines, id, attachment);
     }
     lines.add(kj::str("--", id, "--"));
 
@@ -965,6 +1109,17 @@ private:
     strftime(date, sizeof(date), "%a, %d %b %Y %H:%M:%S %z", tm);
 
     addHeader(lines, "Date", date);
+  }
+
+  static void addAttachment(kj::Vector<kj::String>& lines, kj::StringPtr boundaryId, EmailAttachment::Reader & attachment) {
+    lines.add(kj::str("--", boundaryId));
+    addHeader(lines, "Content-Type", attachment.getContentType());
+    addHeader(lines, "Content-Disposition", attachment.getContentDisposition());
+    addHeader(lines, "Content-Transfer-Encoding", "base64");
+    addHeader(lines, "Content-Id", attachment.getContentId());
+    lines.add(nullptr);
+
+    lines.add(base64_encode(attachment.getContent()));
   }
 };
 


### PR DESCRIPTION
Notes:
- Date is now microseconds since the epoch
- Attachments are always encoded to base64 in sandstorm-http-bridge.c++
- Included code for base64 encoding from libb64 (http://libb64.sourceforge.net/). Only parts I added were calculating the size of the output buffer and handling the edge case for when there's one less new line than usual
- Had to re-write HackSessionContext.send to use simplesmtp directly for attachments
- Mailpile doesn't support outgoing attachments yet, but I've tested it with incoming attachments
