### PR TITLE
Remove check for grainInfo.appVersion since it makes no sense.

### DIFF
--- a/shell/server/backup.js
+++ b/shell/server/backup.js
@@ -146,10 +146,6 @@ Meteor.methods({
           throw new Meteor.Error(500,
                                  "Metadata object for uploaded grain has no AppId");
       }
-      if (!grainInfo.appVersion) {
-          throw new Meteor.Error(500,
-                                 "Metadata object for uploaded grain has no AppVersion");
-      }
 
       var action = UserActions.findOne({appId: grainInfo.appId, userId: this.userId});
       if (!action) {


### PR DESCRIPTION
appVersion is actually a Uint32, so this statement would only work when
appVersion was 0
