### PR TITLE
Reformat apps page

### DIFF
--- a/website/apps/index.html
+++ b/website/apps/index.html
@@ -79,16 +79,16 @@
       <div class="app">
         <button onclick="install('32618df3fb42a66c747d75435cc9efef?url=http://sandstorm.io/apps/etherpad.spk')">Install »</button>
         <h3>Etherpad</h3>
-		Developer: <a href="https://github.com/kentonv/">Kenton Varda</a> | Last Updated: ____
+	Developer: <a href="https://github.com/kentonv/">Kenton Varda</a> | Last Updated: March 19th, 2014
         <p>This is a port of <a href="http://etherpad.org/">Etherpad</a>, a collaborative document
-          editor. Ported by Kenton. No code changes were necessary.</p>
-		<p>License: Apache 2.0 | Source: <a href="https://github.com/ether/etherpad-lite">Github</a></p>
+          editor. No code changes were necessary.</p>
+	<p>License: Apache 2.0 | Source: <a href="https://github.com/ether/etherpad-lite">Github</a></p>
       </div>
 
       <div class="app">
         <button onclick="install('0b4ebbf4242de592b08957ced543feee?url=http://sandstorm.io/apps/mailpile.spk')">Install »</button>
         <h3>Mailpile</h3>
-		Developer: <a href="https://github.com/jparyani/">Jason Paryani</a> | Last Updated: July 7th, 2014
+	Developer: <a href="https://github.com/jparyani/">Jason Paryani</a> | Last Updated: July 7th, 2014
         <p>This is a port of <a href="https://www.mailpile.is/">Mailpile Alpha II</a>, an e-mail app.</p>
         <p>Note: Mailpile is still in alpha. See <a href="https://blog.sandstorm.io/news/2014-07-07-mailpile.html">our blog post about it</a>.</p>
         <p>License: Apache 2.0 | Source: <a href="https://github.com/jparyani/Mailpile/">Github</a></p>
@@ -97,12 +97,12 @@
       <div class="app">
         <button onclick="install('851f6e25c527b3c713c8424573b0214a?url=http://sandstorm.io/apps/ssjekyll6.spk')">Install »</button>
         <h3>Hacker CMS</h3>
-		Developer: <a href="https://github.com/kentonv/">Kenton Varda</a> | Last Updated: ____
+	Developer: <a href="https://github.com/kentonv/">Kenton Varda</a> | Last Updated: June 15th, 2014
         <p>This is a mash-up of <a href="http://jekyllrb.com/">Jekyll</a>,
           <a href="http://ace.c9.io/">Ace</a>, and <a href="http://www.jstree.com/">jsTree</a>
           to create a Markdown-based web site editing and publishing app.  This app was stiched
           together over the course of one day by Kenton.</p>
-        <p>License: 2-Clause BSD | Source: <a href="https://github.com/kentonv/ssjekyll">Github</a>
+        <p>License: 2-Clause BSD | Source: <a href="https://github.com/kentonv/ssjekyll">Github</a></p>
         <p style="text-align: center">
           <a href="https://github.com/kentonv/ssjekyll/blob/master/screenshot.png">
           <img height="240" src="ssjekyll.png"></a>
@@ -111,7 +111,7 @@
       <div class="app">
         <button onclick="install('4e1da8cec67250de8fa80371bc21f4eb?url=http://sandstorm.io/apps/ipython-notebook.spk')">Install »</button>
         <h3>IPython Notebook</h3>
-		Developer: <a href="https://github.com/jparyani/">Jason Paryani</a> | Last Updated: ____
+	Developer: <a href="https://github.com/jparyani/">Jason Paryani</a> | Last Updated: April 21st, 2014
         <p>A port of <a href="http://ipython.org/notebook.html">IPython Notebook</a>, a web-based
           interactive computational environment where you can execute Python code, plot graphs,
           render equations, and more.</p>
@@ -121,17 +121,17 @@
 	  <div class="app">
         <button onclick="install('5151531c1748e612ec0e4fddc71190ed?url=http://sandstorm.io/apps/meteor-todos.spk')">Install »</button>
         <h3>Meteor Todo List</h3>
-		Developer: <a href="https://github.com/kentonv/">Kenton Varda</a> | Last Updated: ____
+	Developer: <a href="https://github.com/kentonv/">Kenton Varda</a> | Last Updated: March 23rd, 2014
         <p>This is a port of the "Todo List" example application that comes with the
         <a href="http://meteor.com">Meteor</a> development tools. No code changes
         were necessary.</p>
-		<p>License: MIT | Source: <a href="https://github.com/meteor/meteor/tree/devel/examples/todos">Github</a></p>
+	<p>License: MIT | Source: <a href="https://github.com/meteor/meteor/tree/devel/examples/todos">Github</a></p>
       </div>
 
       <div class="app">
         <button onclick="install('a487cd628c051e2de9e12b2651ace994?url=http://sandstorm.io/apps/shell-busybox.spk')">Install »</button>
         <h3>Web Shell</h3>
-		Developer: <a href="https://github.com/kevinwallace/">Kevin Wallace</a> | Last Updated: ____
+	Developer: <a href="https://github.com/kevinwallace/">Kevin Wallace</a> | Last Updated: March 26th, 2014
         <p>A very simple front-end to a Busybox shell.  Can be used to poke at
           the Sandstorm sandbox.  (Note:  As of this time, resource-exhaustion-based DoS attacks
           are easy to carry out from a shell.  We're working on tightening things up.  If you are a
@@ -144,7 +144,7 @@
       <div class="app">
         <button onclick="install('f305df6e8ec2acb0aa6ea155bf8aa024?url=http://sandstorm.io/apps/duoludo.spk')">Install »</button>
         <h3>Duoludo</h3>
-		Developer: <a href="https://github.com/dwrensha">David Renshaw</a> | Last Updated: ____
+	Developer: <a href="https://github.com/dwrensha">David Renshaw</a> | Last Updated: March 26th, 2014
         <p>A minimalist platformer game with checkpoints, replay, and collaboration.  A port of
           <a href="http://dwrensha.ws/duoludo">duoludo</a>.</p>
 	<p>License: 3-Clause BSD | Source: <a href="https://github.com/dwrensha/duoludo">Github</a></p>
@@ -153,13 +153,13 @@
       <div class="app">
         <button onclick="install('b06a2f03de7dde47b5ed7de23e960e35?url=http://sandstorm.io/apps/acronymy.spk')">Install »</button>
         <h3>Acronymy</h3>
-		Developer: <a href="https://github.com/dwrensha">David Renshaw</a> | Last Updated: ____
+	Developer: <a href="https://github.com/dwrensha">David Renshaw</a> | Last Updated: April 21st, 2014
         <p>A little game / tech demo. The objective is to define every English word
           as an acronym of other words. The app is notable in that it is written in
           <a href="http://www.rust-lang.org/">Rust</a> directly against the low-level Sandstorm API,
           thus avoiding the need for an HTTP server.</p>
         <p>Also try <a href="https://alpha.sandstorm.io/grain/Evmjn3tJbDCJjT4Be">David's shared instance</a>.</p>
-        <p>License: 2-Clause BSD | Source: <a href="https://github.com/dwrensha/acronymy">Github</a>
+        <p>License: 2-Clause BSD | Source: <a href="https://github.com/dwrensha/acronymy">Github</a></p>
       </div>
 
       <div class="app">


### PR DESCRIPTION
Looks just a wee bit more like an app store, even if it's a static page. Put all the license/source info in a clean format. Split Apps and Games. Thought the one screenshot on the page was overbearingly large. Would like to know when apps on this page are updated. Mostly just experimenting with my ability to do this on Github, not even sure I can figure out how to suggest this merge to the main repository if I leave this page, so I'm going to push this button, and assume Github won't let me do anything I'm not allowed to do? (I totally forgot to add Duoludo's license/source info, but I'm not sure how to back up this train.)
