### PR TITLE
Fix if user has no email address

### DIFF
--- a/shell/server/mail.js
+++ b/shell/server/mail.js
@@ -235,7 +235,16 @@ HackSessionContextImpl.prototype._getUserAddress = function () {
   var user = Meteor.users.findOne(grain.userId);
 
   var email = (user.emails && user.emails.length && user.emails[0].address) || (user.services.google && user.services.google.email) || (user.services.github && user.services.github.email);
-  return {address: email, name: user.profile.name || ''};
+
+  var result = {};
+  if (email) {
+    result.address = email;
+  }
+  if (user.profile.name) {
+    result.name = user.profile.name;
+  }
+
+  return result;
 }
 
 HackSessionContextImpl.prototype.send = function (email) {


### PR DESCRIPTION
This changes getUserAddress to return an empty string for the address if
none are found.
