### PR TITLE
add refererPath field to WebSession::Context

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -975,6 +975,9 @@ private:
   void addCommonHeaders(kj::Vector<kj::String>& lines, WebSession::Context::Reader context) {
     lines.add(kj::str("Host: ", extractHostFromUrl(basePath)));
     lines.add(kj::str("User-Agent: ", userAgent));
+    if (context.hasRefererPath()) {
+      lines.add(kj::str("Referer: ", basePath, "/", context.getRefererPath()));
+    }
     lines.add(kj::str("X-Sandstorm-Username: ", userDisplayName));
     KJ_IF_MAYBE(u, userId) {
       lines.add(kj::str("X-Sandstorm-User-Id: ", *u));

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -69,6 +69,11 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   struct Context {
     # Additional per-request context.
     cookies @0 :List(Util.KeyValue);
+
+    refererPath @1 : Text;
+    # To protect against cross-site request forgery, Sandstorm requires that the `Referer`
+    # header must always match the host of the current session or the Sandstorm shell.
+    # In the former case, the path part of the `Referer` header gets written to this field.
   }
 
   struct PostContent {


### PR DESCRIPTION
A few things in WordPress don't work properly if the `Referer` header is not set. This patch forwards the header and adds some cross-site request forgery protection.
