### PR TITLE
Fix regex index error in install script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -344,7 +344,7 @@ else
   if [[ "$BASE_URL" =~ ^http://localhost(|:[0-9]*)(/.*)?$ ]]; then
     DEFAULT_WILDCARD=*.local.sandstorm.io${BASH_REMATCH[1]}
   elif [[ "$BASE_URL" =~ ^[^:/]*://(.*)$ ]]; then
-    DEFAULT_WILDCARD=*.${BASH_REMATCH[2]}
+    DEFAULT_WILDCARD=*.${BASH_REMATCH[1]}
   else
     DEFAULT_WILDCARD=
   fi


### PR DESCRIPTION
The regex matched was modified in adcb8b3f to remove a group and the
reference to that group was removed, but the second group's index wasn't
properly updated.
