### PR TITLE
rename Util.Variable to Util.Assignable

### DIFF
--- a/src/sandstorm/grain.capnp
+++ b/src/sandstorm/grain.capnp
@@ -335,9 +335,9 @@ interface SessionContext {
   # particular session.  This can be used e.g. to ask the platform to present certain system
   # dialogs to the user.
 
-  getSharedPermissions @0 () -> (var :Util.Variable);
-  # Returns a `Variable(PermissionSet)` indicating the permissions held by the user of this session.
-  # This variable can be persisted beyond the end of the session.  This is useful for detecting if
+  getSharedPermissions @0 () -> (var :Util.Assignable);
+  # Returns an `Assignable(PermissionSet)` indicating the permissions held by the user of this session.
+  # This assignable can be persisted beyond the end of the session.  This is useful for detecting if
   # the user later loses their access and auto-revoking things in that case.  See also `tieToUser()`
   # for an easier way to make a particular capability auto-revoke if the user's permissions change.
 
@@ -407,7 +407,7 @@ struct RoleDef {
 
   title @0 :Util.LocalizedText;
   # Name of the role, e.g. "editor" or "viewer".
-  
+
   verbPhrase @1 :Util.LocalizedText;
   # Verb phrase describing what users in this role can do with the grain.  Should be something
   # like "can edit" or "can view".  When the user shares the view with others, these verb phrases
@@ -429,13 +429,13 @@ struct RoleDef {
 interface SharingLink {
   # Represents one link in the sharing graph.
 
-  getPetname @0 () -> (name :Util.Variable);
-  # Name assigned by the sharer to the recipient.  Variable holds `LocalizedText`.
+  getPetname @0 () -> (name :Util.Assignable);
+  # Name assigned by the sharer to the recipient. Assignable holds `LocalizedText`.
 }
 
 interface ViewSharingLink extends(SharingLink) {
-  getRoleAssignment @0 () -> (var :Util.Variable);
-  # Returns a Variable containing a RoleAssignment.
+  getRoleAssignment @0 () -> (var :Util.Assignable);
+  # Returns an Assignable containing a RoleAssignment.
 
   struct RoleAssignment {
     union {

--- a/src/sandstorm/util.capnp
+++ b/src/sandstorm/util.capnp
@@ -100,30 +100,29 @@ interface ByteStream {
   # is not necessary for the callee to actually implement it.
 }
 
-interface Variable {
-  # A "variable" -- a value that changes over time.  Supports subscribing to updates.
+interface Assignable {
+  # An "assignable" -- a mutable memory cell. Supports subscribing to updates.
   #
   # TODO(someday):  This should be a parameterized type, when Cap'n Proto supports that.
 
   get @0 () -> (value :AnyPointer, setter :Setter);
-  # The returned setter's set() can only be called once, and throws an exception if the variable
-  # has changed since `getForUpdate()` was called.  This can be used to implement optimistic
-  # concurrency.
+  # The returned setter's set() can only be called once, and throws an exception if the assignable
+  # has changed since `get()` was called. This can be used to implement optimistic concurrency.
 
   asGetter @1 () -> (getter :Getter);
-  # Return a read-only capability for this variable, co-hosted with the variable itself for
-  # performance.  If the varibale is persistable, the getter is as well.
+  # Return a read-only capability for this assignable, co-hosted with the assignable itself for
+  # performance.  If the assignable is persistable, the getter is as well.
 
   asSetter @2 () -> (setter :Setter);
-  # Return a write-only capability for this variable, co-hosted with the variable itself for
-  # performance.  If the varibale is persistable, the setter is as well.
+  # Return a write-only capability for this assignable, co-hosted with the assignable itself for
+  # performance.  If the assignable is persistable, the setter is as well.
 
   interface Getter {
     get @0 () -> (value :AnyPointer);
 
     pushTo @1 (setter :Setter) -> (handle :Handle);
-    # Subscribe to updates.  Calls the given setter any time the variable's value changes.  Drop
-    # the returned handle to stop receiving updates.  If the variable is persistent, `setter` must
+    # Subscribe to updates.  Calls the given setter any time the assignable's value changes.  Drop
+    # the returned handle to stop receiving updates.  If the assignable is persistent, `setter` must
     # be as well.
   }
 


### PR DESCRIPTION
"Variable" is the wrong name for these things, and fails to convey that they are mutable and aliasable.

"Assignable" is a precise term coined to describe exactly this kind of thing. See these blog posts by Bob Harper for some discussion:
http://existentialtype.wordpress.com/2012/02/01/words-matter/
http://existentialtype.wordpress.com/2012/02/09/referential-transparency/
