### PR TITLE
destroy WebSocket if sendBytes fails

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -930,7 +930,10 @@ function WebSocketReceiver(socket) {
 
 function pumpWebSocket(socket, rpcStream) {
   socket.on("data", function (chunk) {
-    rpcStream.sendBytes(chunk);
+    rpcStream.sendBytes(chunk).catch(function (err) {
+      console.error("WebSocket sendBytes failed: " + err.stack);
+      socket.destroy();
+    });
   });
   socket.on("end", function (chunk) {
     rpcStream.close();


### PR DESCRIPTION
There a few cases where it's possible for a WebSocket to be connected to a stale WebSession, including when:
1. another client has clicked on the "restart grain" button.
2. the grain's supervisor has crashed and restarted.

Currently, the socket is not destroyed in such cases, and the client can continue writing to it, with all data being silently dropped.

This patch destroys the socket when a write fails, thus propagating the error.

Once we have support for `reactToLostClient()`, I think we'll be able to destroy the socket even sooner.
