### PR TITLE
use `useradd` instead of `adduser` for install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -293,7 +293,7 @@ else
 
     if ! id "$SERVER_USER" > /dev/null 2>&1; then
       if prompt-yesno "User account '$SERVER_USER' doesn't exist. Create it?" yes; then
-        adduser --system --group "$SERVER_USER"
+        useradd --system "$SERVER_USER"
 
         echo "Note: Sandstorm's storage will only be accessible to the group '$SERVER_USER'."
 


### PR DESCRIPTION
as `adduser` is afaik either an alias for `useradd`, or sometimes a wild
wrapper around it, or even non-existant (i.e. archlinux), switch to the
more portable direct `useradd` call.

omitting `--group`, as `useradd(8)` states:

```
By default, a group will also be created for the new user (see [...])
```
