### PR TITLE
add systemd compatibility to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -529,7 +529,9 @@ After=local-fs.target remote-fs.target network.target
 Requires=local-fs.target remote-fs.target network.target
 
 [Service]
-ExecStart=$PWD/sandstorm
+Type=forking
+ExecStart=$PWD/sandstorm start
+ExecStop=$PWD/sandstorm stop
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
not 100% happy, as the unit will only support `start` and `stop`, and i.e. have `status` managed internally. Maybe there's a `Type=` directive for systemd which supports pass-through like an init-script, but in the end this is what systemd does.. so not sure. But for now, this adds basic systemd support.
