### PR TITLE
A couple small fixes for installation on systemd distros.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -474,7 +474,7 @@ else
     SYSTEMD_UNIT="sandstorm.service"
 
     if prompt-yesno "Start sandstorm at system boot?" yes; then
-      if systemctl list-unit-files $SYSTEMD_UNIT | grep -q $SYSTEMD_UNIT; then
+      if systemctl list-unit-files | grep -q $SYSTEMD_UNIT; then
         systemctl stop sandstorm || true
       fi
 


### PR DESCRIPTION
Correct a failure to install due to existence of /etc/init.d despite it being a systemd distro, as well as a minor error stopping a pre-existing systemd service if sandstorm was already installed.

More details in invidual commits.

Successfully installed on CentOS 7 with these fixes.

Great looking project, kudos!
