### PR TITLE
don't try to compute grainlog data if subscriptions aren't ready

### DIFF
--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -371,13 +371,15 @@ Router.map(function () {
     },
 
     data: function () {
-      maybeScrollLog();
-      return {
-        title: Grains.findOne(this.params.grainId).title,
-        html: AnsiUp.ansi_to_html(GrainLog.find({}, {$sort: {_id: 1}})
-            .map(function (entry) { return entry.text; })
-            .join(""), {use_classes:true})
-      };
+      if (this.ready()) {
+        maybeScrollLog();
+        return {
+          title: Grains.findOne(this.params.grainId).title,
+          html: AnsiUp.ansi_to_html(GrainLog.find({}, {$sort: {_id: 1}})
+              .map(function (entry) { return entry.text; })
+              .join(""), {use_classes:true})
+        };
+      }
     }
   });
 });


### PR DESCRIPTION
Fixes #117.

The `data` function gets called regardless of whether `this.ready()` is `true`, and apparently this is by design. Cf. https://github.com/EventedMind/iron-router/issues/265
