### PR TITLE
only call shutdownWrite() when there is no expectedSize

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -929,12 +929,14 @@ public:
     // expected size. (If we have written headers then the size we pass will be ignored.)
     writeHeadersOnce(kj::implicitCast<uint64_t>(0));
 
-    previousWrite = previousWrite.then([this]() {
-      // Since we open a new connection for every request, we can indicate the end of the data by
-      // closing the stream, avoiding the need for chunked encoding when the content length is
-      // unknown.
-      stream->shutdownWrite();
-    });
+    if (expectedSize == nullptr) {
+      previousWrite = previousWrite.then([this]() {
+        // Since we open a new connection for every request, we can indicate the end of the data by
+        // closing the stream, avoiding the need for chunked encoding when the content length is
+        // unknown.
+        stream->shutdownWrite();
+      });
+    }
 
     auto fork = previousWrite.fork();
     previousWrite = fork.addBranch();


### PR DESCRIPTION
Groove Basin interprets the shutdown as aborting the request.

It might also be problematic to call shutdownWrite() in the case when there is no expectedSize. For that case we might be forced to use chunked encoding.
