### PR TITLE
fix undefined reference errors

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -848,10 +848,10 @@ ResponseStream.prototype.done = function () {
 
 ResponseStream.prototype.close = function () {
   if (this.ended) {
-    resolve();
+    this.resolve();
   } else {
     this.streamHandle.close();
-    reject("done() was never called on outbound stream.");
+    this.reject("done() was never called on outbound stream.");
   }
 }
 


### PR DESCRIPTION
Fixes this problem:

```
../src/node-capnp/capnp.cc:2027: error: Uncaught exception in capability close() method.; fromJsException(tryCatch.Exception()) = ../src/node-capnp/capnp.cc:684: error: ReferenceError: resolve is not defined
```
