### PR TITLE
reject with an actual Error

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1025,7 +1025,7 @@ ResponseStream.prototype.close = function () {
     this.resolve();
   } else {
     this.streamHandle.close();
-    this.reject("done() was never called on outbound stream.");
+    this.reject(new Error("done() was never called on outbound stream."));
   }
 }
 


### PR DESCRIPTION
Rejecting with a string causes an error in `shouldRestartGrain()`, which assumes that `error` is an object:

```
 HTTP request failed after response already sent: TypeError: Cannot use 'in' operator to search for 'nature' in done() was never called on outbound stream.
```
