### PR TITLE
fix grain list on iPad

### DIFF
--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -383,11 +383,11 @@ img {
 #applist-grains table tr {
   height: 32px;
   border-bottom: 1px solid #ddd;
+  cursor: pointer;
 }
 
 #applist-grains table tbody tr:hover {
   background-color: #f8f8f8;
-  cursor: pointer;
 }
 
 #applist-grains .button-box button {


### PR DESCRIPTION
In Chrome and Safari on iOS 8.1, clicking on a grain fails to open it. This patch makes it work.
