### PR TITLE
updated nginx configuration to allow wildcard https redirects

### DIFF
--- a/nginx-example.conf
+++ b/nginx-example.conf
@@ -9,7 +9,7 @@ server {
   # Redirect http -> https.
   listen 80;
   server_name alpha.sandstorm.io;
-  return 301 https://alpha.sandstorm.io$request_uri;
+  return 301 https://$host$request_uri$is_args$args;
 }
 
 # For WebSocket forwarding, we want to forward the `Connection` header.


### PR DESCRIPTION
Hello,

I setup a blog using Ghost on my personal server, hosted at `blog.example.com`.
With the current configuration, if I go to `http://blog.example.com`, I get redirected to `https://sandstorm.example.com` instead of `https://blog.example.com`

I found [this stackoverflow post](http://serverfault.com/questions/447258/redirect-wildcard-subdomains-to-https-nginx), and it allows for the blog to be redirected properly.

note, this prevents `someurl.example.com` from being redirected to `sandstorm.example.com`

Please tell me if there is something that can be improved with my pull request, I'm still new at this 
