### PR TITLE
Remove SSLv3 from nginx example because of POODLE attack

### DIFF
--- a/nginx-example.conf
+++ b/nginx-example.conf
@@ -31,7 +31,7 @@ server {
   ssl_session_timeout 5m;
 
   # Configure SSL with perfect forward secrecy and other goodies.
-  ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;
   ssl_prefer_server_ciphers on;
 


### PR DESCRIPTION
I see this has already been done on alpha.sandstorm.io, let's make the example safe as well.
