### PR TITLE
add yet another date format, to support Rack

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -705,6 +705,10 @@ private:
                 if (end == nullptr) {
                   // Not valid per HTTP spec, but MediaWiki seems to return this format sometimes.
                   end = strptime(value.cStr(), "%a, %d-%b-%Y %T GMT", &t);
+                  if (end == nullptr) {
+                    // Not valid per HTTP spec, but used by Rack.
+                    end = strptime(value.cStr(), "%a, %d %b %Y %T -0000", &t);
+                  }
                 }
               }
             }


### PR DESCRIPTION
Although [RFC 2616](http://tools.ietf.org/html/rfc2616#section-3.3.1) requires that "GMT" must be used for the time zone, Rack uses "-0000" instead. The origin of Rack's current behavior is this commit: https://github.com/rack/rack/commit/5e0a9413a80e9b0aa8a74bfc806fb20f2ea0bf3c
