### PR TITLE
fix supervisor crash by handling case when st_nlink == 0

### DIFF
--- a/src/sandstorm/supervisor-main.c++
+++ b/src/sandstorm/supervisor-main.c++
@@ -384,12 +384,17 @@ private:
         // Round the size up to the nearest block; we assume 4k blocks.
         result.bytes = (stats.st_size + 4095) & ~4095ull;
 
-        // Divide by link count so that files with many hardlinks aren't overcounted.
-        result.bytes /= stats.st_nlink;
+        if (stats.st_nlink != 0) {
+          // Note: sometimes the link count actually is zero; it often is, for example, during
+          // `git init`, which rapidly creates and deletes some temporary files.
 
-        // Add sizeof(stats) to approximate the directory entry overhead, and also add
-        // the size of the null-terminated filename rounded up to a word.
-        result.bytes += sizeof(stats) + ((name.size() + 8) & ~7ull);
+          // Divide by link count so that files with many hardlinks aren't overcounted.
+          result.bytes /= stats.st_nlink;
+
+          // Add sizeof(stats) to approximate the directory entry overhead, and also add
+          // the size of the null-terminated filename rounded up to a word.
+          result.bytes += sizeof(stats) + ((name.size() + 8) & ~7ull);
+        }
 
         return result;
       }


### PR DESCRIPTION
I noticed the supervisor crashing with SIGFPE. This fixes the problem.

In case you're curious, here's an strace of the part of `git init --bare` that appears to have triggered the problem:

```
open("/home/david/Desktop/scratch/twhvDvF", O_RDWR|O_CREAT|O_EXCL, 0600) = 3
close(3)                                = 0
unlink("/home/david/Desktop/scratch/twhvDvF") = 0
symlink("testing", "/home/david/Desktop/scratch/twhvDvF") = 0
lstat("/home/david/Desktop/scratch/twhvDvF", {st_dev=makedev(202, 0), st_ino=1256447, st_mode=S_IFLNK|0777, st_nlink=1, st_uid=1000, st_gid=1001, st_blksize=4096, st_blocks=0, st_size=7, st_atime=2014/12/01-14:05:40, st_mtime=2014/12/01-14:05:40, st_ctime=2014/12/01-14:05:40}) = 0
unlink("/home/david/Desktop/scratch/twhvDvF") = 0
```
