### PR TITLE
use C locale instead of C.UTF-8, which is not present on all systems

### DIFF
--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1405,7 +1405,7 @@ private:
     KJ_SYSCALL(clearenv());
 
     // Set up an environment appropriate for us.
-    KJ_SYSCALL(setenv("LANG", "C.UTF-8", true));
+    KJ_SYSCALL(setenv("LANG", "C", true));
     KJ_SYSCALL(setenv("PATH", "/usr/bin:/bin", true));
     KJ_SYSCALL(setenv("LD_LIBRARY_PATH", "/usr/local/lib:/usr/lib:/lib", true));
   }


### PR DESCRIPTION
Mongo crashes on startup when I build Sandstorm from source on Arch Linux. The problem is that the "C.UTF-8" locale is not present. Apparently "C.UTF-8" is Debian specific -- see https://bugzilla.redhat.com/show_bug.cgi?id=902094
