### PR TITLE
detect LANG at compile time; insist that its encoding be utf8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ CXXFLAGS=-O2 -Wall
 BUILD=0
 XZ_FLAGS=
 
+# LANG specifies the locale used in run-bundle.
+ifneq ($(shell echo $(LANG) | grep "\.UTF-8$$" -), $(LANG))
+$(error LANG must end with ".UTF-8")
+endif
+
 # You generally should not modify these.
 CXXFLAGS2=-std=c++1y -Isrc -Itmp $(CXXFLAGS) -DSANDSTORM_BUILD=$(BUILD)
 NODE_INCLUDE=$(HOME)/.meteor/tools/latest/include/node/
@@ -81,7 +86,7 @@ tmp/genfiles: src/sandstorm/*.capnp
 bin/run-bundle: src/sandstorm/run-bundle.c++ src/sandstorm/send-fd.c++ tmp/genfiles
 	@echo "building bin/run-bundle..."
 	@mkdir -p bin
-	@$(CXX) src/sandstorm/run-bundle.c++ src/sandstorm/send-fd.c++ tmp/sandstorm/*.capnp.c++ -o bin/run-bundle -static $(CXXFLAGS2) `pkg-config capnp-rpc --cflags --libs`
+	@$(CXX) src/sandstorm/run-bundle.c++ src/sandstorm/send-fd.c++ tmp/sandstorm/*.capnp.c++ -o bin/run-bundle -static $(CXXFLAGS2) -DENV_LANG=$(LANG) `pkg-config capnp-rpc --cflags --libs`
 
 shell/public/%.png: icons/%.svg
 	convert -scale 24x24 -negate -evaluate multiply 0.87 $< $@

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1404,8 +1404,12 @@ private:
     // locale setting can crash Mongo because we don't have the appropriate locale files available.
     KJ_SYSCALL(clearenv());
 
-    // Set up an environment appropriate for us.
-    KJ_SYSCALL(setenv("LANG", "C.UTF-8", true));
+    // Set up an environment appropriate for us. ENV_LANG is passed in as a flag at compile time.
+#define STR(s) #s
+#define XSTR(s) STR(s)
+    KJ_SYSCALL(setenv("LANG", XSTR(ENV_LANG), true));
+#undef XSTR
+#undef STR
     KJ_SYSCALL(setenv("PATH", "/usr/bin:/bin", true));
     KJ_SYSCALL(setenv("LD_LIBRARY_PATH", "/usr/local/lib:/usr/lib:/lib", true));
   }


### PR DESCRIPTION
A different approach to resolving the issue brought up in #169. This should work out-of-the-box in nearly all cases, including those when C.UTF-8 and en_US.UTF-8 are not present.
