### PR TITLE
subscribe to sessions by sessionId

### DIFF
--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -59,12 +59,8 @@ if (Meteor.isServer) {
     }
   });
 
-  Meteor.publish("sessions", function () {
-    if (this.userId) {
-      return Sessions.find({userId: this.userId});
-    } else {
-      return [];
-    }
+  Meteor.publish("sessions", function (sessionId) {
+    return Sessions.find({_id: sessionId});
   });
 
   Meteor.publish("devApps", function () {
@@ -141,7 +137,6 @@ if (Meteor.isClient) {
 
   Tracker.autorun(function () {
     Meteor.subscribe("credentials");
-    Meteor.subscribe("sessions");
   });
 
   makeDateString = function (date) {


### PR DESCRIPTION
One annoying thing about #175 is that new sessions require two round trips to the server, because there's no simple way to pipeline the "openSession" and the "subscribe" calls. To get it back down to a single round trip, I think we would essentially need to reintroduce the "session-<grainId>" entries that I had been so happy to eliminate.

This patch is a rather more conservative fix for #172. Right now I favor it over #175, but I welcome comments on either.
