### PR TITLE
Fix anonymous user test getting stuck on downgrade info page

### DIFF
--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -170,6 +170,10 @@ module.exports["Test grain anonymous user"] = function (browser) {
     .click('#uploadButton')
     .waitForElementVisible('#step-confirm', long_wait)
     .click('#confirmInstall')
+    // Navigate to app
+    .click('#homelink')
+    .waitForElementVisible('#applist-apps', medium_wait)
+    .click("#applist-apps > ul > li:nth-child(2)")
     .waitForElementVisible('.new-grain-button', short_wait)
     .assert.containsText('.new-grain-button', 'New Hacker CMS Site')
     // Create grain with that user


### PR DESCRIPTION
Sorry, the previous PR was tested with a much older version of sandstorm that didn't exhibit this problem.
