### PR TITLE
Make waits longer to try and solve intermittent failures on build server

### DIFF
--- a/tests/utils.js
+++ b/tests/utils.js
@@ -19,8 +19,8 @@ var wrapLoginGoogle = function(test) {
 };
 
 module.exports = {
-  short_wait: 1000,
-  medium_wait: 10000,
+  short_wait: 5000,
+  medium_wait: 30000,
   long_wait: 60000,
   very_long_wait: 180000,
   testAllLogins: function (tests) {


### PR DESCRIPTION
I ran the tests locally in a loop, and they completed successfully over 30 times without failing. I'm not sure what's causing the intermittent failures on the build server, but upping the wait times can't hurt.
