### PR TITLE
Fix boilerplate text/year in Apache license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -257,18 +257,7 @@ Google's Android.
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2015 Sandstorm Development Group, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This commit updates the Apache license boilerplate with actual information. The Apache license appendix (designed to be removed before publication) states:

```
APPENDIX: How to apply the Apache License to your work.

To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)...
```

Additionally, the copyright year was not included. Copyright notices must reflect the current year. This commit updates the listed year to 2015.

see: http://www.copyright.gov/circs/circ01.pdf for more info