### PR TITLE
Fix replyto

### DIFF
--- a/src/sandstorm/email.capnp
+++ b/src/sandstorm/email.capnp
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This is used specifically with hack-session.capnp.
+# It is subject to change after the Powerbox functionality is implemented.
+
 @0xdd10df585a82c6d8;
 
 $import "/capnp/c++.capnp".namespace("sandstorm");
@@ -44,6 +47,7 @@ struct EmailMessage {
   cc @3 :List(EmailAddress);
   bcc @4 :List(EmailAddress);
   replyTo @5 :EmailAddress; # header is actually reply-to
+  # TODO(someday): replyTo should actually be a List(EmailAddress)
 
   messageId @6 :Text; # header is actually message-id
   references @7 :List(Text);


### PR DESCRIPTION
Fixes #197 

Unfortunately we got the protocol wrong a bit for reply-to, so we now bounce emails that have more than 1 address in the reply-to header.