### PR TITLE
remove broken autoselect code for apiTokenText

### DIFF
--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -187,9 +187,6 @@ if (Meteor.isClient) {
           console.error(error.stack);
         } else {
           Session.set("api-token-" + grainId, result.endpointUrl + "#" + result.token);
-          Meteor.setTimeout(function() {
-            document.getElementById("apiTokenText").select();
-          }, 0);
         }
       });
     },


### PR DESCRIPTION
Since [this commit](https://github.com/sandstorm-io/sandstorm/commit/178e174bbc76b51363f73a84bd3057f1f97af464), which changed the element from an input text box to a link, creating a new webkey dumps this error into the browser console:

```
Exception in setTimeout callback: TypeError: undefined is not a function
```