### PR TITLE
Create /appdemo/ to launch a demo instance of an app

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -487,6 +487,56 @@ $KEY</textarea></p>
   </div>
 </template>
 
+<template name="appdemo">
+  <div id="topbar">{{> homeLink}} App demo</div>
+
+  <div id="demo" class="main-content">
+    <div class="centered-box">
+      <h2></h2>
+      {{#if allowDemo}}
+        {{#if isSignedUp}}
+          {{#if isDemoUser}}
+            <p>You are currently logged in as a one-hour demo user.</p>
+            <p><button onclick="browseHome()">Continue the demo</button></p>
+          {{else}}
+            <p>You are already logged in as a real user.</p>
+          {{/if}}
+        {{else}}
+          {{#if loggingIn}}
+            <p>Logging in...</p>
+          {{else}}
+            <p><input id="demo-display-name" type="hidden" value="">
+               <button id="createDemoUser">Try {{ appName }} »</button></p>
+          {{/if}}
+        {{/if}}
+
+        <h3>What is this?</h3>
+        <p>If you click above, you'll open a temporary instance of {{
+          appName }} on the Sandstorm demo server.</p>
+
+	<p>Sandstorm is an open source hosting platform for personal
+          instances of web apps. Users can upload and install
+          arbitrary software. In addition to improving privacy and
+          control,
+          <a href="https://blog.sandstorm.io/news/2014-07-21-open-source-web-apps-require-federated-hosting.html">
+          this is the only way to make Open Source web apps viable.</a></p>
+        <p>Notes:</p>
+        <ul>
+          <li>Demo accounts last one hour.</li>
+          <li>Demo accounts can only install apps from Sandstorm.io, but this
+            is an artificial limitation. Real users can upload whatever code they want, as
+            each app server runs in a secure sandbox.</li>
+          <li>We only have one machine. It may get slow or crashy under excessive load.</li>
+          <li>We know the UI design needs work. This is a tech demo. ;)</li>
+          <li><a href="https://sandstorm.io">Read more at Sandstorm.io.</a></li>
+        </ul>
+      {{else}}
+        <p>Sorry, this server does not allow demo accounts.</p>
+      {{/if}}
+    </div>
+  </div>
+</template>
+
 <template name="demo">
   <div id="topbar">{{> homeLink}} Demo</div>
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -488,57 +488,11 @@ $KEY</textarea></p>
 </template>
 
 <template name="appdemo">
-  <div id="topbar">{{> homeLink}} App demo</div>
-
-  <div id="demo" class="main-content">
-    <div class="centered-box">
-      <h2></h2>
-      {{#if allowDemo}}
-        {{#if isSignedUp}}
-          {{#if isDemoUser}}
-            <p>You are currently logged in as a one-hour demo user.</p>
-            <p><button onclick="browseHome()">Continue the demo</button></p>
-          {{else}}
-            <p>You are already logged in as a real user.</p>
-          {{/if}}
-        {{else}}
-          {{#if loggingIn}}
-            <p>Logging in...</p>
-          {{else}}
-            <p><input id="demo-display-name" type="hidden" value="">
-               <button id="createDemoUser">Try {{ appName }} »</button></p>
-          {{/if}}
-        {{/if}}
-
-        <h3>What is this?</h3>
-        <p>If you click above, you'll open a temporary instance of {{
-          appName }} on the Sandstorm demo server.</p>
-
-	<p>Sandstorm is an open source hosting platform for personal
-          instances of web apps. Users can upload and install
-          arbitrary software. In addition to improving privacy and
-          control,
-          <a href="https://blog.sandstorm.io/news/2014-07-21-open-source-web-apps-require-federated-hosting.html">
-          this is the only way to make Open Source web apps viable.</a></p>
-        <p>Notes:</p>
-        <ul>
-          <li>Demo accounts last one hour.</li>
-          <li>Demo accounts can only install apps from Sandstorm.io, but this
-            is an artificial limitation. Real users can upload whatever code they want, as
-            each app server runs in a secure sandbox.</li>
-          <li>We only have one machine. It may get slow or crashy under excessive load.</li>
-          <li>We know the UI design needs work. This is a tech demo. ;)</li>
-          <li><a href="https://sandstorm.io">Read more at Sandstorm.io.</a></li>
-        </ul>
-      {{else}}
-        <p>Sorry, this server does not allow demo accounts.</p>
-      {{/if}}
-    </div>
-  </div>
+  {{> demo}}
 </template>
 
 <template name="demo">
-  <div id="topbar">{{> homeLink}} Demo</div>
+  <div id="topbar">{{> homeLink}} {{ pageTitle }} </div>
 
   <div id="demo" class="main-content">
     <div class="centered-box">
@@ -556,7 +510,7 @@ $KEY</textarea></p>
             <p>Logging in...</p>
           {{else}}
             <p><input id="demo-display-name" type="hidden" value="">
-               <button id="createDemoUser">Start the demo »</button></p>
+               <button id="createDemoUser">{{ createDemoUserLabel }} »</button></p>
           {{/if}}
         {{/if}}
 
@@ -568,9 +522,10 @@ $KEY</textarea></p>
         <p>Notes:</p>
         <ul>
           <li>Demo accounts last one hour.</li>
-          <li>Demo accounts can only install apps from Sandstorm.io, but this
-            is an artificial limitation. Real users can upload whatever code they want, as
-            each app server runs in a secure sandbox.</li>
+          <li>Demo accounts can only install approved apps, but this
+            is an artificial limitation. Real users can upload
+            whatever code they want, as each app server runs in a
+            secure sandbox.</li>
           <li>We only have one machine. It may get slow or crashy under excessive load.</li>
           <li>We know the UI design needs work. This is a tech demo. ;)</li>
           <li><a href="https://sandstorm.io">Read more at Sandstorm.io.</a></li>

--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -150,18 +150,18 @@ if (Meteor.isClient && allowDemo) {
   Template.appdemo.events({
     "click #createDemoUser": function (event) {
       /*
-	When clicking on the createDemoUser button on the app demo,
-	we want to:
+        When clicking on the createDemoUser button on the app demo,
+        we want to:
 
-	1. Create the Demo User.
+        1. Create the Demo User.
 
-	2. Log the user in as this Demo User.
+        2. Log the user in as this Demo User.
 
-	3. Install the chosen app.
+        3. Install the chosen app.
 
-	4. Create a new grain with this app.
+        4. Create a new grain with this app.
 
-	5. Take them into this grain.
+        5. Take them into this grain.
 
       */
       // calculate the appId
@@ -177,23 +177,23 @@ if (Meteor.isClient && allowDemo) {
       // We define this here so we can stash a the current appId
       // inside the closure.
       var makeUserCallbackFunction = function(appId) {
-	return function(err) {
+        return function(err) {
           if (err) {
             window.alert(err);
           } else {
-	    // First, find the package ID, since that is what
-	    // addUserActions takes. Choose the package ID with
-	    // highest version number.
-	    var packageId = Packages.findOne({appId: appId},
-					     {sort: {"manifest.appVersion": -1}})._id;
+            // First, find the package ID, since that is what
+            // addUserActions takes. Choose the package ID with
+            // highest version number.
+            var packageId = Packages.findOne({appId: appId},
+                                             {sort: {"manifest.appVersion": -1}})._id;
 
-	    // 3. Install this app for the user.
-	    addUserActions(packageId);
+            // 3. Install this app for the user.
+            addUserActions(packageId);
 
-	    // 4. Create new grain and 5. browse to it.
-	    launchAndEnterGrainByAppId(packageId);
+            // 4. Create new grain and 5. browse to it.
+            launchAndEnterGrainByAppId(packageId);
           }
-	}
+        }
       };
       userCallbackFunction = makeUserCallbackFunction(this.appId);
 
@@ -216,8 +216,8 @@ Router.map(function () {
       return {
         allowDemo: allowDemo,
         isSignedUp: isSignedUpOrDemo(),
-	createDemoUserLabel: "Start the demo",
-	pageTitle: "Demo",
+        createDemoUserLabel: "Start the demo",
+        pageTitle: "Demo",
         isDemoUser: isDemoUser()
       };
     }
@@ -234,23 +234,23 @@ Router.map(function () {
       // find the newest (highest version, so "first" when sorting by
       // inverse order) matching package.
       var thisPackage = Packages.findOne({appId: this.params.appId},
-					 {sort: {"manifest.appVersion": -1}});
+                                        {sort: {"manifest.appVersion": -1}});
 
       // In the case that the app requested is not present, we show
       // this string as the app name.
       var appName = 'missing package';
 
       if (thisPackage) {
-	var actionTitle = thisPackage.manifest.actions[0].title.defaultText;
-	appName = appNameFromActionName(actionTitle);
+        var actionTitle = thisPackage.manifest.actions[0].title.defaultText;
+        appName = appNameFromActionName(actionTitle);
       }
 
       return {
         allowDemo: allowDemo,
         isSignedUp: isSignedUpOrDemo(),
-	createDemoUserLabel: "Try " + appName,
-	pageTitle: appName + " Demo on Sandstorm",
-	appId: this.params.appId,
+        createDemoUserLabel: "Try " + appName,
+        pageTitle: appName + " Demo on Sandstorm",
+        appId: this.params.appId,
         isDemoUser: isDemoUser()
       };
     }

--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -146,6 +146,58 @@ if (Meteor.isClient && allowDemo) {
       });
     }
   });
+
+  Template.appdemo.events({
+    "click #createDemoUser": function (event) {
+      /*
+	When clicking on the createDemoUser button on the app demo,
+	we want to:
+
+	1. Create the Demo User.
+
+	2. Log the user in as this Demo User.
+
+	3. Install the chosen app.
+
+	4. Create a new grain with this app.
+
+	5. Take them into this grain.
+
+      */
+      // calculate the appId
+
+      // 1. Create the Demo User & 2. Log the user in as this Demo User.
+      var displayName = document.getElementById("demo-display-name").value.trim();
+      if (displayName === "") {
+        displayName = "Demo User";
+      } else {
+        displayName += " (demo)";
+      }
+
+      // We define this here so we can stash a the current packageId
+      // inside the closure.
+      var makeUserCallbackFunction = function(packageId) {
+	return function(err) {
+          if (err) {
+            window.alert(err);
+          } else {
+	    // 3. Install this app for the user.
+	    addUserActions(packageId);
+
+	    // 4. Create new grain and 5. browse to it.
+	    launchAndEnterGrainByPackageId(packageId);
+          }
+	}
+      };
+      userCallbackFunction = makeUserCallbackFunction(this.packageId);
+
+      Accounts.callLoginMethod({
+        methodName: "createDemoUser",
+        methodArguments: [displayName],
+        userCallback: userCallbackFunction
+      });
+
+    }});
 }
 
 Router.map(function () {

--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -175,7 +175,9 @@ Router.map(function () {
     data: function () {
       var thisPackage = Packages.findOne({_id: this.params.packageId});
 
-      var appName = '';
+      // In the case that the app requested is not present, we show
+      // this string as the app name.
+      var appName = 'missing package';
 
       if (thisPackage) {
 	var actionTitle = thisPackage.manifest.actions[0].title.defaultText;

--- a/shell/shared/install.js
+++ b/shell/shared/install.js
@@ -153,7 +153,7 @@ Meteor.methods({
 });
 
 if (Meteor.isClient) {
-  function addUserActions(packageId) {
+  addUserActions = function(packageId) {
     var package = Packages.findOne(packageId);
     if (package) {
       // Remove old versions.

--- a/shell/shared/install.js
+++ b/shell/shared/install.js
@@ -61,6 +61,21 @@ if (Meteor.isServer) {
     }
   });
 
+  Meteor.publish("appInfo", function (appId) {
+    // This publishes info about an app, including the latest version
+    // of it, and is safe for anonymous users. Use this when you are
+    // given an appId and must display information about it to
+    // non-logged-in users.
+    check(appId, String);
+
+    var packageCursor = Packages.find({appId: appId},
+				      {sort: {"manifest.appVersion": -1}});
+
+    var package = packageCursor.fetch()[0];
+
+    return packageCursor;
+  });
+
   Meteor.methods({
     cancelDownload: function (packageId) {
       check(packageId, String);

--- a/shell/shared/install.js
+++ b/shell/shared/install.js
@@ -69,7 +69,7 @@ if (Meteor.isServer) {
     check(appId, String);
 
     var packageCursor = Packages.find({appId: appId},
-				      {sort: {"manifest.appVersion": -1}});
+                      {sort: {"manifest.appVersion": -1}});
 
     var package = packageCursor.fetch()[0];
 

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -162,7 +162,56 @@ if (Meteor.isClient) {
     }
 
     return result;
-  }
+  };
+
+  launchAndEnterGrainByPackageId = function(packageId) {
+    var action = UserActions.findOne({packageId: packageId});
+    if (!action) {
+      var packageId = null;
+    }
+    launchAndEnterGrainByActionId(action._id, null, null);
+  };
+
+  launchAndEnterGrainByActionId = function(actionId, devId, devIndex) {
+    // Note that this takes a devId and a devIndex as well. If provided,
+    // they override the actionId.
+    if (devId) {
+      var devApp = DevApps.findOne(devId);
+      if (!devApp) {
+	console.error("no such dev app: ", devId);
+	return;
+      }
+      var devAction = devApp.manifest.actions[devIndex];
+      packageId = devApp.packageId;
+      command = devAction.command;
+      actionTitle = devAction.title.defaultText;
+    } else {
+      var action = UserActions.findOne(actionId);
+      if (!action) {
+        console.error("no such action: ", actionId);
+        return;
+      }
+
+      packageId = action.packageId;
+      command = action.command;
+      actionTitle = action.title;
+    }
+
+    var title = actionTitle;
+    if (title.lastIndexOf("New ", 0) === 0) {
+      title = actionTitle.slice(4);
+    }
+    title = "Untitled " + title;
+
+    // We need to ask the server to start a new grain, then browse to it.
+    Meteor.call("newGrain", packageId, command, title, function (error, grainId) {
+      if (error) {
+        console.error(error);
+      } else {
+        Router.go("grain", {grainId: grainId});
+      }
+    });
+  };
 
   Template.root.helpers({
     filteredGrains: function () {
@@ -330,48 +379,70 @@ if (Meteor.isClient) {
       if (actionId === "dev") {
         var devId = event.currentTarget.getAttribute("data-devid");
         var devIndex = event.currentTarget.getAttribute("data-index");
-        var devApp = DevApps.findOne(devId);
-        if (!devApp) {
-          console.error("no such dev app: ", devId);
-          return;
-        }
-
-        var devAction = devApp.manifest.actions[devIndex];
-
-        packageId = devApp.packageId;
-        command = devAction.command;
-        actionTitle = devAction.title.defaultText;
-      } else {
-        var action = UserActions.findOne(actionId);
-        if (!action) {
-          console.error("no such action: ", actionId);
-          return;
-        }
-
-        packageId = action.packageId;
-        command = action.command;
-        actionTitle = action.title;
       }
 
-      var title = actionTitle;
-      if (title.lastIndexOf("New ", 0) === 0) {
-        title = actionTitle.slice(4);
-      }
-      title = "Untitled " + title;
-
-      // We need to ask the server to start a new grain, then browse to it.
-      Meteor.call("newGrain", packageId, command, title, function (error, grainId) {
-        if (error) {
-          console.error(error);
-        } else {
-          Router.go("grain", {grainId: grainId});
-        }
-      });
+      launchAndEnterGrainByActionId(actionId, devId, devIndex);
     },
 
     "click .action-required button": function (event) {
       event.currentTarget.parentNode.parentNode.style.display = "none";
     },
+  });
+
+  Template.appdemo.helpers({
+    appName: function() {
+      // we ask the server for this in appdemo.js
+      return Session.get('appName');
+    }
+  });
+
+  Template.appdemo.events({
+    "click #createDemoUser": function (event) {
+      /*
+	When clicking on the createDemoUser button on the app demo,
+	we want to:
+
+	1. Create the Demo User.
+
+	2. Log the user in as this Demo User.
+
+	3. Install the chosen app.
+
+	4. Create a new grain with this app.
+
+	5. Take them into this grain.
+
+      */
+      // calculate the appId
+
+      // 1. Create the Demo User & 2. Log the user in as this Demo User.
+      var displayName = document.getElementById("demo-display-name").value.trim();
+      if (displayName === "") {
+        displayName = "Demo User";
+      } else {
+        displayName += " (demo)";
+      }
+
+      Accounts.callLoginMethod({
+        methodName: "createDemoUser",
+        methodArguments: [displayName],
+        userCallback: function (err) {
+          if (err) {
+            window.alert(err);
+          } else {
+	    var packageId = Session.get("packageId");
+
+	    // 3. Install this app for the user.
+	    addUserActions(Session.get(packageId));
+
+	    // 4. Create new grain and 5. browse to it.
+	    launchAndEnterGrainByPackageId(packageId);
+          }
+        }
+      });
+
+    },
+
   });
 
   Template.homeLink.events({
@@ -421,7 +492,7 @@ function isMissingWildcardParent() {
   return Meteor.settings && Meteor.settings.public && Meteor.settings.public.missingWildcardParentUrl;
 }
 
-function appNameFromActionName(name) {
+appNameFromActionName = function(name) {
   // Hack: Historically we only had action titles, like "New Etherpad Document", not app
   //   titles. But for this UI we want app titles. As a transitionary measure, try to
   //   derive the app title from the action title.

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -391,13 +391,6 @@ if (Meteor.isClient) {
     },
   });
 
-  Template.appdemo.helpers({
-    appName: function() {
-      // we ask the server for this in appdemo.js
-      return Session.get('appName');
-    }
-  });
-
   Template.homeLink.events({
     "click #menu-button": function (event) {
       Session.set("showMenu", !Session.get("showMenu"));

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -398,58 +398,6 @@ if (Meteor.isClient) {
     }
   });
 
-  Template.appdemo.events({
-    "click #createDemoUser": function (event) {
-      /*
-	When clicking on the createDemoUser button on the app demo,
-	we want to:
-
-	1. Create the Demo User.
-
-	2. Log the user in as this Demo User.
-
-	3. Install the chosen app.
-
-	4. Create a new grain with this app.
-
-	5. Take them into this grain.
-
-      */
-      // calculate the appId
-
-      // 1. Create the Demo User & 2. Log the user in as this Demo User.
-      var displayName = document.getElementById("demo-display-name").value.trim();
-      if (displayName === "") {
-        displayName = "Demo User";
-      } else {
-        displayName += " (demo)";
-      }
-
-      // We define this here so we can stash a the current packageId
-      // inside the closure.
-      var makeUserCallbackFunction = function(packageId) {
-	return function(err) {
-          if (err) {
-            window.alert(err);
-          } else {
-	    // 3. Install this app for the user.
-	    addUserActions(packageId);
-
-	    // 4. Create new grain and 5. browse to it.
-	    launchAndEnterGrainByPackageId(packageId);
-          }
-	}
-      };
-      userCallbackFunction = makeUserCallbackFunction(this.packageId);
-
-      Accounts.callLoginMethod({
-        methodName: "createDemoUser",
-        methodArguments: [displayName],
-        userCallback: userCallbackFunction
-      });
-
-    }});
-
   Template.homeLink.events({
     "click #menu-button": function (event) {
       Session.set("showMenu", !Session.get("showMenu"));

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -425,8 +425,8 @@ if (Meteor.isClient) {
         displayName += " (demo)";
       }
 
-      /* We define this here so we can stash a the current
-	 packageId inside the closure. */
+      // We define this here so we can stash a the current packageId
+      // inside the closure.
       var makeUserCallbackFunction = function(packageId) {
 	return function(err) {
           if (err) {

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -180,8 +180,8 @@ if (Meteor.isClient) {
     if (devId) {
       var devApp = DevApps.findOne(devId);
       if (!devApp) {
-	console.error("no such dev app: ", devId);
-	return;
+    console.error("no such dev app: ", devId);
+    return;
       }
       var devAction = devApp.manifest.actions[devIndex];
       packageId = devApp.packageId;


### PR DESCRIPTION
The URL structure is /appdemo/:packageId (which is the sha256sum of the
package).

For now, we ignore any query string data provided. Crucially, we ignore a
?url= parameter, which /install/ uses -- since the app demo only works for
apps that are already installed, need no ?url parameter.

This also extracts the code to launch and enter a grain, given either a
package ID or an action ID, into a helper function.

Close #211