### PR TITLE
Requirements for building Sandstorm expanded 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Please install the following:
 * Linux, with reasonably new kernel version.
 * `libcap` with headers (e.g. `libcap-dev` on Debian/Ubuntu)
 * `XZ` for installing packages (`xz-utils` on Debian/Ubuntu)
+* zip and unzip
+* Build essentials for make (`build-essential` on Debian/Ubuntu)
 * [Clang compiler](http://clang.llvm.org/) version 3.4 or better. WARNING: Ubuntu Saucy's
   `clang-3.4` package is NOT Clang 3.4! It's actually some random cut from trunk between 3.3 and
   3.4, and it's not new enough.  Try <a href="http://llvm.org/apt/">the official packages from


### PR DESCRIPTION
* zip and unzip
* Build essentials for make (`build-essential` on Debian/Ubuntu)