### PR TITLE
Add tcp bridge to sandstorm-http-bridge

### DIFF
--- a/shell/server/drivers/ip.js
+++ b/shell/server/drivers/ip.js
@@ -197,6 +197,7 @@ IpNetworkImpl.prototype.getRemoteHostByName = function (address) {
     Dns.lookup(address, 4, function (err, res) {
       if (err) {
         reject(err);
+        return;
       }
 
       var ip = Bignum(ip4ToInt(res));
@@ -210,6 +211,7 @@ IpNetworkImpl.prototype.getIpAddressForHostname = function (address) {
     Dns.lookup(address, 4, function (err, res) {
       if (err) {
         reject(err);
+        return;
       }
 
       var ip = Bignum(ip4ToInt(res));

--- a/src/sandstorm/ip.capnp
+++ b/src/sandstorm/ip.capnp
@@ -56,6 +56,11 @@ interface IpNetwork extends(PowerboxCapability) {
   getRemoteHostByName @1 (address :Text) -> (host :IpRemoteHost);
   # Like `getRemoteHost()` but parse the address from text and perform a DNS lookup if necessary.
   # Textual representations of IP addresses will also be accepted.
+
+  getIpAddressForHostname @2 (hostname :Text) -> (address :IpAddress);
+  # This method performs a DNS lookup and returns a raw IpAddresses corresponding to this hostname.
+  # This is meant solely for legacy apps that need to do DNS lookups. `getRemoteHostByName()` is
+  # much preferred if an app is able to use it.
 }
 
 struct IpAddress {

--- a/src/sandstorm/package.capnp
+++ b/src/sandstorm/package.capnp
@@ -199,6 +199,14 @@ struct BridgeConfig {
   # also has the effect of limiting your clients to only accessing endpoints under that path you
   # provide. It should always end in a trailing '/'.
   # "/" is a valid value, and will give clients access to all paths.
+
+  enableIpBridge @2 :Bool = false;
+  # This enables IP bridge functionality in sandstorm-http-bridge. This requires that the owner
+  # of the grain be an admin, and that iptables is enabled on the host.
+  #
+  # With this enabled, all TCP connections will be seamlessly redirected over the Sandstorm
+  # IP interface (see ip.capnp). For legacy apps, it will apppear that they have full access
+  # to the internet
 }
 
 # ==============================================================================

--- a/src/sandstorm/sandstorm-http-bridge.capnp
+++ b/src/sandstorm/sandstorm-http-bridge.capnp
@@ -30,4 +30,9 @@ interface SandstormHttpBridge {
   getSessionContext @1 (id :Text) -> (context :Grain.SessionContext);
   # Get the SessionContext corresponding to a UiSession. The appropriate `id` value can be read
   # from the X-Sandstorm-Session-Id header inserted by sandstorm-http-bridge.
+
+  getFirstSessionContext @2 () -> (context :Grain.SessionContext);
+  # DEPRECATED: do not use in new apps. This function will be removed at some point.
+  # This is a hack method for getting a SessionContext without a SessionId. It is only meant to be
+  # used for legacy apps such as IpNetworking that don't care what user's session the context is.
 }

--- a/src/sandstorm/sandstorm-ip-bridge.c++
+++ b/src/sandstorm/sandstorm-ip-bridge.c++
@@ -113,9 +113,9 @@ private:
   }
 
 public:
-  AcceptedConnection(kj::Own<kj::AsyncIoStream>&& connectionParam, TcpPort::Client && _port)
+  AcceptedConnection(kj::Own<kj::AsyncIoStream>&& connectionParam, TcpPort::Client && portParam)
       : connection(kj::refcounted<RefcountedAsyncIoStream>(kj::mv(connectionParam))),
-        port(_port), errorHandler(kj::addRef(*connection)), taskSet(errorHandler),
+        port(kj::mv(portParam)), errorHandler(kj::addRef(*connection)), taskSet(errorHandler),
         numOutstandingWrites(0) {
     auto request = port.connectRequest();
     request.setDownstream(kj::heap<Downstream>(kj::addRef(*connection)));

--- a/src/sandstorm/sandstorm-ip-bridge.c++
+++ b/src/sandstorm/sandstorm-ip-bridge.c++
@@ -99,7 +99,9 @@ private:
     // multiple times, so only abort the first. This will have a side-effect
     // of causing tryRead to fail, and erroring out messageLoop() below.
     if (!aborted) {
-      connection->stream->abortRead();
+      try {
+        connection->stream->abortRead();
+      } catch (...) { }
       aborted = true;
     }
   }

--- a/src/sandstorm/sandstorm-ip-bridge.c++
+++ b/src/sandstorm/sandstorm-ip-bridge.c++
@@ -14,12 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This program is useful for including in Sandstorm application packages where
-// the application itself is a legacy HTTP web server that does not understand
-// how to speak the Cap'n Proto interface directly.  This program will start up
-// that server and then redirect incoming requests to it over standard HTTP on
-// the loopback network interface.
-
 #include "sandstorm/sandstorm-ip-bridge.h"
 
 #include <kj/debug.h>

--- a/src/sandstorm/sandstorm-ip-bridge.c++
+++ b/src/sandstorm/sandstorm-ip-bridge.c++
@@ -1,0 +1,181 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2014 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This program is useful for including in Sandstorm application packages where
+// the application itself is a legacy HTTP web server that does not understand
+// how to speak the Cap'n Proto interface directly.  This program will start up
+// that server and then redirect incoming requests to it over standard HTTP on
+// the loopback network interface.
+
+#include "sandstorm/sandstorm-ip-bridge.h"
+
+#include <kj/debug.h>
+#include <netinet/ip.h>
+#include <linux/netfilter_ipv4.h>
+#include <unistd.h>
+
+namespace sandstorm {
+  namespace ipbridge {
+
+  class RefcountedAsyncIoStream: public kj::Refcounted {
+  public:
+    explicit RefcountedAsyncIoStream(kj::Own<kj::AsyncIoStream>&& stream)
+        : stream(kj::mv(stream)) {}
+    kj::Own<kj::AsyncIoStream> stream;
+  };
+
+  static const int BUFFER_SIZE = 8192;
+
+  // TCP handling
+  struct AcceptedConnection {
+    class Downstream final: public ByteStream::Server {
+    private:
+      kj::Own<RefcountedAsyncIoStream> connection;
+
+    public:
+      explicit Downstream(kj::Own<RefcountedAsyncIoStream> && connection) :
+        connection(kj::mv(connection)) {}
+
+      kj::Promise<void> write(WriteContext context) {
+        auto params = context.getParams();
+        return connection->stream->write(params.getData().begin(), params.getData().size());
+      }
+
+      kj::Promise<void> done(DoneContext context) {
+        connection->stream->shutdownWrite();
+        return kj::READY_NOW;
+      }
+    };
+
+  private:
+    kj::Own<RefcountedAsyncIoStream> connection;
+    capnp::byte buffer[BUFFER_SIZE];
+    TcpPort::Client port;
+    kj::Own<ByteStream::Client> upstream;
+
+  public:
+    explicit AcceptedConnection(kj::Own<kj::AsyncIoStream>&& connectionParam, TcpPort::Client port)
+        : connection(kj::refcounted<RefcountedAsyncIoStream>(kj::mv(connectionParam))), port(port) {
+      auto request = port.connectRequest();
+      request.setDownstream(kj::heap<Downstream>(kj::addRef(*connection)));
+      upstream = kj::heap<ByteStream::Client>(request.send().getUpstream());
+    }
+
+    kj::Promise<void> start() {
+      return messageLoop();
+    }
+
+    kj::Promise<void> messageLoop() {
+      return connection->stream->tryRead(buffer, 1, BUFFER_SIZE)
+            .then([this] (size_t size) -> kj::Promise<void> {
+        if (size < 1) {
+          return upstream->doneRequest().send().then([] (auto args) {});  // EOF
+        }
+
+        auto request = upstream->writeRequest();
+        request.setData(kj::ArrayPtr<capnp::byte>(buffer, size));
+        return request.send().then([this] (auto args) {
+          return messageLoop();
+        });
+      });
+    }
+  };
+
+  TcpPort::Client getTcpClient(kj::Own<kj::AsyncIoStream>& connection, HackSessionContext::Client& session) {
+    auto request = session.getIpNetworkRequest().send().getNetwork().getRemoteHostRequest();
+
+    struct sockaddr destaddr;
+    uint size = sizeof(destaddr);  // TODO(soon): make static?
+    connection->getsockopt(SOL_IP, SO_ORIGINAL_DST, &destaddr, &size);
+
+    // TODO(someday): handle ipv6
+    struct sockaddr_in * destaddr_ipv4 = reinterpret_cast<sockaddr_in *>(&destaddr);
+    request.getAddress().setLower64(0x0000FFFF00000000 | ntohl(destaddr_ipv4->sin_addr.s_addr));
+    auto portRequest = request.send().getHost().getTcpPortRequest();
+
+    portRequest.setPortNum(ntohs(destaddr_ipv4->sin_port));
+
+    return portRequest.send().getPort();
+  }
+
+  kj::Promise<void> runTcpBridge(kj::ConnectionReceiver& serverPort,
+                               kj::TaskSet& taskSet, HackSessionContext::Client& session) {
+    return serverPort.accept().then([&](kj::Own<kj::AsyncIoStream>&& connection) {
+      auto connectionState = kj::heap<AcceptedConnection>(kj::mv(connection),
+                                                          getTcpClient(connection, session));
+      auto promise = connectionState->start();
+      taskSet.add(promise.attach(kj::mv(connectionState)));
+      return runTcpBridge(serverPort, taskSet, session);
+    });
+  }
+
+  // UDP handling
+  struct AcceptedUdpConnection {
+  private:
+    class ReturnPort final: public UdpPort::Server {
+    private:
+      kj::Promise<kj::Own<kj::NetworkAddress>> src;
+      kj::Own<kj::NetworkAddress> dest;
+    public:
+      ReturnPort(kj::Promise<kj::Own<kj::NetworkAddress > >&& src, kj::NetworkAddress& dest) :
+        src(kj::mv(src)), dest(dest.clone()) {}
+
+      kj::Promise<void> send(SendContext context) {
+        return src.then([&] (auto srcAddress) {
+          auto port = srcAddress->bindDatagramPort();
+          // TODO(soon): deal with context's returnPort
+          auto data = context.getParams().getMessage();
+          return port->send((void *)data.begin(), data.size(), *dest)
+                .then([this] (auto args) { });
+        });
+      }
+    };
+
+    kj::Own<kj::DatagramReceiver> receiver;
+
+  public:
+    explicit AcceptedUdpConnection(kj::DatagramPort& serverPort, kj::TaskSet& taskSet,
+                                   HackSessionContext::Client& session, kj::Network& network) {
+      receiver = serverPort.makeReceiver({65536, sizeof(sockaddr_in) + 128});
+    }
+
+    kj::Promise<void> loop() {
+      return receiver->receive().then([this] () {
+        return messageLoop();
+      });
+    }
+
+    kj::Promise<void> start() {
+      return loop();
+    }
+
+    kj::Promise<void> messageLoop() {
+      KJ_SYSCALL(write(STDERR_FILENO, "Unhandled UDP packet received by sandstorm-ip-bridge\n",
+                 sizeof("Unhandled UDP packet received by sandstorm-ip-bridge\n")));
+
+      return loop();
+    }
+  };
+
+  kj::Promise<void> runUdpBridge(kj::DatagramPort& serverPort, kj::TaskSet& taskSet,
+                                 HackSessionContext::Client& session, kj::Network& network) {
+    auto connectionState = kj::heap<AcceptedUdpConnection>(serverPort, taskSet, session, network);
+    auto promise = connectionState->start();
+    taskSet.add(promise.attach(kj::mv(connectionState)));
+    return kj::READY_NOW;
+  }
+  }  // namespace ipbridge
+}  // namespace sandstorm

--- a/src/sandstorm/sandstorm-ip-bridge.c++
+++ b/src/sandstorm/sandstorm-ip-bridge.c++
@@ -22,154 +22,155 @@
 #include <unistd.h>
 
 namespace sandstorm {
-  namespace ipbridge {
+namespace ipbridge {
 
-  class RefcountedAsyncIoStream: public kj::Refcounted {
-  public:
-    explicit RefcountedAsyncIoStream(kj::Own<kj::AsyncIoStream>&& stream)
-        : stream(kj::mv(stream)) {}
-    kj::Own<kj::AsyncIoStream> stream;
-  };
+class RefcountedAsyncIoStream: public kj::Refcounted {
+public:
+  explicit RefcountedAsyncIoStream(kj::Own<kj::AsyncIoStream>&& stream)
+      : stream(kj::mv(stream)) {}
+  kj::Own<kj::AsyncIoStream> stream;
+};
 
-  static const int BUFFER_SIZE = 8192;
+static const int BUFFER_SIZE = 8192;
 
-  // TCP handling
-  struct AcceptedConnection {
-    class Downstream final: public ByteStream::Server {
-    private:
-      kj::Own<RefcountedAsyncIoStream> connection;
-
-    public:
-      explicit Downstream(kj::Own<RefcountedAsyncIoStream> && connection) :
-        connection(kj::mv(connection)) {}
-
-      kj::Promise<void> write(WriteContext context) {
-        auto params = context.getParams();
-        return connection->stream->write(params.getData().begin(), params.getData().size());
-      }
-
-      kj::Promise<void> done(DoneContext context) {
-        connection->stream->shutdownWrite();
-        return kj::READY_NOW;
-      }
-    };
-
+// TCP handling
+struct AcceptedConnection {
+  class Downstream final: public ByteStream::Server {
   private:
     kj::Own<RefcountedAsyncIoStream> connection;
-    capnp::byte buffer[BUFFER_SIZE];
-    TcpPort::Client port;
-    kj::Own<ByteStream::Client> upstream;
 
   public:
-    explicit AcceptedConnection(kj::Own<kj::AsyncIoStream>&& connectionParam, TcpPort::Client port)
-        : connection(kj::refcounted<RefcountedAsyncIoStream>(kj::mv(connectionParam))), port(port) {
-      auto request = port.connectRequest();
-      request.setDownstream(kj::heap<Downstream>(kj::addRef(*connection)));
-      upstream = kj::heap<ByteStream::Client>(request.send().getUpstream());
+    explicit Downstream(kj::Own<RefcountedAsyncIoStream> && connection) :
+      connection(kj::mv(connection)) {}
+
+    kj::Promise<void> write(WriteContext context) {
+      auto params = context.getParams();
+      return connection->stream->write(params.getData().begin(), params.getData().size());
     }
 
-    kj::Promise<void> start() {
-      return messageLoop();
+    kj::Promise<void> done(DoneContext context) {
+      connection->stream->shutdownWrite();
+      return kj::READY_NOW;
     }
+  };
 
-    kj::Promise<void> messageLoop() {
-      return connection->stream->tryRead(buffer, 1, BUFFER_SIZE)
-            .then([this] (size_t size) -> kj::Promise<void> {
-        if (size < 1) {
-          return upstream->doneRequest().send().then([] (auto args) {});  // EOF
-        }
+private:
+  kj::Own<RefcountedAsyncIoStream> connection;
+  capnp::byte buffer[BUFFER_SIZE];
+  TcpPort::Client port;
+  kj::Own<ByteStream::Client> upstream;
 
-        auto request = upstream->writeRequest();
-        request.setData(kj::ArrayPtr<capnp::byte>(buffer, size));
-        return request.send().then([this] (auto args) {
-          return messageLoop();
-        });
+public:
+  explicit AcceptedConnection(kj::Own<kj::AsyncIoStream>&& connectionParam, TcpPort::Client port)
+      : connection(kj::refcounted<RefcountedAsyncIoStream>(kj::mv(connectionParam))), port(port) {
+    auto request = port.connectRequest();
+    request.setDownstream(kj::heap<Downstream>(kj::addRef(*connection)));
+    upstream = kj::heap<ByteStream::Client>(request.send().getUpstream());
+  }
+
+  kj::Promise<void> start() {
+    return messageLoop();
+  }
+
+  kj::Promise<void> messageLoop() {
+    return connection->stream->tryRead(buffer, 1, BUFFER_SIZE)
+          .then([this] (size_t size) -> kj::Promise<void> {
+      if (size < 1) {
+        return upstream->doneRequest().send().then([] (auto args) {});  // EOF
+      }
+
+      auto request = upstream->writeRequest();
+      request.setData(kj::ArrayPtr<capnp::byte>(buffer, size));
+      return request.send().then([this] (auto args) {
+        return messageLoop();
+      });
+    });
+  }
+};
+
+TcpPort::Client getTcpClient(kj::Own<kj::AsyncIoStream>& connection, HackSessionContext::Client& session) {
+  auto request = session.getIpNetworkRequest().send().getNetwork().getRemoteHostRequest();
+
+  struct sockaddr destaddr;
+  uint size = sizeof(destaddr);  // TODO(soon): make static?
+  connection->getsockopt(SOL_IP, SO_ORIGINAL_DST, &destaddr, &size);
+
+  // TODO(someday): handle ipv6
+  struct sockaddr_in * destaddr_ipv4 = reinterpret_cast<sockaddr_in *>(&destaddr);
+  request.getAddress().setLower64(0x0000FFFF00000000 | ntohl(destaddr_ipv4->sin_addr.s_addr));
+  auto portRequest = request.send().getHost().getTcpPortRequest();
+
+  portRequest.setPortNum(ntohs(destaddr_ipv4->sin_port));
+
+  return portRequest.send().getPort();
+}
+
+kj::Promise<void> runTcpBridge(kj::ConnectionReceiver& serverPort,
+                             kj::TaskSet& taskSet, HackSessionContext::Client& session) {
+  return serverPort.accept().then([&](kj::Own<kj::AsyncIoStream>&& connection) {
+    auto connectionState = kj::heap<AcceptedConnection>(kj::mv(connection),
+                                                        getTcpClient(connection, session));
+    auto promise = connectionState->start();
+    taskSet.add(promise.attach(kj::mv(connectionState)));
+    return runTcpBridge(serverPort, taskSet, session);
+  });
+}
+
+// UDP handling
+struct AcceptedUdpConnection {
+private:
+  class ReturnPort final: public UdpPort::Server {
+  private:
+    kj::Promise<kj::Own<kj::NetworkAddress>> src;
+    kj::Own<kj::NetworkAddress> dest;
+  public:
+    ReturnPort(kj::Promise<kj::Own<kj::NetworkAddress > >&& src, kj::NetworkAddress& dest) :
+      src(kj::mv(src)), dest(dest.clone()) {}
+
+    kj::Promise<void> send(SendContext context) {
+      return src.then([&] (auto srcAddress) {
+        auto port = srcAddress->bindDatagramPort();
+        // TODO(soon): deal with context's returnPort
+        auto data = context.getParams().getMessage();
+        return port->send((void *)data.begin(), data.size(), *dest)
+              .then([this] (auto args) { });
       });
     }
   };
 
-  TcpPort::Client getTcpClient(kj::Own<kj::AsyncIoStream>& connection, HackSessionContext::Client& session) {
-    auto request = session.getIpNetworkRequest().send().getNetwork().getRemoteHostRequest();
+  kj::Own<kj::DatagramReceiver> receiver;
 
-    struct sockaddr destaddr;
-    uint size = sizeof(destaddr);  // TODO(soon): make static?
-    connection->getsockopt(SOL_IP, SO_ORIGINAL_DST, &destaddr, &size);
-
-    // TODO(someday): handle ipv6
-    struct sockaddr_in * destaddr_ipv4 = reinterpret_cast<sockaddr_in *>(&destaddr);
-    request.getAddress().setLower64(0x0000FFFF00000000 | ntohl(destaddr_ipv4->sin_addr.s_addr));
-    auto portRequest = request.send().getHost().getTcpPortRequest();
-
-    portRequest.setPortNum(ntohs(destaddr_ipv4->sin_port));
-
-    return portRequest.send().getPort();
+public:
+  explicit AcceptedUdpConnection(kj::DatagramPort& serverPort, kj::TaskSet& taskSet,
+                                 HackSessionContext::Client& session, kj::Network& network) {
+    receiver = serverPort.makeReceiver({65536, sizeof(sockaddr_in) + 128});
   }
 
-  kj::Promise<void> runTcpBridge(kj::ConnectionReceiver& serverPort,
-                               kj::TaskSet& taskSet, HackSessionContext::Client& session) {
-    return serverPort.accept().then([&](kj::Own<kj::AsyncIoStream>&& connection) {
-      auto connectionState = kj::heap<AcceptedConnection>(kj::mv(connection),
-                                                          getTcpClient(connection, session));
-      auto promise = connectionState->start();
-      taskSet.add(promise.attach(kj::mv(connectionState)));
-      return runTcpBridge(serverPort, taskSet, session);
+  kj::Promise<void> loop() {
+    return receiver->receive().then([this] () {
+      return messageLoop();
     });
   }
 
-  // UDP handling
-  struct AcceptedUdpConnection {
-  private:
-    class ReturnPort final: public UdpPort::Server {
-    private:
-      kj::Promise<kj::Own<kj::NetworkAddress>> src;
-      kj::Own<kj::NetworkAddress> dest;
-    public:
-      ReturnPort(kj::Promise<kj::Own<kj::NetworkAddress > >&& src, kj::NetworkAddress& dest) :
-        src(kj::mv(src)), dest(dest.clone()) {}
-
-      kj::Promise<void> send(SendContext context) {
-        return src.then([&] (auto srcAddress) {
-          auto port = srcAddress->bindDatagramPort();
-          // TODO(soon): deal with context's returnPort
-          auto data = context.getParams().getMessage();
-          return port->send((void *)data.begin(), data.size(), *dest)
-                .then([this] (auto args) { });
-        });
-      }
-    };
-
-    kj::Own<kj::DatagramReceiver> receiver;
-
-  public:
-    explicit AcceptedUdpConnection(kj::DatagramPort& serverPort, kj::TaskSet& taskSet,
-                                   HackSessionContext::Client& session, kj::Network& network) {
-      receiver = serverPort.makeReceiver({65536, sizeof(sockaddr_in) + 128});
-    }
-
-    kj::Promise<void> loop() {
-      return receiver->receive().then([this] () {
-        return messageLoop();
-      });
-    }
-
-    kj::Promise<void> start() {
-      return loop();
-    }
-
-    kj::Promise<void> messageLoop() {
-      KJ_SYSCALL(write(STDERR_FILENO, "Unhandled UDP packet received by sandstorm-ip-bridge\n",
-                 sizeof("Unhandled UDP packet received by sandstorm-ip-bridge\n")));
-
-      return loop();
-    }
-  };
-
-  kj::Promise<void> runUdpBridge(kj::DatagramPort& serverPort, kj::TaskSet& taskSet,
-                                 HackSessionContext::Client& session, kj::Network& network) {
-    auto connectionState = kj::heap<AcceptedUdpConnection>(serverPort, taskSet, session, network);
-    auto promise = connectionState->start();
-    taskSet.add(promise.attach(kj::mv(connectionState)));
-    return kj::READY_NOW;
+  kj::Promise<void> start() {
+    return loop();
   }
-  }  // namespace ipbridge
+
+  kj::Promise<void> messageLoop() {
+    KJ_SYSCALL(write(STDERR_FILENO, "Unhandled UDP packet received by sandstorm-ip-bridge\n",
+               sizeof("Unhandled UDP packet received by sandstorm-ip-bridge\n")));
+
+    return loop();
+  }
+};
+
+kj::Promise<void> runUdpBridge(kj::DatagramPort& serverPort, kj::TaskSet& taskSet,
+                               HackSessionContext::Client& session, kj::Network& network) {
+  auto connectionState = kj::heap<AcceptedUdpConnection>(serverPort, taskSet, session, network);
+  auto promise = connectionState->start();
+  taskSet.add(promise.attach(kj::mv(connectionState)));
+  return kj::READY_NOW;
+}
+
+}  // namespace ipbridge
 }  // namespace sandstorm

--- a/src/sandstorm/sandstorm-ip-bridge.h
+++ b/src/sandstorm/sandstorm-ip-bridge.h
@@ -26,14 +26,15 @@
 #include <sandstorm/ip.capnp.h>
 
 namespace sandstorm {
-  namespace ipbridge {
-  kj::Promise<void> runTcpBridge(kj::ConnectionReceiver& serverPort,
-                                 kj::TaskSet& taskSet, HackSessionContext::Client& session);
+namespace ipbridge {
 
-  kj::Promise<void> runUdpBridge(kj::DatagramPort& serverPort, kj::TaskSet& taskSet,
-                                 HackSessionContext::Client& session, kj::Network& network);
+kj::Promise<void> runTcpBridge(kj::ConnectionReceiver& serverPort,
+                               kj::TaskSet& taskSet, HackSessionContext::Client& session);
 
-  }  // namespace ipbridge
+kj::Promise<void> runUdpBridge(kj::DatagramPort& serverPort, kj::TaskSet& taskSet,
+                               HackSessionContext::Client& session, kj::Network& network);
+
+}  // namespace ipbridge
 }  // namespace sandstorm
 
 #endif  // SANDSTORM_IP_BRIDGE_H_

--- a/src/sandstorm/sandstorm-ip-bridge.h
+++ b/src/sandstorm/sandstorm-ip-bridge.h
@@ -1,0 +1,39 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2014 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This header contains a proxy server that bridges redirected connections
+// from iptables to the Sandstorm network interface
+
+#ifndef SANDSTORM_IP_BRIDGE_H_
+#define SANDSTORM_IP_BRIDGE_H_
+
+#include <kj/async-io.h>
+#include <sandstorm/hack-session.capnp.h>
+#include <sandstorm/util.capnp.h>
+#include <sandstorm/ip.capnp.h>
+
+namespace sandstorm {
+  namespace ipbridge {
+  kj::Promise<void> runTcpBridge(kj::ConnectionReceiver& serverPort,
+                                 kj::TaskSet& taskSet, HackSessionContext::Client& session);
+
+  kj::Promise<void> runUdpBridge(kj::DatagramPort& serverPort, kj::TaskSet& taskSet,
+                                 HackSessionContext::Client& session, kj::Network& network);
+
+  }  // namespace ipbridge
+}  // namespace sandstorm
+
+#endif  // SANDSTORM_IP_BRIDGE_H_


### PR DESCRIPTION
This is currently controlled by an option in `bridgeConfig` named `enableIpBridge`. We should probably also add something to the web UI to warn users when an app requests this kind of access (on install?).
