### PR TITLE
add fields for content-encoding header on requests

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1199,12 +1199,14 @@ Proxy.prototype.handleRequest = function (request, data, response, retryCount) {
     } else if (request.method === "POST") {
       return session.post(path, {
         mimeType: request.headers["content-type"] || "application/octet-stream",
-        content: data
+        content: data,
+        encoding: request.headers["content-encoding"] || "identity"
       }, context);
     } else if (request.method === "PUT") {
       return session.put(path, {
         mimeType: request.headers["content-type"] || "application/octet-stream",
-        content: data
+        content: data,
+        encoding: request.headers["content-encoding"] || "identity"
       }, context);
     } else if (request.method === "DELETE") {
       return session.delete(path, context);
@@ -1228,12 +1230,13 @@ Proxy.prototype.handleRequestStreaming = function (request, response, contentLen
   var session = this.getSession(request);
 
   var mimeType = request.headers["content-type"] || "application/octet-stream";
+  var encoding = request.headers["content-encoding"] || "identity"
 
   var requestStreamPromise;
   if (request.method === "POST") {
-    requestStreamPromise = session.postStreaming(path, mimeType, context);
+    requestStreamPromise = session.postStreaming(path, mimeType, context, encoding);
   } else if (request.method === "PUT") {
-    requestStreamPromise = session.putStreaming(path, mimeType, context);
+    requestStreamPromise = session.putStreaming(path, mimeType, context, encoding);
   } else {
     throw new Error("Sandstorm only supports streaming POST and PUT requests.");
   }

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1200,13 +1200,13 @@ Proxy.prototype.handleRequest = function (request, data, response, retryCount) {
       return session.post(path, {
         mimeType: request.headers["content-type"] || "application/octet-stream",
         content: data,
-        encoding: request.headers["content-encoding"] || "identity"
+        encoding: request.headers["content-encoding"]
       }, context);
     } else if (request.method === "PUT") {
       return session.put(path, {
         mimeType: request.headers["content-type"] || "application/octet-stream",
         content: data,
-        encoding: request.headers["content-encoding"] || "identity"
+        encoding: request.headers["content-encoding"]
       }, context);
     } else if (request.method === "DELETE") {
       return session.delete(path, context);
@@ -1230,7 +1230,7 @@ Proxy.prototype.handleRequestStreaming = function (request, response, contentLen
   var session = this.getSession(request);
 
   var mimeType = request.headers["content-type"] || "application/octet-stream";
-  var encoding = request.headers["content-encoding"] || "identity"
+  var encoding = request.headers["content-encoding"]
 
   var requestStreamPromise;
   if (request.method === "POST") {

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -988,7 +988,7 @@ public:
     kj::String httpRequest = makeHeaders("POST", params.getPath(), params.getContext(),
       kj::str("Content-Type: ", content.getMimeType()),
       kj::str("Content-Length: ", content.getContent().size()),
-      kj::str("Content-Encoding: ", content.getEncoding()));
+      content.hasEncoding() ? kj::str("Content-Encoding: ", content.getEncoding()) : nullptr);
     return sendRequest(toBytes(httpRequest, content.getContent()), context);
   }
 
@@ -998,7 +998,7 @@ public:
     kj::String httpRequest = makeHeaders("PUT", params.getPath(), params.getContext(),
       kj::str("Content-Type: ", content.getMimeType()),
       kj::str("Content-Length: ", content.getContent().size()),
-      kj::str("Content-Encoding: ", content.getEncoding()));
+      content.hasEncoding() ? kj::str("Content-Encoding: ", content.getEncoding()) : nullptr);
     return sendRequest(toBytes(httpRequest, content.getContent()), context);
   }
 
@@ -1012,7 +1012,7 @@ public:
     PostStreamingParams::Reader params = context.getParams();
     kj::String httpRequest = makeHeaders("POST", params.getPath(), params.getContext(),
         kj::str("Content-Type: ", params.getMimeType()),
-        kj::str("Content-Encoding: ", params.getEncoding()));
+        params.hasEncoding() ? kj::str("Content-Encoding: ", params.getEncoding()) : nullptr);
     return sendRequestStreaming(kj::mv(httpRequest), context);
   }
 

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -100,13 +100,13 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   struct PostContent {
     mimeType @0 :Text;
     content @1 :Data;
-    encoding @2 :Text;  # Content-Encoding header (optional)
+    encoding @2 :Text;  # Content-Encoding header (optional).
   }
 
   struct PutContent {
     mimeType @0 :Text;
     content @1 :Data;
-    encoding @2 :Text;  # Content-Encoding header (optional)
+    encoding @2 :Text;  # Content-Encoding header (optional).
   }
 
   struct Cookie {

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -59,8 +59,8 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   put @3 (path :Text, content :PutContent, context :Context) -> Response;
   delete @4 (path :Text, context :Context) -> Response;
 
-  postStreaming @5 (path :Text, mimeType :Text, context :Context) -> (stream :RequestStream);
-  putStreaming @6 (path :Text, mimeType :Text, context :Context) -> (stream :RequestStream);
+  postStreaming @5 (path :Text, mimeType :Text, context :Context, encoding :Text) -> (stream :RequestStream);
+  putStreaming @6 (path :Text, mimeType :Text, context :Context, encoding :Text) -> (stream :RequestStream);
   # Streaming post/put requests, useful when the input is large. If these throw exceptions, the
   # caller should fall back to regular post() / put() on the assumption that the app doesn't
   # implement streaming.
@@ -101,11 +101,13 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   struct PostContent {
     mimeType @0 :Text;
     content @1 :Data;
+    encoding @2 :Text;
   }
 
   struct PutContent {
     mimeType @0 :Text;
     content @1 :Data;
+    encoding @2 :Text;
   }
 
   struct Cookie {

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -61,12 +61,11 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
 
   postStreaming @5 (path :Text, mimeType :Text, context :Context, encoding :Text) -> (stream :RequestStream);
   putStreaming @6 (path :Text, mimeType :Text, context :Context, encoding :Text) -> (stream :RequestStream);
-  # Streaming post/put requests, useful when the input is large. If these throw exceptions, the
-  # caller should fall back to regular post() / put() on the assumption that the app doesn't
+  # Streaming post/put requests, useful when the input is large. If these throw `unimplemented` exceptions,
+  # the caller should fall back to regular post() / put() on the assumption that the app doesn't
   # implement streaming.
   #
-  # TODO(someday): It seems like Cap'n Proto needs a way to distinguish not-implemented from other
-  #   exception types.
+  # The optional `encoding` field represents the Content-Encoding header.
 
   openWebSocket @2 (path :Text, context :Context,
                     protocol :List(Text), clientStream :WebSocketStream)
@@ -101,13 +100,13 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   struct PostContent {
     mimeType @0 :Text;
     content @1 :Data;
-    encoding @2 :Text;
+    encoding @2 :Text;  # Content-Encoding header (optional)
   }
 
   struct PutContent {
     mimeType @0 :Text;
     content @1 :Data;
-    encoding @2 :Text;
+    encoding @2 :Text;  # Content-Encoding header (optional)
   }
 
   struct Cookie {


### PR DESCRIPTION
Today I learned that the `Content-Encoding` header is allowed in *requests*. See [RFC 7231](http://tools.ietf.org/html/rfc7231#section-3.1.2.2).

For example, sometimes Git [sets this header to "gzip"](https://github.com/git/git/blob/master/remote-curl.c#L590). This [Apache documentation](http://httpd.apache.org/docs/2.2/mod/mod_deflate.html) hints that WebDAV clients do this too.

Until this is fixed, both GitWeb and GitLab can sometime emit the following error on `git fetch` or `git pull`:
"fatal: protocol error: bad line length character"