### PR TITLE
fix for mobile scrolling, see issue  #215

### DIFF
--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -225,11 +225,8 @@ img {
   color: #428bca;
 }
 
-#app.main-content {
+#app.main-content { 
   overflow: hidden;
-  -webkit-overflow-scrolling:touch;
-  overflow-y: scroll;
-  overflow-x: scroll;
 }
 
 #grainLog {
@@ -901,6 +898,10 @@ aside #social>p {
     position: static;
     margin: 100px 150px;
   }
+  #app.main-content {
+  	-webkit-overflow-scrolling:touch;
+    overflow: auto;
+  }  
 }
 
 @media screen and (max-width: 900px) {

--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -227,6 +227,9 @@ img {
 
 #app.main-content {
   overflow: hidden;
+  -webkit-overflow-scrolling:touch;
+  overflow-y: scroll;
+  overflow-x: scroll;
 }
 
 #grainLog {


### PR DESCRIPTION
This fixes the scrolling issue in my test cases with iOS. Tested with GitLab, Etherpad and WordPress where it works perfect. Ethercalc is still a mess on mobile. Didn't work before (no scrolling, no input, constant loading) and still doesn't work because of constant loading. Seems to be an issue of Ethercalc as all other tested apps are working now. It is a quick fix of the mobile experience issue but a over all mobile overhaul is required anyway.