### PR TITLE
Change grain session to be reactive based on user

### DIFF
--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -406,7 +406,7 @@ Router.map(function () {
         return result;
       }
 
-      var session = Sessions.findOne({grainId: grainId});
+      var session = Sessions.findOne({grainId: grainId, userId: Meteor.userId()});
       if (session) {
         result.appOrigin = window.location.protocol + "//" + makeWildcardHost(session.hostId);
         setCurrentSessionId(session._id, result.appOrigin, grainId);


### PR DESCRIPTION
Fixes #186.

I added a userId to Sessions query that happens in the reactive data function for a grain. This could go in the publication instead. The pro for that is it might be more secure, the con is it would make it tough if we ever down the road want users to somehow share session database entries.

This only fixes the issue for a user logging in/out. The change would be much more complicated to fix it for the other fields Kenton mentioned. From a security standpoint, they would have to be observed on the server side since unlike a user logging in/out, those fields are not always under the user's control. 