### PR TITLE
use on_message_complete callback to detect end of HTTP response

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -186,6 +186,7 @@ public:
         return kj::arrayPtr(buffer + nread, actual - nread);
       } else if (messageComplete || actual == 0) {
         // The parser is done or the stream has closed.
+        KJ_ASSERT(headersComplete, "HTTP response from sandboxed app had incomplete headers.");
         return kj::arrayPtr(buffer, 0);
       } else if (headersComplete && status_code / 100 == 2) {
         isStreaming = true;

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -184,7 +184,8 @@ public:
       } else if (upgrade) {
         KJ_ASSERT(nread <= actual && nread >= 0);
         return kj::arrayPtr(buffer + nread, actual - nread);
-      } else if (messageComplete) {
+      } else if (messageComplete || actual == 0) {
+        // The parser is done or the stream has closed.
         return kj::arrayPtr(buffer, 0);
       } else if (headersComplete && status_code / 100 == 2) {
         isStreaming = true;
@@ -418,7 +419,8 @@ private:
       if (nread != actual) {
         const char* error = http_errno_description(HTTP_PARSER_ERRNO(this));
         KJ_FAIL_ASSERT("Failed to parse HTTP response from sandboxed app.", error);
-      } else if (messageComplete) {
+      } else if (messageComplete || actual == 0) {
+        // The parser is done or the stream has closed.
         taskSet.add(responseStream.doneRequest().send().then([](auto x){}));
         return kj::READY_NOW;
       } else {


### PR DESCRIPTION
With our current `sandstorm-http-bridge`, an app with the following node.js server will fail to respond. (Assume there is another server listening on port 10001.)

```
var http = require('http');
var request = require('request');
http.createServer(function (req, res) {
  console.log("got request");
  var proxy = request({url: "http://127.0.0.1:10001", method: req.method});
  proxy.pipe(res);
}).listen(10000, '127.0.0.1');
```

The problem is that `request().pipe(response)` does not close the response stream once its end is reached, and therefore the http bridge never calls `done()` on the response stream, because we currently wait for EOF.

We should instead use the `on_message_complete()` callback, as in this patch. The EOF case is still covered, because in that case the final call to `http_parser_execute()` will have length zero, which signifies EOF, and the parser will know to trigger the callback. (See [the documentation](https://github.com/joyent/http-parser/blob/master/README.md).)

I originally noticed this problem when I was porting ShareLaTeX back in June. This patch will mean that I can simplify my port. I've tested it on most of my other ports, and everything still works as expected.
