### PR TITLE
topbar: show light grey background for menu buttons

### DIFF
--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -157,6 +157,10 @@ body {
   cursor: pointer;
 }
 
+#menu button:hover {
+  background-color: #888;
+}
+
 #topbar #renameGrain {
   background-image: url("/edit.png");
 }


### PR DESCRIPTION
The "delete", "show debug log", and other menu buttons don't change color on hover, which makes it hard to be sure that you're actually supposed to be able to click them.

This commit gives them the same background color as the grain title field on hover.