### PR TITLE
Add dev accounts

### DIFF
--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -729,6 +729,10 @@ input.autoSelect {
   text-align: center;
 }
 
+.devLogin {
+  margin: 16px auto;
+}
+
 ul.backer-list, ul.dev-list {
   list-style: none;
   text-align: center;

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -541,6 +541,33 @@ $KEY</textarea></p>
   </div>
 </template>
 
+<template name="devAccounts">
+  <div id="topbar">{{> homeLink}} {{ pageTitle }} </div>
+
+  <div id="demo" class="main-content">
+    <div class="centered-box">
+      <h2>Developer Accounts</h2>
+        {{#if shouldShowStartDevAccounts}}
+          {{#if loggingIn}}
+            <p>Logging in...</p>
+          {{else}}
+            <button id="loginAliceDevAccount" class="devLogin">Log in as Alice (admin) »</button>
+            <button id="loginBobDevAccount" class="devLogin">Log in as Bob »</button>
+            <button id="loginCarolDevAccount" class="devLogin">Log in as Carol »</button>
+          {{/if}}
+        {{else}}
+            <p>You are already logged in.</p>
+            <p><button onclick="browseHome()">See your apps »</button></p>
+        {{/if}}
+
+        <h3>What is this?</h3>
+        <p>This page is only for developer Sandstorm instances (ie. the ALLOW_DEV_ACCOUNTS setting
+        is enabled in your sandstorm.conf). This page and its functionality will be inaccessible if
+        you ever disable this setting.</p>
+    </div>
+  </div>
+</template>
+
 <template name="about">
   <div id="topbar">{{> homeLink}} About</div>
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -554,6 +554,8 @@ $KEY</textarea></p>
             <button id="loginAliceDevAccount" class="devLogin">Log in as Alice (admin) »</button>
             <button id="loginBobDevAccount" class="devLogin">Log in as Bob »</button>
             <button id="loginCarolDevAccount" class="devLogin">Log in as Carol »</button>
+            <button id="loginDaveDevAccount" class="devLogin">Log in as Dave »</button>
+            <button id="loginEveDevAccount" class="devLogin">Log in as Eve »</button>
           {{/if}}
         {{else}}
             <p>You are already logged in.</p>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -564,8 +564,7 @@ $KEY</textarea></p>
 
         <h3>What is this?</h3>
         <p>This page is only for developer Sandstorm instances (ie. the ALLOW_DEV_ACCOUNTS setting
-        is enabled in your sandstorm.conf). This page and its functionality will be inaccessible if
-        you ever disable this setting.</p>
+        is enabled in your sandstorm.conf).</p>
     </div>
   </div>
 </template>

--- a/shell/run-dev.sh
+++ b/shell/run-dev.sh
@@ -21,7 +21,7 @@ fi
 
 if [ "$SERVER_USER" != "$USER" ]; then
   echo "Please change your Sandstorm installation to be own by your own user" >&2
-  echo "account. E.g. run as root:" >&2 
+  echo "account. E.g. run as root:" >&2
   echo "  $SANDSTORM_HOME/sandstorm stop" >&2
   echo "  find $SANDSTORM_HOME/var -user $SERVER_USER -print0 | \\" >&2
   echo "      xargs -0 chown -h $USER" >&2
@@ -29,7 +29,7 @@ if [ "$SERVER_USER" != "$USER" ]; then
   echo "      xargs -0 chgrp -h $(id -gn)" >&2
   echo "  sed -i -e 's/^SERVER_USER=.*$/SERVER_USER=$USER/g' \\" >&2
   echo "      $SANDSTORM_HOME/sandstorm.conf" >&2
-  echo "  $SANDSTORM_HOME/sandstorm start" >&2  
+  echo "  $SANDSTORM_HOME/sandstorm start" >&2
   exit 1
 fi
 
@@ -61,6 +61,7 @@ cat > $SETTINGS << __EOF__
   "public": {
     "buildstamp": "[local dev front-end]",
     "allowDemoAccounts": true,
+    "allowDevAccounts": true,
     "wildcardHost": "$WILDCARD_HOST"
   },
   "home": "$SANDSTORM_HOME"

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -675,6 +675,8 @@ function Proxy(grainId, sessionId, preferredHostId, isOwner, user, userInfo) {
     var serviceId;
     if (user.expires) {
       serviceId = "demo:" + user._id;
+    } else if (user.devName) {
+      serviceId = "dev:" + user.devName;
     } else if (user.services && user.services.google) {
       serviceId = "google:" + user.services.google.id;
     } else if (user.services && user.services.github) {

--- a/shell/shared/db.js
+++ b/shell/shared/db.js
@@ -205,7 +205,9 @@ if (Meteor.isServer) {
 
   // The first user to sign in should be automatically upgraded to admin.
   Accounts.onCreateUser(function (options, user) {
-    if (Meteor.users.find().count() === 0) {
+    // Dev users are identified by having the devName field
+    // Don't count them in our find and don't give them admin
+    if (Meteor.users.find({devName: {$exists: 0}}).count() === 0 && !user.devName) {
       user.isAdmin = true;
       user.signupKey = "admin";
     }

--- a/shell/shared/devAccounts.js
+++ b/shell/shared/devAccounts.js
@@ -1,0 +1,117 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2014 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var allowDevAccounts = Meteor.settings && Meteor.settings.public &&
+                 Meteor.settings.public.allowDevAccounts;
+
+if (allowDevAccounts) {
+  if (Meteor.isServer) {
+    Meteor.methods({
+      createDevAccount: function (displayName, isAdmin) {
+        // This is a login method that creates or logs in a dev account with the given displayName
+
+        check(displayName, String);
+        isAdmin = isAdmin || false;
+        var userId;
+        var user = Meteor.users.findOne({devName: displayName});
+        if (user) {
+          userId = user._id;
+        } else {
+          userId = Accounts.insertUserDoc({ profile: { name: displayName } },
+                                          { signupKey: "devAccounts", devName: displayName, isAdmin: isAdmin });
+        }
+        // Log them in on this connection.
+        return Accounts._loginMethod(this, "createDevAccount", arguments,
+            "devAccounts", function () { return { userId: userId }; });
+      }
+    });
+  }
+
+  if (Meteor.isClient) {
+    // Monkey-patch accounts-ui so that "demo" shows up nicely.
+    // Alas, this is dependent on private Meteor internals and so could break.
+    // TODO(cleanup): Check again if there are public APIs we could use and if not, ask for some.
+    Meteor.loginWithDevAccounts = function () {
+      Router.go("devAccounts");
+      Accounts._loginButtonsSession.closeDropdown();
+    };
+    Accounts.oauth.registerService("devAccounts");
+    var oldConfiguredHelper = Template._loginButtonsLoggedOutSingleLoginButton.configured;
+    Template._loginButtonsLoggedOutSingleLoginButton.configured = function () {
+      if (this.name === "devAccounts") {
+        return true;
+      } else {
+        return oldConfiguredHelper.apply(this, arguments);
+      }
+    };
+    var oldCapitalizedName = Template._loginButtonsLoggedOutSingleLoginButton.capitalizedName;
+    Template._loginButtonsLoggedOutSingleLoginButton.capitalizedName = function () {
+      if (this.name === "devAccounts") {
+        return "Dev Account";
+      } else {
+        return oldCapitalizedName.apply(this, arguments);
+      }
+    };
+
+    var loginDevAccount = function(displayName, isAdmin) {
+      Accounts.callLoginMethod({
+        methodName: "createDevAccount",
+        methodArguments: [displayName, isAdmin],
+        userCallback: function (err) {
+          if (err) {
+            window.alert(err);
+          } else {
+            Router.go("root");
+          }
+        }
+      });
+    };
+    Template.devAccounts.events({
+      "click #loginAliceDevAccount": function (event) {
+        var displayName = "Alice (admin)";
+        loginDevAccount(displayName, true);
+      },
+      "click #loginBobDevAccount": function (event) {
+        var displayName = "Bob";
+        loginDevAccount(displayName);
+      },
+      "click #loginCarolDevAccount": function (event) {
+        var displayName = "Carol";
+        loginDevAccount(displayName);
+      }
+    });
+  }
+
+  Router.map(function () {
+    this.route("devAccounts", {
+      path: "/devAccounts",
+      waitOn: function () {
+        return Meteor.subscribe("credentials");
+      },
+      data: function () {
+        return {
+          allowDevAccounts: allowDevAccounts,
+          // We show the Start the Demo button if you are not logged in.
+          shouldShowStartDevAccounts: ! isSignedUpOrDemo(),
+          createLocalUserLabel: "Start the devAccounts",
+          pageTitle: "Developer Accounts",
+          isDemoUser: isDemoUser()
+        };
+      }
+    });
+  });
+}
+

--- a/shell/shared/devAccounts.js
+++ b/shell/shared/devAccounts.js
@@ -81,17 +81,25 @@ if (allowDevAccounts) {
     };
     Template.devAccounts.events({
       "click #loginAliceDevAccount": function (event) {
-        var displayName = "Alice (admin)";
+        var displayName = "Alice Dev Admin";
         loginDevAccount(displayName, true);
       },
       "click #loginBobDevAccount": function (event) {
-        var displayName = "Bob";
+        var displayName = "Bob Dev User";
         loginDevAccount(displayName);
       },
       "click #loginCarolDevAccount": function (event) {
-        var displayName = "Carol";
+        var displayName = "Carol Dev User";
         loginDevAccount(displayName);
-      }
+      },
+      "click #loginDaveDevAccount": function (event) {
+        var displayName = "Dave Dev User";
+        loginDevAccount(displayName);
+      },
+      "click #loginEveDevAccount": function (event) {
+        var displayName = "Eve Dev User";
+        loginDevAccount(displayName);
+      },
     });
   }
 

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1095,6 +1095,7 @@ private:
     kj::String updateChannel = nullptr;
     bool allowDemoAccounts = false;
     bool isTesting = false;
+    bool allowDevAccounts = false;
   };
 
   kj::String updateFile;
@@ -1434,6 +1435,8 @@ private:
         }
       } else if (key == "ALLOW_DEMO_ACCOUNTS") {
         config.allowDemoAccounts = value == "true" || value == "yes";
+      } else if (key == "ALLOW_DEV_ACCOUNTS") {
+        config.allowDevAccounts = value == "true" || value == "yes";
       } else if (key == "IS_TESTING") {
         config.isTesting = value == "true" || value == "yes";
       }
@@ -1816,6 +1819,7 @@ private:
           "{\"public\":{\"build\":", buildstamp,
           ", \"kernelTooOld\":", kernelNewEnough ? "false" : "true",
           ", \"allowDemoAccounts\":", config.allowDemoAccounts ? "true" : "false",
+          ", \"allowDevAccounts\":", config.allowDevAccounts ? "true" : "false",
           ", \"isTesting\":", config.isTesting ? "true" : "false",
           ", \"wildcardHost\":\"", config.wildcardHost, "\"",
           "}}").cStr(), true));


### PR DESCRIPTION
This uses a new sandstorm.conf setting named ALLOW_DEV_ACCOUNTS. If set to true, there will be a new Meteor login service named DevAccounts, and clicking it will direct you to a page where you can login as your choice of Alice, Bob, or Carol. Alice will always be an admin.

Fixes #150 