### PR TITLE
Add appName field to UserActions collection. Unbreak things.

### DIFF
--- a/shell/shared/db.js
+++ b/shell/shared/db.js
@@ -60,6 +60,8 @@ UserActions = new Mongo.Collection("userActions");
 //   userId:  User who has installed this action.
 //   packageId:  Package used to run this action.
 //   appId:  Same as Packages.findOne(packageId).appId; denormalized for searchability.
+//   appName:  Same as Packages.findOne(packageId).manifest.appName; denormalized for
+//       seachability.
 //   appVersion:  Same as Packages.findOne(packageId).manifest.appVersion; denormalized for
 //       searchability.
 //   title:  Human-readable title for this action, e.g. "New Spreadsheet".

--- a/shell/shared/db.js
+++ b/shell/shared/db.js
@@ -60,8 +60,8 @@ UserActions = new Mongo.Collection("userActions");
 //   userId:  User who has installed this action.
 //   packageId:  Package used to run this action.
 //   appId:  Same as Packages.findOne(packageId).appId; denormalized for searchability.
-//   appName:  Same as Packages.findOne(packageId).manifest.appName.defaultText; denormalized for
-//       seachability.
+//   appName:  Same as Packages.findOne(packageId).manifest.appName.defaultText; denormalized so
+//       that clients can access it without subscribing to the Packages collection.
 //   appVersion:  Same as Packages.findOne(packageId).manifest.appVersion; denormalized for
 //       searchability.
 //   title:  Human-readable title for this action, e.g. "New Spreadsheet".

--- a/shell/shared/db.js
+++ b/shell/shared/db.js
@@ -60,7 +60,7 @@ UserActions = new Mongo.Collection("userActions");
 //   userId:  User who has installed this action.
 //   packageId:  Package used to run this action.
 //   appId:  Same as Packages.findOne(packageId).appId; denormalized for searchability.
-//   appName:  Same as Packages.findOne(packageId).manifest.appName; denormalized for
+//   appName:  Same as Packages.findOne(packageId).manifest.appName.defaultText; denormalized for
 //       seachability.
 //   appVersion:  Same as Packages.findOne(packageId).manifest.appVersion; denormalized for
 //       searchability.

--- a/shell/shared/install.js
+++ b/shell/shared/install.js
@@ -25,6 +25,7 @@ if (Meteor.isServer) {
         userId: String,
         packageId: String,
         appId: String,
+        appName: Match.Optional(String),
         appVersion: Match.Integer,
         title: String,
         command: {
@@ -171,6 +172,7 @@ if (Meteor.isClient) {
             userId: Meteor.userId(),
             packageId: package._id,
             appId: package.appId,
+            appName: package.manifest.appName && package.manifest.appName.defaultText,
             appVersion: package.manifest.appVersion,
             title: action.title.defaultText,
             command: action.command
@@ -280,7 +282,6 @@ Router.map(function () {
 
       Meteor.call("ensureInstalled", packageId, packageUrl, false,
             function (err, result) {
-         console.log(err, result);
          if (err) {
            Session.set("install-error-" + packageId, err.message);
          }

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -490,7 +490,7 @@ Router.map(function () {
 
         DevApps.find().forEach(function (app) {
           var action = app.manifest && app.manifest.actions && app.manifest.actions[0];
-          var name = app.manifest.appName.defaultText ||
+          var name = (app.manifest.appName && app.manifest.appName.defaultText) ||
               appNameFromActionName(action && action.title && action.title.defaultText);
           appMap[app._id] = {
             name: name,
@@ -502,7 +502,7 @@ Router.map(function () {
 
         UserActions.find({userId: userId}).forEach(function (action) {
           if (!(action.appId in appMap)) {
-            var name = appNameFromActionName(action.title);
+            var name = action.appName || appNameFromActionName(action.title);
             appMap[action.appId] = {
               name: name,
               appId: action.appId


### PR DESCRIPTION
Eek -- my change from #257 made it so that dev apps failed to appear at all if they did not have an `appName` in their manifest! This fixes the problem and actually uses the new `appName` field for installed actions.

We may also want to add an `appName` field to the `Grains` collection.