### PR TITLE
Build from source in Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Please install the following:
 * `unzip`
 * `strace`
 * `curl`
+* `git`
 * ImageMagick
 * [Clang compiler](http://clang.llvm.org/) version 3.4 or better
 * [Meteor](http://meteor.com)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Use a shell script to "provision" the box. This install Sandstorm using
   # the bundled installer.
   config.vm.provision "shell",
-    inline: "cd /vagrant && echo localhost > /etc/hostname && hostname localhost && sudo ./install.sh -d -e"
+    inline: "cd /vagrant && echo localhost > /etc/hostname && hostname localhost && sudo ./install-dev.sh"
 
   # Make the vagrant user part of the sandstorm group so that commands like
   # `spk dev` work

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+# Builds and installs Sandstorm from source on Ubuntu Trusty Tahr.
+
+set -e
+
+sudo apt-get update
+sudo apt-get install git libcap-dev xz-utils imagemagick clang-3.5 zip
+
+sudo ln -s /usr/bin/clang-3.5 /usr/bin/clang
+sudo ln -s /usr/bin/clang++-3.5 /usr/bin/clang
+
+# Install Meteor
+curl https://install.meteor.com/ | sh
+
+# Build and install Sandstorm
+make
+make install


### PR DESCRIPTION
Just a start; you probably want to define two Vagrant configs for `install.sh` vs `install-dev.sh` using `config.vm.define` so that non-developers don't have to build from source.

Warning: not extensively tested.