### PR TITLE
Add ApiSession

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -796,6 +796,8 @@ Proxy.prototype._callNewApiSession = function (request, userInfo) {
   return this.uiView.newSession(userInfo, makeHackSessionContext(this.grainId),
     ApiSession.typeId).then(function (session) {
       return session.session;
+    }, function (err) {
+      return self._callNewWebSession(request, userInfo);
     });
 };
 

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -784,7 +784,7 @@ Proxy.prototype._callNewWebSession = function (request, userInfo) {
   });
 
   return this.uiView.newSession(userInfo, makeHackSessionContext(this.grainId),
-    WebSession.typeId, params).session;
+                                WebSession.typeId, params).session;
 };
 
 Proxy.prototype._callNewApiSession = function (request, userInfo) {
@@ -793,12 +793,13 @@ Proxy.prototype._callNewApiSession = function (request, userInfo) {
   // TODO(someday): We are currently falling back to WebSession if we get any kind of error upon
   // calling newSession with an ApiSession._id.
   // Eventually we'll remove this logic once we're sure apps have updated.
-  return this.uiView.newSession(userInfo, makeHackSessionContext(this.grainId),
-    ApiSession.typeId).then(function (session) {
-      return session.session;
-    }, function (err) {
-      return self._callNewWebSession(request, userInfo);
-    });
+  return this.uiView.newSession(
+    userInfo, makeHackSessionContext(this.grainId), ApiSession.typeId
+  ).then(function (session) {
+    return session.session;
+  }, function (err) {
+    return self._callNewWebSession(request, userInfo);
+  });
 };
 
 Proxy.prototype._callNewSession = function (request, viewInfo) {

--- a/src/sandstorm/api-session.capnp
+++ b/src/sandstorm/api-session.capnp
@@ -1,0 +1,30 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2014 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xeb014c0c3413cbfb;
+
+$import "/capnp/c++.capnp".namespace("sandstorm");
+
+using WebSession = import "web-session.capnp";
+
+interface ApiSession @0xc879e379c625cdc7 extends(WebSession.WebSession) {
+  # A special case of WebSession but for APIs. It doesn't provide much other
+  # than a unique type id that we can identify ApiSessions with
+
+  struct Params {
+    # Currently there are no params for api sessions
+  }
+}

--- a/src/sandstorm/package.capnp
+++ b/src/sandstorm/package.capnp
@@ -188,6 +188,17 @@ struct BridgeConfig {
   # When a request comes in from the user, sandstorm-http-bridge will set the
   # X-Sandstorm-Permissions header to a comma-delimited list of permission names corresponding to
   # the user's permissions.
+
+  apiPath @1 :Text;
+  # This variable's purpose is two-fold:
+  # First, if it's set to anything non-empty, it will enable ApiSessions in sandstorm-http-bridge.
+  # This means calling newSession with an ApiSession type id will return an ApiSession correctly.
+  # Second, as the name implies, this specifies the path to the API in an app. For example, if
+  # your API endpoints always begin with /v1/api/, then you would provide that path. This path will
+  # always be prepended for you, and clients accessing the API will not have to provide it. This
+  # also has the effect of limiting your clients to only accessing endpoints under that path you
+  # provide. It should always end in a trailing '/'.
+  # "/" is a valid value, and will give clients access to all paths.
 }
 
 # ==============================================================================

--- a/src/sandstorm/sandstorm.ekam-manifest
+++ b/src/sandstorm/sandstorm.ekam-manifest
@@ -2,6 +2,7 @@ run-bundle bin/sandstorm
 sandstorm-http-bridge bin
 email.capnp node_modules/sandstorm/email.capnp
 grain.capnp node_modules/sandstorm/grain.capnp
+api-session.capnp node_modules/sandstorm/api-session.capnp
 hack-session.capnp node_modules/sandstorm/hack-session.capnp
 ip.capnp node_modules/sandstorm/ip.capnp
 package.capnp node_modules/sandstorm/package.capnp


### PR DESCRIPTION
Now when calling newSession from a proxy that was initiated from an API
connection, we now call it with a type id of ApiSession.

As a transitional measure, we fallback to WebSession if the call asking
for an ApiSession fails. This will eventually be removed once all apps
have updated.

Added apiPath as a variable to BridgeConfig. This will enable ApiSession
functionality as well as limiting what paths an api token can access.

This is blocking on https://github.com/kentonv/node-capnp/pull/9 getting accepted first.