### PR TITLE
rename Manifest.appName to Manifest.appTitle

### DIFF
--- a/shell/shared/db.js
+++ b/shell/shared/db.js
@@ -60,7 +60,7 @@ UserActions = new Mongo.Collection("userActions");
 //   userId:  User who has installed this action.
 //   packageId:  Package used to run this action.
 //   appId:  Same as Packages.findOne(packageId).appId; denormalized for searchability.
-//   appName:  Same as Packages.findOne(packageId).manifest.appName.defaultText; denormalized so
+//   appTitle:  Same as Packages.findOne(packageId).manifest.appTitle.defaultText; denormalized so
 //       that clients can access it without subscribing to the Packages collection.
 //   appVersion:  Same as Packages.findOne(packageId).manifest.appVersion; denormalized for
 //       searchability.

--- a/shell/shared/install.js
+++ b/shell/shared/install.js
@@ -25,7 +25,7 @@ if (Meteor.isServer) {
         userId: String,
         packageId: String,
         appId: String,
-        appName: Match.Optional(String),
+        appTitle: Match.Optional(String),
         appVersion: Match.Integer,
         title: String,
         command: {
@@ -172,7 +172,7 @@ if (Meteor.isClient) {
             userId: Meteor.userId(),
             packageId: package._id,
             appId: package.appId,
-            appName: package.manifest.appName && package.manifest.appName.defaultText,
+            appTitle: package.manifest.appTitle && package.manifest.appTitle.defaultText,
             appVersion: package.manifest.appVersion,
             title: action.title.defaultText,
             command: action.command

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -490,7 +490,7 @@ Router.map(function () {
 
         DevApps.find().forEach(function (app) {
           var action = app.manifest && app.manifest.actions && app.manifest.actions[0];
-          var name = (app.manifest.appName && app.manifest.appName.defaultText) ||
+          var name = (app.manifest.appTitle && app.manifest.appTitle.defaultText) ||
               appNameFromActionName(action && action.title && action.title.defaultText);
           appMap[app._id] = {
             name: name,
@@ -502,7 +502,7 @@ Router.map(function () {
 
         UserActions.find({userId: userId}).forEach(function (action) {
           if (!(action.appId in appMap)) {
-            var name = action.appName || appNameFromActionName(action.title);
+            var name = action.appTitle || appNameFromActionName(action.title);
             appMap[action.appId] = {
               name: name,
               appId: action.appId

--- a/src/sandstorm/package.capnp
+++ b/src/sandstorm/package.capnp
@@ -72,7 +72,7 @@ struct Manifest {
   # TODO(soon):  Maybe this should be renamed.  A "manifest" is a list of contents, but this
   #   structure doesn't contain a list at all; it contains information on how to use the contents.
 
-  appName @7 :Util.LocalizedText;
+  appTitle @7 :Util.LocalizedText;
   # The name of this app as it should be displayed to the user.
 
   appVersion @4 :UInt32;

--- a/src/sandstorm/spk.c++
+++ b/src/sandstorm/spk.c++
@@ -858,7 +858,7 @@ private:
         "    # This manifest is included in your app package to tell Sandstorm\n"
         "    # about your app.\n"
         "\n"
-        "    appName = (defaultText = \"Example App\"),\n"
+        "    appTitle = (defaultText = \"Example App\"),\n"
         "\n"
         "    appVersion = 0,  # Increment this for every release.\n"
         "\n"


### PR DESCRIPTION
This is for consistency. Elsewhere (e.g. PermissionDef and RoleDef), "title" signifies localized text and "name" signifies something that might be used as a key. Moreover, it appears that @kentonv has already internalized that this field ought to be called "appTitle". (See https://github.com/kentonv/ssjekyll/commit/6b5bb7bcd38bb3a0aaeac56861bab12909adeac1 .)