### PR TITLE
Add interface for background processing and expand SturdyRef infrasturcture

### DIFF
--- a/shell/shared/db.js
+++ b/shell/shared/db.js
@@ -186,8 +186,9 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //
 // Originally API tokens were only used by external users through the HTTP API endpoint. However,
 // now they are also used to implement SturdyRefs, not just held by external users, but also when
-// an app holds a SturdyRef to another app within the same server. See `SturdyRef` in
-// `grain.capnp` -- the type of `external` is an API token.
+// an app holds a SturdyRef to another app within the same server. See the various `save()`,
+// `restore()`, and `drop()` methods in `grain.capnp` (on `SansdtormApi`, `AppPersistent`, and
+// `MainView`) -- the fields of type `Data` are API tokens.
 //
 // Each contains:
 //   _id:       A SHA-256 hash of the token.
@@ -199,10 +200,10 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //   userInfo:  For API tokens created by the app through HackSessionContext, the UserInfo struct
 //              that should be passed to `newSession()` when exercising this token, in decoded (JS
 //              object) format. This is a temporary hack.
-//   sturdyRef: If present, this token represents an arbitrary Cap'n Proto capability exported by
+//   objectId:  If present, this token represents an arbitrary Cap'n Proto capability exported by
 //              the app or its supervisor (whereas without this it strictly represents UiView).
-//              sturdyRef is the JSON-encoded SupervisorSturdyRef (defined in `supervisor.capnp`).
-//              Note that if the SupervisorSturdyRef contains an AppSturdyRef, that field is
+//              sturdyRef is the JSON-encoded SupervisorObjectId (defined in `supervisor.capnp`).
+//              Note that if the SupervisorObjectId contains an AppObjectId, that field is
 //              treated as type AnyPointer, and so encoded as a raw Cap'n Proto message.
 //   frontendRef: If present, this token actually refers to an object implemented by the front-end,
 //              not a particular grain. (`grainId` is not set.) This is an object containing
@@ -215,10 +216,9 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //              the grain identified by `grainId`.
 //   created:   Date when this token was created.
 //   expires:   Optional expiration Date. If undefined, the token does not expire.
-//   owner:     A `SystemSturdyRefOwner` (defined in `supervisor.capnp`, stored as a JSON object)
-//              as passed to the `save()` call that created this token. Not present for tokens
-//              created by the user through the topbar, which are accessible from anywhere on the
-//              internet (but cannot be directly restored from inside an app).
+//   owner:     A `ApiTokenRefOwner` (defined in `supervisor.capnp`, stored as a JSON object)
+//              as passed to the `save()` call that created this token. If not present, treat
+//              as `webkey` (the default for `ApiTokenOwner`).
 
 Notifications = new Mongo.Collection("notifications");
 // Notifications for a user.

--- a/shell/shared/db.js
+++ b/shell/shared/db.js
@@ -199,11 +199,17 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //   userInfo:  For API tokens created by the app through HackSessionContext, the UserInfo struct
 //              that should be passed to `newSession()` when exercising this token, in decoded (JS
 //              object) format. This is a temporary hack.
-//   appRef:    If present, this token represents an arbitrary Cap'n Proto capability exported by
-//              the app (whereas without this it strictly represents UiView). appRef is the encoded,
-//              canonicalized AppSturdyRef (encoded as a Cap'n Proto message with AppSturdyRef as
-//              the root; this is the format that node-capnp automatically uses for `AnyPointer`
-//              fields).
+//   sturdyRef: If present, this token represents an arbitrary Cap'n Proto capability exported by
+//              the app or its supervisor (whereas without this it strictly represents UiView).
+//              sturdyRef is the JSON-encoded SupervisorSturdyRef (defined in `supervisor.capnp`).
+//              Note that if the SupervisorSturdyRef contains an AppSturdyRef, that field is
+//              treated as type AnyPointer, and so encoded as a raw Cap'n Proto message.
+//   frontendRef: If present, this token actually refers to an object implemented by the front-end,
+//              not a particular grain. (`grainId` is not set.) This is an object containing
+//              exactly one of the following fields:
+//       notificationHandle: A `Handle` for an ongoing notification, as returned by
+//                           `NotificationTarget.addOngoing`. The value is an `_id` from the
+//                           `Notifications` collection.
 //   petname:   Human-readable label for this access token, useful for identifying tokens for
 //              revocation. This should be displayed when visualizing incoming capabilities to
 //              the grain identified by `grainId`.
@@ -213,6 +219,17 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //              as passed to the `save()` call that created this token. Not present for tokens
 //              created by the user through the topbar, which are accessible from anywhere on the
 //              internet (but cannot be directly restored from inside an app).
+
+Notifications = new Mongo.Collection("notifications");
+// Notifications for a user.
+//
+// Each contains:
+//   _id:          random
+//   ongoing:      If present, this is an ongoing notification, and this field contains an
+//                 ApiToken referencing the `OngoingNotification` capability.
+//   grainId:      The grain originating this notification, if any.
+//   userId:       The user receiving the notification.
+//   text:         The JSON-ified LocalizedText to display in the notification.
 
 StatsTokens = new Mongo.Collection("statsTokens");
 // Access tokens for the Stats collection

--- a/shell/shared/db.js
+++ b/shell/shared/db.js
@@ -192,7 +192,7 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //
 // Each contains:
 //   _id:       A SHA-256 hash of the token.
-//   grainId:   The grain servicing this API.
+//   grainId:   The grain servicing this API. (Not present if the API isn't serviced by a grain.)
 //   userId:    The `_id` of the user (in the users table) to whom this token should be attributed.
 //              The user's current permissions will be presented to the app whenever the token is
 //              restored, so that the app can limit the token to the user's permissions, especially
@@ -206,8 +206,8 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //              Note that if the SupervisorObjectId contains an AppObjectId, that field is
 //              treated as type AnyPointer, and so encoded as a raw Cap'n Proto message.
 //   frontendRef: If present, this token actually refers to an object implemented by the front-end,
-//              not a particular grain. (`grainId` is not set.) This is an object containing
-//              exactly one of the following fields:
+//              not a particular grain. (`grainId` and `userId` are not set.) This is an object
+//              containing exactly one of the following fields:
 //       notificationHandle: A `Handle` for an ongoing notification, as returned by
 //                           `NotificationTarget.addOngoing`. The value is an `_id` from the
 //                           `Notifications` collection.

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1539,6 +1539,48 @@ public:
 //  kj::Promise<void> shareView(ShareViewContext context) override {
 
 //  }
+
+//  kj::Promise<void> restore(RestoreContext context) override {
+
+//  }
+
+//  kj::Promise<void> drop(DropContext context) override {
+
+//  }
+
+//  kj::Promise<void> deleted(DeletedContext context) override {
+
+//  }
+
+//  kj::Promise<void> stayAwake(StayAwakeContext context) override {
+    // TODO(someday): The supervisor will need to maintain a map of "wake locks". Since wake locks
+    //   by their nature do not outlast the process, this map can be held in-memory. When
+    //   `stayAwake()` is called, the supervisor:
+    //   - Fenerates a new wake lock ID (a random byte string; use libsodium's randombytes()).
+    //   - Adds it to the table, mapping it to the `OngoingNotification` provided by the app.
+    //   - Constructs a wrapper around `OngoingNotification` to be passed to the front-end. The
+    //     wrapper is persistent (using the wake lock ID).
+    //   - Calls SandstormCore.getAdminNotificationTarget().notifyOwnerOngoing(), passing along
+    //     this new wrapper object as well as the `displayInfo` provided from the app.
+    //   - On the handle returned by `notifyOwnerOngoing()`, immediately calls `save()`, storing
+    //     the resulting `SturdyRef` (actually, just an API token) into the wake lock table entry.
+    //   - Constructs a new handle object and returns it from `stayAwake()`.
+    //   - When that handle is destroyed, loads up the wake lock table entry and calls
+    //     SandstormCore.drop() on the handle SturdyRef stored there.
+    //   - When SandstormCore calls the wrapper OngoingNotification's `cancel()` method, forwards
+    //     that call to the app.
+    //   - When SandstormCore drops the wrapper OngoingNotification (via `Supervisor.drop()`),
+    //     drops the underlying OngoingNotification from the app.
+    //   - When everything is dropped, deletes the wake lock table entry.
+    //
+    //   Meanwhile, until the point that SandstormCore drops the OngoingNotification, the
+    //   supervisor does not kill itself during its regular keep-alive check.
+    //
+    //   The main reason this is so complicated is that the front-end is supposed to be able to
+    //   restart independently of the app, but the `OngoingNotification` provided by the app is
+    //   not required to be persistent. The supervisor thus takes care of the complication of
+    //   dealing with persistence through front-end restarts.
+//  }
 };
 
 class SupervisorMain::SupervisorImpl final: public Supervisor::Server {

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1556,14 +1556,15 @@ public:
     // TODO(someday): The supervisor will need to maintain a map of "wake locks". Since wake locks
     //   by their nature do not outlast the process, this map can be held in-memory. When
     //   `stayAwake()` is called, the supervisor:
-    //   - Fenerates a new wake lock ID (a random byte string; use libsodium's randombytes()).
+    //   - Generates a new wake lock ID (a random byte string; use libsodium's randombytes()).
     //   - Adds it to the table, mapping it to the `OngoingNotification` provided by the app.
     //   - Constructs a wrapper around `OngoingNotification` to be passed to the front-end. The
     //     wrapper is persistent (using the wake lock ID).
-    //   - Calls SandstormCore.getAdminNotificationTarget().notifyOwnerOngoing(), passing along
+    //   - Calls SandstormCore.getOwnerNotificationTarget().addOngoing(), passing along
     //     this new wrapper object as well as the `displayInfo` provided from the app.
-    //   - On the handle returned by `notifyOwnerOngoing()`, immediately calls `save()`, storing
-    //     the resulting `SturdyRef` (actually, just an API token) into the wake lock table entry.
+    //   - On the handle returned by `notifyOwnerOngoing()`, immediately calls `save()` (with
+    //     sealFor = this grain; see `SystemPersistent`), storing the resulting `SturdyRef`
+    //     (actually, just an API token) into the wake lock table entry.
     //   - Constructs a new handle object and returns it from `stayAwake()`.
     //   - When that handle is destroyed, loads up the wake lock table entry and calls
     //     SandstormCore.drop() on the handle SturdyRef stored there.

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -49,7 +49,7 @@ interface Supervisor {
   # Wraps `MainView.restore()`. Can also restore capabilities hosted by the supervisor.
 
   drop @6 (ref :SupervisorObjectId);
-  # Wraps `MainView.drop()`. Can also restore capabilities hosted by the supervisor.
+  # Wraps `MainView.drop()`. Can also drop capabilities hosted by the supervisor.
 }
 
 interface SandstormCore {
@@ -86,7 +86,7 @@ interface SandstormCore {
   #   through the restored cap, and then on later save() it should associate the newly-saved object
   #   with the same Powerbox introduction. Similarly, expiration dates need to be propagated.
 
-  getAdminNotificationTarget @2 () -> (owner :Grain.NotificationTarget);
+  getOwnerNotificationTarget @2 () -> (owner :Grain.NotificationTarget);
   # Get the notification target to use for notifications relating to the grain itself, e.g.
   # presence of wake locks.
 }

--- a/src/sandstorm/util.capnp
+++ b/src/sandstorm/util.capnp
@@ -48,12 +48,22 @@ interface Handle {
   # Arbitrary handle to some resource provided by the platform. May or may not be persistent,
   # depending on the use case.
   #
-  # To "drop" a handle means to discard any live references and delete any sturdy references.
-  # The purpose of a handle is to detect when it has been dropped and to free the underlying
-  # resource and cancel any ongoing operation at that time.
-
-  # TODO(someday): How does one drop a handle after persisting it? Should we add a method here
-  #   that invalidates the SturdyRef, or should we put it in Persistent?
+  # To "drop" a handle means to discard any references. The purpose of a handle is to detect when
+  # it has been dropped and to free the underlying resource and cancel any ongoing operation at
+  # that time.
+  #
+  # A handle can be persistent. Once you have called `save()` on it to obtain a SturdyRef, dropping
+  # the live reference will not cancel the operation. You must drop all live references *and*
+  # explicitly drop any SturdyRef. Every interface which supports restoring SturdyRefs also
+  # has a corresponding `drop()` method for this purpose.
+  #
+  # Unfortunately, there is no way to ensure that a SturdyRef will eventually be deleted. A grain
+  # could, for example, call `save()` and then simply fail to store the SturdyRef anywhere, causing
+  # it to be "leaked" until such a time as the grain itself is destroyed. Or worse, a whole server
+  # could be destroyed in a fire, leaking all SturdyRefs stored therein forever. Apps implementing
+  # persistent handles must be designed to account for this, probably by giving the owning user
+  # a way to inspect incoming references and remove them manually. Sandstorm automatically provides
+  # such an interface for all apps it hosts.
 }
 
 interface ByteStream {


### PR DESCRIPTION
This started as an attempt to add interfaces for background processing -- that is, letting the app request that it not be shut down even if no sessions are open.

This expanded into defining some basic interfaces for notifications. Background processing requires displaying a notification to the user, and I didn't want to write a hack that would change as soon as notifications are truly implemented.

Things got complicated when I realized that the front-end is able to restart independently of any particular grain. This implies that capabilities related to keeping the notification open need to be persistent. (We could perhaps add more hacks that define some new kind of ID, but I'd rather start writing things the way we're supposed to be writing them long-term.)

But thinking about that made me realize that the SturdyRef stuff is missing some things. For instance, sometimes the supervisor or the front-end need to host persistent capabilities, therefore ApiToken needs a way to represent those.

Moreover, I realized that we really do need a way to delete a SturdyRef if the "handle" pattern is to extend to persistent handles. So, I went through and added a `drop()` method to go with every `restore()` method, along with a discussion of all of the issues that come along with `drop()` (basically, if you want to use `drop()`, then you must implement `save()` such that it returns a new unique ref every time, because reference counting is not really possible here.)

So, this is what I came up with.

@dwrensha does this affect what you're working on right now? Or does basic sharing turn out not to use SturdyRefs?