### PR TITLE
spk: make --pkg-def switch work correctly

### DIFF
--- a/src/sandstorm/spk.c++
+++ b/src/sandstorm/spk.c++
@@ -495,6 +495,7 @@ private:
         }
 
         packageDef = symbol->asConst().as<spk::PackageDefinition>();
+        sawPkgDef = true;
 
         return true;
       } else {


### PR DESCRIPTION
The variable sawPkgDef was initialized to false, and never set to true when the
pkgdef was loaded successfully.

As a result, specifying --pkg-def would load the user-specified package def, and then ensurePackageDefParsed would additionally attempt to load the default one, which would fail.