### PR TITLE
Mongo 2.6: remove() -> remove({}).

### DIFF
--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -2371,7 +2371,7 @@ private:
   }
 
   void clearDevApps(const Config& config) {
-    mongoCommand(config, kj::str("db.devapps.remove()"));
+    mongoCommand(config, kj::str("db.devapps.remove({})"));
   }
 
   void mongoCommand(const Config& config, kj::StringPtr command, kj::StringPtr db = "meteor") {


### PR DESCRIPTION
`remove()` with no parameters will cause an error once we upgrade Meteor/Mongo.
http://docs.mongodb.org/manual/reference/method/db.collection.remove/