### PR TITLE
Add a dirty hack for backup downloading on Firefox

### DIFF
--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -153,7 +153,24 @@ if (Meteor.isClient) {
         if (err) {
           alert("Backup failed: " + err); // TODO(someday): make this better UI
         } else {
-          window.location = "/downloadBackup/" + id;
+          // Firefox for some reason decides to kill all websockets when we try to download the file
+          // by navigating there. So we're left doing a dirty hack to get around the popup blocker.
+          var isFirefox = typeof InstallTrigger !== "undefined";
+
+          if (isFirefox) {
+            var save = document.createElement("a");
+            save.href = "/downloadBackup/" + id;
+
+            save.download = Session.get("grainFrameTitle") + ".zip";
+            var event = document.createEvent("MouseEvents");
+            event.initMouseEvent(
+                    "click", true, false, window, 0, 0, 0, 0, 0,
+                    false, false, false, false, 0, null
+            );
+            save.dispatchEvent(event);
+          } else {
+            window.location = "/downloadBackup/" + id;
+          }
         }
       });
     },


### PR DESCRIPTION
Fixes #252 

If this hack is unacceptable (and it is a pretty egregious hack), then we may want to do `window.open` on Firefox and just have users deal with the popup blocker.

Also check out https://github.com/jparyani/sandstorm/commit/a989f0013cc0e005c10fac9ae14d45a531e95bf7 if you're curious to see my attempts with an iframe. It did work for Chrome but not for Firefox.