### PR TITLE
Export stats on appDemoUsers separately

### DIFF
--- a/shell/shared/db.js
+++ b/shell/shared/db.js
@@ -167,7 +167,7 @@ DeleteStats = new Mongo.Collection("deleteStats");
 // Contains records of objects that were deleted, for stat-keeping purposes.
 //
 // Each contains:
-//   type: "grain" or "user"
+//   type: "grain" or "user" or "appDemoUser"
 //   lastActive: Date of the user's or grain's last activity.
 
 FileTokens = new Mongo.Collection("fileTokens");

--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -86,12 +86,13 @@ if (Meteor.isServer) {
         // isAppDemoUser is important for stats; see
         // cleanupExpiredUsers().
         check(displayName, String);
+        check(isAppDemoUser, Boolean);
 
         // Create the new user.
         var expires = new Date(Date.now() + DEMO_EXPIRATION_MS);
         var userId = Accounts.insertUserDoc({ profile: { name: displayName } },
                                             { expires: expires,
-                                              isAppDemoUser: !!isAppDemoUser
+                                              isAppDemoUser: isAppDemoUser
                                             });
 
         // Log them in on this connection.

--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -48,7 +48,7 @@ if (Meteor.isServer) {
     // Delete expired demo accounts and all their grains.
 
     var now = new Date();
-    Meteor.users.find({expires: {$lt: now}}, {fields: {_id: 1, lastActive: 1}})
+    Meteor.users.find({expires: {$lt: now}}, {fields: {_id: 1, lastActive: 1, isAppDemoUser: 1}})
                 .forEach(function (user) {
       Grains.find({userId: user._id}, {fields: {_id: 1, lastUsed: 1}})
             .forEach(function (grain) {
@@ -62,7 +62,15 @@ if (Meteor.isServer) {
       console.log("delete user: " + user._id);
       Meteor.users.remove(user._id);
       if (user.lastActive) {
-        DeleteStats.insert({type: "user", lastActive: user.lastActive});
+        // When deleting a user, we can specify it as a "normal" user
+        // (type: user) or as a user who started out by using the app
+        // demo feature (type: appDemoUser).
+        var deleteStatsType = "user";
+        var isAppDemoUser = !! user.isAppDemoUser;
+        if (isAppDemoUser) {
+          deleteStatsType = "appDemoUser";
+        }
+        DeleteStats.insert({type: deleteStatsType, lastActive: user.lastActive});
       }
     });
   }
@@ -71,15 +79,20 @@ if (Meteor.isServer) {
 
   if (allowDemo) {
     Meteor.methods({
-      createDemoUser: function (displayName) {
-        // This is a login method that creates a new temporary user every time it is used.
-
+      createDemoUser: function (displayName, isAppDemoUser) {
+        // This is a login method that creates a new temporary user
+        // every time it is used.
+        //
+        // isAppDemoUser is important for stats; see
+        // cleanupExpiredUsers().
         check(displayName, String);
 
         // Create the new user.
         var expires = new Date(Date.now() + DEMO_EXPIRATION_MS);
         var userId = Accounts.insertUserDoc({ profile: { name: displayName } },
-                                            { expires: expires });
+                                            { expires: expires,
+                                              isAppDemoUser: !!isAppDemoUser
+                                            });
 
         // Log them in on this connection.
         return Accounts._loginMethod(this, "createDemoUser", arguments,
@@ -162,7 +175,7 @@ if (Meteor.isClient && allowDemo) {
 
       Accounts.callLoginMethod({
         methodName: "createDemoUser",
-        methodArguments: [displayName],
+        methodArguments: [displayName, false],
         userCallback: function (err) {
           if (err) {
             window.alert(err);
@@ -226,7 +239,7 @@ if (Meteor.isClient && allowDemo) {
 
         Accounts.callLoginMethod({
           methodName: "createDemoUser",
-          methodArguments: [displayName],
+          methodArguments: [displayName, true],
           userCallback: userCallbackFunction
         });
       }

--- a/shell/shared/stats.js
+++ b/shell/shared/stats.js
@@ -20,7 +20,11 @@ if (Meteor.isServer) {
   function computeStats(since) {
     return {
       activeUsers: Meteor.users.find({lastActive: {$gt: since}}).count() +
-          DeleteStats.find({type: "user", lastActive: {$gt: since}}).count(),
+          DeleteStats.find({$or: [{type: "user"},
+                                  {type: "appDemoUser"}],
+                            lastActive: {$gt: since}}).count(),
+      appDemoUsers: Meteor.users.find({lastActive: {$gt: since}}).count() +
+          DeleteStats.find({type: "appDemoUser", lastActive: {$gt: since}}).count(),
       activeGrains: Grains.find({lastUsed: {$gt: since}}).count() +
           DeleteStats.find({type: "grain", lastActive: {$gt: since}}).count()
     }

--- a/shell/shared/stats.js
+++ b/shell/shared/stats.js
@@ -18,15 +18,39 @@ var DAY_MS = 24*60*60*1000;
 
 if (Meteor.isServer) {
   function computeStats(since) {
+    // We'll need this for a variety of queries.
+    var timeConstraint = {$gt: since};
+
+    // This calculates the number of user accounts that have been used
+    // during the requested time period.
+    var currentlyActiveUsersCount = Meteor.users.find(
+      {lastActive: timeConstraint}).count();
+
+    // This calculates the number of grains that have been used during
+    // the requested time period.
+    var activeGrainsCount = Grains.find({lastUsed: timeConstraint}).count();
+
+    // If Meteor.settings.allowDemoAccounts is true, DeleteStats
+    // contains records of type `user` and `appDemoUser`, indicating
+    // the number of those types of accounts that were created and
+    // then auto-expired through the demo mode's auto-account-expiry.
+    var deletedNormalUsersCount =  DeleteStats.find(
+      {type: "user", lastActive: timeConstraint}).count();
+    var deletedAppDemoUsersCount = DeleteStats.find(
+      {type: "appDemoUser", lastActive: timeConstraint}).count();
+
+    // Similarly, if the demo is enabled, we auto-delete grains; we store that
+    // fact in DeleteStats with type: "grain".
+    var deletedGrainsCount = DeleteStats.find(
+      {type: "grain", lastActive: timeConstraint}).count();
+
+
     return {
-      activeUsers: Meteor.users.find({lastActive: {$gt: since}}).count() +
-          DeleteStats.find({$or: [{type: "user"},
-                                  {type: "appDemoUser"}],
-                            lastActive: {$gt: since}}).count(),
-      appDemoUsers: Meteor.users.find({lastActive: {$gt: since}}).count() +
-          DeleteStats.find({type: "appDemoUser", lastActive: {$gt: since}}).count(),
-      activeGrains: Grains.find({lastUsed: {$gt: since}}).count() +
-          DeleteStats.find({type: "grain", lastActive: {$gt: since}}).count()
+      activeUsers: (currentlyActiveUsersCount +
+                    deletedAppDemoUsersCount +
+                    deletedNormalUsersCount),
+      appDemoUsers: deletedAppDemoUsersCount,
+      activeGrains: (activeGrainsCount + deletedGrainsCount)
     }
   }
 


### PR DESCRIPTION
This change permits us to export appDemo user stats separately when viewing the JSON stats export.

@jparyani promised me that if I pushed this, he'd make the corresponding change on the Sandstorm internal stats dashboard.

For non-internal people interested in Sandstorm stats, you might like to see how to get JSON stats data from your own Sandstorm install:

* http://local.sandstorm.io:6080/stats (or whatever URL reaches your own Sandstorm)
* Click on the API token at the bottom of that page
* Ta-da, stats!

I have tested this in the following way:

* Create two demo users, each of which use an app
* Create an appDemo user by visiting an appdemo URL and logging in, which also creates an instance of that app
* View the mongo data on the User objects; note that there are 2 'demo' users and 1 'appDemo' user
* Remove the time constraint from `cleanupExpiredUsers()` and then look at the `DeleteStats` Mongo collection and notice that there are 2 `users` and 1 `appDemoUser`s

I re-did the manual test steps above, and will leave my laptop on overnight in order to trigger the real time-based `cleanupExpiredUsers()` call in the hopes of having an even more accurate test, but I already believe this is ready to merge.