### PR TITLE
Fix bug that caused proxies to never be deleted.

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -410,7 +410,7 @@ Meteor.startup(function () {
     }
   });
 
-  Sessions.find().observeChanges({
+  Sessions.find().observe({
     removed : function(session) {
       delete proxies[session._id];
       delete proxiesByHostId[session.hostId];


### PR DESCRIPTION
[`cursor.observeChanges()`](http://docs.meteor.com/#/full/observe_changes) reports back only the ID field of changed entries. When deleting proxies, we need the `hostId` field as well, so we should use [`cursor.observe()`](http://docs.meteor.com/#/full/observe).

Right now, we are using `observeChanges()` as if it worked like `observe()`. (This is my fault for not reading the documentation carefully enough when I added this code.) The result is a serious memory leak.
