### PR TITLE
Add email token login system

### DIFF
--- a/shell/.meteor/packages
+++ b/shell/.meteor/packages
@@ -9,6 +9,7 @@ underscore
 random
 sandstorm-accounts-ui
 sandstorm-accounts-packages
+accounts-email-token
 email
 reload
 simplesmtp

--- a/shell/.meteor/versions
+++ b/shell/.meteor/versions
@@ -1,4 +1,5 @@
 accounts-base@1.1.3
+accounts-email-token@0.1.0
 application-configuration@1.0.4
 autoupdate@1.1.4
 base64@1.0.2
@@ -63,6 +64,7 @@ sandstorm-accounts-packages@0.1.0
 sandstorm-accounts-ui@0.1.0
 service-configuration@1.0.3
 session@1.0.5
+sha@1.0.2
 simplesmtp@0.0.0
 spacebars@1.0.4
 spacebars-compiler@1.0.4

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -465,7 +465,14 @@ $KEY</textarea></p>
         <div class="alert alert-success"><strong>Success!</strong> Your settings have been saved.</div>
         {{/if}}
         {{#if failure}}
-        <div class="alert alert-danger"><strong>Failure!</strong> Something went wrong trying to save settings. See <code>&lt;install-location&gt;/var/log/sandstorm.log</code> for details.</div>
+        <div class="alert alert-danger"><strong>Failure!</strong>
+          <ul>
+            {{#each errors}}
+            <li>{{details}}</li>
+            {{/each}}
+          </ul>
+          See <code>&lt;install-location&gt;/var/log/sandstorm.log</code> for details.
+        </div>
         {{/if}}
       </form>
     </div>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -455,7 +455,7 @@ $KEY</textarea></p>
       <form id="admin-settings-form">
         <p><input type="checkbox" name="googleLogin" value="value" checked={{googleEnabled}}> Enable Google Login<br>
            <input type="checkbox" name="githubLogin" value="value" checked={{githubEnabled}}> Enable Github Login<br>
-           <input type="checkbox" name="emailTokenLogin" value="value" checked={{emailTokenEnabled}}> Enable Email + Token Login<br>
+           <input type="checkbox" name="emailTokenLogin" value="value" checked={{emailTokenEnabled}}> Enable Passwordless Email Login<br>
           <span class="details">Choose which services users may use to identify themselves. Anyone can log in, but only users you <a href="/invite">invite</a> will be able to install apps or create files.</span></p>
         <p>SMTP Url: <input type="text" name="smtpUrl" value="{{smtpUrl}}"><br>
           <span class="details">Address of an SMTP (email) server, like <code>smtp://user:pass@host:port</code>. This will be used by email apps and to send <a href="/invite">email invites</a>.</span></p>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -455,6 +455,7 @@ $KEY</textarea></p>
       <form id="admin-settings-form">
         <p><input type="checkbox" name="googleLogin" value="value" checked={{googleEnabled}}> Enable Google Login<br>
            <input type="checkbox" name="githubLogin" value="value" checked={{githubEnabled}}> Enable Github Login<br>
+           <input type="checkbox" name="emailTokenLogin" value="value" checked={{emailTokenEnabled}}> Enable Email + Token Login<br>
           <span class="details">Choose which services users may use to identify themselves. Anyone can log in, but only users you <a href="/invite">invite</a> will be able to install apps or create files.</span></p>
         <p>SMTP Url: <input type="text" name="smtpUrl" value="{{smtpUrl}}"><br>
           <span class="details">Address of an SMTP (email) server, like <code>smtp://user:pass@host:port</code>. This will be used by email apps and to send <a href="/invite">email invites</a>.</span></p>

--- a/shell/packages/accounts-email-token/package.js
+++ b/shell/packages/accounts-email-token/package.js
@@ -1,0 +1,19 @@
+Package.describe({
+  summary: "An accounts package for an email + token login system",
+  version: "0.1.0"
+});
+
+Package.onUse(function (api) {
+  api.use(["underscore", "random", "templating", "iron:router"]);
+  api.use("accounts-base", ["client", "server"]);
+  // Export Accounts (etc) to packages using this one.
+  api.imply("accounts-base", ["client", "server"]);
+  api.use("check");
+  api.use("sha", ["client", "server"]);
+  api.use("email", ["server"]);
+
+  api.addFiles("token_common.js", ["client", "server"]);
+  api.addFiles(["token_client.js", "token_templates.html"], ["client"]);
+  api.addFiles("token_server.js", ["server"]);
+});
+

--- a/shell/packages/accounts-email-token/token_client.js
+++ b/shell/packages/accounts-email-token/token_client.js
@@ -1,0 +1,40 @@
+/**
+ * @summary Log the user in with a password.
+ * @locus Client
+ * @param {String} email The user's email.
+ * @param {String} password The token received in the email.
+ * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
+ */
+Meteor.loginWithEmailToken = function (email, token, callback) {
+  check(email, String);
+  check(token, String);
+
+  Accounts.callLoginMethod({
+    methodArguments: [{emailToken: {
+      email: email,
+      token: token
+    }}],
+    userCallback: function (error, result) {
+      if (error) {
+        callback && callback(error);
+      } else {
+        callback && callback();
+      }
+    }
+  });
+};
+
+// Attempt to create a token for an email
+
+/**
+ * @summary Create a new token for a given email.
+ * @locus Anywhere
+ * @param {String} email The user's email address.
+ * @param {Function} [callback] Client only, optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
+ */
+Accounts.createAndEmailTokenForUser = function (email, callback) {
+  check(email, String);
+
+  Meteor.call("createAndEmailTokenForUser", email, callback);
+};
+

--- a/shell/packages/accounts-email-token/token_client.js
+++ b/shell/packages/accounts-email-token/token_client.js
@@ -24,8 +24,6 @@ Meteor.loginWithEmailToken = function (email, token, callback) {
   });
 };
 
-// Attempt to create a token for an email
-
 /**
  * @summary Create a new token for a given email.
  * @locus Anywhere

--- a/shell/packages/accounts-email-token/token_common.js
+++ b/shell/packages/accounts-email-token/token_common.js
@@ -1,0 +1,44 @@
+Accounts._hashToken = function (token) {
+  return {
+    digest: SHA256(token),
+    algorithm: "sha-256"
+  };
+};
+
+var enabled = false;
+
+Meteor.enableEmailTokenLogin = function () {
+  enabled = true;
+  if (Meteor.isClient) {
+    Accounts.ui.registerService("emailToken", "an Email + Token");
+  }
+};
+
+Meteor.disableEmailTokenLogin = function () {
+  enabled = false;
+  if (Meteor.isClient) {
+    Accounts.ui.deregisterService("emailToken");
+  }
+};
+
+Accounts.isEmailTokenLoginEnabled = function () {
+  return enabled;
+};
+
+Router.route("/_emailToken/:_email/:_token", function () {
+  this.render("Loading");
+  var that = this;
+  Meteor.loginWithEmailToken(this.params._email, this.params._token, function (err) {
+    if (err) {
+      that.render("_emailTokenError", {
+        data: function () {
+          return {
+            error: err
+          };
+        }
+      });
+    } else {
+      Router.go("/");
+    }
+  });
+});

--- a/shell/packages/accounts-email-token/token_common.js
+++ b/shell/packages/accounts-email-token/token_common.js
@@ -1,4 +1,6 @@
-Accounts._hashToken = function (token) {
+Accounts.emailToken = {};
+
+Accounts.emailToken._hashToken = function (token) {
   return {
     digest: SHA256(token),
     algorithm: "sha-256"
@@ -7,21 +9,21 @@ Accounts._hashToken = function (token) {
 
 var enabled = false;
 
-Meteor.enableEmailTokenLogin = function () {
+Accounts.emailToken.enable = function () {
   enabled = true;
   if (Meteor.isClient) {
     Accounts.ui.registerService("emailToken", "an Email + Token");
   }
 };
 
-Meteor.disableEmailTokenLogin = function () {
+Accounts.emailToken.disable = function () {
   enabled = false;
   if (Meteor.isClient) {
     Accounts.ui.deregisterService("emailToken");
   }
 };
 
-Accounts.isEmailTokenLoginEnabled = function () {
+Accounts.emailToken.isEnabled = function () {
   return enabled;
 };
 

--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -63,7 +63,7 @@ Accounts.registerLoginHandler("emailToken", function (options) {
   if (!found) {
     console.error("Token not found:", user.services.emailToken);
     return {
-      error: new Meteor.Error(403, "Token not found")
+      error: new Meteor.Error(403, "Invalid authentication code")
     };
   }
 
@@ -88,11 +88,16 @@ var makeTokenUrl = function (email, token) {
 var sendTokenEmail = function (email, token) {
   var options = {
     to:  email,
-    from: "Sandstorm " + HOSTNAME + " <no-reply@" + HOSTNAME + ">",
-    subject: "Sandstorm token for " + HOSTNAME,
-    text: "A token has requested on your behalf to login to a Sandstorm instance at " + HOSTNAME +
-      ". You will need to either navigate to " + makeTokenUrl(email, token) + " or manually copy " +
-      token + " into the login dropdown."
+    from: HOSTNAME + " <no-reply@" + HOSTNAME + ">",
+    subject: "Log in to " + HOSTNAME,
+    text: "To log in to " + HOSTNAME + ", click on the following link:\n\n" +
+          makeTokenUrl(email, token) + "\n\n" +
+          "Alternatively, enter the following one-time authentication code into the log-in form:\n\n" +
+          token + "\n\n" +
+          "You are receiving this because someone (hopefully you) requested to log in to HOSTNAME " +
+          "with your email address. If you did not request to log into " + HOSTNAME + ", you may " +
+          "ignore this message.\n\n" +
+          "This information will expire in 15 minutes.\n"
   };
 
   Email.send(options);
@@ -121,8 +126,9 @@ var createAndEmailTokenForUser = function (email) {
 
   if (user) {
     if (user.services.emailToken.tokens && user.services.emailToken.tokens.length > 2) {
-      throw new Meteor.Error(403, "Too many tokens have been made for this user. Please find the " +
-        "token in your email, or wait a bit to try again.");
+      throw new Meteor.Error(403, "It looks like we sent a log in email to this address not long " +
+        "ago. Please use the one that was already sent (check your spam folder if you can't find " +
+        "it), or wait a while and try again");
     }
     userId = user._id;
 

--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -1,0 +1,163 @@
+var TOKEN_EXPIRATION_MS = 15 * 60 * 1000;
+
+var cleanupExpiredTokens = function() {
+  Meteor.users.update({}, {
+    $pull: {
+      "services.emailToken.tokens": {
+        createdAt: {$lt: new Date(Date.now() - TOKEN_EXPIRATION_MS)}
+      }
+    }
+  }, { multi: true });
+};
+
+Meteor.startup(cleanupExpiredTokens);
+// Tokens can actually last up to 2 * TOKEN_EXPIRATION_MS
+Meteor.setInterval(cleanupExpiredTokens, TOKEN_EXPIRATION_MS);
+
+Accounts._checkToken = function (user, token) {
+  var found = false;
+  user.services.emailToken.tokens.forEach(function (userToken) {
+    if((userToken.algorithm === token.algorithm) &&
+       (userToken.digest === token.digest)) {
+      found = true;
+    }
+  });
+
+  return found;
+};
+var checkToken = Accounts._checkToken;
+
+// Handler to login with a token.
+Accounts.registerLoginHandler("emailToken", function (options) {
+  if (!options.emailToken)
+    return undefined; // don't handle
+
+  options = options.emailToken;
+  check(options, {
+    email: String,
+    token: String
+  });
+
+  var user = Meteor.users.findOne({"services.emailToken.email": options.email});
+
+  if (!user) {
+    console.error("User not found:", options.email);
+    return {
+      error: new Meteor.Error(403, "User not found")
+    };
+  }
+
+  if (!user.services || !user.services.emailToken ||
+      !(user.services.emailToken.tokens)) {
+    console.error("User has no token set:", options.email);
+    return {
+      error: new Meteor.Error(403, "User has no token set")
+    };
+  }
+
+  var token = Accounts._hashToken(options.token);
+  var found = checkToken(
+    user,
+    token
+  );
+
+  if (!found) {
+    console.error("Token not found:", user.services.emailToken);
+    return {
+      error: new Meteor.Error(403, "Token not found")
+    };
+  }
+
+  Meteor.users.update({_id: user._id}, {$pull: {"services.emailToken.tokens": token}});
+  return {
+    userId: user._id
+  };
+});
+
+var Url = Npm.require("url");
+
+var ROOT_URL = Url.parse(process.env.ROOT_URL);
+var HOSTNAME = ROOT_URL.hostname;
+
+var makeTokenUrl = function (email, token) {
+  return process.env.ROOT_URL + "/_emailToken/" + encodeURIComponent(email) + "/" + encodeURIComponent(token);
+};
+
+///
+/// EMAIL VERIFICATION
+///
+var sendTokenEmail = function (email, token) {
+  var options = {
+    to:  email,
+    from: "Sandstorm " + HOSTNAME + " <no-reply@" + HOSTNAME + ">",
+    subject: "Sandstorm token for " + HOSTNAME,
+    text: "A token has requested on your behalf to login to a Sandstorm instance at " + HOSTNAME +
+      ". You will need to either navigate to " + makeTokenUrl(email, token) + " or manually copy " +
+      token + " into the login dropdown."
+  };
+
+  Email.send(options);
+};
+
+///
+/// CREATING USERS
+///
+// returns the user id
+var createAndEmailTokenForUser = function (email) {
+  // Unknown keys allowed, because a onCreateUserHook can take arbitrary
+  // options.
+  check(email, String);
+
+  var user = Meteor.users.findOne({"services.emailToken.email": email});
+  var userId;
+
+  // TODO(someday): make this shorter, and handle requests that try to brute force it.
+  var token = Random.id(12);
+  var tokenObj = Accounts._hashToken(token);
+  tokenObj.createdAt = new Date();
+
+  if (user) {
+    if (user.services.emailToken.tokens && user.services.emailToken.tokens.length > 2) {
+      throw new Meteor.Error(403, "Too many tokens have been made for this user. Please find the " +
+        "token in your email, or wait a bit to try again.");
+    }
+    userId = user._id;
+
+    Meteor.users.update({_id: userId}, {$push: {"services.emailToken.tokens": tokenObj}});
+  } else {
+    var options = {
+      email: email,
+      profile: {
+        name: email
+      }
+    };
+
+    user = {services: {emailToken: {
+      tokens: [tokenObj],
+      email: options.email
+    }}};
+
+    userId = Accounts.insertUserDoc(options, user);
+  }
+
+  sendTokenEmail(email, token);
+
+  return userId;
+};
+
+// method for create user. Requests come from the client.
+// This method will create a user if it doesn't exist, otherwise it will generate a token.
+// It will always send an email to the user
+Meteor.methods({createAndEmailTokenForUser: function (email) {
+  if (!Accounts.isEmailTokenLoginEnabled()) {
+    throw new Meteor.Error(403, "Email Token service is disabled.");
+  }
+  // Create user. result contains id and token.
+  var user = createAndEmailTokenForUser(email);
+}});
+
+///
+/// INDEXES ON USERS
+///
+Meteor.users._ensureIndex("services.emailToken.email",
+                          {unique: 1, sparse: 1});

--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -103,9 +103,13 @@ var sendTokenEmail = function (email, token) {
 ///
 // returns the user id
 var createAndEmailTokenForUser = function (email) {
-  // Unknown keys allowed, because a onCreateUserHook can take arbitrary
-  // options.
   check(email, String);
+  var atIndex = email.indexOf("@");
+  if (atIndex === -1) {
+    throw new Meteor.Error(400, "No @ symbol was found in your email");
+  }
+
+  var username = email.slice(0, atIndex);
 
   var user = Meteor.users.findOne({"services.emailToken.email": email});
   var userId;
@@ -127,7 +131,7 @@ var createAndEmailTokenForUser = function (email) {
     var options = {
       email: email,
       profile: {
-        name: email
+        name: username
       }
     };
 

--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -126,7 +126,7 @@ var createAndEmailTokenForUser = function (email) {
 
   if (user) {
     if (user.services.emailToken.tokens && user.services.emailToken.tokens.length > 2) {
-      throw new Meteor.Error(403, "It looks like we sent a log in email to this address not long " +
+      throw new Meteor.Error(409, "It looks like we sent a log in email to this address not long " +
         "ago. Please use the one that was already sent (check your spam folder if you can't find " +
         "it), or wait a while and try again");
     }

--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -14,7 +14,7 @@ Meteor.startup(cleanupExpiredTokens);
 // Tokens can actually last up to 2 * TOKEN_EXPIRATION_MS
 Meteor.setInterval(cleanupExpiredTokens, TOKEN_EXPIRATION_MS);
 
-Accounts._checkToken = function (user, token) {
+var checkToken = function (user, token) {
   var found = false;
   user.services.emailToken.tokens.forEach(function (userToken) {
     if((userToken.algorithm === token.algorithm) &&
@@ -25,7 +25,6 @@ Accounts._checkToken = function (user, token) {
 
   return found;
 };
-var checkToken = Accounts._checkToken;
 
 // Handler to login with a token.
 Accounts.registerLoginHandler("emailToken", function (options) {
@@ -55,7 +54,7 @@ Accounts.registerLoginHandler("emailToken", function (options) {
     };
   }
 
-  var token = Accounts._hashToken(options.token);
+  var token = Accounts.emailToken._hashToken(options.token);
   var found = checkToken(
     user,
     token
@@ -113,7 +112,7 @@ var createAndEmailTokenForUser = function (email) {
 
   // TODO(someday): make this shorter, and handle requests that try to brute force it.
   var token = Random.id(12);
-  var tokenObj = Accounts._hashToken(token);
+  var tokenObj = Accounts.emailToken._hashToken(token);
   tokenObj.createdAt = new Date();
 
   if (user) {
@@ -149,7 +148,7 @@ var createAndEmailTokenForUser = function (email) {
 // This method will create a user if it doesn't exist, otherwise it will generate a token.
 // It will always send an email to the user
 Meteor.methods({createAndEmailTokenForUser: function (email) {
-  if (!Accounts.isEmailTokenLoginEnabled()) {
+  if (!Accounts.emailToken.isEnabled()) {
     throw new Meteor.Error(403, "Email Token service is disabled.");
   }
   // Create user. result contains id and token.

--- a/shell/packages/accounts-email-token/token_templates.html
+++ b/shell/packages/accounts-email-token/token_templates.html
@@ -1,0 +1,3 @@
+<template name="_emailTokenError">
+  <h2>Failed to login with token. It may be expired or you may have copied it in wrong.</h2>
+</template>

--- a/shell/packages/accounts-email-token/token_templates.html
+++ b/shell/packages/accounts-email-token/token_templates.html
@@ -1,3 +1,3 @@
 <template name="_emailTokenError">
-  <h2>Failed to login with token. It may be expired or you may have copied it in wrong.</h2>
+  <h2>Invalid authentication code. If it has been more than 15 minutes, the token has expired, otherwise you may have simply mistyped it.</h2>
 </template>

--- a/shell/packages/sandstorm-accounts-packages/accounts.js
+++ b/shell/packages/sandstorm-accounts-packages/accounts.js
@@ -21,11 +21,17 @@ if (Meteor.isClient) {
   };
 }
 
+var services = [];
+
 Accounts.registerService = function (serviceName) {
-  if (_.contains(Accounts.oauth.serviceNames(), serviceName)) {
+  if (_.contains(services, serviceName)) {
     return;
   }
-  if (Meteor.isClient && (serviceName === "demo" || serviceName === "devAccounts")) {
+  services.push(serviceName);
+  if (serviceName === "emailToken") {
+    Meteor.enableEmailTokenLogin();
+  }
+  else if (Meteor.isClient && (serviceName === "demo" || serviceName === "devAccounts")) {
     var serviceUserDisplay;
     if (serviceName === "demo") {
       serviceUserDisplay = "a Demo User";
@@ -39,10 +45,14 @@ Accounts.registerService = function (serviceName) {
 };
 
 Accounts.deregisterService = function (serviceName) {
-  if (!_.contains(Accounts.oauth.serviceNames(), serviceName)) {
+  if (!_.contains(services, serviceName)) {
     return;
   }
-  if (Meteor.isClient && (serviceName === "demo" || serviceName === "devAccounts")) {
+  services = _.without(services, serviceName);
+  if (serviceName === "emailToken") {
+    Meteor.disableEmailTokenLogin();
+  }
+  else if (Meteor.isClient && (serviceName === "demo" || serviceName === "devAccounts")) {
     Accounts.ui.deregisterService(serviceName);
   } else {
     Accounts.oauth.deregisterService(serviceName);

--- a/shell/packages/sandstorm-accounts-packages/accounts.js
+++ b/shell/packages/sandstorm-accounts-packages/accounts.js
@@ -29,7 +29,7 @@ Accounts.registerService = function (serviceName) {
   }
   services.push(serviceName);
   if (serviceName === "emailToken") {
-    Meteor.enableEmailTokenLogin();
+    Accounts.emailToken.enable();
   }
   else if (Meteor.isClient && (serviceName === "demo" || serviceName === "devAccounts")) {
     var serviceUserDisplay;
@@ -50,7 +50,7 @@ Accounts.deregisterService = function (serviceName) {
   }
   services = _.without(services, serviceName);
   if (serviceName === "emailToken") {
-    Meteor.disableEmailTokenLogin();
+    Accounts.emailToken.disable();
   }
   else if (Meteor.isClient && (serviceName === "demo" || serviceName === "devAccounts")) {
     Accounts.ui.deregisterService(serviceName);

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -65,7 +65,7 @@ getLoginServices = function () {
 };
 
 hasPasswordService = function () {
-  return Accounts.isEmailTokenLoginEnabled && Accounts.isEmailTokenLoginEnabled();
+  return Accounts.emailToken && Accounts.emailToken.isEnabled();
 };
 
 dropdown = function () {

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -49,6 +49,7 @@ getLoginServices = function () {
   // First look for OAuth services.
   var services = (Accounts.oauth && Accounts.oauth.serviceNames) ? Accounts.oauth.serviceNames() : [];
 
+  services = _.without(services, "emailToken");
   // Be equally kind to all login services. This also preserves
   // backwards-compatibility. (But maybe order should be
   // configurable?)
@@ -56,7 +57,7 @@ getLoginServices = function () {
 
   // Add password, if it's there; it must come last.
   if (hasPasswordService())
-    services.push('password');
+    services.push('emailToken');
 
   return _.map(services, function(name) {
     return {name: name};
@@ -64,7 +65,7 @@ getLoginServices = function () {
 };
 
 hasPasswordService = function () {
-  return !!Package['accounts-password'];
+  return Accounts.isEmailTokenLoginEnabled && Accounts.isEmailTokenLoginEnabled();
 };
 
 dropdown = function () {

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -56,7 +56,7 @@ getLoginServices = function () {
   services.sort();
 
   // Add password, if it's there; it must come last.
-  if (hasPasswordService())
+  if (hasEmailTokenService())
     services.push('emailToken');
 
   return _.map(services, function(name) {
@@ -64,12 +64,12 @@ getLoginServices = function () {
   });
 };
 
-hasPasswordService = function () {
+hasEmailTokenService = function () {
   return Accounts.emailToken && Accounts.emailToken.isEnabled();
 };
 
 dropdown = function () {
-  return hasPasswordService() || getLoginServices().length > 1;
+  return hasEmailTokenService() || getLoginServices().length > 1;
 };
 
 // XXX improve these. should this be in accounts-password instead?

--- a/shell/packages/sandstorm-accounts-ui/login_buttons_dropdown.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons_dropdown.html
@@ -80,7 +80,7 @@
     {{/if}}
   {{/each}}
 
-  {{#unless hasPasswordService}}
+  {{#unless hasEmailTokenService}}
     {{> _loginButtonsMessages}}
   {{/unless}}
 </template>
@@ -101,11 +101,11 @@
 
       {{#if inSignupFlow}}
       <div class="login-button login-button-form-submit" id="login-buttons-token">
-        Enter token from email
+        Log in
       </div>
       {{else}}
       <div class="login-button login-button-form-submit" id="login-buttons-email">
-        Send login token to email
+        Send Login Email
       </div>
       {{/if}}
 

--- a/shell/packages/sandstorm-accounts-ui/login_buttons_dropdown.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons_dropdown.html
@@ -94,43 +94,23 @@
 </template>
 
 <template name="_loginButtonsLoggedOutPasswordService">
-  {{#if inForgotPasswordFlow}}
-    {{> _forgotPasswordForm}}
-  {{else}}
     <div class="login-form login-password-form">
       {{#each fields}}
         {{> _loginButtonsFormField}}
       {{/each}}
 
-      {{> _loginButtonsMessages}}
-
-      <div class="login-button login-button-form-submit" id="login-buttons-password">
-        {{#if inSignupFlow}}
-          Create account
-        {{else}}
-          Sign in
-        {{/if}}
-      </div>
-
-      {{#if inLoginFlow}}
-        {{#if showCreateAccountLink}}
-          <div class="additional-link-container">
-            <a id="signup-link" class="additional-link">Create account</a>
-          </div>
-        {{/if}}
-
-        {{#if showForgotPasswordLink}}
-          <div class="additional-link-container">
-            <a id="forgot-password-link" class="additional-link">Forgot password</a>
-          </div>
-        {{/if}}
-      {{/if}}
-
       {{#if inSignupFlow}}
-        {{> _loginButtonsBackToLoginLink}}
+      <div class="login-button login-button-form-submit" id="login-buttons-token">
+        Enter token from email
+      </div>
+      {{else}}
+      <div class="login-button login-button-form-submit" id="login-buttons-email">
+        Send login token to email
+      </div>
       {{/if}}
+
+      {{> _loginButtonsMessages}}
     </div>
-  {{/if}}
 </template>
 
 <template name="_forgotPasswordForm">

--- a/shell/packages/sandstorm-accounts-ui/login_buttons_dropdown.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons_dropdown.js
@@ -88,7 +88,7 @@ Template._loginButtonsLoggedOutDropdown.events({
 Template._loginButtonsLoggedOutDropdown.helpers({
   // additional classes that can be helpful in styling the dropdown
   additionalClasses: function () {
-    if (!hasPasswordService()) {
+    if (!hasEmailTokenService()) {
       return false;
     } else {
       if (loginButtonsSession.get('inSignupFlow')) {
@@ -105,7 +105,7 @@ Template._loginButtonsLoggedOutDropdown.helpers({
     return loginButtonsSession.get('dropdownVisible');
   },
 
-  hasPasswordService: hasPasswordService
+  hasEmailTokenService: hasEmailTokenService
 });
 
 // return all login services, with password last
@@ -120,7 +120,7 @@ Template._loginButtonsLoggedOutAllServices.helpers({
     return getLoginServices().length > 1;
   },
 
-  hasPasswordService: hasPasswordService
+  hasEmailTokenService: hasEmailTokenService
 });
 
 Template._loginButtonsLoggedOutPasswordService.helpers({
@@ -133,7 +133,7 @@ Template._loginButtonsLoggedOutPasswordService.helpers({
     ];
 
     var signupFields = [
-      {fieldName: 'token', fieldLabel: 'Token', inputType: 'email',
+      {fieldName: 'token', fieldLabel: 'Enter authentication code from email', inputType: 'email',
        visible: function () {
          return true;
        }}

--- a/shell/packages/sandstorm-accounts-ui/login_buttons_session.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons_session.js
@@ -19,7 +19,8 @@ var VALID_KEYS = [
   'configureLoginServiceDialogVisible',
   'configureLoginServiceDialogServiceName',
   'configureLoginServiceDialogSaveDisabled',
-  'configureOnDesktopVisible'
+  'configureOnDesktopVisible',
+  'email'
 ];
 
 var validateKey = function (key) {

--- a/shell/packages/sandstorm-accounts-ui/login_buttons_session.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons_session.js
@@ -19,8 +19,7 @@ var VALID_KEYS = [
   'configureLoginServiceDialogVisible',
   'configureLoginServiceDialogServiceName',
   'configureLoginServiceDialogSaveDisabled',
-  'configureOnDesktopVisible',
-  'email'
+  'configureOnDesktopVisible'
 ];
 
 var validateKey = function (key) {
@@ -53,7 +52,6 @@ Accounts._loginButtonsSession = {
   },
 
   closeDropdown: function () {
-    this.set('inSignupFlow', false);
     this.set('inForgotPasswordFlow', false);
     this.set('inChangePasswordFlow', false);
     this.set('inMessageOnlyFlow', false);

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -683,6 +683,8 @@ function Proxy(grainId, sessionId, preferredHostId, isOwner, user, userInfo, isA
       serviceId = "google:" + user.services.google.id;
     } else if (user.services && user.services.github) {
       serviceId = "github:" + user.services.github.id;
+    } else if (user.services && user.services.emailToken) {
+      serviceId = "emailToken:" + user.services.emailToken.email;
     } else {
       // Make sure that if we add a new user type we don't forget to update this.
       throw new Meteor.Error(500, "Unknown user type.");

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -40,6 +40,7 @@ Router.map(function () {
       });
       state.set("successes", 0);
       state.set("failures", 0);
+      state.set("errors", []);
       this.render();
     }
   });
@@ -81,6 +82,9 @@ if (Meteor.isClient) {
     if (err) {
       this.set("failures", this.get("failures") + 1);
       console.error(err);
+      var errors = this.get("errors");
+      errors.push(err);
+      this.set("errors", errors);
     } else {
       this.set("successes", this.get("successes") + 1);
     }
@@ -91,7 +95,13 @@ if (Meteor.isClient) {
       var state = Iron.controller().state;
       state.set("successes", 0);
       state.set("failures", 0);
+      state.set("errors", []);
       var handleErrorBound = handleError.bind(state);
+      if (event.target.emailTokenLogin.checked && !event.target.smtpUrl.value) {
+        handleErrorBound(new Meteor.Error(400, "Bad Request", "Trying to enable Passwordless " +
+          "email login while SMTP url is invalid."));
+        return false;
+      }
       Meteor.call("setAccountSetting", "google", event.target.googleLogin.checked, handleErrorBound);
       Meteor.call("setAccountSetting", "github", event.target.githubLogin.checked, handleErrorBound);
       Meteor.call("setAccountSetting", "emailToken", event.target.emailTokenLogin.checked, handleErrorBound);
@@ -134,6 +144,9 @@ if (Meteor.isClient) {
     },
     failure: function () {
       return Iron.controller().state.get("failures");
+    },
+    errors: function () {
+      return Iron.controller().state.get("errors");
     }
   });
 }


### PR DESCRIPTION
This is an alternate login system, based loosely on accounts-password.

Users input their email, and the server sends a message to that address
containing a token. The user either clicks a link out of that email or
manually copies the token into an input box, and then they are logged
in. This package (accounts-email-token), was intended to be generic
enough to be used outside Sandstorm, and may at some point be moved out
and put onto atmosphere.

On the Sandstorm side, the only things that needed to chage were the
admin page, and the accounts-ui. It's a bit of a mess since we're
building on top of meteor's accounts-ui that has a bunch of custom logic
for accounts-password that I tried to re-use as much as possible.