### PR TITLE
Fix typo in install script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -485,8 +485,8 @@ else
   fi
 
   if [ "yes" = "$SANDCATS_SUCCESSFUL" ] ; then
-    # Do not prompt for WILDCARD_URL; simply use default.
-    WILDCARD_URL="$DEFAULT_WILDCARD"
+    # Do not prompt for WILDCARD_HOST; simply use default.
+    WILDCARD_HOST="$DEFAULT_WILDCARD"
   else
     echo "Sandstorm requires you to set up a wildcard DNS entry pointing at the server."
     echo "This allows Sandstorm to allocate new hosts on-the-fly for sandboxing purposes."


### PR DESCRIPTION
Script usage results:
```
root@sandstorm:/tmp# bash install.sh -c
install.sh: line 297: cc: command not found
WARNING: Couldn't compile user namespace test. We'll assume user namespaces
  are enabled.
Where would you like to put Sandstorm? [/opt/sandstorm] 
As a Sandstorm user, you are invited to use a free Internet hostname as a subdomain of sandcats.io.
Choose your desired Sandcats subdomain (alphanumeric, max 20 characters).
Type the word none to skip this step.
What *.sandcats.io subdomain would you like? [] doctaphred
We need your email on file so we can help you recover your domain if you lose access. No spam.
Enter your email address: [] doctaphred@gmail.com
Registering...
Successfully registered!
Congratulations! We have registered your doctaphred.sandcats.io name.
Your credentials to use it are in /opt/sandstorm/var/sandcats; consider making a backup.
Local user account to run server under: [sandstorm] 
User account 'sandstorm' doesn't exist. Create it? [yes] 
Note: Sandstorm's storage will only be accessible to the group 'sandstorm'.
Server main HTTP port: [6080] 
Database port (choose any unused port): [6081] 
If you want to be able to send e-mail invites and password reset messages, 
enter a mail server URL of the form 'smtp://user:pass@host:port'.  Leave 
blank if you don't care about these features.
Mail URL: [] 
Automatically keep Sandstorm updated? [yes] 
install.sh: line 390: WILDCARD_HOST: unbound variable
```