### PR TITLE
Begin implementing a separate 'back-end' process responsible for managin...

### DIFF
--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -150,7 +150,11 @@ cp /usr/share/locale/locale.alias bundle/usr/share/locale
 strip bundle/sandstorm bundle/bin/*
 find bundle -name '*.so' | xargs strip
 
-git rev-parse HEAD > bundle/git-revision
+if [ -e .git ]; then
+  git rev-parse HEAD > bundle/git-revision
+else
+  echo "unknown" > bundle/git-revision
+fi
 echo "$USER@$HOSTNAME $(date)" > bundle/buildstamp
 
 cat > bundle/README.md << '__EOF__'

--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -93,7 +93,6 @@ rm -f bundle/README
 mkdir -p bundle/bin
 ln -s ../sandstorm bundle/bin/spk
 ln -s ../sandstorm bundle/bin/minibox
-ln -s ../sandstorm bundle/bin/sandstorm-supervisor
 cp bin/sandstorm-http-bridge bundle/bin/sandstorm-http-bridge
 cp bin/sandstorm bundle/sandstorm
 cp $METEOR_DEV_BUNDLE/bin/node bundle/bin

--- a/shell/server/backup.js
+++ b/shell/server/backup.js
@@ -31,6 +31,18 @@ var mkdir = Meteor.wrapAsync(Fs.mkdir),
     readFile = Meteor.wrapAsync(Fs.readFile),
     writeFile = Meteor.wrapAsync(Fs.writeFile);
 
+function recursiveRmdir(dir) {
+  Fs.readdirSync(dir).forEach(function (filename) {
+    filename = Path.join(dir, filename);
+    if(Fs.lstatSync(filename).isDirectory()) {
+      recursiveRmdir(filename);
+    } else {
+      Fs.unlinkSync(filename);
+    }
+  });
+  Fs.rmdirSync(dir);
+};
+
 function recursiveRmdirIfExists(dir) {
   if (Fs.existsSync(dir)) {
     if (Fs.lstatSync(dir).isDirectory()) {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1353,7 +1353,9 @@ function WebSocketReceiver(socket) {
 function pumpWebSocket(socket, rpcStream) {
   socket.on("data", function (chunk) {
     rpcStream.sendBytes(chunk).catch(function (err) {
-      console.error("WebSocket sendBytes failed: " + err.stack);
+      if (err.type !== "disconnected") {
+        console.error("WebSocket sendBytes failed: " + err.stack);
+      }
       socket.destroy();
     });
   });

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -284,7 +284,7 @@ function startGrainInternal(packageId, grainId, ownerId, command, isNew, isDev) 
       .then(function (results) {
     return {
       owner: ownerId,
-      supervisor: results.grain
+      supervisor: results.supervisor
     };
   });
 
@@ -297,7 +297,7 @@ shutdownGrain = function (grainId, ownerId, keepSessions) {
     Sessions.remove({grainId: grainId});
   }
 
-  var grain = sandstormBackend.getGrain(ownerId, grainId).grain;
+  var grain = sandstormBackend.getGrain(ownerId, grainId).supervisor;
   return grain.shutdown().then(function () {
     grain.close();
     throw new Error("expected shutdown() to throw disconnected");
@@ -711,7 +711,7 @@ function Proxy(grainId, ownerId, sessionId, preferredHostId, isOwner, user, user
 
 Proxy.prototype.getConnection = function () {
   if (!this.supervisor) {
-    this.supervisor = sandstormBackend.getGrain(this.ownerId, this.grainId).grain;
+    this.supervisor = sandstormBackend.getGrain(this.ownerId, this.grainId).supervisor;
     this.uiView = null;
   }
   if (!this.uiView) {
@@ -1450,7 +1450,7 @@ Meteor.publish("grainLog", function (grainId) {
   try {
     // Wait for watchLog() to return because it will always write the initial tail before
     // returning.
-    var supervisor = sandstormBackend.getGrain(grain.userId, grainId).grain;
+    var supervisor = sandstormBackend.getGrain(grain.userId, grainId).supervisor;
     var handle = waitPromise(supervisor.watchLog(8192, receiver)).handle;
     connected = true;
     this.onStop(function() {

--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -57,7 +57,7 @@ if (Meteor.isServer) {
         if (grain.lastUsed) {
           DeleteStats.insert({type: "grain", lastActive: grain.lastUsed});
         }
-        deleteGrain(grain._id);
+        deleteGrain(grain._id, grain.userId);
       });
       console.log("delete user: " + user._id);
       Meteor.users.remove(user._id);

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -121,7 +121,7 @@ Meteor.methods({
           DeleteStats.insert({type: "grain", lastActive: grain.lastUsed});
         }
         if (!this.isSimulation) {
-          deleteGrain(grainId, this.userId);
+          waitPromise(deleteGrain(grainId, this.userId));
           Meteor.call("deleteUnusedPackages", grain.appId);
         }
       }

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -75,7 +75,11 @@ if (Meteor.isServer) {
         }
       }, function (err) {
         if (!stopped) {
-          self.error(err);
+          if (err.type === "disconnected") {
+            self.stop();
+          } else {
+            self.error(err);
+          }
         }
       });
     }
@@ -88,7 +92,11 @@ if (Meteor.isServer) {
       }
     }, function (err) {
       if (!stopped) {
-        self.error(err);
+        if (err.type === "disconnected") {
+          self.stop();
+        } else {
+          self.error(err);
+        }
       }
     });
 

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -121,7 +121,7 @@ Meteor.methods({
           DeleteStats.insert({type: "grain", lastActive: grain.lastUsed});
         }
         if (!this.isSimulation) {
-          deleteGrain(grainId);
+          deleteGrain(grainId, this.userId);
           Meteor.call("deleteUnusedPackages", grain.appId);
         }
       }
@@ -496,8 +496,9 @@ Router.map(function () {
     data: function () {
       if (this.ready()) {
         maybeScrollLog();
+        var grain = Grains.findOne(this.params.grainId);
         return {
-          title: Grains.findOne(this.params.grainId).title,
+          title: grain ? grain.title : "(deleted grain)",
           html: AnsiUp.ansi_to_html(GrainLog.find({}, {$sort: {_id: 1}})
               .map(function (entry) { return entry.text; })
               .join(""), {use_classes:true})

--- a/shell/shared/install.js
+++ b/shell/shared/install.js
@@ -146,7 +146,7 @@ Meteor.methods({
 
     if (!this.isSimulation) {
       Grains.find(selector).forEach(function (grain) {
-        shutdownGrain(grain._id);
+        shutdownGrain(grain._id, grain.userId);
       });
     }
 

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -212,6 +212,7 @@ if (Meteor.isClient) {
     Meteor.call("newGrain", packageId, command, title, function (error, grainId) {
       if (error) {
         console.error(error);
+        alert(error.message);
       } else {
         Router.go("grain", {grainId: grainId});
       }

--- a/src/sandstorm/backend.c++
+++ b/src/sandstorm/backend.c++
@@ -199,7 +199,7 @@ kj::Promise<void> BackendImpl::startGrain(StartGrainContext context) {
                    validateId(params.getPackageId()), params.getCommand(),
                    params.getIsNew(), params.getDevMode(), false)
       .then([context](Supervisor::Client client) mutable {
-    context.getResults().setGrain(kj::mv(client));
+    context.getResults().setSupervisor(kj::mv(client));
   });
 }
 
@@ -208,7 +208,7 @@ kj::Promise<void> BackendImpl::getGrain(GetGrainContext context) {
   if (iter != supervisors.end()) {
     return iter->second.promise.addBranch()
         .then([context](Supervisor::Client client) mutable {
-      context.getResults().setGrain(kj::mv(client));
+      context.getResults().setSupervisor(kj::mv(client));
     });
   }
 

--- a/src/sandstorm/backend.c++
+++ b/src/sandstorm/backend.c++
@@ -166,17 +166,13 @@ kj::Promise<kj::String> BackendImpl::readAll(kj::AsyncInputStream& input, kj::Ve
 BackendImpl::RunningGrain::RunningGrain(
     BackendImpl& backend, kj::String grainId, kj::Own<kj::AsyncIoStream> stream)
     : backend(backend), grainId(kj::mv(grainId)),
-      stream(kj::mv(stream)), client(*this->stream) {
-  KJ_DBG("RunningGrain()");
-}
+      stream(kj::mv(stream)), client(*this->stream) {}
 
 BackendImpl::RunningGrain::~RunningGrain() noexcept(false) {
-  KJ_DBG("~RunningGrain()");
   backend.supervisors.erase(grainId);
 }
 
 kj::Promise<void> BackendImpl::startGrain(StartGrainContext context) {
-  KJ_DBG("startGrain");
   auto params = context.getParams();
   return bootGrain(params.getGrainId(), params.getPackageId(), params.getCommand(),
                    params.getIsNew(), params.getDevMode(), false)

--- a/src/sandstorm/backend.c++
+++ b/src/sandstorm/backend.c++
@@ -1,0 +1,218 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "backend.h"
+#include <kj/debug.h>
+#include "util.h"
+
+namespace sandstorm {
+
+BackendImpl::BackendImpl(kj::LowLevelAsyncIoProvider& ioProvider, kj::Network& network)
+    : ioProvider(ioProvider), network(network), tasks(*this) {}
+
+void BackendImpl::taskFailed(kj::Exception&& exception) {
+  KJ_LOG(ERROR, exception);
+}
+
+// =======================================================================================
+
+kj::Promise<Supervisor::Client> BackendImpl::bootGrain(
+    kj::StringPtr grainId, kj::StringPtr packageId,
+    spk::Manifest::Command::Reader command, bool isNew, bool devMode, bool isRetry) {
+  auto iter = supervisors.find(grainId);
+  if (iter != supervisors.end()) {
+    KJ_REQUIRE(!isNew, "new grain matched existing grainId");
+
+    // Supervisor for this grain is already running. Join that.
+    return iter->second.promise.addBranch()
+        .then([=](Supervisor::Client&& client) mutable {
+      // We should send a keepAlive() to make sure the supervisor is still up.
+      auto promise = client.keepAliveRequest().send();
+      return promise.then([KJ_MVCAP(client)](auto) mutable -> kj::Promise<Supervisor::Client> {
+        // Success.
+        return kj::mv(client);
+      }, [=](kj::Exception&& exception) mutable -> kj::Promise<Supervisor::Client> {
+        // Exception?
+        if (exception.getType() == kj::Exception::Type::DISCONNECTED) {
+          // Oops, disconnected. onDisconnect() should have already fired causing the RunningGrain
+          // to unregister itself. Give it an extra turn using evalLater() just in case, then
+          // re-run.
+          KJ_ASSERT(!isRetry, "retry supervisor startup logic failed");
+          return kj::evalLater([=]() mutable {
+            return bootGrain(grainId, packageId, command, isNew, devMode, true);
+          });
+        } else {
+          return kj::mv(exception);
+        }
+      });
+    });
+  }
+
+  // Grain is not currently running, so let's start it.
+  kj::Own<kj::AsyncInputStream> stdoutPipe;
+  {
+    kj::Vector<kj::String> argv;
+
+    argv.add(kj::heapString("supervisor"));
+
+    if (isNew) {
+      argv.add(kj::heapString("-n"));
+    }
+
+    if (devMode) {
+      argv.add(kj::heapString("--dev"));
+    }
+
+    for (auto env: command.getEnviron()) {
+      argv.add(kj::str("-e", env.getKey(), "=", env.getValue()));
+    }
+
+    argv.add(kj::heapString(packageId));
+    argv.add(kj::heapString(grainId));
+
+    argv.add(kj::heapString("--"));
+
+    if (command.hasDeprecatedExecutablePath()) {
+      argv.add(kj::heapString(command.getDeprecatedExecutablePath()));
+    }
+    for (auto arg: command.getArgv()) {
+      argv.add(kj::heapString(arg));
+    }
+
+    Subprocess::Options options(KJ_MAP(a, argv) -> const kj::StringPtr { return a; });
+    options.executable = "/sandstorm";
+
+    int pipefds[2];
+    KJ_SYSCALL(pipe2(pipefds, O_CLOEXEC));
+    kj::AutoCloseFd stdoutOut(pipefds[1]);
+    stdoutPipe = ioProvider.wrapInputFd(pipefds[0],
+        kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP |
+        kj::LowLevelAsyncIoProvider::ALREADY_CLOEXEC);
+    options.stdout = stdoutOut;
+    Subprocess(kj::mv(options)).detach();
+  }
+
+  // Wait until supervisor prints something on stdout, indicating that it is ready.
+  static byte dummy[256];
+  auto promise = stdoutPipe->read(dummy, 1, sizeof(dummy));
+
+  // Meanwhile parse the socket address.
+  auto addressPromise =
+      network.parseAddress(kj::str("unix:/var/sandstorm/grains/", grainId, "/socket"));
+
+  // When both of those are done, connect to the address.
+  auto finalPromise = promise
+      .then([this,KJ_MVCAP(addressPromise)](size_t n) mutable {
+    return kj::mv(addressPromise);
+  }).then([](kj::Own<kj::NetworkAddress>&& address) {
+    return address->connect();
+  }).then([this,KJ_MVCAP(stdoutPipe),grainId = kj::heapString(grainId)]
+          (kj::Own<kj::AsyncIoStream>&& connection) mutable {
+    // Connected. Create the RunningGrain and fulfill promises.
+    auto ignorePromise = ignoreAll(*stdoutPipe);
+    tasks.add(ignorePromise.attach(kj::mv(stdoutPipe)));
+
+    auto grain = kj::heap<RunningGrain>(*this, kj::mv(grainId), kj::mv(connection));
+    auto client = grain->getSupervisor();
+    tasks.add(grain->onDisconnect().attach(kj::mv(grain)));
+    return client;
+  }).fork();
+
+  // Add the promise to our map.
+  StartingGrain startingGrain = {
+    kj::heapString(grainId),
+    kj::mv(finalPromise)
+  };
+  kj::StringPtr grainIdPtr = startingGrain.grainId;
+  auto result = startingGrain.promise.addBranch();
+  KJ_ASSERT(supervisors.insert(std::make_pair(grainIdPtr, kj::mv(startingGrain))).second);
+
+  return result;
+}
+
+kj::Promise<void> BackendImpl::ignoreAll(kj::AsyncInputStream& input) {
+  static byte dummy[256];
+  return input.read(dummy, sizeof(dummy)).then([&input]() { ignoreAll(input); });
+}
+
+BackendImpl::RunningGrain::RunningGrain(
+    BackendImpl& backend, kj::String grainId, kj::Own<kj::AsyncIoStream> stream)
+    : backend(backend), grainId(kj::mv(grainId)),
+      stream(kj::mv(stream)), client(*this->stream) {
+  KJ_DBG("RunningGrain()");
+}
+
+BackendImpl::RunningGrain::~RunningGrain() noexcept(false) {
+  KJ_DBG("~RunningGrain()");
+  backend.supervisors.erase(grainId);
+}
+
+kj::Promise<void> BackendImpl::startGrain(StartGrainContext context) {
+  KJ_DBG("startGrain");
+  auto params = context.getParams();
+  return bootGrain(params.getGrainId(), params.getPackageId(), params.getCommand(),
+                   params.getIsNew(), params.getDevMode(), false)
+      .then([context](Supervisor::Client client) mutable {
+    context.getResults().setGrain(kj::mv(client));
+  });
+}
+
+kj::Promise<void> BackendImpl::getGrain(GetGrainContext context) {
+  auto iter = supervisors.find(context.getParams().getGrainId());
+  if (iter != supervisors.end()) {
+    return iter->second.promise.addBranch()
+        .then([context](Supervisor::Client client) mutable {
+      context.getResults().setGrain(kj::mv(client));
+    });
+  }
+
+  return KJ_EXCEPTION(DISCONNECTED, "grain is not running");
+}
+
+kj::Promise<void> BackendImpl::deleteGrain(DeleteGrainContext context) {
+  auto grainId = context.getParams().getGrainId();
+  auto iter = supervisors.find(grainId);
+  kj::Promise<void> shutdownPromise = nullptr;
+  if (iter != supervisors.end()) {
+    shutdownPromise = iter->second.promise.addBranch()
+        .then([context](Supervisor::Client client) mutable {
+      return client.shutdownRequest().send().then([](auto) {});
+    }).then([]() -> kj::Promise<void> {
+      return KJ_EXCEPTION(FAILED, "expected shutdown() to throw disconnected exception");
+    }, [](kj::Exception&& e) -> kj::Promise<void> {
+      if (e.getType() == kj::Exception::Type::DISCONNECTED) {
+        return kj::READY_NOW;
+      } else {
+        return kj::mv(e);
+      }
+    });
+  } else {
+    shutdownPromise = kj::READY_NOW;
+  }
+
+  return shutdownPromise.then([grainId]() {
+    recursivelyDelete(kj::str("/var/sandstorm/grains/", grainId));
+  });
+}
+
+// =======================================================================================
+
+kj::Promise<void> BackendImpl::installPackage(InstallPackageContext context)  {
+  return KJ_EXCEPTION(UNIMPLEMENTED);
+}
+
+} // namespace sandstorm
+

--- a/src/sandstorm/backend.c++
+++ b/src/sandstorm/backend.c++
@@ -166,7 +166,14 @@ kj::Promise<Supervisor::Client> BackendImpl::bootGrain(
 
 kj::Promise<void> BackendImpl::ignoreAll(kj::AsyncInputStream& input) {
   static byte dummy[256];
-  return input.read(dummy, sizeof(dummy)).then([&input]() { ignoreAll(input); });
+  return input.tryRead(dummy, sizeof(dummy), sizeof(dummy))
+      .then([&input](size_t n) -> kj::Promise<void> {
+    if (n < sizeof(dummy)) {
+      return kj::READY_NOW;
+    } else {
+      return ignoreAll(input);
+    }
+  });
 }
 
 kj::Promise<kj::String> BackendImpl::readAll(kj::AsyncInputStream& input, kj::Vector<char> soFar) {

--- a/src/sandstorm/backend.capnp
+++ b/src/sandstorm/backend.capnp
@@ -46,10 +46,16 @@ interface Backend {
     saveAs @0 (packageId :Text) -> (appId :Text, manifest :Package.Manifest);
   }
 
-  backupGrain @4 (ownerId :Text, grainId :Text, info :GrainInfo, stream :Util.ByteStream);
+  getPackage @4 (packageId :Text) -> (appId :Text, manifest :Package.Manifest);
+  # Get info from an already-installed package.
+
+  deletePackage @5 (packageId :Text);
+  # Delete a package from disk. Succeeds silently if the package doesn't exist.
+
+  backupGrain @6 (ownerId :Text, grainId :Text, info :GrainInfo, stream :Util.ByteStream);
   # Makes a .zip of the contents of the given grain and writes the content to `stream`.
 
-  restoreGrain @5 (ownerId :Text, grainId :Text) -> (stream :GrainUploadStream);
+  restoreGrain @7 (ownerId :Text, grainId :Text) -> (stream :GrainUploadStream);
   # Upload a .zip created with backupGrain() and unpack it into a new grain.
 
   interface GrainUploadStream extends(Util.ByteStream) {

--- a/src/sandstorm/backend.capnp
+++ b/src/sandstorm/backend.capnp
@@ -1,0 +1,58 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xdcbc0d702b1b47a5;
+
+$import "/capnp/c++.capnp".namespace("sandstorm");
+
+using Util = import "util.capnp";
+using Package = import "package.capnp";
+using Supervisor = import "supervisor.capnp".Supervisor;
+using GrainInfo = import "grain.capnp".GrainInfo;
+
+interface Backend {
+  # Interface that thet Sandstorm front-end uses to talk to the "back end", i.e. the container
+  # scheduler. While Sandstorm is running, the backend interface is exported as a socket at
+  # "/var/sandstorm/socket/backend".
+
+  const socketPath :Text = "/var/sandstorm/socket/backend";
+
+  startGrain @0 (ownerId :Text, grainId :Text, packageId :Text,
+                 command :Package.Manifest.Command, isNew :Bool, devMode :Bool = false)
+             -> (grain :Supervisor);
+  # Start a grain.
+
+  getGrain @1 (ownerId :Text, grainId :Text) -> (grain :Supervisor);
+  # Get the grain if it's running, or throw a DISCONNECTED exception otherwise.
+
+  deleteGrain @2 (ownerId :Text, grainId :Text);
+  # Delete a grain from disk. Succeeds silently if the grain doesn't exist.
+
+  installPackage @3 () -> (stream :PackageUploadStream);
+  interface PackageUploadStream extends(Util.ByteStream) {
+    saveAs @0 (packageId :Text) -> (appId :Text, manifest :Package.Manifest);
+  }
+
+  backupGrain @4 (ownerId :Text, grainId :Text, info :GrainInfo, stream :Util.ByteStream);
+  # Makes a .zip of the contents of the given grain and writes the content to `stream`.
+
+  restoreGrain @5 (ownerId :Text, grainId :Text) -> (stream :GrainUploadStream);
+  # Upload a .zip created with backupGrain() and unpack it into a new grain.
+
+  interface GrainUploadStream extends(Util.ByteStream) {
+    getInfo @0 () -> (info :GrainInfo);
+  }
+}

--- a/src/sandstorm/backend.capnp
+++ b/src/sandstorm/backend.capnp
@@ -32,10 +32,10 @@ interface Backend {
 
   startGrain @0 (ownerId :Text, grainId :Text, packageId :Text,
                  command :Package.Manifest.Command, isNew :Bool, devMode :Bool = false)
-             -> (grain :Supervisor);
+             -> (supervisor :Supervisor);
   # Start a grain.
 
-  getGrain @1 (ownerId :Text, grainId :Text) -> (grain :Supervisor);
+  getGrain @1 (ownerId :Text, grainId :Text) -> (supervisor :Supervisor);
   # Get the grain if it's running, or throw a DISCONNECTED exception otherwise.
 
   deleteGrain @2 (ownerId :Text, grainId :Text);

--- a/src/sandstorm/backend.h
+++ b/src/sandstorm/backend.h
@@ -1,0 +1,80 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SANDSTORM_BACKEND_H_
+#define SANDSTORM_BACKEND_H_
+
+#include <sandstorm/backend.capnp.h>
+#include <map>
+#include <kj/async-io.h>
+#include <capnp/rpc-twoparty.h>
+#include <kj/one-of.h>
+
+namespace sandstorm {
+
+class BackendImpl: public Backend::Server, private kj::TaskSet::ErrorHandler {
+public:
+  BackendImpl(kj::LowLevelAsyncIoProvider& ioProvider, kj::Network& network);
+
+protected:
+  kj::Promise<void> startGrain(StartGrainContext context) override;
+  kj::Promise<void> getGrain(GetGrainContext context) override;
+  kj::Promise<void> deleteGrain(DeleteGrainContext context) override;
+  kj::Promise<void> installPackage(InstallPackageContext context) override;
+
+private:
+  kj::LowLevelAsyncIoProvider& ioProvider;
+  kj::Network& network;
+  kj::TaskSet tasks;
+
+  class RunningGrain {
+  public:
+    RunningGrain(BackendImpl& backend, kj::String grainId, kj::Own<kj::AsyncIoStream> stream);
+    ~RunningGrain() noexcept(false);
+
+    inline kj::StringPtr getGrainId() { return grainId; }
+    inline kj::Promise<void> onDisconnect() { return client.onDisconnect(); }
+
+    inline Supervisor::Client getSupervisor() {
+      return client.bootstrap().castAs<Supervisor>();
+    }
+
+  private:
+    BackendImpl& backend;
+    kj::String grainId;
+    kj::Own<kj::AsyncInputStream> stdout;
+    kj::Own<kj::AsyncIoStream> stream;
+    capnp::TwoPartyClient client;
+  };
+
+  struct StartingGrain {
+    kj::String grainId;
+    kj::ForkedPromise<Supervisor::Client> promise;
+  };
+
+  std::map<kj::StringPtr, StartingGrain> supervisors;
+
+  kj::Promise<Supervisor::Client> bootGrain(kj::StringPtr grainId, kj::StringPtr packageId,
+      spk::Manifest::Command::Reader command, bool isNew, bool devMode, bool isRetry);
+
+  static kj::Promise<void> ignoreAll(kj::AsyncInputStream& input);
+
+  void taskFailed(kj::Exception&& exception) override;
+};
+
+}  // namespace sandstorm
+
+#endif // SANDSTORM_BACKEND_H_

--- a/src/sandstorm/backend.h
+++ b/src/sandstorm/backend.h
@@ -22,6 +22,7 @@
 #include <kj/async-io.h>
 #include <capnp/rpc-twoparty.h>
 #include <kj/one-of.h>
+#include <kj/vector.h>
 
 namespace sandstorm {
 
@@ -67,10 +68,14 @@ private:
 
   std::map<kj::StringPtr, StartingGrain> supervisors;
 
+  class PackageUploadStreamImpl;
+
   kj::Promise<Supervisor::Client> bootGrain(kj::StringPtr grainId, kj::StringPtr packageId,
       spk::Manifest::Command::Reader command, bool isNew, bool devMode, bool isRetry);
 
   static kj::Promise<void> ignoreAll(kj::AsyncInputStream& input);
+  static kj::Promise<kj::String> readAll(kj::AsyncInputStream& input,
+      kj::Vector<char> soFar = kj::Vector<char>());
 
   void taskFailed(kj::Exception&& exception) override;
 };

--- a/src/sandstorm/backend.h
+++ b/src/sandstorm/backend.h
@@ -35,6 +35,8 @@ protected:
   kj::Promise<void> getGrain(GetGrainContext context) override;
   kj::Promise<void> deleteGrain(DeleteGrainContext context) override;
   kj::Promise<void> installPackage(InstallPackageContext context) override;
+  kj::Promise<void> getPackage(GetPackageContext context) override;
+  kj::Promise<void> deletePackage(DeletePackageContext context) override;
 
 private:
   kj::LowLevelAsyncIoProvider& ioProvider;

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1727,6 +1727,7 @@ private:
       inPipe = nullptr;
 
       kj::StringPtr socketPath = Backend::SOCKET_PATH;
+      sandstorm::recursivelyCreateParent(socketPath);
       unlink(socketPath.cStr());
 
       auto io = kj::setupAsyncIo();

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -37,6 +37,7 @@
 #include <sys/syscall.h>
 #include <sys/utsname.h>
 #include <sys/capability.h>
+#include <sys/eventfd.h>
 #include <linux/securebits.h>
 #include <sched.h>
 #include <grp.h>
@@ -56,6 +57,7 @@
 #include "util.h"
 #include "spk.h"
 #include "minibox.h"
+#include "backend.h"
 
 namespace sandstorm {
 
@@ -650,17 +652,6 @@ public:
                   .build();
             },
             "For internal use only.")
-        .addSubCommand("supervise",
-            [this]() {
-              return kj::MainBuilder(context, VERSION,
-                      "Run a sandstorm-supervisor process inside the server's namespace. This is "
-                      "mainly used to make it easier to run the front-end in dev mode.")
-                  .expectZeroOrMoreArgs("<supervisor-args>",
-                      KJ_BIND_METHOD(*this, addSuperviseArg))
-                  .callAfterParsing(KJ_BIND_METHOD(*this, supervise))
-                  .build();
-            },
-            "For internal use only.")
         .build();
   }
 
@@ -1029,54 +1020,6 @@ public:
     return true;
   }
 
-  kj::MainBuilder::Validity supervise() {
-    changeToInstallDir();
-
-    // Verify that Sandstorm is running.
-    if (getRunningPid() == nullptr) {
-      context.exitError("Sandstorm is not running.");
-    }
-
-    // Connect to the devmode socket. The server daemon listens on this socket for commands.
-    // See `runDevDaemon()`.
-    auto sock = connectToDevDaemon();
-
-    // Send the command code.
-    kj::FdOutputStream((int)sock).write(&DEVMODE_COMMAND_SUPERVISE, 1);
-
-    // Forward our standard I/O FDs.
-    sendFd(sock, STDIN_FILENO);
-    sendFd(sock, STDOUT_FILENO);
-    sendFd(sock, STDERR_FILENO);
-
-    // Send supervisor args.
-    kj::FdOutputStream((int)sock).write(superviseArgs.begin(), superviseArgs.size());
-
-    // Send EOF.
-    KJ_SYSCALL(shutdown(sock, SHUT_WR));
-
-    // Wait for exit status.
-    int status;
-    kj::FdInputStream((int)sock).read(&status, sizeof(status));
-
-    if (WIFEXITED(status)) {
-      _exit(WEXITSTATUS(status));
-    } else if (WIFSIGNALED(status)) {
-      // Try to kill ourself with the same signal to emulate the same outcome.
-      KJ_SYSCALL(kill(getpid(), WTERMSIG(status)));
-      // Otherwise just report it.
-      context.exitError(kj::str("Supervisor terminated by signal: ", WTERMSIG(status)));
-    } else {
-      context.exitError("Supervisor terminated with status I didn't understand.");
-    }
-  }
-
-  kj::MainBuilder::Validity addSuperviseArg(kj::StringPtr arg) {
-    superviseArgs.addAll(arg);
-    superviseArgs.add('\0');
-    return true;
-  }
-
 private:
   kj::ProcessContext& context;
 
@@ -1100,8 +1043,6 @@ private:
 
   kj::String updateFile;
   kj::StringPtr devtoolsBindir = "/usr/local/bin";
-
-  kj::Vector<char> superviseArgs;
 
   bool changedDir = false;
   bool unsharedUidNamespace = false;
@@ -1564,6 +1505,10 @@ private:
 
     auto sigfd = prepareMonitoringLoop();
 
+    context.warning("** Starting back-end...");
+    pid_t backendPid = startBackend(config);
+    uint64_t backendStartTime = getTime();
+
     context.warning("** Starting MongoDB...");
     pid_t mongoPid = startMongo(config);
     int64_t mongoStartTime = getTime();
@@ -1571,7 +1516,7 @@ private:
     // Create the mongo user if it hasn't been created already.
     maybeCreateMongoUser(config);
 
-    context.warning("** Mongo started; now starting front-end...");
+    context.warning("** Back-end and Mongo started; now starting front-end...");
 
     // If we're root, run the dev daemon. At present the dev daemon requires root (in order to
     // use FUSE), so we don't run it if we aren't root.
@@ -1606,6 +1551,7 @@ private:
         // which is us.
 
         // Reap zombies until there are no more.
+        bool backendDied = false;
         bool mongoDied = false;
         bool nodeDied = false;
         for (;;) {
@@ -1614,6 +1560,8 @@ private:
           if (deadPid <= 0) {
             // No more zombies.
             break;
+          } else if (deadPid == backendPid) {
+            backendDied = true;
           } else if (deadPid == mongoPid) {
             mongoDied = true;
           } else if (deadPid == nodePid) {
@@ -1626,12 +1574,26 @@ private:
         }
 
         // Deal with mongo or node dying.
+        if (backendDied) {
+          maybeWaitAfterChildDeath("Back-end", backendStartTime);
+          backendPid = startBackend(config);
+          backendStartTime = getTime();
+        }
         if (mongoDied) {
           maybeWaitAfterChildDeath("MongoDB", mongoStartTime);
           mongoPid = startMongo(config);
           mongoStartTime = getTime();
-        } else if (nodeDied) {
+        }
+        if (nodeDied) {
           maybeWaitAfterChildDeath("Front-end", nodeStartTime);
+          nodePid = startNode(config);
+          nodeStartTime = getTime();
+        }
+
+        if (mongoDied && !nodeDied) {
+          // If the back-end died then we unfortunately need to restart node as well.
+          context.warning("** Restarting front-end due to back-end failure");
+          killChild("Front-end", nodePid);
           nodePid = startNode(config);
           nodeStartTime = getTime();
         }
@@ -1656,6 +1618,7 @@ private:
         context.warning("** Shutting down due to signal");
         killChild("Front-end", nodePid);
         killChild("MongoDB", mongoPid);
+        killChild("Back-end", backendPid);
         killChild("Dev daemon", devDaemonPid);
         context.exit();
       }
@@ -1663,9 +1626,7 @@ private:
   }
 
   pid_t startMongo(const Config& config) {
-    pid_t outerPid;
-    KJ_SYSCALL(outerPid = fork());
-    if (outerPid == 0) {
+    Subprocess process([&]() -> int {
       dropPrivs(config.uids);
       clearSignalMask();
 
@@ -1677,15 +1638,11 @@ private:
           "--replSet", "ssrs", "--oplogSize", "16",
           EXEC_END_ARGS));
       KJ_UNREACHABLE;
-    }
+    });
 
     // Wait for mongod to return, meaning the database is up.  Then get its real pid via the
     // pidfile.
-    int status;
-    KJ_SYSCALL(waitpid(outerPid, &status, 0));
-
-    KJ_ASSERT(WIFEXITED(status) && WEXITSTATUS(status) == 0,
-        "MongoDB failed on startup. Check var/log/mongo.log.");
+    process.waitForSuccess();
 
     // Even after the startup command exits, MongoDB takes exactly two seconds to elect itself as
     // master of the repl set (of which it is the only damned member). Unforutnately, if Node
@@ -1760,10 +1717,52 @@ private:
     }
   }
 
+  pid_t startBackend(const Config& config) {
+    int pipeFds[2];
+    KJ_SYSCALL(pipe2(pipeFds, O_CLOEXEC));
+    kj::AutoCloseFd inPipe(pipeFds[0]);
+    kj::AutoCloseFd outPipe(pipeFds[1]);
+
+    Subprocess process([&]() -> int {
+      inPipe = nullptr;
+
+      kj::StringPtr socketPath = Backend::SOCKET_PATH;
+      unlink(socketPath.cStr());
+
+      auto io = kj::setupAsyncIo();
+      auto& network = io.provider->getNetwork();
+      auto listener = network.parseAddress(kj::str("unix:", socketPath))
+          .wait(io.waitScope)->listen();
+
+      if (runningAsRoot) {
+        // Make socket available to server user.
+        KJ_SYSCALL(chmod(socketPath.cStr(), 0770));
+        KJ_SYSCALL(chown(socketPath.cStr(), 0, config.uids.gid));
+      }
+
+      dropPrivs(config.uids);
+      clearSignalMask();
+
+      capnp::TwoPartyServer server(kj::heap<BackendImpl>(*io.lowLevelProvider, network));
+
+      // Signal readiness.
+      write(outPipe, "ready", 5);
+      outPipe = nullptr;
+
+      server.listen(*listener).wait(io.waitScope);
+      KJ_UNREACHABLE;
+    });
+
+    outPipe = nullptr;
+    KJ_ASSERT(sandstorm::readAll(inPipe) == "ready", "starting back-end failed");
+
+    pid_t result = process.getPid();
+    process.detach();
+    return result;
+  }
+
   pid_t startNode(const Config& config) {
-    pid_t result;
-    KJ_SYSCALL(result = fork());
-    if (result == 0) {
+    Subprocess process([&]() -> int {
       dropPrivs(config.uids);
       clearSignalMask();
 
@@ -1825,8 +1824,10 @@ private:
           "}}").cStr(), true));
       KJ_SYSCALL(execl("/bin/node", "/bin/node", "main.js", EXEC_END_ARGS));
       KJ_UNREACHABLE;
-    }
+    });
 
+    pid_t result = process.getPid();
+    process.detach();
     return result;
   }
 
@@ -2156,69 +2157,11 @@ private:
   static constexpr kj::byte DEVMODE_COMMAND_CONNECT = 1;
   // Command code sent by `sandstorm dev` command, which is invoked by `spk dev`.
 
-  static constexpr kj::byte DEVMODE_COMMAND_GETNS = 2;
-  // Command code sent by sandstorm-supervisor when it needs to enter our namespace.
-  //
-  // TODO(cleanup): This constant is also defined in supervisor-main.c++. Share them.
-
-  static constexpr kj::byte DEVMODE_COMMAND_SUPERVISE = 3;
-  // Command code sent by `sandstorm supervise` command, which is invoked by the front-end when
-  // running in meteor dev mode (outside of the sandbox) in order to start an app. The front-end
-  // can't just invoke sandstorm-supervisor directly in this case since it's not in the proper
-  // namespace. This command must be followed by three file descriptors (to represent stdin,
-  // stdout, stderr), a series of NUL-terminated strings representing the arguments, and then
-  // EOF.
-
   [[noreturn]] void runDevSession(const Config& config, kj::AutoCloseFd internalFd) {
     auto exception = kj::runCatchingExceptions([&]() {
       // When someone connects, we expect them to pass us a one-byte command code.
       kj::byte commandCode;
       kj::FdInputStream((int)internalFd).read(&commandCode, 1);
-      if (commandCode == DEVMODE_COMMAND_GETNS) {
-        // Oh, they just want to know our namespace.
-        auto nsfd = raiiOpen("/proc/self/ns/mnt", O_RDONLY);
-        sendFd(internalFd, nsfd);
-        return;
-      } else if (commandCode == DEVMODE_COMMAND_SUPERVISE) {
-        // Oh, they want us to run a sandstorm-supervisor.
-
-        // Receive the standard FDs and dup2() them into place.
-        KJ_SYSCALL(dup2(receiveFd(internalFd), STDIN_FILENO));
-        KJ_SYSCALL(dup2(receiveFd(internalFd), STDOUT_FILENO));
-        KJ_SYSCALL(dup2(receiveFd(internalFd), STDERR_FILENO));
-
-        // Re-enable child reaping.
-        KJ_SYSCALL(signal(SIGCHLD, SIG_DFL));
-
-        // Supervisor should run unprivileged.
-        dropPrivs(config.uids);
-
-        // Compute args.
-        auto args = readAll(internalFd);
-        kj::StringPtr argsPtr = args;
-
-        kj::Vector<const char*> argv;
-        argv.add("/bin/sandstorm-supervisor");
-        while (argsPtr.size() > 0) {
-          argv.add(argsPtr.begin());
-          argsPtr = argsPtr.slice(KJ_ASSERT_NONNULL(
-              argsPtr.findFirst('\0'), "Invalid args pack; each arg must end with '\0'!") + 1);
-        }
-        argv.add(nullptr);
-
-        // Execute.
-        pid_t child;
-        KJ_SYSCALL(child = fork());
-        if (child == 0) {
-          KJ_SYSCALL(execv(argv[0], const_cast<char**>(argv.begin())));
-          KJ_UNREACHABLE;
-        } else {
-          int status;
-          KJ_SYSCALL(waitpid(child, &status, 0));
-          kj::FdOutputStream((int)internalFd).write(&status, sizeof(status));
-          _exit(0);
-        }
-      }
 
       KJ_REQUIRE(commandCode == DEVMODE_COMMAND_CONNECT);
       context.warning("** Accepted new dev session connection...");
@@ -2469,8 +2412,6 @@ private:
 };
 
 constexpr kj::byte RunBundleMain::DEVMODE_COMMAND_CONNECT;
-constexpr kj::byte RunBundleMain::DEVMODE_COMMAND_GETNS;
-constexpr kj::byte RunBundleMain::DEVMODE_COMMAND_SUPERVISE;
 
 }  // namespace sandstorm
 

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1405,13 +1405,17 @@ private:
 
     // Clean up the temp directory.
     KJ_REQUIRE(changedDir);
-    if (access("../tmp", F_OK) == 0) {
-      recursivelyDelete("../tmp");
-    }
-    mkdir("../tmp", 0770);
-    KJ_SYSCALL(chmod("../tmp", 0770));
-    if (runningAsRoot) {
-      KJ_SYSCALL(chown("../tmp", 0, config.uids.gid));
+
+    static const char* const TMPDIRS[2] = { "../tmp", "../var/sandstorm/tmp" };
+    for (const char* tmpDir: TMPDIRS) {
+      if (access(tmpDir, F_OK) == 0) {
+        recursivelyDelete(tmpDir);
+      }
+      mkdir(tmpDir, 0770);
+      KJ_SYSCALL(chmod(tmpDir, 0770 | S_ISVTX));
+      if (runningAsRoot) {
+        KJ_SYSCALL(chown(tmpDir, 0, config.uids.gid));
+      }
     }
 
     auto sigfd = prepareMonitoringLoop();

--- a/src/sandstorm/sandstorm.ekam-manifest
+++ b/src/sandstorm/sandstorm.ekam-manifest
@@ -9,3 +9,4 @@ package.capnp node_modules/sandstorm/package.capnp
 supervisor.capnp node_modules/sandstorm/supervisor.capnp
 util.capnp node_modules/sandstorm/util.capnp
 web-session.capnp node_modules/sandstorm/web-session.capnp
+backend.capnp node_modules/sandstorm/backend.capnp

--- a/src/sandstorm/spk.c++
+++ b/src/sandstorm/spk.c++
@@ -1315,14 +1315,17 @@ private:
     kj::AutoCloseFd ownFd;
     int spkfd;
 
+    kj::StringPtr tmpNear;
     if (spkfile == "-") {
       spkfd = STDIN_FILENO;
+      tmpNear = "/tmp/spk-unpack";
     } else {
       ownFd = raiiOpen(spkfile, O_RDONLY);
       spkfd = ownFd;
+      tmpNear = spkfile;
     }
 
-    printAppId(unpackImpl(spkfd, dirname, spkfile,
+    printAppId(unpackImpl(spkfd, dirname, tmpNear,
         [&](kj::StringPtr problem) -> kj::String {
       rmdir(dirname.cStr());
       validationError(spkfile, problem);

--- a/src/sandstorm/spk.c++
+++ b/src/sandstorm/spk.c++
@@ -1278,7 +1278,7 @@ private:
   }
 
   kj::MainBuilder::Validity setUnpackSpkfile(kj::StringPtr name) {
-    if (access(name.cStr(), F_OK) < 0) {
+    if (name != "-" && access(name.cStr(), F_OK) < 0) {
       return "Not found.";
     }
 
@@ -1304,14 +1304,27 @@ private:
   }
 
   kj::MainBuilder::Validity doUnpack() {
+    if (dirname == nullptr) {
+      return "must specify directory name when filename doesn't end with \".spk\"";
+    }
     if (access(dirname.cStr(), F_OK) == 0) {
-      return "Output directory already exists.";
+      return "output directory already exists";
     }
     KJ_SYSCALL(mkdir(dirname.cStr(), 0777), dirname);
 
-    auto spkfd = raiiOpen(spkfile, O_RDONLY);
+    kj::AutoCloseFd ownFd;
+    int spkfd;
+
+    if (spkfile == "-") {
+      spkfd = STDIN_FILENO;
+    } else {
+      ownFd = raiiOpen(spkfile, O_RDONLY);
+      spkfd = ownFd;
+    }
+
     printAppId(unpackImpl(spkfd, dirname, spkfile,
         [&](kj::StringPtr problem) -> kj::String {
+      rmdir(dirname.cStr());
       validationError(spkfile, problem);
     }));
 

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -50,6 +50,10 @@ interface Supervisor {
 
   drop @6 (ref :SupervisorObjectId);
   # Wraps `MainView.drop()`. Can also drop capabilities hosted by the supervisor.
+
+  watchLog @7 (backlogAmount :UInt64, stream :Util.ByteStream) -> (handle :Util.Handle);
+  # Write the last `backlogAmount` bytes of the grain's debug log to `stream`, and then watch the
+  # log for changes, writing them to `stream` as they happen, until `handle` is dropped.
 }
 
 interface SandstormCore {

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -30,6 +30,18 @@
 
 namespace sandstorm {
 
+Pipe Pipe::make() {
+  int fds[2];
+  KJ_SYSCALL(pipe2(fds, O_CLOEXEC));
+  return { kj::AutoCloseFd(fds[0]), kj::AutoCloseFd(fds[1]) };
+}
+
+Pipe Pipe::makeAsync() {
+  int fds[2];
+  KJ_SYSCALL(pipe2(fds, O_CLOEXEC | O_ASYNC));
+  return { kj::AutoCloseFd(fds[0]), kj::AutoCloseFd(fds[1]) };
+}
+
 kj::AutoCloseFd raiiOpen(kj::StringPtr name, int flags, mode_t mode) {
   int fd;
   KJ_SYSCALL(fd = open(name.cStr(), flags, mode), name);

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -145,7 +145,7 @@ kj::AutoCloseFd openTemporary(kj::StringPtr near) {
 
   int fd;
   auto name = kj::str(near, ".XXXXXX");
-  KJ_SYSCALL(fd = mkostemp(name.begin(), O_CLOEXEC));
+  KJ_SYSCALL(fd = mkostemp(name.begin(), O_CLOEXEC), name);
   kj::AutoCloseFd result(fd);
   KJ_SYSCALL(unlink(name.cStr()));
   return result;
@@ -602,7 +602,7 @@ kj::Array<byte> base64Decode(kj::StringPtr input) {
 // =======================================================================================
 
 Subprocess::Subprocess(Options&& options)
-    : name(kj::heapString(options.executable)) {
+    : name(kj::heapString(options.argv.size() > 0 ? options.argv[0] : options.executable)) {
   KJ_SYSCALL(pid = fork());
   if (pid == 0) {
     KJ_DEFER(_exit(1));  // Do not under any circumstances return from this stack frame!

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -227,6 +227,8 @@ void recursivelyCreateParent(kj::StringPtr path) {
       if (firstTry && error == ENOENT) {
         recursivelyCreateParent(parent);
         firstTry = false;
+      } else if (error == EEXIST) {
+        break;
       } else if (error != EINTR) {
         KJ_FAIL_SYSCALL("mkdir(parent)", error, parent);
       }

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -202,7 +202,7 @@ public:
     // An array of 'NAME=VALUE' pairs specifying the child's environment. If null, inherits the
     // parent's environment.
 
-    Options(kj::StringPtr executable): executable(executable), argv(&executable, 1) {}
+    Options(kj::StringPtr executable): executable(executable), argv(&this->executable, 1) {}
     Options(kj::ArrayPtr<const kj::StringPtr> argv): executable(argv[0]), argv(argv) {}
     Options(kj::Array<const kj::StringPtr>&& argv)
         : executable(argv[0]), argv(argv), ownArgv(kj::mv(argv)) {}

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -49,6 +49,14 @@ namespace sandstorm {
 typedef unsigned int uint;
 typedef unsigned char byte;
 
+struct Pipe {
+  kj::AutoCloseFd readEnd;
+  kj::AutoCloseFd writeEnd;
+
+  static Pipe make();
+  static Pipe makeAsync();
+};
+
 kj::AutoCloseFd raiiOpen(kj::StringPtr name, int flags, mode_t mode = 0666);
 kj::AutoCloseFd raiiOpenAt(int dirfd, kj::StringPtr name, int flags, mode_t mode = 0666);
 

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -129,6 +129,9 @@ void recursivelyDelete(kj::StringPtr path);
 // Since this may be used in KJ_DEFER to delete temporary directories, all exceptions are
 // recoverable (won't throw if already unwinding).
 
+void recursivelyCreateParent(kj::StringPtr path);
+// Create the parent directory of `path` if it doesn't exist, and the parent's parent, and so on.
+
 kj::String readAll(int fd);
 // Read entire contents of the file descirptor to a String.
 


### PR DESCRIPTION
...g non-mongo storage and app execution.

The front-end talks to the back-end process via RPC.

So far this change implements starting and deleting grains via the API. This has the pleasant side effect of simplifying the means by which a run-dev.sh frontend starts grains.

Future changes will make backup/restore and package installation go through the API as well.