### PR TITLE
Answer: yes, the subscriptions do get stopped when the user browses away.

### DIFF
--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -401,7 +401,6 @@ Router.map(function () {
     path: "/grain/:grainId/:path(.*)?",
 
     waitOn: function () {
-      // TODO(perf):  Do these subscriptions get stop()ed when the user browses away?
       return [
         Meteor.subscribe("grainTitle", this.params.grainId),
         Meteor.subscribe("devApps"),
@@ -494,7 +493,6 @@ Router.map(function () {
     layoutTemplate: "lightLayout",
 
     waitOn: function () {
-      // TODO(perf):  Do these subscriptions get stop()ed when the user browses away?
       return [
         Meteor.subscribe("grainTitle", this.params.grainId),
         Meteor.subscribe("grainLog", this.params.grainId)

--- a/shell/shared/install.js
+++ b/shell/shared/install.js
@@ -251,7 +251,6 @@ Router.map(function () {
     path: "/install/:packageId",
 
     waitOn: function () {
-      // TODO(perf):  Do these subscriptions get stop()ed when the user browses away?
       return [
         Meteor.subscribe("packageInfo", this.params.packageId),
         Meteor.subscribe("credentials"),
@@ -404,7 +403,6 @@ Router.map(function () {
     path: "/install",
 
     waitOn: function () {
-      // TODO(perf):  Do these subscriptions get stop()ed when the user browses away?
       return Meteor.subscribe("credentials");
     },
 

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -606,7 +606,6 @@ Router.map(function () {
     path: "/restore",
 
     waitOn: function () {
-      // TODO(perf):  Do these subscriptions get stop()ed when the user browses away?
       return Meteor.subscribe("credentials");
     },
 

--- a/shell/shared/signup.js
+++ b/shell/shared/signup.js
@@ -175,7 +175,6 @@ Router.map(function () {
     path: "/signup/:key",
 
     waitOn: function () {
-      // TODO(perf):  Do these subscriptions get stop()ed when the user browses away?
       return [
         Meteor.subscribe("signupKey", this.params.key),
         Meteor.subscribe("credentials")
@@ -204,7 +203,6 @@ Router.map(function () {
     path: "/invite",
 
     waitOn: function () {
-      // TODO(perf):  Do these subscriptions get stop()ed when the user browses away?
       return [
         Meteor.subscribe("credentials"),
         Meteor.subscribe("selfEmail")

--- a/shell/shared/stats.js
+++ b/shell/shared/stats.js
@@ -139,7 +139,6 @@ Router.map(function () {
     path: "/stats",
 
     waitOn: function () {
-      // TODO(perf):  Do these subscriptions get stop()ed when the user browses away?
       return [
         Meteor.subscribe("activityStats"),
         Meteor.subscribe("realTimeStats"),


### PR DESCRIPTION
According to the [Iron Router docs](https://github.com/iron-meteor/iron-router/blob/devel/Guide.md#using-hooks), the `waitOn` callback is executed in a reactive context. (Note that [`waitOn` gets treated like a hook](https://github.com/iron-meteor/iron-router/blob/86bab2112e44c2e0649006b4ce2f73927e5b0da3/lib/router.js#L351).) According to the [Meteor docs](http://docs.meteor.com/#/full/meteor_subscribe), subscriptions that are created in a reactive context are automatically stopped when the computation is invalidated:

> If you call Meteor.subscribe within a reactive computation, for example using Tracker.autorun, the subscription will automatically be cancelled when the computation is invalidated or stopped; it's not necessary to call stop on subscriptions made from inside autorun. 

By examining websocket frames in Chrome, I have experimentally verified that appropriate `unsub` messages do indeed get sent. 