### PR TITLE
For appDemo feature, use appTitle if it exists

### DIFF
--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -264,8 +264,9 @@ Router.map(function () {
       var appName = 'missing package';
 
       if (thisPackage) {
-        var actionTitle = thisPackage.manifest.actions[0].title.defaultText;
-        appName = appNameFromActionName(actionTitle);
+        var manifest = thisPackage.manifest;
+        var action = manifest.actions[0];
+        appName = (manifest.appTitle && manifest.appTitle.defaultText) || appNameFromActionName(action.title.defaultText);
       }
 
       return {


### PR DESCRIPTION
This addresses an issue where right now, if you want to Let's Chat, you
end up being offered to "Try Let's >>" because the word "Chat" is eaten
by the appNameFromActionName function.