### PR TITLE
Shut down dev app grains from the frontend.

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -298,7 +298,6 @@ shutdownGrain = function (grainId, ownerId, keepSessions) {
   }
 
   var grain = sandstormBackend.getGrain(ownerId, grainId).supervisor;
-  delete runningGrains[grainId];
   return grain.shutdown().then(function () {
     grain.close();
     throw new Error("expected shutdown() to throw disconnected");
@@ -813,6 +812,7 @@ Proxy.prototype.resetConnection = function () {
   }
   if (this.supervisor) {
     this.supervisor.close();
+    delete runningGrains[this.grainId];
     delete this.supervisor;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/sandstorm-io/sandstorm/issues/340.
Bonus: now `spk dev` will only restart grains whose appId matches the app being developed.