### PR TITLE
Fix bug: this -> self.

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -880,7 +880,7 @@ Proxy.prototype._callNewSession = function (request, viewInfo) {
     }
     userInfo.deprecatedPermissionsBlob = buf;
 
-    if (this.isApi) {
+    if (self.isApi) {
       return self._callNewApiSession(request, userInfo);
     } else {
       return self._callNewWebSession(request, userInfo);


### PR DESCRIPTION
Oops! This caused API sessions to always fall back to web sessions.