### PR TITLE
Add token for admin settings page

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -951,9 +951,9 @@ set_permissions() {
 
   # Set ownership of files.  We want the dirs to be root:sandstorm but the contents to be
   # sandstorm:sandstorm.
-  chown -R $SERVER_USER:$GROUP var/{log,pid,mongo} var/sandstorm/{apps,grains,downloads}
-  chown root:$GROUP var/{log,pid,mongo} var/sandstorm/{apps,grains,downloads}
-  chmod -R g=rwX,o= var/{log,pid,mongo} var/sandstorm/{apps,grains,downloads}
+  chown -R $SERVER_USER:$GROUP var/{log,pid,mongo} var/sandstorm/{apps,grains,downloads,adminToken}
+  chown root:$GROUP var/{log,pid,mongo} var/sandstorm/{apps,grains,downloads,adminToken}
+  chmod -R g=rwX,o= var/{log,pid,mongo} var/sandstorm/{apps,grains,downloads,adminToken}
 
   # Don't allow listing grain IDs directly.  (At the moment, this is faux security since
   # an attacker could just read the database, but maybe that will change someday...)
@@ -1090,15 +1090,22 @@ __EOF__
   service sandstorm start
 }
 
+generate_admin_token() {
+  ADMIN_TOKEN=$(./sandstorm admin-token --quiet)
+}
+
 print_success() {
   if [ "yes" = "$SANDSTORM_NEEDS_TO_BE_STARTED" ] ; then
     echo "Setup complete. To start your server now, run:"
     echo "  $DIR/sandstorm start"
-    echo "It will then run at:"
+    echo "You should then configure the site at:"
   else
-    echo "Setup complete. Your server should be running at:"
+    echo "Setup complete. You should configure the site at:"
   fi
-  echo "  ${BASE_URL:-(unknown; bad config)}"
+  echo "  ${BASE_URL:-(unknown; bad config)}/admin/$ADMIN_TOKEN"
+  echo "WARNING: This token expires in 15 minutes."
+  echo "You can generate a new token by running 'sandstorm admin-token' from the command line"
+  echo
   echo "To learn how to control the server, run:"
   if [ "yes" = "$CURRENTLY_UID_ZERO" ] ; then
     echo "  sandstorm help"
@@ -1256,6 +1263,7 @@ save_config
 download_latest_bundle_and_extract_if_needed
 extract_bundle_if_provided
 make_runtime_directories
+generate_admin_token
 set_permissions
 install_sandstorm_symlinks
 ask_about_starting_at_boot

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -190,7 +190,7 @@ limitations under the License.
       {{#if isFirstRun}}
         <p>
           This Sandstorm instance has no users. You should generate a token from the command line
-          in order to access the admin settings page.
+          with `sandstorm admin-token` in order to access the admin settings page.
         </p>
       {{else}}
         {{#if allowDemoAccounts}}
@@ -584,8 +584,8 @@ $KEY</textarea></p>
       {{else}}
         <p>
           You are not logged in as admin and there isn't a valid token specified. You should
-          either log in as an admin user or generate a token from the command line in order to access
-          the admin settings page.
+          either log in as an admin user or generate a token from the command line by doing
+          `sandstorm admin-token` in order to access the admin settings page.
         </p>
       {{/if}}
     </div>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -188,8 +188,10 @@ limitations under the License.
         <p class="build-tag">Build {{build}}</p>
 
       {{#if isFirstRun}}
-        <p>Sign in to set up your server!</p>
-        <div id="sign-in-arrow"></div>
+        <p>
+          This Sandstorm instance has no users. You should generate a token from the command line
+          in order to access the admin settings page.
+        </p>
       {{else}}
         {{#if allowDemoAccounts}}
           <p><a href="/demo">Try the demo!</a></p>
@@ -552,32 +554,40 @@ $KEY</textarea></p>
 
   <div id="admin-settings" class="main-content">
     <div class="centered-box">
-      <form id="admin-settings-form">
-        <p><input type="checkbox" name="googleLogin" value="value" checked={{googleEnabled}}> Enable Google Login<br>
-           <input type="checkbox" name="githubLogin" value="value" checked={{githubEnabled}}> Enable Github Login<br>
-           <input type="checkbox" name="emailTokenLogin" value="value" checked={{emailTokenEnabled}}> Enable Passwordless Email Login<br>
-          <span class="details">Choose which services users may use to identify themselves. Anyone can log in, but only users you <a href="/invite">invite</a> will be able to install apps or create files.</span></p>
-        <p>SMTP Url: <input type="text" name="smtpUrl" value="{{smtpUrl}}"><br>
-          <span class="details">Address of an SMTP (email) server, like <code>smtp://user:pass@host:port</code>. This will be used by email apps and to send <a href="/invite">email invites</a>.</span></p>
-        <p>Splash Dialog: <input type="textarea" name="splashDialog" value="{{splashDialog}}"><br>
-           Signup Dialog: <input type="textarea" name="signupDialog" value="{{signupDialog}}"><br>
-          <span class="details">This will be used as text in the splash page and signup page respectively.</span></p>
-        <p><button id="admin-settings-save">Save</button></p>
+      {{#if isUserPermitted}}
+        <form id="admin-settings-form">
+          <p><input type="checkbox" name="googleLogin" value="value" checked={{googleEnabled}}> Enable Google Login<br>
+             <input type="checkbox" name="githubLogin" value="value" checked={{githubEnabled}}> Enable Github Login<br>
+             <input type="checkbox" name="emailTokenLogin" value="value" checked={{emailTokenEnabled}}> Enable Passwordless Email Login<br>
+            <span class="details">Choose which services users may use to identify themselves. Anyone can log in, but only users you <a href="/invite">invite</a> will be able to install apps or create files.</span></p>
+          <p>SMTP Url: <input type="text" name="smtpUrl" value="{{smtpUrl}}"><br>
+            <span class="details">Address of an SMTP (email) server, like <code>smtp://user:pass@host:port</code>. This will be used by email apps and to send <a href="/invite">email invites</a>.</span></p>
+          <p>Splash Dialog: <input type="textarea" name="splashDialog" value="{{splashDialog}}"><br>
+             Signup Dialog: <input type="textarea" name="signupDialog" value="{{signupDialog}}"><br>
+            <span class="details">This will be used as text in the splash page and signup page respectively.</span></p>
+          <p><button id="admin-settings-save">Save</button></p>
 
-        {{#if success}}
-        <div class="alert alert-success"><strong>Success!</strong> Your settings have been saved.</div>
-        {{/if}}
-        {{#if failure}}
-        <div class="alert alert-danger"><strong>Failure!</strong>
-          <ul>
-            {{#each errors}}
-            <li>{{details}}</li>
-            {{/each}}
-          </ul>
-          See <code>&lt;install-location&gt;/var/log/sandstorm.log</code> for details.
-        </div>
-        {{/if}}
-      </form>
+          {{#if success}}
+          <div class="alert alert-success"><strong>Success!</strong> Your settings have been saved.</div>
+          {{/if}}
+          {{#if failure}}
+          <div class="alert alert-danger"><strong>Failure!</strong>
+            <ul>
+              {{#each errors}}
+              <li>{{details}}</li>
+              {{/each}}
+            </ul>
+            See <code>&lt;install-location&gt;/var/log/sandstorm.log</code> for details.
+          </div>
+          {{/if}}
+        </form>
+      {{else}}
+        <p>
+          You are not logged in as admin and there isn't a valid token specified. You should
+          either log in as an admin user or generate a token from the command line in order to access
+          the admin settings page.
+        </p>
+      {{/if}}
     </div>
   </div>
 </template>

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -193,7 +193,6 @@ if (Meteor.isServer) {
   var SANDSTORM_ADMIN_TOKEN = SANDSTORM_VARDIR + "/adminToken";
 
   var tokenIsValid = function(token) {
-    console.log(SANDSTORM_ADMIN_TOKEN);
     if (Fs.existsSync(SANDSTORM_ADMIN_TOKEN)) {
       var stats = Fs.statSync(SANDSTORM_ADMIN_TOKEN);
       var expireTime = new Date(Date.now() - ADMIN_TOKEN_EXPIRATION_TIME);

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 var NUM_SETTINGS = 6;
+var ADMIN_TOKEN_EXPIRATION_TIME = 15 * 60 * 1000;
 var publicAdminSettings = ["google", "github", "emailToken", "splashDialog", "signupDialog"];
 
 DEFAULT_SPLASH_DIALOG = "Contact the server admin for an invite.";
@@ -22,23 +23,27 @@ DEFAULT_SIGNUP_DIALOG = "You've been invited to join this Sandstorm server!";
 
 Router.map(function () {
   this.route("admin", {
-    path: "/admin",
+    path: "/admin/:_token?",
 
     waitOn: function () {
       return [
-        Meteor.subscribe("admin")
+        Meteor.subscribe("admin", this.params._token),
+        Meteor.subscribe("adminToken", this.params._token)
       ];
     },
 
     data: function () {
+      var adminToken = AdminToken.findOne();
       return {
-        settings: Settings.find()
+        settings: Settings.find(),
+        token: this.params._token,
+        isUserPermitted: isAdmin() || (adminToken && adminToken.tokenIsValid)
       };
     },
 
     action: function () {
       var state = this.state;
-      Meteor.call("getSmtpUrl", function(error, result){
+      Meteor.call("getSmtpUrl", this.params._token, function(error, result){
         state.set("smtpUrl", result);
       });
       state.set("successes", 0);
@@ -50,6 +55,7 @@ Router.map(function () {
 });
 
 if (Meteor.isClient) {
+  AdminToken = new Mongo.Collection("adminToken");  // see Meteor.publish("adminToken")
   Meteor.subscribe("publicAdminSettings");
 
   Meteor.startup(function () {
@@ -93,24 +99,42 @@ if (Meteor.isClient) {
     }
   };
 
+  var successTracker;
   Template.admin.events({
     "submit #admin-settings-form": function (event) {
       var state = Iron.controller().state;
+      var token = this.token;
       state.set("successes", 0);
       state.set("failures", 0);
       state.set("errors", []);
+
+      if (successTracker) {
+        successTracker.stop();
+        successTracker = null;
+      }
+      if (token) {
+        successTracker = Tracker.autorun(function () {
+          if (state.get("successes") == NUM_SETTINGS) {
+            Meteor.call("clearAdminToken", token, function (err) {
+              if (err) {
+                console.error("Failed to clear admin token: ", err);
+              }
+            });
+          }
+        });
+      }
       var handleErrorBound = handleError.bind(state);
       if (event.target.emailTokenLogin.checked && !event.target.smtpUrl.value) {
         handleErrorBound(new Meteor.Error(400, "Bad Request",
             "You must configure an SMTP server to use email login."));
         return false;
       }
-      Meteor.call("setAccountSetting", "google", event.target.googleLogin.checked, handleErrorBound);
-      Meteor.call("setAccountSetting", "github", event.target.githubLogin.checked, handleErrorBound);
-      Meteor.call("setAccountSetting", "emailToken", event.target.emailTokenLogin.checked, handleErrorBound);
-      Meteor.call("setSetting", "smtpUrl", event.target.smtpUrl.value, handleErrorBound);
-      Meteor.call("setSetting", "splashDialog", event.target.splashDialog.value, handleErrorBound);
-      Meteor.call("setSetting", "signupDialog", event.target.signupDialog.value, handleErrorBound);
+      Meteor.call("setAccountSetting", token, "google", event.target.googleLogin.checked, handleErrorBound);
+      Meteor.call("setAccountSetting", token, "github", event.target.githubLogin.checked, handleErrorBound);
+      Meteor.call("setAccountSetting", token, "emailToken", event.target.emailTokenLogin.checked, handleErrorBound);
+      Meteor.call("setSetting", token, "smtpUrl", event.target.smtpUrl.value, handleErrorBound);
+      Meteor.call("setSetting", token, "splashDialog", event.target.splashDialog.value, handleErrorBound);
+      Meteor.call("setSetting", token, "signupDialog", event.target.signupDialog.value, handleErrorBound);
 
       return false;
     }
@@ -165,6 +189,24 @@ if (Meteor.isClient) {
 }
 
 if (Meteor.isServer) {
+  var Fs = Npm.require("fs");
+  var SANDSTORM_ADMIN_TOKEN = SANDSTORM_VARDIR + "/adminToken";
+
+  var tokenIsValid = function(token) {
+    console.log(SANDSTORM_ADMIN_TOKEN);
+    if (Fs.existsSync(SANDSTORM_ADMIN_TOKEN)) {
+      var stats = Fs.statSync(SANDSTORM_ADMIN_TOKEN);
+      var expireTime = new Date(Date.now() - ADMIN_TOKEN_EXPIRATION_TIME);
+      if (stats.mtime < expireTime) {
+        return false;
+      } else {
+        return Fs.readFileSync(SANDSTORM_ADMIN_TOKEN, {encoding: "utf8"}) === token;
+      }
+    } else {
+      return false;
+    }
+  };
+
   var registerServiceOnStartup = function (serviceName) {
     var setting = Settings.findOne({_id: serviceName});
     if ((!setting && (serviceName === "github" || serviceName === "google")) ||
@@ -172,6 +214,7 @@ if (Meteor.isServer) {
       Accounts.registerService(serviceName);
     }
   };
+
   Meteor.startup(function () {
     registerServiceOnStartup("google");
     registerServiceOnStartup("github");
@@ -179,9 +222,9 @@ if (Meteor.isServer) {
   });
 
   Meteor.methods({
-    setAccountSetting: function (serviceName, value) {
-      if (!isAdmin()) {
-        throw new Meteor.Error(403, "Unauthorized", "User must be admin");
+    setAccountSetting: function (token, serviceName, value) {
+      if (!isAdmin() && !tokenIsValid(token)) {
+        throw new Meteor.Error(403, "Unauthorized", "User must be admin or provide a valid token");
       }
 
       var setting = Settings.findOne({_id: serviceName});
@@ -192,33 +235,30 @@ if (Meteor.isServer) {
         Accounts.deregisterService(serviceName);
       }
     },
-    setSetting: function (name, value) {
-      if (!isAdmin()) {
-        throw new Meteor.Error(403, "Unauthorized", "User must be admin");
+    setSetting: function (token, name, value) {
+      if (!isAdmin() && !tokenIsValid(token)) {
+        throw new Meteor.Error(403, "Unauthorized", "User must be admin or provide a valid token");
       }
 
       Settings.upsert({_id: name}, {$set: {value: value}});
     },
-    getSmtpUrl: function (name, value) {
-      if (!isAdmin()) {
-        throw new Meteor.Error(403, "Unauthorized", "User must be admin");
+    getSmtpUrl: function (token) {
+      if (!isAdmin() && !tokenIsValid(token)) {
+        throw new Meteor.Error(403, "Unauthorized", "User must be admin or provide a valid token");
       }
 
       return getSmtpUrl();
-    }
-  });
-
-  Settings.allow({
-    insert: function (userId) {
-      return isAdminById(userId);
     },
-    update: function (userId) {
-      return isAdminById(userId);
+    clearAdminToken: function(token) {
+      if (tokenIsValid(token)) {
+        Fs.unlinkSync(SANDSTORM_ADMIN_TOKEN);
+        console.log("Admin token deleted.");
+      }
     }
   });
 
-  Meteor.publish("admin", function () {
-    if (this.userId && isAdminById(this.userId)) {
+  Meteor.publish("admin", function (token) {
+    if ((this.userId && isAdminById(this.userId)) || tokenIsValid(token)) {
       return Settings.find();
     } else {
       return [];
@@ -227,5 +267,10 @@ if (Meteor.isServer) {
 
   Meteor.publish("publicAdminSettings", function () {
     return Settings.find({_id: { $in: publicAdminSettings}});
+  });
+
+  Meteor.publish("adminToken", function (token) {
+    this.added("adminToken", "adminToken", {tokenIsValid: tokenIsValid(token)});
+    this.ready();
   });
 }

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -23,6 +23,7 @@
 #include <capnp/dynamic.h>
 #include <capnp/serialize.h>
 #include <sandstorm/package.capnp.h>
+#include <sodium/randombytes.h>
 #include <stdlib.h>
 #include <signal.h>
 #include <limits.h>
@@ -1008,8 +1009,7 @@ public:
 
     // Get 20 random bytes for token.
     kj::byte bytes[20];
-    kj::FdInputStream random(raiiOpen("/dev/urandom", O_RDONLY));
-    random.read(bytes, sizeof(bytes));
+    randombytes_buf(bytes, sizeof(bytes));
     auto hexString = hexEncode(bytes);
 
     auto config = readConfig();

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -658,8 +658,8 @@ public:
               return kj::MainBuilder(context, VERSION,
                       "Generates a new admin token that you can use to access the admin settings "
                       "page. This is meant for initial setup, or if an admin account is locked out.")
-                  .addOption({"short"}, [this]() { shortOutput = true; return true; },
-                      "Pass this flag if you wish to output only the token.")
+                  .addOption({'q', "quiet"}, [this]() { shortOutput = true; return true; },
+                      "Output only the token.")
                   .callAfterParsing(KJ_BIND_METHOD(*this, adminToken))
                   .build();
             },

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1010,7 +1010,7 @@ public:
     kj::byte bytes[20];
     kj::FdInputStream random(raiiOpen("/dev/urandom", O_RDONLY));
     random.read(bytes, sizeof(bytes));
-    auto hexString = bytesToHex(bytes);
+    auto hexString = hexEncode(bytes);
 
     auto config = readConfig();
 

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -80,11 +80,6 @@ kj::Array<byte> toBytes(kj::StringPtr text, kj::ArrayPtr<const byte> data = null
   return result;
 }
 
-kj::String hexEncode(const kj::ArrayPtr<const byte> input) {
-  const char DIGITS[] = "0123456789abcdef";
-  return kj::strArray(KJ_MAP(b, input) { return kj::heapArray<char>({DIGITS[b/16], DIGITS[b%16]}); }, "");
-}
-
 struct HttpStatusInfo {
   WebSession::Response::Which type;
 

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -601,6 +601,18 @@ kj::Array<byte> base64Decode(kj::StringPtr input) {
 
 // =======================================================================================
 
+kj::String bytesToHex(kj::ArrayPtr<const byte> input) {
+  kj::String out = kj::heapString(input.size() * 2);
+  const char * hex = "0123456789abcdef";
+  char * outPtr = out.begin();
+  const kj::byte * inPtr = input.begin();
+  for(; inPtr < input.end(); outPtr+=2, inPtr++){
+      outPtr[0] = hex[((*inPtr)>>4) & 0xf];
+      outPtr[1] = hex[(*inPtr) & 0xf];
+  }
+  return out;
+}
+
 Subprocess::Subprocess(Options&& options)
     : name(kj::heapString(options.argv.size() > 0 ? options.argv[0] : options.executable)) {
   KJ_SYSCALL(pid = fork());

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -601,16 +601,9 @@ kj::Array<byte> base64Decode(kj::StringPtr input) {
 
 // =======================================================================================
 
-kj::String bytesToHex(kj::ArrayPtr<const byte> input) {
-  kj::String out = kj::heapString(input.size() * 2);
-  const char * hex = "0123456789abcdef";
-  char * outPtr = out.begin();
-  const kj::byte * inPtr = input.begin();
-  for(; inPtr < input.end(); outPtr+=2, inPtr++){
-      outPtr[0] = hex[((*inPtr)>>4) & 0xf];
-      outPtr[1] = hex[(*inPtr) & 0xf];
-  }
-  return out;
+kj::String hexEncode(const kj::ArrayPtr<const byte> input) {
+  const char DIGITS[] = "0123456789abcdef";
+  return kj::strArray(KJ_MAP(b, input) { return kj::heapArray<char>({DIGITS[b/16], DIGITS[b%16]}); }, "");
 }
 
 Subprocess::Subprocess(Options&& options)

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -168,6 +168,9 @@ kj::String base64Encode(kj::ArrayPtr<const byte> input, bool breakLines);
 kj::Array<byte> base64Decode(kj::StringPtr input);
 // Decode base64 input to bytes. Non-base64 characters in the input will be ignored.
 
+kj::String bytesToHex(kj::ArrayPtr<const byte> input);
+// Return the hex string corresponding to this array of bytes.
+
 class Subprocess {
 public:
   struct Options {

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -168,7 +168,7 @@ kj::String base64Encode(kj::ArrayPtr<const byte> input, bool breakLines);
 kj::Array<byte> base64Decode(kj::StringPtr input);
 // Decode base64 input to bytes. Non-base64 characters in the input will be ignored.
 
-kj::String bytesToHex(kj::ArrayPtr<const byte> input);
+kj::String hexEncode(const kj::ArrayPtr<const byte> input);
 // Return the hex string corresponding to this array of bytes.
 
 class Subprocess {


### PR DESCRIPTION
This will automatically generate an admin token in the installer and direct users there to configure a login system. Also, added a command `admin-token` to the sandstorm binary to generate said token.