### PR TITLE
Use git tags to record commit <=> version info

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -58,15 +58,6 @@ echo "**** Building build $BUILD ****"
 
 make BUILD=$BUILD
 
-echo "**** Pushing build $BUILD ****"
-
-echo $BUILD > tmp/$CHANNEL
-gcutil push fe $TARBALL /var/www/dl.sandstorm.io
-gcutil push fe tmp/$CHANNEL /var/www/install.sandstorm.io
-
-gcutil ssh smalldemo sudo service sandstorm update
-gcutil ssh alpha sudo service sandstorm update dev
-
 echo "**** Tagging this commit ****"
 
 # The git tag stores the version number as a normal-looking version
@@ -79,3 +70,12 @@ TAG_NAME="v${DISPLAY_VERSION}"
 GIT_REVISION="$(<bundle/git-revision)"
 git tag "$TAG_NAME" "$GIT_REVISION" -m "Release Sandstorm ${DISPLAY_VERSION}"
 git push origin "$TAG_NAME"
+
+echo "**** Pushing build $BUILD ****"
+
+echo $BUILD > tmp/$CHANNEL
+gcutil push fe $TARBALL /var/www/dl.sandstorm.io
+gcutil push fe tmp/$CHANNEL /var/www/install.sandstorm.io
+
+gcutil ssh smalldemo sudo service sandstorm update
+gcutil ssh alpha sudo service sandstorm update dev

--- a/release.sh
+++ b/release.sh
@@ -75,7 +75,7 @@ echo "**** Tagging this commit ****"
 
 BUILD_MINOR="$(( $BUILD % 1000 ))"
 DISPLAY_VERSION="${BRANCH_NUMBER}.${BUILD_MINOR}"
-TAG_NAME="sandstorm-${DISPLAY_VERSION}"
+TAG_NAME="v${DISPLAY_VERSION}"
 GIT_REVISION="$(<bundle/git-revision)"
 git tag "$TAG_NAME" "$GIT_REVISION" -m "Release Sandstorm ${DISPLAY_VERSION}"
 git push origin "$TAG_NAME"

--- a/release.sh
+++ b/release.sh
@@ -48,6 +48,10 @@ fi
 BASE_BUILD=$(( BRANCH_NUMBER * 1000 ))
 BUILD=$(( BASE_BUILD > LAST_BUILD ? BASE_BUILD : LAST_BUILD + 1 ))
 
+# The tarball stores the version number as an integer, e.g. 75 for
+# build 75 within branch 0, or 2121 for build 121 within branch 2, so
+# that the Sandstorm auto-updater can avoid having complicated
+# version-comparison logic.
 TARBALL=sandstorm-$BUILD.tar.xz
 
 echo "**** Building build $BUILD ****"
@@ -62,3 +66,16 @@ gcutil push fe tmp/$CHANNEL /var/www/install.sandstorm.io
 
 gcutil ssh smalldemo sudo service sandstorm update
 gcutil ssh alpha sudo service sandstorm update dev
+
+echo "**** Tagging this commit ****"
+
+# The git tag stores the version number as a normal-looking version
+# number, like 0.75 for build 75 within branch 0, or 2.121 for build
+# 121 within branch 2.
+
+BUILD_MINOR="$(( $BUILD % 1000 ))"
+DISPLAY_VERSION="${BRANCH_NUMBER}.${BUILD_MINOR}"
+TAG_NAME="sandstorm-${DISPLAY_VERSION}"
+GIT_REVISION="$(<bundle/git-revision)"
+git tag "$TAG_NAME" "$GIT_REVISION" -m "Release Sandstorm ${DISPLAY_VERSION}"
+git push origin "$TAG_NAME"


### PR DESCRIPTION
With this commit, we will start publishing git tags, which would have made my life a little easier earlier today.