### PR TITLE
sandstorm-http-bridge: fill in dummy Host header for API sessions.

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -1015,6 +1015,9 @@ private:
       lines.add(kj::str("X-Sandstorm-Base-Path: ", basePath));
       lines.add(kj::str("Host: ", extractHostFromUrl(basePath)));
       lines.add(kj::str("X-Forwarded-Proto: ", extractProtocolFromUrl(basePath)));
+    } else {
+      // Dummy value. Some API servers (e.g. git-http-backend) fail if Host is not present.
+      lines.add(kj::str("Host: sandbox"));
     }
     lines.add(kj::str("X-Sandstorm-Session-Id: ", sessionId));
 


### PR DESCRIPTION
Fixes #343, allowing git-http-backend to set a nonempty `BridgeConfig.apiPath`.