### PR TITLE
AppInstaller.downloadPath no longer exists.

### DIFF
--- a/shell/server/installer.js
+++ b/shell/server/installer.js
@@ -321,10 +321,7 @@ AppInstaller.prototype.doDownloadTo = function (out) {
 
   this.downloadRequest = request;
 
-  request.on("error", this.wrapCallback(function (err) {
-    Fs.unlinkSync(this.downloadPath);
-    throw err;
-  }));
+  request.on("error", this.wrapCallback(function (err) { throw err; }));
 }
 
 AppInstaller.prototype.done = function(manifest) {


### PR DESCRIPTION
This prevents the actual error from getting reported in cases like https://github.com/sandstorm-io/sandstorm/issues/349.