### PR TITLE
Display the sourcePath value that caused an error. Fix Typo.

### DIFF
--- a/src/sandstorm/union-fs.c++
+++ b/src/sandstorm/union-fs.c++
@@ -708,7 +708,7 @@ fuse::Node::Client makeUnionFs(kj::StringPtr sourceDir, spk::SourceMap::Reader s
     // root to be a symlink.
     if (packagePath.size() == 0) {
       struct stat stats;
-      KJ_SYSCALL(lstat(sourcePath.cStr(), &stats));
+      KJ_SYSCALL(lstat(sourcePath.cStr(), &stats), sourcePath);
       if (S_ISLNK(stats.st_mode)) {
         char* real;
         KJ_SYSCALL(real = realpath(sourcePath.cStr(), NULL));

--- a/src/sandstorm/union-fs.h
+++ b/src/sandstorm/union-fs.h
@@ -28,7 +28,7 @@ namespace sandstorm {
 fuse::Node::Client makeUnionFs(kj::StringPtr sourceDir, spk::SourceMap::Reader sourceMap,
                                spk::Manifest::Reader manifest, spk::BridgeConfig::Reader bridgeConfig,
                                kj::StringPtr bridgePath, kj::Function<void(kj::StringPtr)>& callback);
-// Creates a new filesystem based os `sourceMap`. Whenever a file is opened (for the first time),
+// Creates a new filesystem based on `sourceMap`. Whenever a file is opened (for the first time),
 // `callback` will be invoked with the (virtual) path name.
 //
 // `manifest` is used to populate the special file `/sandstorm-manifest`, and `bridgePath` is the


### PR DESCRIPTION
This partially addresses https://github.com/sandstorm-io/sandstorm/issues/210.
Ideally, we would not ever dump stack traces for errors caused by bad input from the user. But I think this  fix is good enough for now.