### PR TITLE
Release install.sh along with the rest of Sandstorm

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -76,6 +76,7 @@ echo "**** Pushing build $BUILD ****"
 echo $BUILD > tmp/$CHANNEL
 gcutil push fe $TARBALL /var/www/dl.sandstorm.io
 gcutil push fe tmp/$CHANNEL /var/www/install.sandstorm.io
+gcutil push fe install.sh /var/www/install.sandstorm.io
 
 gcutil ssh smalldemo sudo service sandstorm update
 gcutil ssh alpha sudo service sandstorm update dev


### PR DESCRIPTION
This avoids a condition where we do a release but forget to update
the installer.

@ocdtrekkie just ran into this -- the install.sh fix from last week seemingly didn't get pushed to `https://install.sandstorm.io`.

@kentonv if you prefer to handle this a different way, I'm all ears, but it seems to me that we'll be happiest having exactly one release process, rather than one for `install.sh` and another for the rest of Sandstorm.