### PR TITLE
Enable DNS configuration (sandcats) by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,9 @@ while getopts ":cdeu" opt; do
       ;;
     e)
       USE_EXTERNAL_INTERFACE="yes"
+      # For now, choosing an external interfaces opts you in to to
+      # being asked about dynamic DNS via sandcats.io.
+      USE_SANDCATS="yes"
       ;;
     u)
       PREFER_ROOT=no

--- a/install.sh
+++ b/install.sh
@@ -744,11 +744,11 @@ function register_sandcats_name() {
   echo "We need your email on file so we can help you recover your domain if you lose access. No spam."
   SANDCATS_REGISTRATION_EMAIL=$(prompt "Enter your email address:" "")
 
-  # If the user fails to enter an email address, bail out.
-  if [ "" = "$SANDCATS_REGISTRATION_EMAIL" ] ; then
-    echo "OK. I assume you don't want the Sandcats service. Feel free to Ctrl-C and re-run the install."
-    return
-  fi
+  # If the user fails to enter an email address, let them try again.
+  while [ "" = "$SANDCATS_REGISTRATION_EMAIL" ] ; do
+    echo "For the DNS service, we really do need an email address. To cancel, type: Ctrl-C."
+    SANDCATS_REGISTRATION_EMAIL=$(prompt "Enter your email address:" "")
+  done
 
   echo "Registering..."
   HTTP_STATUS=$(


### PR DESCRIPTION
This change adjusts the install script so that if you choose that you
want Sandstorm to listen on external network interfaces, then we ask
you about configuring sandcats.io for dynamic DNS.

This tiny change is desireable, rather than rewriting the installer
immediately, because @ocdtrekkie is giving a talk about Sandstorm
on Sat Apr 25 at the Chicago Linux Users Group, and I would prefer
to ensure that his talk goes smoothly than to land a big install.sh
rewrite right now.