### PR TITLE
Compute transitive shares.

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -333,6 +333,27 @@ limitations under the License.
             </li>
           {{/each}}
           </ul>
+          {{#if transitiveShares}}
+            <button class="hide-transitive-shares">hide transitive shares</button>
+            {{#if transitiveShares.empty}}
+              <p> You currently grant access to nobody. </p>
+            {{else}}
+              <ul>
+                {{#each transitiveShares}}
+                  <li>
+                    <div>{{displayName recipient}} was granted access by:</div>
+                    <ul>
+                      {{#each sharers}}
+                        <li>{{displayName sharer}} ({{dateString created}})</li>
+                      {{/each}}
+                    </ul>
+                  </li>
+                {{/each}}
+              </ul>
+            {{/if}}
+          {{else}}
+            <button class="show-transitive-shares">show transitive shares</button>
+          {{/if}}
         {{/if}}
       {{/if}}
     {{/if}}

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -334,9 +334,10 @@ limitations under the License.
           {{/each}}
           </ul>
           {{#if transitiveShares}}
-            <button class="hide-transitive-shares">hide transitive shares</button>
+            <button class="hide-transitive-shares">hide reshares</button>
             {{#if transitiveShares.empty}}
-              <p> You currently grant access to nobody. </p>
+              <p></p>
+              <p> There are no reshares. </p>
             {{else}}
               <ul>
                 {{#each transitiveShares}}
@@ -352,7 +353,7 @@ limitations under the License.
               </ul>
             {{/if}}
           {{else}}
-            <button class="show-transitive-shares">show transitive shares</button>
+            <button class="show-transitive-shares">show reshares</button>
           {{/if}}
         {{/if}}
       {{/if}}

--- a/shell/lib/db.js
+++ b/shell/lib/db.js
@@ -127,6 +127,8 @@ Sessions = new Mongo.Collection("sessions");
 //   timestamp:  Time of last keep-alive message to this session.  Sessions time out after some
 //       period.
 //   userId:  User who owns this session.
+//   hashedToken: If the session is owned by an anonymous user, the _id of the entry in ApiTokens
+//       that was used to open it.
 
 SignupKeys = new Mongo.Collection("signupKeys");
 // Invite keys which may be used by users to get access to Sandstorm.

--- a/shell/server/permissions.js
+++ b/shell/server/permissions.js
@@ -220,7 +220,7 @@ transitiveShares = function(grainId, userId) {
   //
   // Returns `result`, where `result.users` is a dictionary that maps the ID of each downstream
   // user to an array of incoming edges, each of type `{sharer: <userId>, created: <timestamp>}`,
-  // and `result.token` is a list of strings, each the `_id` of an entry in ApiTokens.
+  // and `result.tokens` is a list of strings, each the `_id` of an entry in ApiTokens.
 
   var result = {users: {}, tokens: []};
 

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -47,11 +47,15 @@ if (Meteor.isServer) {
   Meteor.publish("grainTopBar", function (grainId) {
     check(grainId, String);
     var self = this;
+
+    // Alice is allowed to know Bob's display name if Bob has received a role assignment from Alice
+    // for *any* grain.
     var handle = RoleAssignments.find({sharer: this.userId}).observe({
       added: function(roleAssignment) {
         var user = Meteor.users.findOne(roleAssignment.recipient);
-        self.added("displayNames", user._id,
-                   {displayName: user.profile.name});
+        if (user) {
+          self.added("displayNames", user._id, {displayName: user.profile.name});
+        }
       },
     });
     this.onStop(function() { handle.stop(); });
@@ -177,7 +181,7 @@ if (Meteor.isClient) {
       } else {
         if (window.confirm("Really forget this grain?")) {
           Session.set("showMenu", false);
-          Meteor.call("deleteRoleAssignments", this.grainId, this.userId);
+          Meteor.call("deleteRoleAssignments", this.grainId);
           Router.go("root");
         }
       }
@@ -307,6 +311,28 @@ if (Meteor.isClient) {
                             {$set : {active : true}});
     },
 
+    "click button.show-transitive-shares": function (event) {
+      var grainId = this.grainId;
+      Meteor.call("transitiveShares", this.grainId, Meteor.userId(), function(error, downstream) {
+        if (error) {
+          console.error(error.stack);
+        } else {
+          var shares = [];
+          for (var recipient in downstream.users) {
+            shares.push({recipient: recipient, sharers: downstream.users[recipient]});
+          }
+          if (shares.length == 0) {
+            shares = {empty: true};
+          }
+          Session.set("transitive-shares-" + grainId, shares);
+        }
+      });
+    },
+
+    "click button.hide-transitive-shares": function (event) {
+      Session.set("transitive-shares-" + this.grainId, undefined);
+    },
+
     "click #privatize-grain": function (event) {
       Grains.update(this.grainId, {$set: {private: true}});
     },
@@ -375,7 +401,14 @@ if (Meteor.isClient) {
     },
 
     displayName: function (userId) {
-      return DisplayNames.findOne(userId).displayName;
+      var name = DisplayNames.findOne(userId);
+      if (name) {
+        return name.displayName;
+      } else if (userId === Meteor.userId()) {
+        return Meteor.user().profile.name + " (you)";
+      } else {
+        return "Unknown User (" + userId + ")";
+      }
     },
   });
 
@@ -507,6 +540,7 @@ function grainRouteHelper(route, result, openSessionMethod, openSessionArg, root
                                                forSharing: true}).fetch(),
   result.existingAssignments = RoleAssignments.find({grainId: grainId,
                                                      sharer : Meteor.userId()}).fetch(),
+  result.transitiveShares = Session.get("transitive-shares-" + grainId);
   result.showMenu = Session.get("showMenu");
 
   var err = route.state.get("error");

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -319,7 +319,11 @@ if (Meteor.isClient) {
         } else {
           var shares = [];
           for (var recipient in downstream.users) {
-            shares.push({recipient: recipient, sharers: downstream.users[recipient]});
+            if (!RoleAssignments.findOne({grainId: grainId, recipient: recipient,
+                                          sharer: Meteor.userId()})) {
+              // There is not a direct share from the current user to this recipient.
+              shares.push({recipient: recipient, sharers: downstream.users[recipient]});
+            }
           }
           if (shares.length == 0) {
             shares = {empty: true};

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -320,7 +320,7 @@ if (Meteor.isClient) {
           var shares = [];
           for (var recipient in downstream.users) {
             if (!RoleAssignments.findOne({grainId: grainId, recipient: recipient,
-                                          sharer: Meteor.userId()})) {
+                                          sharer: Meteor.userId(), active: true})) {
               // There is not a direct share from the current user to this recipient.
               shares.push({recipient: recipient, sharers: downstream.users[recipient]});
             }


### PR DESCRIPTION
This adds a `transitiveShares()` function to permissions.js and uses it in two places:
 1. To compute a closer approximation to which sessions need to be killed when permissions change.
 2. To implement a new "show transitive shares" button in the share menu. Looks like this:

![transitive-shares](https://cloud.githubusercontent.com/assets/495768/7538737/1ff30df2-f570-11e4-8819-a1c176184d36.png)