### PR TITLE
Improve the UI for setting and modifying token petnames.

### DIFF
--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -145,6 +145,12 @@ body {
   background-color: #888;
 }
 
+.popup .token-petname:hover {
+  cursor: pointer;
+  color: white;
+  background-color: #888;
+}
+
 #menu button {
   background-position: center;
   background-repeat: no-repeat;

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -239,7 +239,8 @@ limitations under the License.
       {{/if}}
     {{else}}
       <p>A webkey allows you to connect an external app (e.g. a mobile app) to this app.</p>
-      <p>Label: <input type="text" id="api-token-petname" placeholder="e.g. 'Android app'">
+      <p><form id="newApiToken">
+      Label: <input type="text" id="api-token-petname" placeholder="e.g. 'Android app'">
       {{#with viewInfo}}
         {{#if roles}}
           Role:
@@ -252,12 +253,17 @@ limitations under the License.
           </select>
         {{/if}}
       {{/with}}
-      <button id="newApiToken">Create</button></p>
+      <button>Create</button></form></p>
       {{#if existingTokens}}
         <p>Your existing webkeys:</p>
         <ul>
         {{#each existingTokens}}
-          <li>{{petname}} ({{dateString created}}) <button class="revoke-token" title="delete" data-token-id="{{_id}}">delete</button></li>
+          <li>
+            <span class="token-petname" data-token-id="{{_id}}">
+              {{petname}} ({{dateString created}})
+            </span>
+            <button class="revoke-token" title="revoke" data-token-id="{{_id}}">revoke</button>
+          </li>
         {{/each}}
         </ul>
       {{/if}}
@@ -290,7 +296,9 @@ limitations under the License.
         {{/if}}
       {{else}}
         <p>Create a secret link to share with other users.</p>
-        <p>Label: <input type="text" id="share-token-petname" placeholder="e.g. 'for Bob'">
+        <p><form id="new-share-token">
+        Label: <input onclick="select()" type="text"
+                id="share-token-petname" value="unlabeled sharing link">
         {{#with viewInfo}}
           {{#if roles}}
             Role:
@@ -303,12 +311,16 @@ limitations under the License.
             </select>
           {{/if}}
         {{/with}}
-        <button id="new-share-token">Create</button></p>
+        <button>Create</button>
+        </form></p>
         {{#if existingShareTokens}}
           <p> Your existing links: </p>
           <ul>
           {{#each existingShareTokens}}
-            <li> {{petname}} ({{dateString created}})
+            <li>
+              <span class="token-petname" data-token-id="{{_id}}">
+                {{petname}} ({{dateString created}})
+              </span>
               <button class="revoke-token" title="revoke" data-token-id="{{_id}}">revoke</button>
             </li>
           {{/each}}

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -29,6 +29,11 @@ if (Meteor.isServer) {
   });
 
   ApiTokens.allow({
+    update: function (userId, apiToken, fieldNames) {
+      // Allow owner to change the petname.
+      return userId && apiToken.userId === userId &&
+        (fieldNames.length === 1 && fieldNames[0] === "petname");
+    },
     remove: function (userId, token) {
       return userId && token.userId === userId;
     }
@@ -235,7 +240,8 @@ if (Meteor.isClient) {
     "click #api-token-popup-closer": function (event) {
       Session.set("show-api-token", false);
     },
-    "click #newApiToken": function (event) {
+    "submit #newApiToken": function (event) {
+      event.preventDefault();
       var grainId = this.grainId;
       Session.set("api-token-" + grainId, "pending");
       var roleList = document.getElementById("api-token-role");
@@ -276,7 +282,8 @@ if (Meteor.isClient) {
     "click #reset-share-token": function (event) {
       Session.set("share-token-" + this.grainId, undefined);
     },
-    "click #new-share-token": function (event) {
+    "submit #new-share-token": function (event) {
+      event.preventDefault();
       var grainId = this.grainId;
       Session.set("share-token-" + grainId, "pending");
       var roleList = document.getElementById("share-token-role");
@@ -295,6 +302,16 @@ if (Meteor.isClient) {
           Session.set("share-token-" + grainId, getOrigin() + "/shared/" + result.token);
         }
       });
+    },
+
+    "click .token-petname": function (event) {
+      // TODO(soon): Find a less-annoying way to get this input, perhaps by allowing the user
+      //   to edit the petname in place.
+      var petname = window.prompt("Set new label:", this.petname);
+      if (petname) {
+        ApiTokens.update(event.currentTarget.getAttribute("data-token-id"),
+                         {$set: {petname: petname}});
+      }
     },
 
     "click button.revoke-role-assignment": function (event) {

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -183,7 +183,7 @@ module.exports["Test grain anonymous user"] = function (browser) {
     .assert.containsText('#grainTitle', 'Untitled Hacker CMS Site')
     .click('#show-share-grain')
     .waitForElementVisible("#new-share-token", short_wait)
-    .click('#new-share-token')
+    .submitForm('#new-share-token')
     .waitForElementVisible('#share-token-text', medium_wait)
     // Navigate to the url with an anonymous user
     .getText('#share-token-text', function(response) {


### PR DESCRIPTION
Fixes https://github.com/sandstorm-io/sandstorm/issues/383. Fills in a default petname "unlabeled sharing link" to make it more clear that you don't need to specify a petname. Allows petnames to be edited after token creation.

