### PR TITLE
Work In Progress: sandstorm install script tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ bundle/
 .vagrant/
 phantomjsdriver.log
 selenium-debug.log
+
+*~
+*#
+.#*

--- a/install.sh
+++ b/install.sh
@@ -183,6 +183,7 @@ handle_args() {
   if [ $# = 1 ] && [[ ! $1 =~ ^- ]]; then
     BUNDLE_FILE="$1"
   elif [ $# != 0 ]; then
+    echo "$@"
     usage
   fi
 }

--- a/install.sh
+++ b/install.sh
@@ -183,7 +183,6 @@ handle_args() {
   if [ $# = 1 ] && [[ ! $1 =~ ^- ]]; then
     BUNDLE_FILE="$1"
   elif [ $# != 0 ]; then
-    echo "$@"
     usage
   fi
 }

--- a/installer-tests/Vagrantfile
+++ b/installer-tests/Vagrantfile
@@ -1,0 +1,62 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # We base ourselves off the trusty (Ubuntu 14.04) base box.
+  config.vm.box = "trusty64"
+
+  # The url from which to fetch that base box.
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+
+  # In this Vagrantbox purely to test the install script, we do not forward
+  # any ports. If we need to test if ports are available, we can do that by
+  # SSH-ing in.
+
+  # Use a shell script to "provision" the box. just sets up a different hostname
+  # than vagrant, because I find "vagrant" to be a weird hostname.
+  config.vm.provision "shell",
+                      inline: "cd /vagrant && echo localhost > /etc/hostname && hostname localhost"
+
+  # Make sure to share the dir one _above_ this one as /vagrant.
+  config.vm.synced_folder "..", "/vagrant"
+
+  # Calculate the number of CPUs and the amount of RAM the system has,
+  # in a platform-dependent way; further logic below.
+  cpus = nil
+  total_kB_ram = nil
+
+  host = RbConfig::CONFIG['host_os']
+  if host =~ /darwin/
+    cpus = `sysctl -n hw.ncpu`.to_i
+    total_kB_ram =  `sysctl -n hw.memsize`.to_i / 1024
+  elsif host =~ /linux/
+    cpus = `nproc`.to_i
+    total_kB_ram = `grep MemTotal /proc/meminfo | awk '{print $2}'`.to_i
+  end
+
+  # Use the same number of CPUs within Vagrant as the system, with 1
+  # as a default.
+  #
+  # Use at least 512MB of RAM, and if the system has more than 2GB of
+  # RAM, use 1/4 of the system RAM. This seems a reasonable compromise
+  # between having the Vagrant guest operating system not run out of
+  # RAM entirely (which it basically would if we went much lower than
+  # 512MB) and also allowing it to use up a healthily large amount of
+  # RAM so it can run faster on systems that can afford it.
+  config.vm.provider :virtualbox do |vb|
+    if cpus.nil?
+      vb.cpus = 1
+    else
+      vb.cpus = cpus
+    end
+
+    if total_kB_ram.nil? or total_kB_ram < 2048000
+      vb.memory = 512
+    else
+      vb.memory = (total_kB_ram / 1024 / 4)
+    end
+  end
+end

--- a/installer-tests/install-without-root.t
+++ b/installer-tests/install-without-root.t
@@ -1,0 +1,54 @@
+Title: Can install without root, with -u
+Vagrant-Destroy-If-bash: -d $HOME/sandstorm
+Vagrant-Precondition-bash: ! -d $HOME/sandstorm
+Cleanup: vagrant_destroy()
+Cwd: SANDSTORM_SOURCE_TREE
+
+$[run]/vagrant/install.sh -u
+$[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
+
+1. A full server with automatic setup (press enter to accept this default)
+2. A development server, for writing apps.
+
+How are you going to use this Sandstorm install? [1] $[type]2
+Expose to localhost only? [yes] $[type]
+Where would you like to put Sandstorm? $[type]
+Automatically keep Sandstorm updated? [yes]$[type]
+Sandstorm supports 'dev accounts', a feature that lets anyone log in
+as admin and other sample users to a Sandstorm server. We recommend
+it for app development, and absolutely do not recommend it for
+a server on the public Internet.
+Enable dev accounts? [yes] $[type]
+Server main HTTP port: [6080] $[type]
+Database port (choose any unused port): [6081]$[type]
+Note: local.sandstorm.io maps to 127.0.0.1, i.e. your local machine.
+For reasons that will become clear in the next step, you should use this
+instead of 'localhost'.
+URL users will enter in browser: [http://local.sandstorm.io:6080]$[type]
+Sandstorm requires you to set up a wildcard DNS entry pointing at the server.
+This allows Sandstorm to allocate new hosts on-the-fly for sandboxing purposes.
+Please enter a DNS hostname containing a '*' which maps to your server. For
+example, if you have mapped *.foo.example.com to your server, you could enter
+"*.foo.example.com". You can also specify that hosts should have a special
+prefix, like "ss-*.foo.example.com". Note that if your server's main page
+is served over SSL, the wildcard address must support SSL as well, which
+implies that you must have a wildcard certificate. For local-machine servers,
+we have mapped *.local.sandstorm.io to 127.0.0.1 for your convenience, so you
+can use "*.local.sandstorm.io" here. If you are serving off a non-standard
+port, you must include it here as well.
+Wildcard host: [*.local.sandstorm.io:6080]$[type]
+
+Config written to
+Finding latest build for dev channel...
+$[slow]Downloading: https://dl.sandstorm.io/sandstorm-
+$[slow]Start sandstorm at system boot (using sysvinit)? [yes] $[type]
+Setup complete. To start your server now, run:
+sandstorm start
+You should then configure the site at:
+  http://local.sandstorm.io:6080/admin/
+WARNING: This token expires in 15 minutes.
+You can generate a new token by running 'sandstorm admin-token' from the command line
+
+To learn how to control the server, run:
+help
+$[exitcode]0

--- a/installer-tests/no-root.t
+++ b/installer-tests/no-root.t
@@ -1,0 +1,26 @@
+Title: Can't install Sandstorm without root, by default
+Cwd: SANDSTORM_SOURCE_TREE
+Vagrant-Precondition-bash: ! -d $HOME/sandstorm
+Vagrant-Precondition-bash: ! -d /opt/sandstorm
+Vagrant-Postcondition-bash: ! -d $HOME/sandstorm
+Vagrant-Postcondition-bash: ! -d /opt/sandstorm
+
+$[run]/vagrant/install.sh
+$[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
+
+1. A full server with automatic setup (press enter to accept this default)
+2. A development server, for writing apps.
+
+How are you going to use this Sandstorm install? [1] $[type]2
+If you want app developer mode for a Sandstorm install, you need root
+due to limitations in the Linux kernel.
+
+To set up Sandstorm, we will need to use sudo.
+Sandstorm's database and web interface won't run as root.
+OK to continue? [yes] $[type]no
+If you are OK with a local Sandstorm install for testing
+but not app development, re-run install.sh with -u to bypass this message.
+For developer mode to work, the script needs root, or read above to bypass.
+*** INSTALLATION FAILED ***
+Report bugs at: http://github.com/sandstorm-io/sandstorm
+$[exitcode]1

--- a/installer-tests/run_tests.py
+++ b/installer-tests/run_tests.py
@@ -1,5 +1,154 @@
+import glob
+import os
+import pexpect
+import subprocess
+import re
+
+def _expect(line, current_cmd, do_re_escape=True, do_detect_slow=True, strip_comments=True,
+            verbose=True):
+    timeout = 1
+    if do_detect_slow:
+        if line.startswith('$[slow]'):
+            print 'Slow line...'
+            timeout = 30
+            line = line.replace('$[slow]', '', 1)
+
+    if verbose:
+        print 'expecting', line
+
+    if do_re_escape:
+        line = re.escape(line)
+
+    current_cmd.expect(line, timeout=timeout)
+
+
+TEST_ROOT=os.path.dirname(os.path.abspath(__file__))
+SANDSTORM_SOURCE_TREE=os.path.abspath(os.path.join(os.path.abspath(__file__), '..', '..'))
+SANDSTORM_IN_HOME=os.path.join(os.environ['HOME'], 'sandstorm')
+
+def vagrant_destroy():
+    subprocess.check_output(['vagrant', 'destroy', '-f'], cwd=TEST_ROOT)
+
+def handle_test_script(lines):
+    current_cmd = None
+    next_timeout = 1
+
+    for line in lines:
+        # Figure out what we want to do, given this line.
+        if line.startswith('$[run]'):
+            arg = line.replace('$[run]', '')
+            arg = 'vagrant ssh -c "' + arg + '"'
+            print 'starting', arg, '...'
+            current_cmd = pexpect.spawn(arg, cwd=TEST_ROOT)
+        elif '$[exitcode]' in line:
+            left, right = map(lambda s: s.strip(), line.split('$[exitcode]'))
+            # Expect end of file.
+            current_cmd.expect(pexpect.EOF, timeout=1)
+            current_cmd.close()
+            assert current_cmd.exitstatus == int(right)
+
+        elif '$[type]' in line:
+            # First, we expect the left side.
+            left, right = map(lambda s: s.strip(), line.split('$[type]'))
+            _expect(left, current_cmd=current_cmd)
+
+            # Then we sendline the right side.
+            current_cmd.sendline(right)
+        else:
+            # For now, assume the action is expect.
+            _expect(line, current_cmd=current_cmd)
+
+
+def handle_headers(headers_list):
+    postconditions = []
+    cleanups = []
+
+    for header in headers_list:
+        key, value = map(lambda s: s.strip(), header.split(':'))
+        key = key.lower()
+        if key == 'title':
+            print 'Test title:', value
+
+        if key == 'vagrant-destroy-if-bash':
+            print 'hmm'
+            full_bash_cmd = 'if [ %s ] ; then exit 0 ; else exit 1 ; fi' % (value,)
+            exitcode = subprocess.call(['vagrant', 'ssh', '-c', full_bash_cmd], cwd=TEST_ROOT)
+            if exitcode == 0:
+                print 'Destroying...'
+                vagrant_destroy()
+                print 'Recreating...'
+                vagrant_up()
+
+        if key == 'vagrant-precondition-bash':
+            full_bash_cmd = 'if [ %s ] ; then exit 0 ; else exit 1 ; fi' % (value,)
+            subprocess.check_output(['vagrant', 'ssh', '-c', full_bash_cmd], cwd=TEST_ROOT)
+
+        if key == 'precondition':
+            evald_value = eval(value)
+            assert eval(value), "value of " + value + " was " + str(evald_value)
+
+        if key == 'cwd':
+            evald_value = eval(value)
+            print 'chdir() ing to', evald_value
+            os.chdir(evald_value)
+
+        if key == 'postcondition':
+            postconditions.append([key, value])
+
+        if key == 'cleanup':
+            cleanups.append([key, value])
+
+    return postconditions, cleanups
+
+
+def handle_postconditions(postconditions_list):
+    for key, value in postconditions_list:
+            evald_value = eval(value)
+            assert eval(value), "value of " + value + " was " + str(evald_value)
+
+def vagrant_up():
+    subprocess.check_output(['vagrant', 'up'], cwd=TEST_ROOT)
+
+
+def run_one_test(filename, state):
+    vagrant_up()
+    lines = open(filename).read().split('\n')
+    position_of_blank_line = lines.index('')
+
+    headers, test_script = lines[:position_of_blank_line], lines[position_of_blank_line+1:]
+
+    print repr(headers)
+    postconditions, cleanups = handle_headers(headers)
+    handle_test_script(test_script)
+
+    handle_postconditions(postconditions)
+    restore_state(state)
+    handle_cleanups(cleanups)
+
+
+def handle_cleanups(cleanups):
+    for key, value in cleanups:
+        print 'Doing cleanup task', value
+        try:
+            eval(value)
+        except Exception, e:
+            print 'Ran into error', e
+            print 'Dazed and confused, but trying to continue.'
+
+
+def save_state():
+    return {'cwd': os.getcwd()}
+
+
+def restore_state(state):
+    os.chdir(state['cwd'])
+
+
 def main():
-    print 'yes'
+    for filename in glob.glob('*.t'):
+        state = save_state()
+        run_one_test(filename, state)
+
 
 
 if __name__ == '__main__':

--- a/installer-tests/run_tests.py
+++ b/installer-tests/run_tests.py
@@ -1,0 +1,6 @@
+def main():
+    print 'yes'
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is some code to automatically test `install.sh`.

It doesn't test all cases yet, not by a long shot, but I wanted to get @jparyani and/or @zarvox to give it a quick look-over and suggest ways it could be better.

If you can't think of any, that's fine, but that probably means you're not being creative enough. (-;

(I plan to make some changes before shipping this.)

Open questions:

* If I'm driving the install script's tests via Vagrant, then how can this run on our Jenkins server? (One answer: Adjust Vagrant to use the libvirt backend. Another answer: Run this stuff somewhere we can run VirtualBox, like @kentonv's closet.)

* Is this syntax (see `installer-tests/*.t`) basically reasonable for people?

* Should I document this syntax somewhere?

* Should I go find an actual parsing library and learn how to use it?

* I'd like to capture the full conversation on the PTYs, so that in the case of test failures, one doesn't have to eyeball pexpect's error output (which is not too bad, so this isn't a showstopper).

* How do we avoid making our install stats look inflated due to running the tests? (Answer for now: (a) pass a `User-Agent` header through to `curl` when it's being run through the installer, and (b) adjust the stats system to ignore all requests from the "office" as well as all requests that come in with that `User-Agent` header.)

Things I know I'll have to do and don't totally know how, but intend to figure out:

* Figure out an enhancement to this syntax to let us specify which VM to run it on. This way, we can e.g. test on Fedora, and Docker inside Ubuntu 14.04, and so on.

Things I already know how to do, and plan to:

* Adjust the handling of `Vagrant-Precondition-bash` so that if the precondition fails, the test destroys the VM and then recreates it and then brings the VM back up again.

Things I'm considering doing:

* Creating a library of helper bash functions, and having Vagrant inject those into the VM, so I can simplify the various `Vagrant-Precondition-bash` lines to call those functions rather than contain lots of copy-pasta.

Please don't merge this yet, but feedback welcome.