### PR TITLE
Add install script tests, and fix sysctl/userns detection (WIP (do not merge yet))

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -144,6 +144,9 @@ USE_SANDCATS="no"
 SANDCATS_SUCCESSFUL="no"
 CURRENTLY_UID_ZERO="no"
 PREFER_ROOT="yes"
+USERNS_CLONE_AT_ALL=""
+USERNS_CLONE_UNPRIVILEGED_NEEDS_SYSCTL_SET=""
+SYSCTL_PROBABLY_WORKS="yes"
 
 # Defaults for some config options, so that if the user requests no
 # prompting, they get these values.
@@ -276,77 +279,171 @@ assert_usable_kernel() {
   fi
 }
 
-assert_userns_clone() {
+detect_userns_clone() {
+  # You might think it's a little bit silly to embed an x86_64 binary
+  # in this shell script, just find out if user namespaces work for
+  # unprivileged users.
+  #
+  # However, here's the story:
+  #
+  # - Many people use the Debian backports kernel (where user
+  #   namespaces work great) with older userspace, so we can't
+  #   run unshare(1) with the --user option to test it, since
+  #   their version of unshare(1) doesn't have a --user option.
+  #
+  # - Many people run Arch Linux, where user namespaces are disabled
+  #   as a kernel option.
+  #
+  # - Many people run Debian and/or Ubuntu, where user namespaces are
+  #   enabled but require a sysctl to enable.
+  #
+  # - We used to compile a test binary, but sometimes people would
+  #   install Sandstorm on cloud VMs where there is no compiler.
+  #
+  # Source of this program: https://github.com/paulproteus/tiny-rust-demo
+
+  # If the kernel has this sysctl, then it has user namespaces. We
+  # also check the value, since we want unprivileged users to be able
+  # to create user namespaces.
+
   if [ -e /proc/sys/kernel/unprivileged_userns_clone ]; then
+    USERNS_CLONE_AT_ALL="yes"
     if [ "$(</proc/sys/kernel/unprivileged_userns_clone)" == "0" ]; then
-      echo "Sandstorm requires sysctl kernel.unprivileged_userns_clone to be enabled."
-      echo "Currently, it is not enabled on your system."
-      if prompt-yesno "Shall I enable it for you?" yes; then
-        if [ ! -e /etc/sysctl.conf ]; then
-          fail "Can't find /etc/sysctl.conf. I don't know how to set sysctls" \
-               "permanently on your system. Please set it manually and try again."
-        fi
-        cat >> /etc/sysctl.conf << __EOF__
+      USERNS_CLONE_UNPRIVILEGED_NEEDS_SYSCTL_SET="yes"
+    fi
+    return
+  fi
+
+  # In the absence of that, we attempt to create a user namespace with
+  # this test program.
+  local USERNS_TEST_PROGRAM="$(mktemp)"
+  printf '\x7fELF\x02\x01\x01\x00kmc!!!\n\x00\x02\x00>\x00\x01\x00\x00\x00\x7f\x00@\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x008\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\xbb\x00\x00\x00\x00\x00\x00\x00\xbb\x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\xb8<\x00\x00\x00\x0f\x05P\xb8f\x00\x00\x00\x0f\x05H\x85\xc0u\x11\xb8i\x00\x00\x00\xbf\xfe\xff\x00\x00\x0f\x05H\x85\xc0u\x14\xb8\x10\x01\x00\x00\xbf\x00\x00\x00\x10\x0f\x05H\x89\xc7\xe8\xc7\xff\xff\xff\xbf\x02\x00\x00\x00\xe8\xbd\xff\xff\xff' > "$USERNS_TEST_PROGRAM"
+  chmod a+x "$USERNS_TEST_PROGRAM"
+  if "$USERNS_TEST_PROGRAM" ; then
+    USERNS_CLONE_AT_ALL="yes"
+    USERNS_CLONE_UNPRIVILEGED_NEEDS_SYSCTL_SET="no"
+  else
+    USERNS_CLONE_AT_ALL="no"
+  fi
+
+  # Clean up after ourselves.
+  rm -f "$USERNS_TEST_PROGRAM"
+}
+
+assert_userns_clone_works_or_can_be_made_to_work() {
+  # The purpose of this function is to bail out early if people have no way
+  # to run Sandstorm and we can't help them via e.g. sysctl.
+
+  # If they don't have working unprivileged user namespaces, then we bail.
+  if [ "$USERNS_CLONE_AT_ALL" = "no" ] ; then
+    fail "Your kernel does not appear to be compiled with" \
+         "support for unprivileged user namespaces (CONFIG_USER_NS=y), or something else is" \
+         "preventing creation of user namespaces. This feature is critical for sandboxing." \
+         "Arch Linux is known to ship with a kernel that disables this feature; if you are" \
+         "using Arch, you will unfortunately need to compile your own kernel (see" \
+         "https://bugs.archlinux.org/task/36969). If you are not using Arch, and don't" \
+         "know why your system wouldn't have user namespaces, please file a bug against" \
+         "Sandstorm so we can figure out what happened."
+  fi
+
+  # We know that unprivileged user namespaces basically work. If they
+  # work, and the user doesn't need a sysctl set, then we are happy.
+  if [ "$USERNS_CLONE_UNPRIVILEGED_NEEDS_SYSCTL_SET" = "no" ] ; then
+    return
+  fi
+
+  # At this point, we're going to need this sysctl set.
+  #
+  # But that won't work under one of a few circumstances. Let's identify
+  # those so we know to bail out.
+  local SYSCTL_PROBABLY_WORKS="yes"
+
+  # If /proc/sys is mounted read-only, then they won't be able to run
+  # sysctl with our help.
+  #
+  # This applies to Docker containers and probably other sorts of
+  # containers, too.
+  if egrep -q '/proc/sys\s+proc\s+ro' /proc/mounts ; then
+    SYSCTL_PROBABLY_WORKS="no"
+  fi
+
+  # If this system doesn't have a sysctl.conf, then we don't know how
+  # to set the default value for the next reboot.
+  if [ ! -e /etc/sysctl.conf ] ; then
+    SYSCTL_PROBABLY_WORKS="no"
+  fi
+
+  # OK, so they need the sysctl set.
+  #
+  # If, however, they _can't_ set the sysctl, make the install fail
+  # now.
+  if [ "$SYSCTL_PROBABLY_WORKS" = "no" ] ; then
+    echo "# sysctl -w kernel.unprivileged_userns_clone=1"
+    echo "# cat >> /etc/sysctl.conf << __EOF__"
+    echo ""
+    echo "# Enable non-root users to create sandboxes (needed by Sandstorm)."
+    echo "kernel.unprivileged_userns_clone = 1"
+    echo "__EOF__"
+    echo ""
+    fail "You are using a Debian-derived Linux kernel, which needs a configuration option" \
+         "set in order to run Sandstorm. To set that option, please run the shell commands" \
+         "above as root. (If you are running this in a container through e.g. Docker, you will" \
+         "have to run the above commands _outside_ the container.)"
+  fi
+
+  # OK, so either it already works, or we know it's a reasonable idea to ask
+  # the user to let us enable the sysctl.
+}
+
+enable_userns_sysctl_if_needed() {
+  # This function enables the Debian/Ubuntu-specific unprivileged
+  # userns sysctl.
+  #
+  # We only run it if we need to.
+  if [ "$USERNS_CLONE_UNPRIVILEGED_NEEDS_SYSCTL_SET" != "yes" ] ; then
+    return
+  fi
+
+  # It only makes sense when running as root, so if we are not
+  # currently running as root, just skip this code.
+  if [ "no" = "$CURRENTLY_UID_ZERO" ] ; then
+    return
+  fi
+
+  local PRINT_USERNS_INFO="yes"
+  local ACCEPTED_SYSCTL_SWITCH="no"
+
+  if [ "yes" = "${ACCEPTED_FULL_SERVER_INSTALL:-}" ] ; then
+    PRINT_USERNS_PROMPT="no"
+    ACCEPTED_SYSCTL_SWITCH="yes"
+  fi
+
+  if [ "${PRINT_USERNS_PROMPT}" = "yes" ] ; then
+    echo "Sandstorm requires sysctl kernel.unprivileged_userns_clone to be enabled."
+    echo "Currently, it is not enabled on your system."
+    if prompt-yesno "Shall I enable it for you?" yes; then
+      ACCEPTED_SYSCTL_SWITCH="yes"
+    fi
+  fi
+
+  if [ "$ACCEPTED_SYSCTL_SWITCH" = "yes" ] ; then
+    if [ ! -e /etc/sysctl.conf ]; then
+      fail "Can't find /etc/sysctl.conf. I don't know how to set sysctls" \
+           "permanently on your system. Please set it manually and try again."
+    fi
+
+    cat >> /etc/sysctl.conf << __EOF__
 
 # Enable non-root users to create sandboxes (needed by Sandstorm).
 kernel.unprivileged_userns_clone = 1
 __EOF__
-        sysctl -w kernel.unprivileged_userns_clone=1 || fail "'sysctl -w" \
-          "kernel.unprivileged_userns_clone=1' failed. If you are inside docker, please run the" \
-          "command manually inside your host and update /etc/sysctl.conf."
-      else
-        fail "OK, please enable this option yourself and try again."
-      fi
-    fi
+
+    sysctl -w kernel.unprivileged_userns_clone=1 >/dev/null \
+      || fail "'sysctl -w" \
+              "kernel.unprivileged_userns_clone=1' failed. If you are inside docker, please run the" \
+              "command manually inside your host and update /etc/sysctl.conf."
   else
-    # Figure out if user namespaces work at all.
-    rm -f /tmp/sandstorm-userns-test /tmp/sandstorm-userns-test.c
-    cat > /tmp/sandstorm-userns-test.c << __EOF__
-#define _GNU_SOURCE
-#include <sched.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <stdio.h>
-
-int main() {
-  /* We're trying to verify that UID namespaces work when not root, so make sure we're
-   * not root. */
-  if (getuid() == 0) {
-    /* Number here doesn't really matter, but 65534 is usually "nobody". */
-    if (setuid(65534) < 0) {
-      perror("setuid");
-      return 1;
-    }
-  }
-
-  /* OK, let's see if we can create a UID namespace. */
-  if (unshare(CLONE_NEWUSER) < 0) {
-    /* Nope. */
-    perror("unshare");
-    return 1;
-  }
-
-  return 0;
-}
-__EOF__
-    if cc /tmp/sandstorm-userns-test.c -o /tmp/sandstorm-userns-test; then
-      if ! /tmp/sandstorm-userns-test; then
-        rm -f /tmp/sandstorm-userns-test /tmp/sandstorm-userns-test.c
-        fail "Your kernel does not appear to be compiled with" \
-             "support for unprivileged user namespaces (CONFIG_USER_NS=y), or something else is" \
-             "preventing creation of user namespaces. This feature is critical for sandboxing." \
-             "Arch Linux is known to ship with a kernel that disables this feature; if you are" \
-             "using Arch, you will unfortunately need to compile your own kernel (see" \
-             "https://bugs.archlinux.org/task/36969). If you are not using Arch, and don't" \
-             "know why your system wouldn't have user namespaces, please file a bug against" \
-             "Sandstorm so we can figure out what happened."
-      fi
-    else
-      echo "WARNING: Couldn't compile user namespace test. We'll assume user namespaces" >&2
-      echo "  are enabled." >&2
-    fi
-
-    rm -f /tmp/sandstorm-userns-test /tmp/sandstorm-userns-test.c
+    fail "OK, please enable this option yourself and try again."
   fi
 }
 
@@ -484,6 +581,9 @@ dev_server_install() {
     echo "* Add you ($USER) to the $DEFAULT_SERVER_USER group so you can read/write app data."
     echo "* Expose the service only on localhost aka local.sandstorm.io, not the public Internet."
     echo "* Enable 'dev accounts', for easy developer login."
+    if [ "yes" == "$USERNS_CLONE_UNPRIVILEGED_NEEDS_SYSCTL_SET" ] ; then
+      echo "* Configure your system to enable unprivileged user namespaces, via sysctl"
+    fi
     if [ "unknown" == "$INIT_SYSTEM" ]; then
       echo "*** WARNING: Could not detect how to run Sandstorm at startup on your system. ***"
     else
@@ -552,6 +652,9 @@ full_server_install() {
       echo "*** WARNING: Could not detect how to run Sandstorm at startup on your system. ***"
     else
       echo "* Configure Sandstorm to start on System boot (with $INIT_SYSTEM)"
+    fi
+    if [ "yes" == "$USERNS_CLONE_UNPRIVILEGED_NEEDS_SYSCTL_SET" ] ; then
+      echo "* Configure your system to enable unprivileged user namespaces, via sysctl."
     fi
     echo ""
 
@@ -1436,15 +1539,17 @@ sandcats_generate_keys() {
 # Now that the steps exist as functions, run them in an order that
 # would result in a working install.
 detect_current_uid
+detect_userns_clone
+assert_userns_clone_works_or_can_be_made_to_work
 handle_args "$@"
 assert_on_terminal
 assert_linux_x86_64
 assert_usable_kernel
-assert_userns_clone
 assert_dependencies
 assert_valid_bundle_file
 detect_init_system
 choose_install_mode
+enable_userns_sysctl_if_needed
 choose_external_or_internal
 choose_install_dir
 load_existing_settings

--- a/installer-tests/Vagrantfile
+++ b/installer-tests/Vagrantfile
@@ -1,0 +1,83 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # We have a few box types.
+
+  # In general, we use a shell script to "provision" the box. just
+  # sets up a different hostname than vagrant, because I find
+  # "vagrant" to be a weird hostname.
+  config.ssh.shell = "bash"
+  config.vm.provision "shell",
+                       inline: "cd /vagrant && echo localhost > /etc/hostname && hostname localhost"
+
+
+  # Make sure to share the dir one *above* the current working directory. That way, we get
+  # the Sandstorm source tree, which includes the all-important install.sh.
+  config.vm.synced_folder "..", "/vagrant"
+
+  # In this Vagrantbox purely to test the install script, we do not
+  # forward any ports. If we need to test if ports are available, we
+  # can do that by SSH-ing in.
+
+  # Calculate the number of CPUs and the amount of RAM the system has,
+  # in a platform-dependent way; further logic below.
+  cpus = nil
+  total_kB_ram = nil
+
+  host = RbConfig::CONFIG['host_os']
+  if host =~ /darwin/
+    cpus = `sysctl -n hw.ncpu`.to_i
+    total_kB_ram =  `sysctl -n hw.memsize`.to_i / 1024
+  elsif host =~ /linux/
+    cpus = `nproc`.to_i
+    total_kB_ram = `grep MemTotal /proc/meminfo | awk '{print $2}'`.to_i
+  end
+
+  # Use the same number of CPUs within Vagrant as the system, with 1
+  # as a default.
+  #
+  # Use at least 512MB of RAM, and if the system has more than 2GB of
+  # RAM, use 1/4 of the system RAM. This seems a reasonable compromise
+  # between having the Vagrant guest operating system not run out of
+  # RAM entirely (which it basically would if we went much lower than
+  # 512MB) and also allowing it to use up a healthily large amount of
+  # RAM so it can run faster on systems that can afford it.
+  config.vm.provider :virtualbox do |vb|
+    if cpus.nil?
+      vb.cpus = 1
+    else
+      vb.cpus = cpus
+    end
+
+    if total_kB_ram.nil? or total_kB_ram < 2048000
+      vb.memory = 512
+    else
+      vb.memory = (total_kB_ram / 1024 / 4)
+    end
+  end
+
+
+  config.vm.define "default", primary: true do |default|
+    # The default is the Ubuntu 14.04 ("trusty tahr") cloud image.
+    default.vm.box = "trusty64"
+
+    # The url from which to fetch that base box.
+    default.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  end
+
+  config.vm.define "jessie" do |jessie|
+    # The default is the Ubuntu 14.04 ("trusty tahr") cloud image.
+    jessie.vm.box = "thoughtbot/debian-jessie-64"
+
+    jessie.vm.provision "shell",
+                       inline: "sudo sed -i s,ftp.us.debian.org,http.debian.net, /etc/apt/sources.list"
+    jessie.vm.provision "shell",
+                       inline: "if [ ! -d /usr/share/doc/curl ] ; then sudo apt-get -qq update && sudo DEBIAN_FRONTEND=noninteractive apt-get -q -y install curl ; fi"
+
+  end
+
+end

--- a/installer-tests/full-server-install-on-jessie-with-userns-sysctl.t
+++ b/installer-tests/full-server-install-on-jessie-with-userns-sysctl.t
@@ -1,0 +1,44 @@
+Title: Can install with root on Debian jessie, in full server mode
+Vagrant-Box: jessie
+Vagrant-Precondition-bash: ! -d $HOME/sandstorm
+Vagrant-Precondition-bash: ! -d /opt/sandstorm
+Cleanup: uninstall_sandstorm(parsed_headers['vagrant-box'])
+
+$[run]sudo cat /proc/sys/kernel/unprivileged_userns_clone
+$[slow]0
+$[run]OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh
+$[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
+
+1. A full server with automatic setup (press enter to accept this default)
+2. A development server, for writing apps.
+
+How are you going to use this Sandstorm install? [1] $[type]1
+We're going to:
+
+* Install Sandstorm in /opt/sandstorm
+* Automatically keep Sandstorm up-to-date
+* Create a service user (sandstorm) that owns Sandstorm's files
+* Configure Sandstorm to start on System boot (with sysvinit)
+* Configure your system to enable unprivileged user namespaces, via sysctl.
+
+To set up Sandstorm, we will need to use sudo.
+OK to continue? [yes] $[type]
+$[slow]Re-running script as root...
+As a Sandstorm user, you are invited to use a free Internet hostname as a subdomain of sandcats.io.
+$[slow]Choose your desired Sandcats subdomain (alphanumeric, max 20 characters).
+Type the word none to skip this step, or help for help.
+What *.sandcats-dev.sandstorm.io subdomain would you like? []$[type]gensym
+We need your email on file so we can help you recover your domain if you lose access. No spam.
+Enter your email address: [] $[type]install-script@asheesh.org
+Registering your domain.
+$[slow]Congratulations! We have registered your
+Your credentials to use it are in /opt/sandstorm/var/sandcats; consider making a backup.
+$[slow]Downloading: https://dl.sandstorm.io
+$[slow]Sandstorm started. PID =
+Setup complete. You should configure the site at:
+  http://
+To learn how to control the server, run:
+  sandstorm help
+$[exitcode]0
+$[run]sudo bash -c 'echo 0 > /proc/sys/kernel/unprivileged_userns_clone'
+$[slow]0

--- a/installer-tests/install-without-root.t
+++ b/installer-tests/install-without-root.t
@@ -1,0 +1,54 @@
+Title: Can install without root, with -u
+Vagrant-Box: default
+Vagrant-Destroy-If-bash: -d $HOME/sandstorm
+Vagrant-Precondition-bash: ! -d $HOME/sandstorm
+Cleanup: vagrant_destroy()
+
+$[run]/vagrant/install.sh -u
+$[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
+
+1. A full server with automatic setup (press enter to accept this default)
+2. A development server, for writing apps.
+
+How are you going to use this Sandstorm install? [1] $[type]2
+Expose to localhost only? [yes] $[type]
+Where would you like to put Sandstorm? $[type]
+Automatically keep Sandstorm updated? [yes]$[type]
+Sandstorm supports 'dev accounts', a feature that lets anyone log in
+as admin and other sample users to a Sandstorm server. We recommend
+it for app development, and absolutely do not recommend it for
+a server on the public Internet.
+Enable dev accounts? [yes] $[type]
+Server main HTTP port: [6080] $[type]
+Database port (choose any unused port): [6081]$[type]
+Note: local.sandstorm.io maps to 127.0.0.1, i.e. your local machine.
+For reasons that will become clear in the next step, you should use this
+instead of 'localhost'.
+URL users will enter in browser: [http://local.sandstorm.io:6080]$[type]
+Sandstorm requires you to set up a wildcard DNS entry pointing at the server.
+This allows Sandstorm to allocate new hosts on-the-fly for sandboxing purposes.
+Please enter a DNS hostname containing a '*' which maps to your server. For
+example, if you have mapped *.foo.example.com to your server, you could enter
+"*.foo.example.com". You can also specify that hosts should have a special
+prefix, like "ss-*.foo.example.com". Note that if your server's main page
+is served over SSL, the wildcard address must support SSL as well, which
+implies that you must have a wildcard certificate. For local-machine servers,
+we have mapped *.local.sandstorm.io to 127.0.0.1 for your convenience, so you
+can use "*.local.sandstorm.io" here. If you are serving off a non-standard
+port, you must include it here as well.
+Wildcard host: [*.local.sandstorm.io:6080]$[type]
+
+Config written to
+Finding latest build for dev channel...
+$[slow]Downloading: https://dl.sandstorm.io/sandstorm-
+$[slow]Start sandstorm at system boot (using sysvinit)? [yes] $[type]
+Setup complete. To start your server now, run:
+sandstorm start
+You should then configure the site at:
+  http://local.sandstorm.io:6080/admin/
+WARNING: This token expires in 15 minutes.
+You can generate a new token by running 'sandstorm admin-token' from the command line
+
+To learn how to control the server, run:
+help
+$[exitcode]0

--- a/installer-tests/no-root.t
+++ b/installer-tests/no-root.t
@@ -1,0 +1,26 @@
+Title: Can't install Sandstorm without root, by default
+Vagrant-Box: default
+Vagrant-Precondition-bash: ! -d $HOME/sandstorm
+Vagrant-Precondition-bash: ! -d /opt/sandstorm
+Vagrant-Postcondition-bash: ! -d $HOME/sandstorm
+Vagrant-Postcondition-bash: ! -d /opt/sandstorm
+
+$[run]/vagrant/install.sh
+$[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
+
+1. A full server with automatic setup (press enter to accept this default)
+2. A development server, for writing apps.
+
+How are you going to use this Sandstorm install? [1] $[type]2
+If you want app developer mode for a Sandstorm install, you need root
+due to limitations in the Linux kernel.
+
+To set up Sandstorm, we will need to use sudo.
+Sandstorm's database and web interface won't run as root.
+OK to continue? [yes] $[type]no
+If you are OK with a local Sandstorm install for testing
+but not app development, re-run install.sh with -u to bypass this message.
+For developer mode to work, the script needs root, or read above to bypass.
+*** INSTALLATION FAILED ***
+Report bugs at: http://github.com/sandstorm-io/sandstorm
+$[exitcode]1

--- a/installer-tests/run_tests.py
+++ b/installer-tests/run_tests.py
@@ -1,0 +1,224 @@
+import glob
+import os
+import pexpect
+import random
+import subprocess
+import sys
+import re
+
+
+def _expect(line, current_cmd, do_re_escape=True, do_detect_slow=True,
+            strip_comments=True, verbose=True):
+    timeout = 1
+    if do_detect_slow:
+        if line.startswith('$[slow]'):
+            print 'Slow line...'
+            timeout = int(os.environ.get('SLOW_TEXT_TIMEOUT', 30))
+            line = line.replace('$[slow]', '', 1)
+
+    if verbose:
+        print 'expecting', line
+
+    if do_re_escape:
+        line = re.escape(line)
+
+    current_cmd.expect(line, timeout=timeout)
+
+
+TEST_ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+def vagrant_destroy():
+    subprocess.check_output(['vagrant', 'destroy', '-f'], cwd=TEST_ROOT)
+
+
+def handle_test_script(vagrant_box_name, lines):
+    current_cmd = None
+
+    for line in lines:
+        # Figure out what we want to do, given this line.
+        if line.startswith('$[run]'):
+            arg = line.replace('$[run]', '')
+            arg = 'vagrant ssh ' + vagrant_box_name + ' -c "' + arg + '"'
+            print 'starting', arg, '...'
+            current_cmd = pexpect.spawn(arg, cwd=TEST_ROOT)
+        elif '$[exitcode]' in line:
+            left, right = map(lambda s: s.strip(), line.split('$[exitcode]'))
+            # Expect end of file.
+            current_cmd.expect(pexpect.EOF, timeout=1)
+            current_cmd.close()
+            assert current_cmd.exitstatus == int(right)
+
+        elif '$[type]' in line:
+            # First, we expect the left side.
+            left, right = map(lambda s: s.strip(), line.split('$[type]'))
+            _expect(left, current_cmd=current_cmd)
+
+            if right == 'gensym':
+                # instead of typing the literal string gensym, we generate
+                # a hopefully unique collection of letters and numbers.
+                right = ''.join(
+                    random.sample('abcdefghijklmnopqrstuvwxyz0123456789', 10))
+
+            # Then we sendline the right side.
+            current_cmd.sendline(right)
+        else:
+            # For now, assume the action is expect.
+            _expect(line, current_cmd=current_cmd)
+
+
+def parse_test_file(headers_list):
+    postconditions = []
+    cleanups = []
+    parsed_headers = {}
+
+    for header in headers_list:
+        key, value = map(lambda s: s.strip(), header.split(':'))
+        key = key.lower()
+
+        if key == 'vagrant-box':
+            parsed_headers['vagrant-box'] = value
+
+        if key == 'title':
+            parsed_headers['title'] = value
+
+        if key == 'vagrant-destroy-if-bash':
+            if key not in parsed_headers:
+                parsed_headers[key] = []
+            parsed_headers[key].append(value)
+
+        if key == 'vagrant-precondition-bash':
+            if key not in parsed_headers:
+                parsed_headers[key] = []
+            parsed_headers[key].append(value)
+
+        if key == 'precondition':
+            if key not in parsed_headers:
+                parsed_headers[key] = []
+            parsed_headers[key].append(value)
+
+        if key == 'postcondition':
+            postconditions.append([key, value])
+
+        if key == 'cleanup':
+            cleanups.append([key, value])
+
+    # Some keys are required.
+    #
+    # Also uh I should probably be using capnproto for this, hmm.
+    for required_key in ['vagrant-box']:
+        assert required_key in parsed_headers, "Missing %s" % (required_key,)
+
+    return parsed_headers, postconditions, cleanups
+
+
+def handle_headers(parsed_headers):
+    vagrant_box_name = parsed_headers['vagrant-box']
+
+    # Bring up VM, if needed.
+    vagrant_up(vagrant_box_name)
+
+    values = parsed_headers.get('vagrant-destroy-if-bash')
+    if values:
+        for value in values:
+            full_bash_cmd = 'if [ %s ] ; then exit 0 ; else exit 1 ; fi' % (
+                value,)
+            exitcode = subprocess.call(['vagrant', 'ssh', vagrant_box_name,
+                                        '-c', full_bash_cmd], cwd=TEST_ROOT)
+            if exitcode == 0:
+                print 'Destroying all...'
+                vagrant_destroy()
+                print 'Recreating as needed...'
+                vagrant_up(vagrant_box_name)
+
+    values = parsed_headers.get('vagrant-precondition-bash')
+    if values:
+        for value in values:
+            full_bash_cmd = 'if [ %s ] ; then exit 0 ; else exit 1 ; fi' % (
+                value,)
+            subprocess.check_output(['vagrant', 'ssh', vagrant_box_name,
+                                     '-c', full_bash_cmd], cwd=TEST_ROOT)
+
+
+def handle_postconditions(postconditions_list):
+    for key, value in postconditions_list:
+            evald_value = eval(value)
+            assert eval(value), "value of " + value + " was " + str(
+                evald_value)
+
+
+def vagrant_up(vagrant_box_name):
+    subprocess.check_output(['vagrant', 'up', vagrant_box_name], cwd=TEST_ROOT)
+
+
+def run_one_test(filename, state):
+    lines = open(filename).read().split('\n')
+    position_of_blank_line = lines.index('')
+
+    headers, test_script = (lines[:position_of_blank_line],
+                            lines[position_of_blank_line+1:])
+
+    print repr(headers)
+    parsed_headers, postconditions, cleanups = parse_test_file(headers)
+
+    # Make the VM etc., if necessary.
+    handle_headers(parsed_headers)
+
+    # Run the test script, using pexpect to track its output.
+    try:
+        handle_test_script(parsed_headers['vagrant-box'], test_script)
+    except Exception, e:
+        print e
+        raise
+        print 'Dazed and confused, but trying to continue.'
+
+    # Run any sanity-checks in the test script, as needed.
+    handle_postconditions(postconditions)
+
+    # If the test knows it needs to do some cleanup, e.g. destroying
+    # its VM, then do so.
+    handle_cleanups(parsed_headers, cleanups)
+
+
+def uninstall_sandstorm(vagrant_box_name):
+    for cmd in [
+            'sudo pkill -9 sandstorm || true',
+            'sudo rm -rf /opt/sandstorm',
+            'sudo rm -rf $HOME/sandstorm',
+            'X=/proc/sys/kernel/unprivileged_userns_clone if [ -e $X ] ; then echo 0 | sudo dd of=$X ; fi',
+            'sudo pkill -9 sudo || true',
+    ]:
+        exitcode = subprocess.call(['vagrant', 'ssh', vagrant_box_name,
+                                    '-c', cmd], cwd=TEST_ROOT)
+        assert (exitcode == 0), "Ran %s, got %s" (cmd, exitcode)
+
+
+def handle_cleanups(parsed_headers, cleanups):
+    for key, value in cleanups:
+        print 'Doing cleanup task', value
+        try:
+            eval(value)
+        except Exception, e:
+            print 'Ran into error', e
+            raise
+            print 'Dazed and confused, but trying to continue.'
+
+
+def save_state():
+    return {'cwd': os.getcwd()}
+
+
+def restore_state(state):
+    os.chdir(state['cwd'])
+
+
+def main():
+    filenames = sys.argv[1:]
+    if not filenames:
+        filenames = glob.glob('*.t')
+    for filename in filenames:
+        state = save_state()
+        run_one_test(filename, state)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit:

* Introduces the installer-tests directory, which contains

* A Vagrantfile, indicating how to run a variety of operating systems
  for testing the Sandstorm installer, and

* run_tests.py, a quick sketch of how to read sample command line
  interaction scripts and verify that they still work, and

* Three tests for run_tests.py, to avoid regressions in the install
  script.

It also fixes install.sh to properly handle enabling the sysctl for
unprivileged_userns_clone.

Close #396