### PR TITLE
Fixes account-email-token ignoring Settings.smtpUrl

### DIFF
--- a/shell/.meteor/packages
+++ b/shell/.meteor/packages
@@ -9,6 +9,7 @@ underscore
 random
 sandstorm-accounts-ui
 sandstorm-accounts-packages
+sandstorm-email
 accounts-email-token
 email
 reload

--- a/shell/.meteor/versions
+++ b/shell/.meteor/versions
@@ -62,6 +62,7 @@ routepolicy@1.0.3
 sandstorm-accounts-oauth@1.1.4
 sandstorm-accounts-packages@0.1.0
 sandstorm-accounts-ui@0.1.0
+sandstorm-email@0.1.0
 service-configuration@1.0.3
 session@1.0.5
 sha@1.0.2

--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -26,6 +26,13 @@ var checkToken = function (user, token) {
   return found;
 };
 
+// The name of the email package to use. It refers to a variable named in the global scope.
+var EMAIL_PACKAGE= "Email";
+
+Accounts.emailToken.setEmailPackage = function (packageName) {
+  EMAIL_PACKAGE = packageName;
+};
+
 // Handler to login with a token.
 Accounts.registerLoginHandler("emailToken", function (options) {
   if (!options.emailToken)
@@ -100,7 +107,7 @@ var sendTokenEmail = function (email, token) {
           "This information will expire in 15 minutes.\n"
   };
 
-  Email.send(options);
+  global[EMAIL_PACKAGE].send(options);
 };
 
 ///

--- a/shell/packages/sandstorm-email/.npm/package/.gitignore
+++ b/shell/packages/sandstorm-email/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/shell/packages/sandstorm-email/.npm/package/README
+++ b/shell/packages/sandstorm-email/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/shell/packages/sandstorm-email/.npm/package/npm-shrinkwrap.json
+++ b/shell/packages/sandstorm-email/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,26 @@
+{
+  "dependencies": {
+    "mailcomposer": {
+      "version": "0.1.15",
+      "dependencies": {
+        "mimelib-noiconv": {
+          "version": "0.1.9"
+        }
+      }
+    },
+    "simplesmtp": {
+      "version": "0.3.10",
+      "dependencies": {
+        "rai": {
+          "version": "0.1.12"
+        },
+        "xoauth2": {
+          "version": "0.1.8"
+        }
+      }
+    },
+    "stream-buffers": {
+      "version": "0.2.5"
+    }
+  }
+}

--- a/shell/packages/sandstorm-email/email.js
+++ b/shell/packages/sandstorm-email/email.js
@@ -1,0 +1,172 @@
+var Future = Npm.require('fibers/future');
+var urlModule = Npm.require('url');
+var MailComposer = Npm.require('mailcomposer').MailComposer;
+
+Email = {};
+EmailTest = {};
+
+var makePool = function (mailUrlString) {
+  var mailUrl = urlModule.parse(mailUrlString);
+  if (mailUrl.protocol !== 'smtp:')
+    throw new Error("Email protocol in $MAIL_URL (" +
+                    mailUrlString + ") must be 'smtp'");
+
+  var port = +(mailUrl.port);
+  var auth = false;
+  if (mailUrl.auth) {
+    var parts = mailUrl.auth.split(':', 2);
+    auth = {user: parts[0] && decodeURIComponent(parts[0]),
+            pass: parts[1] && decodeURIComponent(parts[1])};
+  }
+
+  var simplesmtp = Npm.require('simplesmtp');
+  var pool = simplesmtp.createClientPool(
+    port,  // Defaults to 25
+    mailUrl.hostname,  // Defaults to "localhost"
+    { secureConnection: (port === 465),
+      // XXX allow maxConnections to be configured?
+      auth: auth });
+
+  pool._future_wrapped_sendMail = _.bind(Future.wrap(pool.sendMail), pool);
+  return pool;
+};
+
+// We construct smtpPool at the first call to Email.send, so that
+// Meteor.startup code can set $MAIL_URL.
+var smtpPoolFuture = new Future;;
+var configured = false;
+
+var getPool = function () {
+  // We check MAIL_URL in case someone else set it in Meteor.startup code.
+  if (!configured) {
+    configured = true;
+    AppConfig.configurePackage('email', function (config) {
+      // XXX allow reconfiguration when the app config changes
+      if (smtpPoolFuture.isResolved())
+        return;
+      var url = config.url || process.env.MAIL_URL;
+      var pool = null;
+      if (url)
+        pool = makePool(url);
+      smtpPoolFuture.return(pool);
+    });
+  }
+
+  return smtpPoolFuture.wait();
+};
+
+var next_devmode_mail_id = 0;
+var output_stream = process.stdout;
+
+// Testing hooks
+EmailTest.overrideOutputStream = function (stream) {
+  next_devmode_mail_id = 0;
+  output_stream = stream;
+};
+
+EmailTest.restoreOutputStream = function () {
+  output_stream = process.stdout;
+};
+
+var devModeSend = function (mc) {
+  var devmode_mail_id = next_devmode_mail_id++;
+
+  var stream = output_stream;
+
+  // This approach does not prevent other writers to stdout from interleaving.
+  stream.write("====== BEGIN MAIL #" + devmode_mail_id + " ======\n");
+  stream.write("(Mail not sent; to enable sending, set the MAIL_URL " +
+               "environment variable.)\n");
+  mc.streamMessage();
+  mc.pipe(stream, {end: false});
+  var future = new Future;
+  mc.on('end', function () {
+    stream.write("====== END MAIL #" + devmode_mail_id + " ======\n");
+    future['return']();
+  });
+  future.wait();
+};
+
+var smtpSend = function (pool, mc) {
+  pool._future_wrapped_sendMail(mc).wait();
+};
+
+/**
+ * Mock out email sending (eg, during a test.) This is private for now.
+ *
+ * f receives the arguments to Email.send and should return true to go
+ * ahead and send the email (or at least, try subsequent hooks), or
+ * false to skip sending.
+ */
+var sendHooks = [];
+EmailTest.hookSend = function (f) {
+  sendHooks.push(f);
+};
+
+// Old comment below
+/**
+ * Send an email.
+ *
+ * Connects to the mail server configured via the MAIL_URL environment
+ * variable. If unset, prints formatted message to stdout. The "from" option
+ * is required, and at least one of "to", "cc", and "bcc" must be provided;
+ * all other options are optional.
+ *
+ * @param options
+ * @param options.from {String} RFC5322 "From:" address
+ * @param options.to {String|String[]} RFC5322 "To:" address[es]
+ * @param options.cc {String|String[]} RFC5322 "Cc:" address[es]
+ * @param options.bcc {String|String[]} RFC5322 "Bcc:" address[es]
+ * @param options.replyTo {String|String[]} RFC5322 "Reply-To:" address[es]
+ * @param options.subject {String} RFC5322 "Subject:" line
+ * @param options.text {String} RFC5322 mail body (plain text)
+ * @param options.html {String} RFC5322 mail body (HTML)
+ * @param options.headers {Object} custom RFC5322 headers (dictionary)
+ */
+
+// New API doc comment below
+/**
+ * @summary Send an email. Throws an `Error` on failure to contact mail server
+ * or if mail server returns an error. All fields should match
+ * [RFC5322](http://tools.ietf.org/html/rfc5322) specification.
+ * @locus Server
+ * @param {Object} options
+ * @param {String} options.from "From:" address (required)
+ * @param {String|String[]} options.to,cc,bcc,replyTo
+ *   "To:", "Cc:", "Bcc:", and "Reply-To:" addresses
+ * @param {String} [options.subject]  "Subject:" line
+ * @param {String} [options.text|html] Mail body (in plain text or HTML)
+ * @param {Object} [options.headers] Dictionary of custom headers
+ */
+Email.send = function (options) {
+  for (var i = 0; i < sendHooks.length; i++)
+    if (! sendHooks[i](options))
+      return;
+
+  var mc = new MailComposer();
+
+  // setup message data
+  // XXX support attachments (once we have a client/server-compatible binary
+  //     Buffer class)
+  mc.setMessageOption({
+    from: options.from,
+    to: options.to,
+    cc: options.cc,
+    bcc: options.bcc,
+    replyTo: options.replyTo,
+    subject: options.subject,
+    text: options.text,
+    html: options.html
+  });
+
+  _.each(options.headers, function (value, name) {
+    mc.addHeader(name, value);
+  });
+
+  var pool = getPool();
+  if (pool) {
+    smtpSend(pool, mc);
+  } else {
+    devModeSend(mc);
+  }
+};

--- a/shell/packages/sandstorm-email/email.js
+++ b/shell/packages/sandstorm-email/email.js
@@ -41,7 +41,7 @@ var makePool = function (mailUrlString) {
 
 // We construct smtpPool at the first call to Email.send, so that
 // Meteor.startup code can set $MAIL_URL.
-var smtpPoolFuture = new Future();
+var pool;
 var configured = false;
 
 Meteor.startup(function() {
@@ -65,17 +65,12 @@ var getPool = function () {
   // We check MAIL_URL in case someone else set it in Meteor.startup code.
   if (!configured) {
     configured = true;
-    // XXX allow reconfiguration when the app config changes
-    if (smtpPoolFuture.isResolved())
-      return;
     var url = getSmtpUrl();
-    var pool = null;
     if (url)
       pool = makePool(url);
-    smtpPoolFuture.return(pool);
   }
 
-  return smtpPoolFuture.wait();
+  return pool;
 };
 
 var next_devmode_mail_id = 0;
@@ -176,6 +171,6 @@ SandstormEmail.rawSend = function (mc) {
   if (pool) {
     smtpSend(pool, mc);
   } else {
-    devModeSend(mc);
+    throw new Exception("SMTP pool is misconfigured.");
   }
 };

--- a/shell/packages/sandstorm-email/email.js
+++ b/shell/packages/sandstorm-email/email.js
@@ -56,6 +56,9 @@ Meteor.startup(function() {
       configured = false;
     }
   });
+
+  // Accounts.emailToken is set to use "Email" by default. Change it to use our mail service.
+  Accounts.emailToken.setEmailPackage("SandstormEmail");
 });
 
 var getPool = function () {
@@ -157,12 +160,7 @@ SandstormEmail.send = function (options) {
     mc.addHeader(name, value);
   });
 
-  var pool = getPool();
-  if (pool) {
-    smtpSend(pool, mc);
-  } else {
-    devModeSend(mc);
-  }
+  SandstormEmail.rawSend(mc);
 };
 
 /**

--- a/shell/packages/sandstorm-email/package.js
+++ b/shell/packages/sandstorm-email/package.js
@@ -1,0 +1,18 @@
+Package.describe({
+  summary: "Send email messages. Forked from meteor/email.",
+  version: "0.1.0"
+});
+
+Npm.depends({
+  // Pinned at older version. 0.1.16+ uses mimelib, not mimelib-noiconv which is
+  // much bigger. We need a better solution.
+  mailcomposer: "0.1.15",
+  simplesmtp: "0.3.10",
+  "stream-buffers": "0.2.5"});
+
+Package.onUse(function (api) {
+  api.use('underscore', 'server');
+  api.use('application-configuration');
+  api.export('SandstormEmail', 'server');;
+  api.addFiles('email.js', 'server');
+});

--- a/shell/packages/sandstorm-email/package.js
+++ b/shell/packages/sandstorm-email/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  summary: "Send email messages. Forked from meteor/email.",
+  summary: "Send email messages. Forked from meteor/email (https://github.com/meteor/meteor/tree/092b97d2da2794dcd30167e0008ab0b0a1e444fc/packages/email).",
   version: "0.1.0"
 });
 

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -291,6 +291,15 @@ if (Meteor.isServer) {
   var Fs = Npm.require("fs");
   var SANDSTORM_ADMIN_TOKEN = SANDSTORM_VARDIR + "/adminToken";
 
+  var getSmtpUrl = function () {
+    var setting = Settings.findOne({_id: "smtpUrl"});
+    if (setting) {
+      return setting.value;
+    } else {
+      return process.env.MAIL_URL;
+    }
+  };
+
   var tokenIsValid = function(token) {
     if (Fs.existsSync(SANDSTORM_ADMIN_TOKEN)) {
       var stats = Fs.statSync(SANDSTORM_ADMIN_TOKEN);


### PR DESCRIPTION
I went with adding a sandstorm-email package, that provides a drop in replacement for the `Email` global object, named `SandstormEmail`.