### PR TITLE
Add "Self-install" link for demo users

### DIFF
--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -97,7 +97,7 @@ body {
 }
 
 #topbar-right #alert:hover {
-  background-color: #ba97c3
+  background-color: #9d3aa5;
 }
 
 #topbar a {

--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -86,9 +86,9 @@ body {
   z-index: 3;
 }
 
-#topbar-right #crowdfunding {
+#topbar-right #alert {
   display: inline-block;
-  background-color: #eb1478;
+  background-color: #762f87;
   color: white;
   text-decoration: none;
   padding-left: 8px;
@@ -96,8 +96,8 @@ body {
   margin-right: 8px;
 }
 
-#topbar-right #crowdfunding:hover {
-  background-color: #F086B7;
+#topbar-right #alert:hover {
+  background-color: #ba97c3
 }
 
 #topbar a {
@@ -241,12 +241,6 @@ img {
   bottom: 0px;
   color: black;
   overflow: auto;
-}
-
-.main-content a {
-  font-weight: bold;
-  text-decoration: none;
-  color: #428bca;
 }
 
 #app.main-content {
@@ -686,6 +680,11 @@ input.autoSelect {
   text-align: center;
   font-size: 2em;
   margin-bottom: 0;
+}
+#about a {
+  font-weight: bold;
+  text-decoration: none;
+  color: #428bca;
 }
 #about p.heading-subtext {
   text-align: center;

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -765,7 +765,7 @@ $KEY</textarea></p>
             secure sandbox.</li>
           <li>We only have one machine. It may get slow or crashy under excessive load.</li>
           <li>We know the UI design needs work. This is a tech demo. ;)</li>
-          <li><a href="http://igg.me/at/sandstorm">Read more and fund us on Indiegogo.</a></li>
+          <li><a href="https://sandstorm.io">Read more at Sandstorm.io.</a></li>
         </ul>
       {{else}}
         <p>Sorry, this server does not allow demo accounts.</p>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -41,6 +41,9 @@ limitations under the License.
   </div>
   {{else}}
   <div id="topbar-right">
+    {{#if isDemoUser}}
+    <a id="alert" href="https://sandstorm.io/install/">Run your own »</a>
+    {{/if}}
     {{> loginButtons align="right"}}
   </div>
   {{/if}}
@@ -762,7 +765,7 @@ $KEY</textarea></p>
             secure sandbox.</li>
           <li>We only have one machine. It may get slow or crashy under excessive load.</li>
           <li>We know the UI design needs work. This is a tech demo. ;)</li>
-          <li><a href="https://sandstorm.io">Read more at Sandstorm.io.</a></li>
+          <li><a href="http://igg.me/at/sandstorm">Read more and fund us on Indiegogo.</a></li>
         </ul>
       {{else}}
         <p>Sorry, this server does not allow demo accounts.</p>

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -642,6 +642,7 @@ Router.map(function () {
       return grainRouteHelper(this,
                               {grainId: grainId, title: title,
                                isOwner: grain && grain.userId && grain.userId === Meteor.userId(),
+                               isDemoUser: isDemoUser(),
                                oldSharingModel: grain && !grain.private},
                                "openSession", grainId,
                                "/grain/" + grainId);


### PR DESCRIPTION
**Goal**

People seem to use the "appDemo" links we have in the wild, e.g. etherpad.org => "Or try a demo" => https://demo.sandstorm.io/appdemo/h37dm17aa89yrd8zuqpdn36p6zntumtv08fjpu8a8zrte7q1cn60 , and for those people, I don't think they actually understand they can install Sandstorm then+there and get the app.

**Status**

I've gotten color feedback from @neynah and I think this is ready to ship.

The `/install/` page supports `#appname` as a way to provide extra info. For now, this code doesn't use that; it merely uses the generic `#demo`, which does everything except add the specific app name.

(I am hoping to ship this as-is, and then add the app name stuff later.)

The `/install/` page will go to this thing: https://github.com/sandstorm-io/sandstorm-website/pull/69

**Technical details**

This re-uses the styles from the Indiegogo campagin, and partially
reverts commit 0eb64bfb2b2d10a4194a62d02ce576cacdcf308f.

In the future, for demo users, they will get a link to
https://sandstorm.io/demo/#appname so that they see a customized page
that appeals to their love of appname.
