### PR TITLE
Self install now

### DIFF
--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -97,7 +97,7 @@ body {
 }
 
 #topbar-right #alert:hover {
-  background-color: #ba97c3
+  background-color: #9d3aa5;
 }
 
 #topbar a {

--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -86,9 +86,9 @@ body {
   z-index: 3;
 }
 
-#topbar-right #crowdfunding {
+#topbar-right #alert {
   display: inline-block;
-  background-color: #eb1478;
+  background-color: #762f87;
   color: white;
   text-decoration: none;
   padding-left: 8px;
@@ -96,8 +96,8 @@ body {
   margin-right: 8px;
 }
 
-#topbar-right #crowdfunding:hover {
-  background-color: #F086B7;
+#topbar-right #alert:hover {
+  background-color: #ba97c3
 }
 
 #topbar a {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -765,7 +765,7 @@ $KEY</textarea></p>
             secure sandbox.</li>
           <li>We only have one machine. It may get slow or crashy under excessive load.</li>
           <li>We know the UI design needs work. This is a tech demo. ;)</li>
-          <li><a href="http://igg.me/at/sandstorm">Read more and fund us on Indiegogo.</a></li>
+          <li><a href="https://sandstorm.io">Read more at Sandstorm.io.</a></li>
         </ul>
       {{else}}
         <p>Sorry, this server does not allow demo accounts.</p>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -42,7 +42,7 @@ limitations under the License.
   {{else}}
   <div id="topbar-right">
     {{#if isDemoUser}}
-    <a id="alert" href="https://sandstorm.io/install/">Run your own »</a>
+    <a id="alert" href="https://sandstorm.io/install/#{{ installPageParams }}">Run your own »</a>
     {{/if}}
     {{> loginButtons align="right"}}
   </div>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -41,6 +41,9 @@ limitations under the License.
   </div>
   {{else}}
   <div id="topbar-right">
+    {{#if isDemoUser}}
+    <a id="alert" href="https://sandstorm.io/install/">Run your own »</a>
+    {{/if}}
     {{> loginButtons align="right"}}
   </div>
   {{/if}}
@@ -762,7 +765,7 @@ $KEY</textarea></p>
             secure sandbox.</li>
           <li>We only have one machine. It may get slow or crashy under excessive load.</li>
           <li>We know the UI design needs work. This is a tech demo. ;)</li>
-          <li><a href="https://sandstorm.io">Read more at Sandstorm.io.</a></li>
+          <li><a href="http://igg.me/at/sandstorm">Read more and fund us on Indiegogo.</a></li>
         </ul>
       {{else}}
         <p>Sorry, this server does not allow demo accounts.</p>

--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -287,10 +287,7 @@ Router.map(function () {
       var appName = 'missing package';
 
       if (thisPackage) {
-        var manifest = thisPackage.manifest;
-        var action = manifest.actions[0];
-        appName = (manifest.appTitle && manifest.appTitle.defaultText) ||
-                  appNameFromActionName(action.title.defaultText);
+        appName = appNameFromPackage(thisPackage);
       }
 
       return {

--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -129,6 +129,29 @@ if (Meteor.isServer) {
       return packageCursor;
     });
 
+    // For the demo, we allow users to learn package information about
+    // a grain they own.
+    //
+    // We only do this for the demo merely to avoid sending too much
+    // data to the client. It is not a security/privacy risk since it
+    // only exposes this information for grains the user owns.
+    Meteor.publish("packageByGrainId", function (grainId) {
+      var publishThis = [];
+      // We need to publish the packageId so that client-side code can
+      // find the right package.
+      var thisGrainCursor = Grains.find({_id: grainId, userId: this.userId},
+                                        {fields: {packageId: 1}});
+      publishThis.push(thisGrainCursor);
+
+      if (thisGrainCursor.count()) {
+        var thisGrain = thisGrainCursor.fetch()[0];
+        var thisPackageCursor = Packages.find({_id: thisGrain.packageId});
+        publishThis.push(thisPackageCursor);
+      }
+
+      return publishThis;
+    });
+
     Meteor.setInterval(cleanupExpiredUsers, DEMO_EXPIRATION_MS);
 
     // The demo displays some assets loaded from sandstorm.io.

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -396,22 +396,17 @@ if (Meteor.isClient) {
       //   title.
       var params = "demo";
 
-      if (! this.grainId) {
-        return params;
-      }
-
-      var thisPackageId = Grains.findOne(
-        {_id: this.grainId}).packageId;
-
-      // If we don't seem to find the package, then bail out now.
-      if (! thisPackageId) {
-        return params;
-      }
-
-      var thisPackage = Packages.findOne({_id: thisPackageId});
-
-      if (thisPackage) {
-        params = appNameFromPackage(thisPackage);
+      // Try our hardest to find the package's name, falling back on
+      // the default if needed.
+      if (this.grainId) {
+        var thisPackageId = Grains.findOne(
+          {_id: this.grainId}).packageId;
+        if (thisPackageId) {
+          var thisPackage = Packages.findOne({_id: thisPackageId});
+          if (thisPackage) {
+            params = appNameFromPackage(thisPackage);
+          }
+        }
       }
 
       return params;

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -642,6 +642,7 @@ Router.map(function () {
       return grainRouteHelper(this,
                               {grainId: grainId, title: title,
                                isOwner: grain && grain.userId && grain.userId === Meteor.userId(),
+                               isDemoUser: isDemoUser(),
                                oldSharingModel: grain && !grain.private},
                                "openSession", grainId,
                                "/grain/" + grainId);

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -410,10 +410,8 @@ if (Meteor.isClient) {
 
       var thisPackage = Packages.findOne({_id: thisPackageId});
 
-      if (thisPackage && thisPackage.manifest) {
-        var manifest = thisPackage.manifest;
-        var action = manifest.actions[0];
-        params = (manifest.appTitle && manifest.appTitle.defaultText) || appNameFromActionName(action.title.defaultText);
+      if (thisPackage) {
+        params = appNameFromPackage(thisPackage);
       }
 
       return params;

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -479,6 +479,16 @@ function isMissingWildcardParent() {
   return Meteor.settings && Meteor.settings.public && Meteor.settings.public.missingWildcardParentUrl;
 }
 
+appNameFromPackage = function(package) {
+  // This function takes a Package object from Mongo and returns an
+  // app title.
+  var manifest = package.manifest;
+  var action = manifest.actions[0];
+  appName = (manifest.appTitle && manifest.appTitle.defaultText) ||
+    appNameFromActionName(action.title.defaultText);
+  return appName;
+}
+
 appNameFromActionName = function(name) {
   // Hack: Historically we only had action titles, like "New Etherpad Document", not app
   //   titles. But for this UI we want app titles. As a transitionary measure, try to


### PR DESCRIPTION
**Goal**

People seem to use the "appDemo" links we have in the wild, e.g. etherpad.org => "Or try a demo" => https://demo.sandstorm.io/appdemo/h37dm17aa89yrd8zuqpdn36p6zntumtv08fjpu8a8zrte7q1cn60 , and for those people, I don't think they actually understand they can install Sandstorm then+there and get the app.

**Status**

* This supports linking to `/install/#appName` in the case that you are a demo user, looking at a particular app.

* This defaults to `/install/#demo` if it can't find an `appName` (e.g. if you're in the shell).

* The `/install/` page supports `#appname` as a way to provide extra info. To test that, visit e.g. https://sandstorm.io/install/#EtherCalc

* I had the colors sanity-checked by @neynah.

* This pull request supercedes https://github.com/sandstorm-io/sandstorm/pull/408 . Please review and/or merge.

**Technical details**

This re-uses the styles from the Indiegogo campagin, and partially
reverts commit 0eb64bfb2b2d10a4194a62d02ce576cacdcf308f.

When the demo is enabled, users get Package information about the grains they own.