### PR TITLE
Invoke sub-make with the same make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ tmp/ekam-bin: tmp/.deps
 	@mkdir -p tmp
 	@rm -f tmp/ekam-bin
 	@which ekam >/dev/null && ln -s "`which ekam`" tmp/ekam-bin || \
-	    (cd deps/ekam && make bin/ekam-bootstrap && \
+	    (cd deps/ekam && $(MAKE) bin/ekam-bootstrap && \
 	     cd ../.. && ln -s ../deps/ekam/bin/ekam-bootstrap tmp/ekam-bin)
 
 tmp/.ekam-run: tmp/ekam-bin src/sandstorm/* tmp/.deps


### PR DESCRIPTION
On some systems GNU make is installed as gmake.  $(MAKE) will pass that
through.