### PR TITLE
Add cli tests

### DIFF
--- a/tests/nightwatch.json
+++ b/tests/nightwatch.json
@@ -1,5 +1,5 @@
 {
-  "src_folders" : ["tests", "apps"],
+  "src_folders" : ["tests", "apps", "unittests"],
   "output_folder" : "reports",
   "custom_commands_path" : "commands",
 
@@ -10,11 +10,11 @@
     "host" : "127.0.0.1",
     "port" : 4444
   },
+  "disable_colors" : true,
 
   "test_settings" : {
     "default" : {
       "launch_url" : "http://local.sandstorm.io:6080",
-      "disable_colors" : true,
       "selenium_port"  : 4444,
       "selenium_host"  : "localhost",
       "silent": true,
@@ -27,7 +27,15 @@
         "browserName": "firefox",
         "javascriptEnabled" : true,
         "acceptSslCerts" : true
-      }
+      },
+      "exclude" : "./unittests/*"
+    },
+    "unittests" : {
+      "selenium" : {
+        "start_session" : false
+      },
+      "filter" : "./unittests/*",
+      "exclude" : ""
     },
 
     "phantomjs" : {

--- a/tests/package.json
+++ b/tests/package.json
@@ -3,7 +3,7 @@
   "description": "Tests for the sandstorm platform",
   "version": "0.0.1",
   "devDependencies": {
-    "nightwatch": "0.6.7",
+    "nightwatch": "0.6.11",
     "phantomjs": "~1.9.10",
     "selenium-standalone": "^4.2.2"
   },
@@ -15,6 +15,7 @@
     "test": "./run-tests.sh"
   },
   "dependencies": {
+    "chai": "^2.3.0",
     "mailcomposer": "^0.2.12",
     "mailparser": "0.5.1",
     "simplesmtp": "0.3.35",

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "nightwatch": "0.6.11",
     "phantomjs": "~1.9.10",
-    "selenium-standalone": "^4.2.2"
+    "selenium-standalone": "4.2.2"
   },
   "repository": {
     "type": "git",

--- a/tests/run-local.sh
+++ b/tests/run-local.sh
@@ -90,7 +90,7 @@ if [ "$RUN_SELENIUM" != "false" ] ; then
   XVFB_PID=$!
 fi
 
-SANDSTORM_DIR=$THIS_DIR/tmp-sandstorm
+export SANDSTORM_DIR=$THIS_DIR/tmp-sandstorm
 export OVERRIDE_SANDSTORM_DEFAULT_DIR=$SANDSTORM_DIR
 export PORT=$(shuf -i 10000-20000 -n 1)
 export MONGO_PORT=$(shuf -i 20001-30000 -n 1)

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -22,6 +22,8 @@ THIS_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
 cd "$THIS_DIR"
 
+export SANDSTORM_BIN="${SANDSTORM_DIR:-/opt/sandstorm}/sandstorm"
+
 test -e assets/ssjekyll5.spk || curl http://sandstorm.io/apps/ssjekyll5.spk > assets/ssjekyll5.spk
 test -e assets/ssjekyll6.spk || curl http://sandstorm.io/apps/ssjekyll6.spk > assets/ssjekyll6.spk
 test -e assets/ssjekyll7.spk || curl http://sandstorm.io/apps/ssjekyll7.spk > assets/ssjekyll7.spk
@@ -30,8 +32,8 @@ set +e
 
 if [[ -z "$LAUNCH_URL" ]]
 then
-  nightwatch
+  nightwatch -e unittests && nightwatch -e default
 else
   sed "s|.*launch_url.*|\"launch_url\" : \"$LAUNCH_URL\",|g" nightwatch.json > nightwatch.tmp.json
-  nightwatch -c ./nightwatch.tmp.json
+  nightwatch -e unittests -c ./nightwatch.tmp.json && nightwatch -e default -c ./nightwatch.tmp.json
 fi

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -22,7 +22,7 @@ THIS_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
 cd "$THIS_DIR"
 
-export SANDSTORM_BIN="${SANDSTORM_DIR:-/opt/sandstorm}/sandstorm"
+export SANDSTORM_DIR="${SANDSTORM_DIR:-/opt/sandstorm}"
 
 test -e assets/ssjekyll5.spk || curl http://sandstorm.io/apps/ssjekyll5.spk > assets/ssjekyll5.spk
 test -e assets/ssjekyll6.spk || curl http://sandstorm.io/apps/ssjekyll6.spk > assets/ssjekyll6.spk

--- a/tests/unittests/cli.js
+++ b/tests/unittests/cli.js
@@ -1,0 +1,65 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2014 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+"use strict";
+
+var _ = require("underscore");
+var execFile = require("child_process").execFile;
+var assert = require("chai").assert;
+
+var SANDSTORM_BIN = process.env["SANDSTORM_BIN"] || "/opt/sandstorm/sandstorm";
+
+function execSandstorm(args, cb) {
+  execFile(SANDSTORM_BIN, args, {timeout: 60000}, cb);
+}
+
+module.exports = {
+  "sandstorm help" : function (client, done) {
+    execSandstorm(["help"], function (err, stdout, stderr) {
+      if (err) throw err;
+
+      assert.include(stdout, "Controls the Sandstorm server.", "`help` contains the expected output");
+      done();
+    });
+  },
+  "sandstorm admin-token" : function (client, done) {
+    execSandstorm(["admin-token"], function (err, stdout, stderr) {
+      if (err) throw err;
+
+      assert.include(stdout, "Generated new admin token.", "`admin-token` contains the expected output");
+      done();
+    });
+  },
+  "sandstorm admin-token -q" : function (client, done) {
+    execSandstorm(["admin-token", "-q"], function (err, stdout, stderr) {
+      if (err) throw err;
+
+      // Expect output of 40 character token + newline
+      assert.lengthOf(stdout, 41, "`admin-token -q` contains the expected output");
+      done();
+    });
+  },
+  "sandstorm reset-oauth" : function (client, done) {
+    execSandstorm(["reset-oauth"], function (err, stdout, stderr) {
+      if (err) throw err;
+
+      assert.include(stdout, "reset OAuth configuration", "`reset-oauth` contains the expected output");
+      done();
+    });
+  },
+};
+
+

--- a/tests/unittests/cli.js
+++ b/tests/unittests/cli.js
@@ -19,8 +19,10 @@
 var _ = require("underscore");
 var execFile = require("child_process").execFile;
 var assert = require("chai").assert;
+var fs = require("fs");
 
-var SANDSTORM_BIN = process.env["SANDSTORM_BIN"] || "/opt/sandstorm/sandstorm";
+var SANDSTORM_DIR = process.env["SANDSTORM_DIR"] || "/opt/sandstorm";
+var SANDSTORM_BIN = SANDSTORM_DIR + "/sandstorm";
 
 function execSandstorm(args, cb) {
   execFile(SANDSTORM_BIN, args, {timeout: 60000}, cb);
@@ -47,8 +49,9 @@ module.exports = {
     execSandstorm(["admin-token", "-q"], function (err, stdout, stderr) {
       if (err) throw err;
 
-      // Expect output of 40 character token + newline
-      assert.lengthOf(stdout, 41, "`admin-token -q` contains the expected output");
+      // remove trailing newline from stdout
+      client.assert.equal(stdout.slice(0, -1), fs.readFileSync(SANDSTORM_DIR + "/var/sandstorm/adminToken").toString(),
+        "`admin-token -q` contains the expected output");
       done();
     });
   },


### PR DESCRIPTION
This uses nightwatch's unit test functionality to run some simple tests to make sure the `sandstorm` command line is working. We should extend this to `spk` and test more complicated scenarios.