### PR TITLE
Add "make test" and extend tests/run-local.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ IMAGES= \
 # Meta rules
 
 .SUFFIXES:
-.PHONY: all install clean continuous shell-env fast deps bootstrap-ekam deps update-deps
+.PHONY: all install clean continuous shell-env fast deps bootstrap-ekam deps update-deps test
 
 all: sandstorm-$(BUILD).tar.xz
 
@@ -81,6 +81,9 @@ update: sandstorm-$(BUILD)-fast.tar.xz
 	@sudo sandstorm update $<
 
 fast: sandstorm-$(BUILD)-fast.tar.xz
+
+test: sandstorm-$(BUILD)-fast.tar.xz
+	tests/run-local.sh sandstorm-$(BUILD)-fast.tar.xz
 
 # ====================================================================
 # Dependencies


### PR DESCRIPTION
run-local.sh now spawns an Xvfb and selenium-standalone and cleans up after
itself.  This behavior can be disabled (if you wanted to run a long-lived
selenium server) with the --no-selenium flag.

@jparyani Take a look at this when you have a chance, and adjust the test machine accordingly/show me the appropriate knobs to turn?  Also, should I be calling run-tests.sh as well as run-local.sh in make test?