### PR TITLE
Add troubleshooting link to login dropdown

### DIFF
--- a/shell/packages/sandstorm-accounts-ui/login_buttons.less
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.less
@@ -412,3 +412,7 @@
     line-height: 1;
   }
 }
+
+#troubleshooting-link {
+  text-align: center;
+}

--- a/shell/packages/sandstorm-accounts-ui/login_buttons_dropdown.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons_dropdown.html
@@ -80,6 +80,13 @@
     {{/if}}
   {{/each}}
 
+  {{#if showTroubleshooting}}
+    {{> _loginButtonsLoggedOutPasswordServiceSeparator}}
+    <p id="troubleshooting-link">
+      <a href="https://github.com/sandstorm-io/sandstorm/wiki/Self-hosting-FAQ">troubleshooting</a>
+    </p>
+  {{/if}}
+
   {{#unless hasEmailTokenService}}
     {{> _loginButtonsMessages}}
   {{/unless}}

--- a/shell/packages/sandstorm-accounts-ui/login_buttons_dropdown.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons_dropdown.js
@@ -126,7 +126,12 @@ Template._loginButtonsLoggedOutAllServices.helpers({
     return getLoginServices().length > 1;
   },
 
-  hasEmailTokenService: hasEmailTokenService
+  hasEmailTokenService: hasEmailTokenService,
+
+  showTroubleshooting: function () {
+    return !(Meteor.settings && Meteor.settings.public &&
+      Meteor.settings.public.hideTroubleshooting);
+  }
 });
 
 Template._loginButtonsLoggedOutPasswordService.helpers({

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1075,6 +1075,7 @@ private:
     bool allowDemoAccounts = false;
     bool isTesting = false;
     bool allowDevAccounts = false;
+    bool hideTroubleshooting = false;
     uint smtpListenPort = 30025;
   };
 
@@ -1420,6 +1421,8 @@ private:
         config.allowDevAccounts = value == "true" || value == "yes";
       } else if (key == "IS_TESTING") {
         config.isTesting = value == "true" || value == "yes";
+      } else if (key == "HIDE_TROUBLESHOOTING") {
+        config.hideTroubleshooting = value == "true" || value == "yes";
       } else if (key == "SMTP_LISTEN_PORT") {
         KJ_IF_MAYBE(p, parseUInt(value, 10)) {
           config.smtpListenPort = *p;
@@ -1874,6 +1877,7 @@ private:
           ", \"allowDemoAccounts\":", config.allowDemoAccounts ? "true" : "false",
           ", \"allowDevAccounts\":", config.allowDevAccounts ? "true" : "false",
           ", \"isTesting\":", config.isTesting ? "true" : "false",
+          ", \"hideTroubleshooting\":", config.hideTroubleshooting ? "true" : "false",
           ", \"wildcardHost\":\"", config.wildcardHost, "\"");
       if (config.sandcatsHostname.size() > 0) {
           settingsString = kj::str(settingsString,


### PR DESCRIPTION
This is gated on `HIDE_TROUBLESHOOTING` in sandstorm.conf

Fixes #414