### PR TITLE
Change libseccomp repo to new Github location in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ deps/ekam:
 deps/libseccomp:
 	@$(call color,downloading libseccomp)
 	@mkdir -p deps
-	git clone git://git.code.sf.net/p/libseccomp/libseccomp deps/libseccomp
+	git clone https://github.com/seccomp/libseccomp deps/libseccomp
 
 deps/libsodium:
 	@$(call color,downloading libsodium)


### PR DESCRIPTION
This changes the deps/libseccomp Makefile target to clone libseccomp from [their newer Github repository](https://github.com/seccomp/libseccomp), rather than [their old Source Forge one](http://sourceforge.net/projects/libseccomp/?source=directory).

 This fixes issue #430.

