### PR TITLE
fix ownership and permissions for var/sandstorm

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1084,10 +1084,6 @@ set_permissions() {
   chown -R $SERVER_USER:$GROUP var/{log,pid,mongo} var/sandstorm/{apps,grains,downloads,adminToken}
   chown root:$GROUP var/{log,pid,mongo,sandstorm} var/sandstorm/{apps,grains,downloads,adminToken}
   chmod -R g=rwX,o= var/{log,pid,mongo,sandstorm} var/sandstorm/{apps,grains,downloads,adminToken}
-
-  # Don't allow listing grain IDs directly.  (At the moment, this is faux security since
-  # an attacker could just read the database, but maybe that will change someday...)
-  chmod g-r var/sandstorm/grains
 }
 
 install_sandstorm_symlinks() {

--- a/install.sh
+++ b/install.sh
@@ -1082,8 +1082,8 @@ set_permissions() {
   # Set ownership of files.  We want the dirs to be root:sandstorm but the contents to be
   # sandstorm:sandstorm.
   chown -R $SERVER_USER:$GROUP var/{log,pid,mongo} var/sandstorm/{apps,grains,downloads,adminToken}
-  chown root:$GROUP var/{log,pid,mongo} var/sandstorm/{apps,grains,downloads,adminToken}
-  chmod -R g=rwX,o= var/{log,pid,mongo} var/sandstorm/{apps,grains,downloads,adminToken}
+  chown root:$GROUP var/{log,pid,mongo,sandstorm} var/sandstorm/{apps,grains,downloads,adminToken}
+  chmod -R g=rwX,o= var/{log,pid,mongo,sandstorm} var/sandstorm/{apps,grains,downloads,adminToken}
 
   # Don't allow listing grain IDs directly.  (At the moment, this is faux security since
   # an attacker could just read the database, but maybe that will change someday...)

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1453,13 +1453,22 @@ private:
     // Run the update monitor process.  This process runs two subprocesses:  the sandstorm server
     // and the auto-updater.
 
-    // Fix permissions on pidfile. We do this here rather than back where we opened it because
-    // a previous version failed to do this and we want it fixed immediately on upgrade.
     if (runningAsRoot) {
+      // Fix permissions on pidfile. We do this here rather than back where we opened it because
+      // a previous version failed to do this and we want it fixed immediately on upgrade.
       KJ_SYSCALL(fchown(pidfile, 0, config.uids.gid));
       KJ_SYSCALL(fchmod(pidfile, 0660));
+
       // Additionally, fix permissions on sandcats-related data, which was originally owned by root
       fixSandcatsPermissions(config);
+
+      // Fix permissions on /var/sandstorm, which was originally owned by root:root.
+      KJ_SYSCALL(chown("../var/sandstorm", 0, config.uids.gid));
+      KJ_SYSCALL(chmod("../var/sandstorm", 0770));
+
+      // Fix permissions on /var/sandstorm/grains, which originally had mode 0730 because grain
+      // IDs were secret.
+      KJ_SYSCALL(chmod("../var/sandstorm/grains", 0770));
     }
 
     cleanupOldVersions();


### PR DESCRIPTION
Currently, the install script makes <install_dir>/var/sandstorm owned by root:root. I might be missing something (cc @paulproteus), but I think this is a mistake; it should have the same ownership and permissions as all of the other directories.

Note that admin tokens live in this directory. After this patch you will be able to do `sandstorm admin-token` without `sudo`.