### PR TITLE
Compress tarballs with more cores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ sandstorm-$(BUILD).tar.xz: bundle
 
 sandstorm-$(BUILD)-fast.tar.xz: bundle
 	@$(call color,compress fast bundle)
-	@tar c --transform="s,^bundle,sandstorm-$(BUILD)," bundle | xz -c -0 > sandstorm-$(BUILD)-fast.tar.xz
+	@tar c --transform="s,^bundle,sandstorm-$(BUILD)," bundle | xz -c -0 --threads=0 > sandstorm-$(BUILD)-fast.tar.xz
 
 .docker: Dockerfile
 	@$(call color,docker build)


### PR DESCRIPTION
For release tarballs:
  - increases compressed tarball size by 8 bytes
  - reduces compression time from 139.3 to 135.5 seconds

For -fast tarballs:
  - increases compressed tarball size by ~400k
  - reduces compression time from 9.7 seconds to 2.4 seconds