### PR TITLE
db.addUser -> db.createUser

### DIFF
--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1771,7 +1771,7 @@ private:
 
       // Create the mongo user.
       auto command = kj::str(
-        "db.addUser({user: \"sandstorm\", pwd: \"", password, "\", "
+        "db.createUser({user: \"sandstorm\", pwd: \"", password, "\", "
         "roles: [\"readWriteAnyDatabase\",\"userAdminAnyDatabase\",\"dbAdminAnyDatabase\"]})");
       mongoCommand(config, command, "admin");
 


### PR DESCRIPTION
Meteor 1.1.0.2 uses Mongo 2.6, in which [`addUser()` is depcrecated](http://docs.mongodb.org/v2.6/reference/method/db.addUser/). It looks to be totally gone in [Mongo 3.0](http://docs.mongodb.org/v3.0/reference/method/js-user-management/). The replacement is [`createUser()`](http://docs.mongodb.org/v2.6/reference/method/db.createUser/).