### PR TITLE
Avoid DNS TXT record resolutions for hostnames with pseudo-TLDs.

### DIFF
--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -45,8 +45,10 @@ function isSandstormShell(hostname) {
 
 function hasPseudoTLD(hostname) {
   // Returns true if this hostname ends in one of the major pseudo-TLDs.
-  let tld = hostname.split(".").pop();
-  return (tld === ("onion" || "i2p" || "gnu"));
+  var tld = hostname.split(".").pop();
+  var pseudoTLDs = ["onion", "i2p", "gnu"];
+
+  return (_.contains(pseudoTLDs, tld));
 }
 
 Meteor.startup(function () {


### PR DESCRIPTION
- ADD function `hasPseudoTLD()` to shell/server/pre-meteor.js which
  checks if an hostname has any of the major pseudo-TLDs.
- CHANGE `Meteor.startup()` function in shell/server/pre-meteor.js to
  avoid attempting to resolve DNS TXT records for requests with
  hostnames which have a pseudo-TLD.
