### PR TITLE
install.sh: fix unbound variable in userns sysctl prompting

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -416,7 +416,7 @@ enable_userns_sysctl_if_needed() {
     return
   fi
 
-  local PRINT_USERNS_INFO="yes"
+  local PRINT_USERNS_PROMPT="yes"
   local ACCEPTED_SYSCTL_SWITCH="no"
 
   if [ "yes" = "${ACCEPTED_FULL_SERVER_INSTALL:-}" ] ; then


### PR DESCRIPTION
This should make it possible to install Sandstorm automatically on Debian
Jessie, which defaults to having unprivileged user namespaces disabled via
sysctl.

Discovered when testing vagrant-spk with the Debian Jessie vagrant boxes.