### PR TITLE
Don't accept a half-formed changelog.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,9 +169,10 @@ tmp/.shell-env: tmp/.ekam-run $(IMAGES) shell/client/changelog.html
 	@bash -O extglob -c 'cp src/capnp/!(*test*).capnp node_modules/capnp'
 
 shell/client/changelog.html: CHANGELOG.md
-	@echo '<template name="changelog">' > shell/client/changelog.html
-	@markdown CHANGELOG.md >> shell/client/changelog.html
-	@echo '</template>' >> shell/client/changelog.html
+	@echo '<template name="changelog">' > tmp/changelog.html
+	@markdown CHANGELOG.md >> tmp/changelog.html
+	@echo '</template>' >> tmp/changelog.html
+	@cp tmp/changelog.html shell/client/changelog.html
 
 shell/public/%.png: icons/%.svg
 	@$(call color,convert $<)


### PR DESCRIPTION
If you try `make update` and don't have markdown installed, the build will fail with an error about markdown failing. This is as expected. However, in the current setup, if you try again the build will get farther and then fail with the following error, even if you've successfully installed markdown in the meantime:

```
==== meteor frontend ====
Errors prevented bundling:                    
While building the application:               
client/changelog.html:1: unclosed <template>
```

This patch fixes the problem.
