### PR TITLE
Remove now-unneeded definition of dateString.

### DIFF
--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -436,8 +436,6 @@ if (Meteor.isClient) {
       return "";
     },
 
-    dateString: function (date) { return makeDateString(date); },
-
     setGrainWindowTitle:  function() {
       var appTitle = Session.get("grainFrameTitle");
       if (appTitle) {


### PR DESCRIPTION
`dateString` is now a global template helper, since: https://github.com/sandstorm-io/sandstorm/commit/ff63479b0a2b816ff39510d565b84b82c1504ad4