### PR TITLE
Rename use of error.type to error.kjType

### DIFF
--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -66,7 +66,7 @@ function dismissNotification(notificationId, callCancel) {
           castedNotification.close();
           notificationCap.close();
         } catch (err) {
-          if (err.type !== "disconnected") {
+          if (err.kjType !== "disconnected") {
             // ignore disconnected errors, since cancel may shutdown the grain before the supervisor
             // responds.
             throw err;

--- a/shell/server/drivers/external-ui-view.js
+++ b/shell/server/drivers/external-ui-view.js
@@ -244,7 +244,7 @@ ExternalWebSession.prototype._requestHelper = function (method, path, context, c
     req.setTimeout(15000, function () {
       req.abort();
       err = new Error("Request timed out.");
-      err.type = "overloaded";
+      err.kjType = "overloaded";
       reject(err);
     });
 

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -87,7 +87,7 @@ if (Meteor.isServer) {
         }
       }, function (err) {
         if (!stopped) {
-          if (err.type === "disconnected") {
+          if (err.kjType === "disconnected") {
             self.stop();
           } else {
             self.error(err);
@@ -104,7 +104,7 @@ if (Meteor.isServer) {
       }
     }, function (err) {
       if (!stopped) {
-        if (err.type === "disconnected") {
+        if (err.kjType === "disconnected") {
           self.stop();
         } else {
           self.error(err);


### PR DESCRIPTION
This is blocked on https://github.com/kentonv/node-capnp/pull/20

This is needed due to a bug in v8. See
https://code.google.com/p/v8/issues/detail?id=2397