### PR TITLE
Installer tests can live in jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ IMAGES= \
 # Meta rules
 
 .SUFFIXES:
-.PHONY: all install clean continuous shell-env fast deps bootstrap-ekam deps update-deps test
+.PHONY: all install clean continuous shell-env fast deps bootstrap-ekam deps update-deps test installer-test
 
 all: sandstorm-$(BUILD).tar.xz
 
@@ -86,6 +86,9 @@ fast: sandstorm-$(BUILD)-fast.tar.xz
 
 test: sandstorm-$(BUILD)-fast.tar.xz
 	tests/run-local.sh sandstorm-$(BUILD)-fast.tar.xz
+
+installer-test:
+	(cd installer-tests && bash prepare-for-tests.sh && python run_tests.py --rsync --uninstall-first)
 
 # ====================================================================
 # Dependencies

--- a/installer-tests/README.md
+++ b/installer-tests/README.md
@@ -141,3 +141,9 @@ It's a smart idea to remove lines that you don't care about. This is
 safe since the default "Expect some text" directive is willing to skip
 over things you didn't specify. (This does mean there currently is no
 support for asserting some text does _not_ show up.)
+
+To avoid filling the Sandstorm install logs with requests that come
+from these tests, pass a `CURL_USER_AGENT=testing` environment
+variable to `install.sh`. The install script will pass that through to
+`curl`, and the Sandstorm stats code knows to ignore requests from
+that come in with that `User-Agent` header.

--- a/installer-tests/README.md
+++ b/installer-tests/README.md
@@ -53,7 +53,8 @@ We Vagrant's `libvirt` backend, configured to use `qemu`, so that we
 can run this on Sandstorm's Jenkins service (which is already
 virtualized, so tools like VirtualBox can't easily run there). The
 `libvirt` backend is not installed by default, so we make sure it is
-available in `prepare-for-tests.sh`.
+available in `prepare-for-tests.sh`. To use this provider as the
+default, we set an environment variable when invoking Vagrant.
 
 Because we use the `libvirt` backend (with `qemu`), and because most
 Vagrant boxes are distributed as VirtualBox images, we use

--- a/installer-tests/README.md
+++ b/installer-tests/README.md
@@ -114,6 +114,9 @@ The following are valid body directives:
 * `$[slow]`: Wait longer than usual (by default, 30 sec) for this text
   to appear.
 
+* `$[veryslow]`: Wait _even_ longer than usual (twice as long as
+  `$[slow]`) for this text to appear.
+
 * `$[run]`: Run a command, with future text assertions covering this
   particular program.
 

--- a/installer-tests/README.md
+++ b/installer-tests/README.md
@@ -99,7 +99,7 @@ The following are valid test headers.
   zero or more per test.)
 
 The `run_tests.py` program interprets test headers
-case-inensitively. I like to write them in the capitalization style
+case-insensitively. I like to write them in the capitalization style
 above, since I'm so very used to email headers being capitalized like
 that.
 

--- a/installer-tests/README.md
+++ b/installer-tests/README.md
@@ -1,0 +1,142 @@
+# Sandstorm installer tests
+
+This directory contains code and tests used to test Sandstorm's
+install script.
+
+A quick overview:
+
+* The tests are in the `*.t` files in this directory.
+
+* To run the test suite, do: `python run_tests.py`
+
+* You can choose to run just one test by doing: `python run_tests.py that_file.t`
+
+* Before you run any tests, you probably need to run `./prepare-for-tests.sh`.
+
+You might consider this codebase a little over-wrought just to test a
+shell script. If so, sorry about that.
+
+# Goals
+
+Some goals of this project:
+
+* Create tests that verify that when we change install.sh, we don't
+  break its behavior on a variety of operating systems and
+  environments. (For example: Make sure Sandstorm can install on
+  Debian.  Make sure the installer properly aborts with an error
+  message on Arch Linux. Make sure Sandstorm can install within a
+  Docker container.)
+
+* Ensure we can run those tests automatically, periodically.
+
+* Avoid adding misleading information to various logs that we examine
+  to get a sense of how popular Sandstorm is.
+
+# Technical details
+
+## About the *.t language
+
+The tests are written in a custom, semi-hacky domain-specific language
+for running terminal programs and validating that the output of the
+program is what we expect.
+
+The test files contain a header and a body. Each contains different
+directives.
+
+## About the use of Vagrant
+
+The `run_tests.py` script uses Vagrant to manage a variety of
+operating system images we can boot into. You can see the details in
+`Vagrantfile` in this directory.
+
+We Vagrant's `libvirt` backend, configured to use `qemu`, so that we
+can run this on Sandstorm's Jenkins service (which is already
+virtualized, so tools like VirtualBox can't easily run there). The
+`libvirt` backend is not installed by default, so we make sure it is
+available in `prepare-for-tests.sh`.
+
+Because we use the `libvirt` backend (with `qemu`), and because most
+Vagrant boxes are distributed as VirtualBox images, we use
+`vagrant-mutate` to convert them. That's a little tragic, but there
+you go.
+
+Since running the installer requires a copy of the Sandstorm
+installer, we copy the contents of `../` (aka, the Sandstorm git
+repository) into the VM using Vagrant's `rsync` "shared folders"
+support.
+
+## Test headers
+
+The following are valid test headers.
+
+* `Title`: The name of the test. Mostly unused, but hopefully keeps
+  you sane when editing multiple tests. Arguably redundant with the
+  filename; maybe I should remove it. (Specify exactly one per test.)
+
+* `Vagrant-Box`: The name of a box, defined in _this directory's_
+  `Vagrantfile`. Through careful choice of a `Vagrant-Box` value,
+  you can. (Specify exactly one per test.)
+
+* `Vagrant-Destroy-If-Bash`: A bash script that, if it exits with a
+  true status code, causes `run_tests.py` to destroy the Vagrant box
+  in question, and re-create it, before running the test. This can
+  prevent some tests from interfering with each other. Use this
+  directive sparingly, as it is slow! (Specify zero or more per test.)
+
+* `Vagrant-Precondition-Bash`: A bash script that, if it exits with a
+  true status code, allows this test to run. If it exits with a false
+  status code, `run_tests.py` will skip the test and exit with a
+  non-zero status code. (Specify zero or more per test.)
+
+* `Postcondition`: A Python expression that must return `True` for the
+  test to succeed. (Note: This appears to be totally unused, so this
+  might go away soon.) (Specify zero or more per test.)
+
+* `Vagrant-Postcondition`Bash`: A bash script that, if it exits with
+  a true status code, allows the test to be considered a success. If
+  it exits with a false status, it means the test failed. (Specify
+  zero or more per test.)
+
+The `run_tests.py` program interprets test headers
+case-inensitively. I like to write them in the capitalization style
+above, since I'm so very used to email headers being capitalized like
+that.
+
+## Body directives
+
+The following are valid body directives:
+
+* `Some text`: This is the default directive; it means, expect this
+  text to appear, waiting up to 1 second for it. It is OK if other text
+  appears before this text.
+
+* `$[slow]`: Wait longer than usual (by default, 30 sec) for this text
+  to appear.
+
+* `$[run]`: Run a command, with future text assertions covering this
+  particular program.
+
+* `$[type]foo`: Provide `foo` to standard input of the program.
+
+* `$[type]gensym`: `gensym` is a special-cased input sequence; instead
+  of providng the string `gensym` to the program, we generate a
+  (non-cryptographically-secure) random string of 10 alphanumeric
+  characters. This way, we can type something different in every time
+  the test runs, which is helpful for choosing a Sandcats domain name.
+
+* `$[exitcode] n`: Verify that the command most recently run via
+  `$[run]` has exited, and that it exited with the status code `n`
+  (for example, `0`).
+
+## Advanced hints about how to use body directives smartly
+
+It's a smart idea to remove fragments of lines that might change over
+time. For example, if a script prints `Today's date is 2015-06-04`,
+you should only assert that it prints `Today's date is`. This is safe
+since the default "Expect some text" directive will verify the initial
+text, and skip right over the text after it.
+
+It's a smart idea to remove lines that you don't care about. This is
+safe since the default "Expect some text" directive is willing to skip
+over things you didn't specify. (This does mean there currently is no
+support for asserting some text does _not_ show up.)

--- a/installer-tests/Vagrantfile
+++ b/installer-tests/Vagrantfile
@@ -5,7 +5,8 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # We have a few box types.
+  # We have a few box types. The boxes, such as trust64 or
+  # thoughtbot_jessie, are created by prepare-for-tests.sh.
 
   # In general, we use a shell script to "provision" the box. just
   # sets up a different hostname than vagrant, because I find
@@ -37,16 +38,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "default", primary: true do |default|
-    # The default is the Ubuntu 14.04 ("trusty tahr") cloud image.
     default.vm.box = "trusty64"
-
-    # The url from which to fetch that base box.
-    default.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
   end
 
   config.vm.define "jessie" do |jessie|
-    # This is the thoughtbot jessie image, converted to libvirt; see
-    # prepare-for-tests.sh.
     jessie.vm.box = "thoughtbot_jessie"
 
     jessie.vm.provision "shell",

--- a/installer-tests/Vagrantfile
+++ b/installer-tests/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # "vagrant" to be a weird hostname.
   config.ssh.shell = "bash"
   config.vm.provision "shell",
-                       inline: "cd /vagrant && echo localhost > /etc/hostname && hostname localhost"
+                       inline: "echo localhost > /etc/hostname && hostname localhost"
 
 
   # Make sure to share the dir one *above* the current working directory. That way, we get

--- a/installer-tests/Vagrantfile
+++ b/installer-tests/Vagrantfile
@@ -65,6 +65,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
+  # Use qemu driver for libvirt. See README.md for rationale.
   config.vm.provider :libvirt do |libvirt|
     libvirt.driver = 'qemu'
   end

--- a/installer-tests/Vagrantfile
+++ b/installer-tests/Vagrantfile
@@ -17,7 +17,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Make sure to share the dir one *above* the current working directory. That way, we get
   # the Sandstorm source tree, which includes the all-important install.sh.
-  config.vm.synced_folder "..", "/vagrant"
+  config.vm.synced_folder "..", "/vagrant",
+                          type: "rsync",
+                          rsync__exclude: ".git/",
+                          rsync__args: [
+                            "--archive",
+                            "--delete"]
 
   # In this Vagrantbox purely to test the install script, we do not
   # forward any ports. If we need to test if ports are available, we

--- a/installer-tests/Vagrantfile
+++ b/installer-tests/Vagrantfile
@@ -28,42 +28,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # forward any ports. If we need to test if ports are available, we
   # can do that by SSH-ing in.
 
-  # Calculate the number of CPUs and the amount of RAM the system has,
-  # in a platform-dependent way; further logic below.
-  cpus = nil
-  total_kB_ram = nil
-
-  host = RbConfig::CONFIG['host_os']
-  if host =~ /darwin/
-    cpus = `sysctl -n hw.ncpu`.to_i
-    total_kB_ram =  `sysctl -n hw.memsize`.to_i / 1024
-  elsif host =~ /linux/
-    cpus = `nproc`.to_i
-    total_kB_ram = `grep MemTotal /proc/meminfo | awk '{print $2}'`.to_i
-  end
-
-  # Use the same number of CPUs within Vagrant as the system, with 1
-  # as a default.
-  #
-  # Use at least 512MB of RAM, and if the system has more than 2GB of
-  # RAM, use 1/4 of the system RAM. This seems a reasonable compromise
-  # between having the Vagrant guest operating system not run out of
-  # RAM entirely (which it basically would if we went much lower than
-  # 512MB) and also allowing it to use up a healthily large amount of
-  # RAM so it can run faster on systems that can afford it.
-  config.vm.provider :virtualbox do |vb|
-    if cpus.nil?
-      vb.cpus = 1
-    else
-      vb.cpus = cpus
-    end
-
-    if total_kB_ram.nil? or total_kB_ram < 2048000
-      vb.memory = 512
-    else
-      vb.memory = (total_kB_ram / 1024 / 4)
-    end
-  end
+  # Similarly, when testing the install script, we don't need a lot of
+  # CPU or RAM, so we use whatever is Vagrant's default.
 
   # Use qemu driver for libvirt. See README.md for rationale.
   config.vm.provider :libvirt do |libvirt|

--- a/installer-tests/Vagrantfile
+++ b/installer-tests/Vagrantfile
@@ -65,6 +65,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.driver = 'qemu'
+  end
 
   config.vm.define "default", primary: true do |default|
     # The default is the Ubuntu 14.04 ("trusty tahr") cloud image.

--- a/installer-tests/Vagrantfile
+++ b/installer-tests/Vagrantfile
@@ -78,8 +78,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "jessie" do |jessie|
-    # The default is the Ubuntu 14.04 ("trusty tahr") cloud image.
-    jessie.vm.box = "thoughtbot/debian-jessie-64"
+    # This is the thoughtbot jessie image, converted to libvirt; see
+    # prepare-for-tests.sh.
+    jessie.vm.box = "thoughtbot_jessie"
 
     jessie.vm.provision "shell",
                        inline: "sudo sed -i s,ftp.us.debian.org,http.debian.net, /etc/apt/sources.list"

--- a/installer-tests/automatic-dev-install-on-jessie.t
+++ b/installer-tests/automatic-dev-install-on-jessie.t
@@ -10,7 +10,7 @@ $[run]sudo CURL_USER_AGENT=testing bash /vagrant/install.sh -d
 $[slow]Sandstorm requires sysctl kernel.unprivileged_userns_clone to be enabled.
 Config written to /opt/sandstorm/sandstorm.conf.
 Finding latest build for dev channel...
-$[slow]Downloading: https://dl.sandstorm.io/
+$[veryslow]Downloading: https://dl.sandstorm.io/
 $[slow]Sandstorm started.
 Setup complete. You should configure the site at:
   http://local.sandstorm.io:6080/admin/

--- a/installer-tests/automatic-dev-install-on-jessie.t
+++ b/installer-tests/automatic-dev-install-on-jessie.t
@@ -1,0 +1,19 @@
+Title: Auto-install with root on Debian jessie, in dev mode
+Vagrant-Box: jessie
+Vagrant-Precondition-bash: ! -d $HOME/sandstorm
+Vagrant-Precondition-bash: ! -d /opt/sandstorm
+Cleanup: uninstall_sandstorm(parsed_headers['vagrant-box'])
+
+$[run]sudo cat /proc/sys/kernel/unprivileged_userns_clone
+$[slow]0
+$[run]sudo CURL_USER_AGENT=testing bash /vagrant/install.sh -d
+$[slow]Sandstorm requires sysctl kernel.unprivileged_userns_clone to be enabled.
+Config written to /opt/sandstorm/sandstorm.conf.
+Finding latest build for dev channel...
+$[slow]Downloading: https://dl.sandstorm.io/
+$[slow]Sandstorm started.
+Setup complete. You should configure the site at:
+  http://local.sandstorm.io:6080/admin/
+To learn how to control the server, run:
+  sandstorm help
+$[exitcode]0

--- a/installer-tests/full-server-install-on-jessie-with-userns-sysctl.t
+++ b/installer-tests/full-server-install-on-jessie-with-userns-sysctl.t
@@ -24,7 +24,7 @@ We're going to:
 To set up Sandstorm, we will need to use sudo.
 OK to continue? [yes] $[type]
 $[slow]Re-running script as root...
-As a Sandstorm user, you are invited to use a free Internet hostname as a subdomain of sandcats.io.
+$[slow]As a Sandstorm user, you are invited to use a free Internet hostname as a subdomain of sandcats.io.
 $[slow]Choose your desired Sandcats subdomain (alphanumeric, max 20 characters).
 Type the word none to skip this step, or help for help.
 What *.sandcats-dev.sandstorm.io subdomain would you like? []$[type]gensym

--- a/installer-tests/full-server-install-on-jessie-with-userns-sysctl.t
+++ b/installer-tests/full-server-install-on-jessie-with-userns-sysctl.t
@@ -33,7 +33,7 @@ Enter your email address: [] $[type]install-script@asheesh.org
 Registering your domain.
 $[slow]Congratulations! We have registered your
 Your credentials to use it are in /opt/sandstorm/var/sandcats; consider making a backup.
-$[slow]Downloading: https://dl.sandstorm.io
+$[veryslow]Downloading: https://dl.sandstorm.io
 $[slow]Sandstorm started. PID =
 Setup complete. You should configure the site at:
   http://

--- a/installer-tests/full-server-install-on-jessie-with-userns-sysctl.t
+++ b/installer-tests/full-server-install-on-jessie-with-userns-sysctl.t
@@ -40,5 +40,3 @@ Setup complete. You should configure the site at:
 To learn how to control the server, run:
   sandstorm help
 $[exitcode]0
-$[run]sudo bash -c 'echo 0 > /proc/sys/kernel/unprivileged_userns_clone'
-$[slow]0

--- a/installer-tests/install-without-root.t
+++ b/installer-tests/install-without-root.t
@@ -2,7 +2,7 @@ Title: Can install without root, with -u
 Vagrant-Box: default
 Vagrant-Destroy-If-bash: -d $HOME/sandstorm
 Vagrant-Precondition-bash: ! -d $HOME/sandstorm
-Cleanup: vagrant_destroy()
+Cleanup: uninstall_sandstorm(parsed_headers['vagrant-box'])
 
 $[run]CURL_USER_AGENT=testing /vagrant/install.sh -u
 $[slow]Sandstorm makes it easy to run web apps on your own server. You can have:

--- a/installer-tests/install-without-root.t
+++ b/installer-tests/install-without-root.t
@@ -40,7 +40,7 @@ Wildcard host: [*.local.sandstorm.io:6080]$[type]
 
 Config written to
 Finding latest build for dev channel...
-$[slow]Downloading: https://dl.sandstorm.io/sandstorm-
+$[veryslow]Downloading: https://dl.sandstorm.io/sandstorm-
 $[slow]Start sandstorm at system boot (using sysvinit)? [yes] $[type]
 Setup complete. To start your server now, run:
 sandstorm start

--- a/installer-tests/prepare-for-tests.sh
+++ b/installer-tests/prepare-for-tests.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script exists to find out if you have vagrant and libvirt set
+# up, and to help you do first-time setup tasks so you can run the
+# installer tests.
+
+# These two functions are borrowed from install.sh.
+
+error() {
+  if [ $# != 0 ]; then
+    echo -en '\e[0;31m' >&2
+    echo "$@" | (fold -s || cat) >&2
+    echo -en '\e[0m' >&2
+  fi
+}
+
+fail() {
+  error "$@"
+  exit 1
+}
+
+# Look for executable dependencies.
+for dep in vagrant ; do
+    which $dep > /dev/null || fail "Please install $dep(1)."
+done
+
+# Check if Vagrant has the mutate plugin; if not, we install it, since
+# we use it during this script to convert a few Vagrant base boxes
+# into libvirt format.
+(vagrant plugin list | grep -q mutate) || vagrant plugin install vagrant-mutate
+
+# Download this particular random Debian Jessie VM and then convert it to
+# libvirt format.
+(vagrant box list | grep -q thoughtbot_jessie) || vagrant box add thoughtbot_jessie https://vagrantcloud.com/thoughtbot/boxes/debian-jessie-64/versions/0.1.0/providers/virtualbox.box
+(vagrant box list | grep -q 'thoughtbot_jessie.*libvirt') || vagrant mutate thoughtbot_jessie libvirt
+
+# Do the same for the main Trusty (Ubuntu 14.04) VM.
+(vagrant box list | grep -q 'trusty64') || vagrant box add trusty64 https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box
+(vagrant box list | grep -q 'trusty64.*libvirt') || vagrant mutate trusty64 libvirt

--- a/installer-tests/run_tests.py
+++ b/installer-tests/run_tests.py
@@ -2,9 +2,9 @@ import glob
 import os
 import pexpect
 import random
+import re
 import subprocess
 import sys
-import re
 
 
 def _expect(line, current_cmd, do_re_escape=True, do_detect_slow=True,

--- a/installer-tests/run_tests.py
+++ b/installer-tests/run_tests.py
@@ -159,11 +159,12 @@ def run_one_test(filename, state):
     headers, test_script = (lines[:position_of_blank_line],
                             lines[position_of_blank_line+1:])
 
-    print repr(headers)
     parsed_headers, postconditions, cleanups = parse_test_file(headers)
 
     # Make the VM etc., if necessary.
     handle_headers(parsed_headers)
+    print "*** Running test:", parsed_headers['title']
+    print " -> Extra info:", repr(headers)
 
     # Run the test script, using pexpect to track its output.
     try:

--- a/installer-tests/run_tests.py
+++ b/installer-tests/run_tests.py
@@ -143,7 +143,13 @@ def handle_postconditions(postconditions_list):
 
 
 def vagrant_up(vagrant_box_name):
-    subprocess.check_output(['vagrant', 'up', vagrant_box_name], cwd=TEST_ROOT)
+    env_for_subprocess = os.environ.copy()
+    env_for_subprocess['VAGRANT_DEFAULT_PROVIDER'] = 'libvirt'
+    subprocess.check_output(
+        ['vagrant', 'up', vagrant_box_name],
+        cwd=TEST_ROOT,
+        env=env_for_subprocess,
+    )
 
 
 def run_one_test(filename, state):

--- a/installer-tests/run_tests.py
+++ b/installer-tests/run_tests.py
@@ -92,11 +92,6 @@ def parse_test_file(headers_list):
                 parsed_headers[key] = []
             parsed_headers[key].append(value)
 
-        if key == 'precondition':
-            if key not in parsed_headers:
-                parsed_headers[key] = []
-            parsed_headers[key].append(value)
-
         if key == 'postcondition':
             postconditions.append([key, value])
 

--- a/installer-tests/run_tests.py
+++ b/installer-tests/run_tests.py
@@ -163,7 +163,7 @@ def vagrant_up(vagrant_box_name):
     )
 
 
-def run_one_test(filename, state):
+def run_one_test(filename):
     lines = open(filename).read().split('\n')
     position_of_blank_line = lines.index('')
 
@@ -217,21 +217,12 @@ def handle_cleanups(parsed_headers, cleanups):
             print 'Dazed and confused, but trying to continue.'
 
 
-def save_state():
-    return {'cwd': os.getcwd()}
-
-
-def restore_state(state):
-    os.chdir(state['cwd'])
-
-
 def main():
     filenames = sys.argv[1:]
     if not filenames:
         filenames = glob.glob('*.t')
     for filename in filenames:
-        state = save_state()
-        run_one_test(filename, state)
+        run_one_test(filename)
 
 if __name__ == '__main__':
     main()

--- a/installer-tests/run_tests.py
+++ b/installer-tests/run_tests.py
@@ -10,11 +10,22 @@ import re
 def _expect(line, current_cmd, do_re_escape=True, do_detect_slow=True,
             strip_comments=True, verbose=True):
     timeout = 1
+
+    slow_text_timeout = int(os.environ.get('SLOW_TEXT_TIMEOUT', 30))
+    veryslow_text_timeout = 2 * slow_text_timeout
+
     if do_detect_slow:
-        if line.startswith('$[slow]'):
+        slow_token = '$[slow]'
+        if line.startswith(slow_token):
             print 'Slow line...'
-            timeout = int(os.environ.get('SLOW_TEXT_TIMEOUT', 30))
-            line = line.replace('$[slow]', '', 1)
+            timeout = slow_text_timeout
+            line = line.replace(slow_token, '', 1)
+
+        veryslow_token = '$[veryslow]'
+        if line.startswith(veryslow_token):
+            print 'Very slow line...'
+            timeout = veryslow_text_timeout
+            line = line.replace(veryslow_token, '', 1)
 
     if verbose:
         print 'expecting', line


### PR DESCRIPTION
This adjusts the tests in `installer-tests/` so that they:

* Run using `libvirt` and `qemu`, so they can run on Jenkins, and

* Have a `README.md` that explains how the tests work.

I'm running all the tests locally to make sure they all pass this way. If so, I'd like to merge this. For now, still waiting on verification that they all pass.