### PR TITLE
Add token templating

### DIFF
--- a/shell/lib/db.js
+++ b/shell/lib/db.js
@@ -234,6 +234,9 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //   owner:     A `ApiTokenRefOwner` (defined in `supervisor.capnp`, stored as a JSON object)
 //              as passed to the `save()` call that created this token. If not present, treat
 //              as `webkey` (the default for `ApiTokenOwner`).
+//   expiresIfUnused:
+//              Optional Date after which the token, if it has not been used yet, expires.
+//              This field should be cleared on a token's first use.
 
 Notifications = new Mongo.Collection("notifications");
 // Notifications for a user.

--- a/shell/public/offer-template.html
+++ b/shell/public/offer-template.html
@@ -19,21 +19,20 @@ pre {
   <body>
     <pre id="text"></pre>
 <script>
-// Templates are namespaced in localStorage by the prefix "template"
-var templateToken = "template" + window.location.hash.substring(1);
-var record = JSON.parse(localStorage.getItem(templateToken));
-console.log(record);
+// Templates are namespaced in sessionStorage by the prefix "offerTemplate"
+var templateToken = "offerTemplate" + window.location.hash.substring(1);
+var record = JSON.parse(sessionStorage.getItem(templateToken));
 document.getElementById("text").textContent = record.renderedTemplate;
 
-// Clean up localStorage templates that have expired.
+// Clean up sessionStorage templates that have expired.
 // First, collect expired template keys
 var i;
 var toDelete = [];
-for (i = 0; i < localStorage.length ; i++) {
-  var key = localStorage.key(i);
+for (i = 0; i < sessionStorage.length ; i++) {
+  var key = sessionStorage.key(i);
   // we only care about templates
-  if (key.startsWith("template")) {
-    var data = localStorage.getItem(key);
+  if (key.startsWith("offerTemplate")) {
+    var data = sessionStorage.getItem(key);
     if (data.expires < Date.now()) {
         toDelete.push(key);
     }
@@ -41,7 +40,7 @@ for (i = 0; i < localStorage.length ; i++) {
 }
 // Then, wipe expired keys.
 for (i = 0; i < toDelete.length; i++) {
-  localStorage.deleteItem(toDelete[i]);
+  sessionStorage.deleteItem(toDelete[i]);
 }
 </script>
   </body>

--- a/shell/public/tokentemplate.html
+++ b/shell/public/tokentemplate.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Sandstorm template</title>
+    <style>
+body {
+  margin: 0;
+  padding: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
+  border: 0;
+}
+pre {
+  margin: 0;
+  padding: 0;
+}
+    </style>
+  </head>
+  <body>
+    <pre id="text"></pre>
+<script>
+// Templates are namespaced in localStorage by the prefix "template"
+var templateToken = "template" + window.location.hash.substring(1);
+var record = JSON.parse(localStorage.getItem(templateToken));
+console.log(record);
+document.getElementById("text").textContent = record.renderedTemplate;
+
+// Clean up localStorage templates that have expired.
+// First, collect expired template keys
+var i;
+var toDelete = [];
+for (i = 0; i < localStorage.length ; i++) {
+  var key = localStorage.key(i);
+  // we only care about templates
+  if (key.startsWith("template")) {
+    var data = localStorage.getItem(key);
+    if (data.expires < Date.now()) {
+        toDelete.push(key);
+    }
+  }
+}
+// Then, wipe expired keys.
+for (i = 0; i < toDelete.length; i++) {
+  localStorage.deleteItem(toDelete[i]);
+}
+</script>
+  </body>
+</html>

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -251,8 +251,13 @@ Meteor.methods({
       allAccess: Match.Optional(null),
       roleId: Match.Optional(Match.Integer),
     });
-    check(destroyIfNotUsedByTime, Match.Optional(Number));
-    var selfDestructAt = destroyIfNotUsedByTime > 0 ? new Date(destroyIfNotUsedByTime) : null;
+    // Meteor bug #3877: we get null here instead of undefined when we
+    // explicitly pass in undefined.
+    if (destroyIfNotUsedByTime) {
+      check(destroyIfNotUsedByTime, Number);
+    }
+    var selfDestructAt = (destroyIfNotUsedByTime && (destroyIfNotUsedByTime > 0)) ?
+        new Date(destroyIfNotUsedByTime) : null;
 
     var grain = Grains.findOne(grainId);
     if (!grain) {

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -237,9 +237,8 @@ HackSessionContextImpl.prototype.generateApiToken = function (petname, userInfo,
 };
 
 Meteor.methods({
-  newApiToken: function (grainId, petname, roleAssignment, forSharing) {
+  newApiToken: function (grainId, petname, roleAssignment, forSharing, destroyIfNotUsedByTime) {
     // Create a new user-oriented API token.
-
     if (!this.userId) {
       throw new Meteor.Error(403, "Must be logged in to create an API token.");
     }
@@ -252,6 +251,8 @@ Meteor.methods({
       allAccess: Match.Optional(null),
       roleId: Match.Optional(Match.Integer),
     });
+    check(destroyIfNotUsedByTime, Match.Optional(Number));
+    var selfDestructAt = destroyIfNotUsedByTime > 0 ? new Date(destroyIfNotUsedByTime) : null;
 
     var grain = Grains.findOne(grainId);
     if (!grain) {
@@ -270,11 +271,21 @@ Meteor.methods({
       created: new Date(),
       expires: null,
       forSharing: forSharing,
+      expiresIfUnused: selfDestructAt
     });
 
     return {token: token, endpointUrl: endpointUrl};
   }
 });
+
+var cleanupSelfDestructing = function() {
+  var now = new Date();
+  ApiTokens.remove({expiresIfUnused: {$lt: now}});
+};
+
+// Make self-destructing tokens actually self-destruct, so they don't
+// clutter the token list view.
+Meteor.setInterval(cleanupSelfDestructing, 60 * 1000);
 
 HackSessionContextImpl.prototype.listApiTokens = function () {
   return inMeteor((function () {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -574,6 +574,15 @@ getProxyForApiToken = function (token) {
           throw new Meteor.Error(403, "Authorization token expired");
         }
 
+        if (tokenInfo.expiresIfUnused) {
+          if (tokenInfo.expiresIfUnused.getTime() <= Date.now()) {
+            throw new Meteor.Error(403, "Authorization token expired");
+          } else {
+            // It's getting used now, so clear the expiresIfUnused field.
+            ApiTokens.update(tokenInfo._id, {$set: {expiresIfUnused: null}});
+          }
+        }
+
         var grain = Grains.findOne(tokenInfo.grainId);
         if (!grain) {
           // Grain was deleted, I guess.

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -513,11 +513,13 @@ if (Meteor.isClient) {
         Session.set("grainFrameTitle", event.data.setTitle);
       } else if (event.data.renderTemplate) {
         // Request creation of a single-use template with a privileged API token.
-        // Why?  Apps should not be able to obtain capabilities to themselves
-        // directly, but often need a way to provide instructions to users to
-        // copy/paste with some privileged token contained within.  By
-        // providing this templating in the platform, we can ensure that the
-        // token is only visible to the shell's origin.
+        // Why?  Apps should not be able to obtain capabilities-as-keys to
+        // themselves directly, because those can be leaked through an
+        // arbitrary bit stream or covert channel.  However, apps often need a
+        // way to provide instructions to users to copy/paste with some
+        // privileged token contained within.  By providing this templating in
+        // the platform, we can ensure that the token is only visible to the
+        // shell's origin.
         var call = event.data.renderTemplate;
         check(call, Object);
         var rpcId = call.rpcId;
@@ -536,7 +538,7 @@ if (Meteor.isClient) {
           check(call.petname, String);
           petname = call.petname;
         } else {
-          petname = "template token";
+          petname = "connected external app";
         }
         // Tokens expire by default in 5 minutes from generation date
         var selfDestructTime = Date.now() + (5 * 60 * 1000);
@@ -544,24 +546,24 @@ if (Meteor.isClient) {
                     selfDestructTime, function (error, result) {
           if (error) {
             //Session.set("api-token-" + currentGrainId, undefined);
-            window.alert("Failed to create token for template.\n" + error);
+            window.alert("Failed to create token for offer template.\n" + error);
             console.error(error.stack);
           } else {
             var tokenId = result.token;
             // Generate random key id2.
             var id2 = Random.secret();
-            // Store apitoken id1 and template in local storage in the template
-            // namespace under key id2.
-            var key = "template" + id2;
+            // Store apitoken id1 and template in local storage in the offer
+            // template namespace under key id2.
+            var key = "offerTemplate" + id2;
             var renderedTemplate = template.replace("$API_TOKEN", tokenId)
                                            .replace("$API_HOST", makeWildcardHost("api"));
-            localStorage.setItem(key, JSON.stringify({
+            sessionStorage.setItem(key, JSON.stringify({
                 "renderedTemplate": renderedTemplate,
-                "expiry": "soon"
+                "expiry": selfDestructTime
               })
             );
             // Send message to event.source with URL containing id2
-            templateLink = window.location.origin + "/tokentemplate.html#" + id2;
+            templateLink = window.location.origin + "/offer-template.html#" + id2;
             event.source.postMessage({rpcId: rpcId, uri: templateLink}, event.origin);
           }
         });
@@ -635,7 +637,8 @@ function grainRouteHelper(route, result, openSessionMethod, openSessionArg, root
   result.apiTokenPending = apiToken === "pending",
   result.showApiToken = Session.get("show-api-token"),
   result.existingTokens = ApiTokens.find({grainId: grainId, userId: Meteor.userId(),
-                                          forSharing: {$ne: true}}).fetch(),
+                                          forSharing: {$ne: true},
+                                          expiresIfUnused: null}).fetch(),
   result.shareToken = shareToken,
   result.shareTokenPending = shareToken === "pending",
   result.showShareGrain = Session.get("show-share-grain"),

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -256,7 +256,7 @@ if (Meteor.isClient) {
         assignment = {none: null};
       }
       Meteor.call("newApiToken", this.grainId, document.getElementById("api-token-petname").value,
-                  assignment, false,
+                  assignment, false, undefined,
                   function (error, result) {
         if (error) {
           Session.set("api-token-" + grainId, undefined);
@@ -298,7 +298,7 @@ if (Meteor.isClient) {
         assignment = {none: null};
       }
       Meteor.call("newApiToken", grainId, document.getElementById("share-token-petname").value,
-                  assignment, true,
+                  assignment, true, undefined,
                   function (error, result) {
         if (error) {
           console.error(error.stack);
@@ -511,6 +511,60 @@ if (Meteor.isClient) {
             currentGrainId + event.data.setPath);
       } else if (event.data.setTitle) {
         Session.set("grainFrameTitle", event.data.setTitle);
+      } else if (event.data.renderTemplate) {
+        // Request creation of a single-use template with a privileged API token.
+        // Why?  Apps should not be able to obtain capabilities to themselves
+        // directly, but often need a way to provide instructions to users to
+        // copy/paste with some privileged token contained within.  By
+        // providing this templating in the platform, we can ensure that the
+        // token is only visible to the shell's origin.
+        var call = event.data.renderTemplate;
+        check(call, Object);
+        var rpcId = call.rpcId;
+        check(rpcId, String);
+        var template = call.template;
+        check(template, String);
+        var assignment = undefined;
+        if (call.roleId) {
+          check(call.roleId, Match.Integer);
+          assignment = {roleId: call.roleId};
+        } else {
+          assignment = {none: null};
+        }
+        var petname = undefined;
+        if (call.petname) {
+          check(call.petname, String);
+          petname = call.petname;
+        } else {
+          petname = "template token";
+        }
+        // Tokens expire by default in 5 minutes from generation date
+        var selfDestructTime = Date.now() + (5 * 60 * 1000);
+        Meteor.call("newApiToken", currentGrainId, petname, assignment, false,
+                    selfDestructTime, function (error, result) {
+          if (error) {
+            //Session.set("api-token-" + currentGrainId, undefined);
+            window.alert("Failed to create token for template.\n" + error);
+            console.error(error.stack);
+          } else {
+            var tokenId = result.token;
+            // Generate random key id2.
+            var id2 = Random.secret();
+            // Store apitoken id1 and template in local storage in the template
+            // namespace under key id2.
+            var key = "template" + id2;
+            var renderedTemplate = template.replace("$API_TOKEN", tokenId)
+                                           .replace("$API_HOST", makeWildcardHost("api"));
+            localStorage.setItem(key, JSON.stringify({
+                "renderedTemplate": renderedTemplate,
+                "expiry": "soon"
+              })
+            );
+            // Send message to event.source with URL containing id2
+            templateLink = window.location.origin + "/tokentemplate.html#" + id2;
+            event.source.postMessage({rpcId: rpcId, uri: templateLink}, event.origin);
+          }
+        });
       } else {
         console.log("postMessage from app not understood: " + event.data);
       }


### PR DESCRIPTION
Grains can now make a request to the shell via postMessage() with a template
which can substitute a privileged API token for $API_TOKEN and the API host for
$API_HOST.  The grain will receive a postMessage reply from the shell with a
single-use URL in the shell's origin that will display the rendered template.
The app should iframe this URL in a place in the document inline where it wants
the template to appear.  Apps should *not* persist this URL anywhere.

Implementation detail: the privileged token will expire 5 minutes after
creation, if it is not used in that timeframe.  This helps avoid cluttering the
DB (and UI) with a bunch of tokens that were generated for this templating magic
that the user didn't end up using.