### PR TITLE
Check for kernel version before user namespaces

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1542,13 +1542,13 @@ sandcats_generate_keys() {
 
 # Now that the steps exist as functions, run them in an order that
 # would result in a working install.
+assert_usable_kernel
 detect_current_uid
 detect_userns_clone
 assert_userns_clone_works_or_can_be_made_to_work
 handle_args "$@"
 assert_on_terminal
 assert_linux_x86_64
-assert_usable_kernel
 assert_dependencies
 assert_valid_bundle_file
 detect_init_system

--- a/installer-tests/Vagrantfile
+++ b/installer-tests/Vagrantfile
@@ -41,6 +41,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     default.vm.box = "trusty64"
   end
 
+  config.vm.define "precise64", primary: true do |default|
+    default.vm.box = "precise64"
+  end
+
   config.vm.define "jessie" do |jessie|
     jessie.vm.box = "thoughtbot_jessie"
 

--- a/installer-tests/fail-on-old-kernel.t
+++ b/installer-tests/fail-on-old-kernel.t
@@ -1,0 +1,13 @@
+Title: Can't install Sandstorm on old kernels
+Vagrant-Box: precise64
+Vagrant-Precondition-bash: ! -d $HOME/sandstorm
+Vagrant-Precondition-bash: ! -d /opt/sandstorm
+Vagrant-Postcondition-bash: ! -d $HOME/sandstorm
+Vagrant-Postcondition-bash: ! -d /opt/sandstorm
+
+$[run]CURL_USER_AGENT=testing /vagrant/install.sh
+$[slow]Detected Linux kernel version:
+Sorry, your kernel is too old to run Sandstorm.
+*** INSTALLATION FAILED ***
+Report bugs at: http://github.com/sandstorm-io/sandstorm
+$[exitcode]1

--- a/installer-tests/fail-on-old-kernel.t
+++ b/installer-tests/fail-on-old-kernel.t
@@ -1,9 +1,5 @@
 Title: Can't install Sandstorm on old kernels
 Vagrant-Box: precise64
-Vagrant-Precondition-bash: ! -d $HOME/sandstorm
-Vagrant-Precondition-bash: ! -d /opt/sandstorm
-Vagrant-Postcondition-bash: ! -d $HOME/sandstorm
-Vagrant-Postcondition-bash: ! -d /opt/sandstorm
 
 $[run]CURL_USER_AGENT=testing /vagrant/install.sh
 $[slow]Detected Linux kernel version:

--- a/installer-tests/prepare-for-tests.sh
+++ b/installer-tests/prepare-for-tests.sh
@@ -38,3 +38,7 @@ done
 # Do the same for the main Trusty (Ubuntu 14.04) VM.
 (vagrant box list | grep -q 'trusty64') || vagrant box add trusty64 https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box
 (vagrant box list | grep -q 'trusty64.*libvirt') || vagrant mutate trusty64 libvirt
+
+# Do the same for the main Precise (Ubuntu 12.04) VM.
+(vagrant box list | grep -q 'precise64') || vagrant box add precise64 https://vagrantcloud.com/hashicorp/boxes/precise64/versions/1.1.0/providers/virtualbox.box
+(vagrant box list | grep -q 'precise64.*libvirt') || vagrant mutate precise64 libvirt


### PR DESCRIPTION
This way, if someone has a Linux distribution that is too old to
run Sandstorm, we give them relevant advice.

Close #478