### PR TITLE
Allow Sandstorm apps to be the target of GitHub webhooks

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -639,7 +639,7 @@ function apiUseBasicAuth(req) {
   // For clients with no convenient way to add an "Authorization: Bearer" header, we allow the token
   // to be transmitted as a basic auth password.
   var agent = req.headers["user-agent"];
-  if (agent && agent.slice(0, 4) === "git/") {
+  if (agent && ((agent.slice(0, 4) === "git/") || (agent.slice(0, 16) === "GitHub-Hookshot/"))) {
     return true;
   } else {
     return false;


### PR DESCRIPTION
This whitelists user agents starting with "GitHub-Hookshot/", per
https://developer.github.com/webhooks/#payloads

Closes #509.