### PR TITLE
Add shell/lib to the dependencies of the shell-build target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ shell/public/%.png: icons/%.svg
 shell/public/%-m.png: icons/%.svg
 	@convert -background none -scale 32x32 $< $@
 
-shell-build: shell/client/* shell/server/* shell/shared/* shell/public/* shell/.meteor/packages shell/.meteor/release shell/.meteor/versions tmp/.shell-env
+shell-build: shell/lib/* shell/client/* shell/server/* shell/shared/* shell/public/* shell/.meteor/packages shell/.meteor/release shell/.meteor/versions tmp/.shell-env
 	@$(call color,meteor frontend)
 	@OLD=`pwd` && cd shell && PYTHONPATH=$$HOME/.meteor/tools/latest/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib meteor build --directory "$$OLD/shell-build"
 


### PR DESCRIPTION
Right now, if you edit migrations.js and then do `make update`, your changes won't get applied because the Makefile thinks that nothing has changed. This fixes the problem.