### PR TITLE
Merge RoleAssignments into ApiTokens.

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -346,79 +346,62 @@ limitations under the License.
           <p><button id="reset-share-token">Go back</button></p>
         {{/if}}
       {{else}}
-        <p>Create a secret link to share with other users.</p>
-        <p><form id="new-share-token">
-        Label: <input onclick="select()" type="text"
-                id="share-token-petname" value="unlabeled sharing link">
-        {{#with viewInfo}}
-          {{#if roles}}
-            Role:
-            <select id="share-token-role" title="select a role">
-              {{#each roles}}
-                <option title={{verbPhrase.defaultText}}
-                        style="{{#if obsolete}}display:none{{/if}}"
-                        selected={{default}}>
-                  {{title.defaultText}}</option>
-              {{/each}}
-            </select>
-          {{/if}}
-        {{/with}}
-        <button>Create</button>
-        </form></p>
-        {{#if existingShareTokens}}
-          <p> Your existing links: </p>
-          <ul>
-          {{#each existingShareTokens}}
-            <li>
-              <span class="token-petname" data-token-id="{{_id}}">
-                {{petname}} ({{dateString created}})
-              </span>
-              <button class="revoke-token" title="revoke" data-token-id="{{_id}}">revoke</button>
-            </li>
-          {{/each}}
-          </ul>
-        {{else}}
-          You have not created any links.
-        {{/if}}
-        {{#if existingAssignments}}
-          <p></p>
-          <p> You have shared access with these users: </p>
-          <ul>
-          {{#each existingAssignments}}
-            <li class="{{#if active}}{{else}}revoked-role-assignment{{/if}}">
-              {{displayName recipient}} ({{dateString created}})
-              {{#if active}}
-                <button class="revoke-role-assignment"
-                        title="revoke" data-id="{{_id}}">revoke</button>
-              {{else}}
-                <button class="restore-role-assignment"
-                        title="restore" data-id="{{_id}}">restore</button>
-              {{/if}}
-            </li>
-          {{/each}}
-          </ul>
-          {{#if transitiveShares}}
-            <button class="hide-transitive-shares">hide reshares</button>
-            {{#if transitiveShares.empty}}
-              <p></p>
-              <p> There are no reshares. </p>
-            {{else}}
-              <ul>
-                {{#each transitiveShares}}
-                  <li>
-                    <div>{{displayName recipient}} was granted access by:</div>
-                    <ul>
-                      {{#each sharers}}
-                        <li>{{displayName sharer}} ({{dateString created}})</li>
-                      {{/each}}
-                    </ul>
-                  </li>
-                {{/each}}
-              </ul>
-            {{/if}}
+        {{#if transitiveShares}}
+          {{#if transitiveShares.empty}}
+            <p></p>
+            <p> You have granted access to nobody. </p>
           {{else}}
-            <button class="show-transitive-shares">show reshares</button>
+            <p>Users who have received access through you:</p>
+            <ul>
+              {{#each transitiveShares}}
+                <li>
+                  <div>{{displayName recipient}} was granted access by:</div>
+                  <ul>
+                    {{#each shares}}
+                      <li>{{displayName userId}} ({{dateString created}})</li>
+                    {{/each}}
+                  </ul>
+                </li>
+              {{/each}}
+            </ul>
           {{/if}}
+          <button class="hide-transitive-shares">back</button>
+        {{else}}
+          <p>Create a secret link to share with other users.</p>
+          <p><form id="new-share-token">
+          Label: <input onclick="select()" type="text"
+                  id="share-token-petname" value="unlabeled sharing link">
+          {{#with viewInfo}}
+            {{#if roles}}
+              Role:
+              <select id="share-token-role" title="select a role">
+                {{#each roles}}
+                  <option title={{verbPhrase.defaultText}}
+                          style="{{#if obsolete}}display:none{{/if}}"
+                          selected={{default}}>
+                    {{title.defaultText}}</option>
+                {{/each}}
+              </select>
+            {{/if}}
+          {{/with}}
+          <button>Create</button>
+          </form></p>
+          {{#if existingShareTokens}}
+            <p> Your existing links: </p>
+            <ul>
+            {{#each existingShareTokens}}
+              <li>
+                <span class="token-petname" data-token-id="{{_id}}">
+                  {{petname}} ({{dateString created}})
+                </span>
+                <button class="revoke-token" title="revoke" data-token-id="{{_id}}">revoke</button>
+              </li>
+            {{/each}}
+            </ul>
+          {{else}}
+            You have not created any links.
+          {{/if}}
+           <button class="show-transitive-shares">see who has access</button>
         {{/if}}
       {{/if}}
     {{/if}}

--- a/shell/lib/db.js
+++ b/shell/lib/db.js
@@ -91,32 +91,9 @@ Grains = new Mongo.Collection("grains");
 //       web publishing. This field is initialized when first requested by the app.
 
 RoleAssignments = new Mongo.Collection("roleAssignments");
-// Edges in the permissions sharing graph.
-//
-// To share a permission with another user is to declare "if I have this permission, then so should
-// the recipient". A bundle of such declarations by a single sharer directed at a single recipient
-// for a single grain is called a "role assignment". A grain's owner always has every permission,
-// but permissions for other users must be computed from this collection.
-//
-// Any grain for which a user has received a role assignment should show up in that user's grain
-// list. However, the user may only access a grain if there is a path of *active* role assignments
-// leading from the grain owner to that user, precisely as if every role assignment carried a
-// special "can open grain" permission.
-//
-// Each contains:
-//   _id: random
-//   grainId: The `_id` of the grain whose permissions are being shared.
-//   sharer: The `_id` of the user who is sharing these permissions.
-//   recipient: The `_id` of the user who receives these permissions.
-//   roleAssignment: A JSON-encoded Grain.ViewSharingLink.RoleAssignment representing the
-//                   received permissions. The sharer is allowed to modify this later.
-//   active: Flag indicating that this role assignment has not been revoked. The sharer is allowed
-//           to flip this bit, but only the recipient is allowed to delete the role assignment.
-//   petname: Human-readable label chosen by and only visible to the sharer.
-//   title: Human-readable title as chosen by the recipient. Used in the same places that
-//          `grain.title` is used for the grain's owner.
-//   created: Date when this role assignment was created.
-//   parent: If present, the `_id` of the entry in ApiTokens from which this was derived.
+// *OBSOLETE* Before `user` was a variant of ApiTokenOwner, this collection was used to store edges
+// in the permissions sharing graph. This functionality has been subsumed by the ApiTokens
+// collection.
 
 Contacts = new Mongo.Collection("contacts");
 // Edges in the social graph.
@@ -238,8 +215,10 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //                           `Notifications` collection.
 //   parentToken: If present, then this token represents exactly the capability represented by
 //              the ApiToken with _id = parentToken, except possibly (if it is a UiView) attenuated
-//              by `roleAssignment` (if present). None of `grainId`, `userId`, `userInfo`,
-//              `objectId`, or `frontendRef` are present when `parentToken` is present.
+//              by `roleAssignment` (if present). To facilitate permissions computations, if the
+//              capability is a UiView, then `grainId` is set to the backing grain and `userId` is
+//              set to the user who shared the view. None of `userInfo`, `objectId`, or
+//              `frontendRef` are present when `parentToken` is present.
 //   petname:   Human-readable label for this access token, useful for identifying tokens for
 //              revocation. This should be displayed when visualizing incoming capabilities to
 //              the grain identified by `grainId`.
@@ -280,7 +259,13 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //     }
 //     child :group {
 //       parentToken :Text;
-//       roleAssignment :Maybe(RoleAssignment);
+//       union {
+//         uiView :group {
+//           grainId :Text;
+//           userId :Text;
+//           roleAssignment :RoleAssignment = (allAccess = ());
+//         }
+//         other :Void;
 //     }
 //   }
 //   requirements: List(Supervisor.MembraneRequirement);

--- a/shell/lib/server/migrations.js
+++ b/shell/lib/server/migrations.js
@@ -75,13 +75,28 @@ var denormalizeInviteInfo = function() {
   });
 }
 
+function mergeRoleAssignmentsIntoApiTokens() {
+  RoleAssignments.find().forEach(function(roleAssignment) {
+    ApiTokens.insert({
+      grainId: roleAssignment.grainId,
+      userId: roleAssignment.sharer,
+      roleAssignment: roleAssignment.roleAssignment,
+      petname: roleAssignment.petname,
+      created: roleAssignment.created,
+      owner: {user: {userId: roleAssignment.recipient,
+                     title: roleAssignment.title}},
+    });
+  });
+}
+
 // This must come after all the functions named within are defined.
 // Only append to this list!  Do not modify or remove list entries;
 // doing so is likely change the meaning and semantics of user databases.
 var MIGRATIONS = [
   updateLoginStyleToRedirect,
   enableLegacyOAuthProvidersIfNotInSettings,
-  denormalizeInviteInfo
+  denormalizeInviteInfo,
+  mergeRoleAssignmentsIntoApiTokens,
 ];
 
 function migrateToLatest() {

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -812,7 +812,7 @@ Router.map(function () {
       var grain = Grains.findOne(grainId);
       if (grain) {
         title = grain.title;
-      } else {
+      } else if (Meteor.userId()) {
         var token = ApiTokens.findOne({grainId: grainId,
                                        "owner.user.userId": Meteor.userId()},
                                       {sort:{created:1}});

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -31,23 +31,15 @@ if (Meteor.isServer) {
   });
 
   ApiTokens.allow({
-    update: function (userId, apiToken, fieldNames) {
+    update: function (userId, apiToken, fieldNames, modifier) {
       // Allow owner to change the petname.
-      return userId && apiToken.userId === userId &&
-        (fieldNames.length === 1 && fieldNames[0] === "petname");
+      return userId &&
+        ((apiToken.userId === userId &&
+          (fieldNames.length === 1 && fieldNames[0] === "petname")) ||
+         Match.test(apiToken.owner, {user: Match.ObjectIncluding({userId: userId})}))
     },
     remove: function (userId, token) {
       return userId && token.userId === userId;
-    }
-  });
-
-  RoleAssignments.allow({
-    update: function (userId, roleAssignment, fieldNames) {
-      // Allow recipient to rename their reference to a shared grain.
-      return (userId && roleAssignment.recipient === userId &&
-              fieldNames.length === 1 && fieldNames[0] === "title")
-        || (userId && roleAssignment.sharer === userId &&
-            fieldNames.length === 1 && fieldNames[0] === "active");
     }
   });
 
@@ -55,11 +47,12 @@ if (Meteor.isServer) {
     check(grainId, String);
     var self = this;
 
-    // Alice is allowed to know Bob's display name if Bob has received a role assignment from Alice
+    // Alice is allowed to know Bob's display name if Bob has received a UiView from Alice
     // for *any* grain.
-    var handle = RoleAssignments.find({sharer: this.userId}).observe({
-      added: function(roleAssignment) {
-        var user = Meteor.users.findOne(roleAssignment.recipient);
+    var handle = ApiTokens.find({userId: this.userId,
+                                 "owner.user.userId": {$exists: true}}).observe({
+      added: function(token) {
+        var user = Meteor.users.findOne(token.owner.user.userId);
         if (user) {
           self.added("displayNames", user._id, {displayName: user.profile.name});
         }
@@ -68,8 +61,8 @@ if (Meteor.isServer) {
     this.onStop(function() { handle.stop(); });
     return [Grains.find({_id : grainId, $or: [{userId: this.userId}, {private: {$ne: true}}]},
                         {fields: {title: 1, userId: 1, private: 1}}),
-            ApiTokens.find({grainId: grainId, userId: this.userId}),
-            RoleAssignments.find({$or : [{sharer: this.userId}, {recipient: this.userId}]}),
+            ApiTokens.find({grainId: grainId,
+                            $or : [{"owner.user.userId": this.userId}, {userId: this.userId}]}),
            ];
   });
 
@@ -166,11 +159,11 @@ Meteor.methods({
       }
     }
   },
-  deleteRoleAssignments: function (grainId) {
+  forgetGrain: function (grainId) {
     check(grainId, String);
 
     if (this.userId) {
-      RoleAssignments.remove({grainId: grainId, recipient: this.userId});
+      ApiTokens.remove({grainId: grainId, "owner.user.userId": this.userId});
     }
   },
 });
@@ -197,12 +190,12 @@ if (Meteor.isClient) {
         if (this.isOwner) {
           Grains.update(this.grainId, {$set: {title: title}});
         } else {
-          var roleAssignment = RoleAssignments.findOne({grainId: this.grainId,
-                                                        recipient: Meteor.userId()},
-                                                       {sort:{created:1}});
-          if (roleAssignment) {
-            RoleAssignments.update(roleAssignment._id,
-                                   {$set: {title : title}});
+          var token = ApiTokens.findOne({grainId: this.grainId, objectId: {$exists: false},
+                                         "owner.user.userId": Meteor.userId()},
+                                        {sort:{created:1}});
+          if (token) {
+            ApiTokens.update(token._id,
+                             {$set: {"owner.user.title" : title}});
           }
         }
       }
@@ -217,7 +210,7 @@ if (Meteor.isClient) {
       } else {
         if (window.confirm("Really forget this grain?")) {
           Session.set("showMenu", false);
-          Meteor.call("deleteRoleAssignments", this.grainId);
+          Meteor.call("forgetGrain", this.grainId);
           Router.go("root");
         }
       }
@@ -349,34 +342,27 @@ if (Meteor.isClient) {
       }
     },
 
-    "click button.revoke-role-assignment": function (event) {
-      RoleAssignments.update(event.currentTarget.getAttribute("data-id"),
-                            {$set : {active : false}});
-    },
-
-    "click button.restore-role-assignment": function (event) {
-      RoleAssignments.update(event.currentTarget.getAttribute("data-id"),
-                            {$set : {active : true}});
-    },
-
     "click button.show-transitive-shares": function (event) {
       var grainId = this.grainId;
-      Meteor.call("transitiveShares", this.grainId, Meteor.userId(), function(error, downstream) {
+      Meteor.call("transitiveShares", this.grainId, function(error, downstream) {
         if (error) {
           console.error(error.stack);
         } else {
-          var shares = [];
-          for (var recipient in downstream.users) {
-            if (!RoleAssignments.findOne({grainId: grainId, recipient: recipient,
-                                          sharer: Meteor.userId(), active: true})) {
-              // There is not a direct share from the current user to this recipient.
-              shares.push({recipient: recipient, sharers: downstream.users[recipient]});
+          var sharesByRecipient = {};
+          downstream.forEach(function (token) {
+            if (Match.test(token.owner, {user: Match.ObjectIncluding({userId: String})})) {
+              var recipient = token.owner.user.userId;
+              if (!sharesByRecipient[recipient]) {
+                sharesByRecipient[recipient] = {recipient: recipient, shares: []};
+              }
+              sharesByRecipient[recipient].shares.push(token);
             }
+          });
+          var result = _.values(sharesByRecipient);
+          if (result.length == 0) {
+            result = {empty: true};
           }
-          if (shares.length == 0) {
-            shares = {empty: true};
-          }
-          Session.set("transitive-shares-" + grainId, shares);
+          Session.set("transitive-shares-" + grainId, result);
         }
       });
     },
@@ -733,8 +719,6 @@ function grainRouteHelper(route, result, openSessionMethod, openSessionArg, root
   result.showShareGrain = Session.get("show-share-grain");
   result.existingShareTokens = ApiTokens.find({grainId: grainId, userId: Meteor.userId(),
                                                forSharing: true}).fetch();
-  result.existingAssignments = RoleAssignments.find({grainId: grainId,
-                                                     sharer : Meteor.userId()}).fetch();
   result.transitiveShares = Session.get("transitive-shares-" + grainId);
   result.showMenu = Session.get("showMenu");
   result.rootPath = rootPath;
@@ -829,10 +813,11 @@ Router.map(function () {
       if (grain) {
         title = grain.title;
       } else {
-        var roleAssignment = RoleAssignments.findOne({grainId: grainId, recipient: Meteor.userId()},
-                                                     {sort:{created:1}});
-        if (roleAssignment) {
-          title = roleAssignment.title;
+        var token = ApiTokens.findOne({grainId: grainId,
+                                       "owner.user.userId": Meteor.userId()},
+                                      {sort:{created:1}});
+        if (token) {
+          title = token.owner.user.title;
         }
       }
       return grainRouteHelper(this,
@@ -880,8 +865,8 @@ Router.map(function () {
           this.state.set("error", undefined);
           var apiToken = tokenInfo.apiToken;
           if (!Grains.findOne({_id: apiToken.grainId, userId: Meteor.userId()}) &&
-              !RoleAssignments.findOne({sharer: apiToken.userId, recipient: Meteor.userId()})) {
-            // The user neither owns the grain nor holds any role assignments from this sharer.
+              !ApiTokens.findOne({userId: apiToken.userId, "owner.user.userId": Meteor.userId()})) {
+            // The user neither owns the grain nor holds any sturdyrefs from this sharer.
             // Therefore, we ask whether they would like to go incognito.
             // TODO(soon): Base this decision on the contents of the Contacts collection.
             return {interstitial: true, token: this.params.token};

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -53,7 +53,7 @@ if (Meteor.isServer) {
       return [
         UserActions.find({userId: this.userId}),
         Grains.find({userId: this.userId}),
-        RoleAssignments.find({recipient: this.userId}),
+        ApiTokens.find({'owner.user.userId': this.userId}),
       ];
     } else {
       return [];
@@ -412,10 +412,11 @@ if (Meteor.isClient) {
       if (selectedTab.sharedWithMe) {
         var result = [];
         var uniqueGrains = {};
-        RoleAssignments.find({}, {sort:{created:1}}).forEach(function(roleAssignment) {
-          if (!(roleAssignment.grainId in uniqueGrains)) {
-            result.push({_id : roleAssignment.grainId, title: roleAssignment.title});
-            uniqueGrains[roleAssignment.grainId] = true;
+        ApiTokens.find({'owner.user.userId': userId},
+                       {sort:{created:1}}).forEach(function(apiToken) {
+          if (!(apiToken.grainId in uniqueGrains)) {
+            result.push({_id : apiToken.grainId, title: apiToken.owner.user.title});
+            uniqueGrains[apiToken.grainId] = true;
           }
         });
         return result;
@@ -856,7 +857,8 @@ Router.map(function () {
         apps: apps,
         showMenu: Session.get("showMenu"),
         appMap: appMap,
-        hideSplashScreen: isSignedUpOrDemo() || RoleAssignments.findOne({recipient: Meteor.userId()})
+        hideSplashScreen: isSignedUpOrDemo() ||
+          ApiTokens.findOne({"owner.user.userId": Meteor.userId()})
       };
     }
   });

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -253,6 +253,17 @@ struct ApiTokenOwner {
 
     frontend @4 :Void;
     # Owned by the front-end, i.e. stored in its Mongo database.
+
+    user :group {
+      # Owned by a user. If the token represents a UiView, then it will show up in this user's
+      # grain list.
+
+      userId @6 :Text;
+      # The ID (`_id` in the users table) of the user who is allowed to restore this token.
+
+      title @7 :Text;
+      # Title as chosen by the user.
+    }
   }
 }
 


### PR DESCRIPTION
We're also going to need to update a bunch of code for this to work (particularly in permissions.js). I'm submitting this as a request for comments about the big picture.

The migration translates each RoleAssignment into a direct edge from the attenuated UiView to the user. They essentially become "shares by identity". In contrast, new ApiTokens created by redeeming webkeys will always have the `parentToken` field set.

I think we could go even farther and merge Grains into ApiTokens. That would entail adding a new "raw UiView" provider in addition to the existing "attenuated UiView" provider.

