### PR TITLE
Add two nudge arrows for demo users

### DIFF
--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -692,7 +692,7 @@ div.popup h2 {
 #install.instep-confirm  #step-confirm  .confirm-form { display: block; }
 #install.instep-run      #step-run      .done-notice { display: block; }
 
-#my-files-arrow, #sign-in-arrow {
+#demo-install-arrow, #my-files-arrow, #sign-in-arrow {
   position: absolute;
   left: 0;
   top: 0;
@@ -701,6 +701,12 @@ div.popup h2 {
   z-index: -1;
 
   background-image: url(/files-arrow.svg);
+}
+
+#demo-install-arrow {
+  /* Point at the first button in the shell, rather */
+  /* than pointing at the top bar. */
+  top: 3.35em;
 }
 
 #sign-in-arrow {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -164,6 +164,13 @@ limitations under the License.
             </div>
           {{/if}}
         {{/if}}
+        {{#if emptyDemoUser}}
+          {{#unless selectedTab.sharedWithMe}}
+            <div id="demo-install-arrow"></div>
+          {{/unless}}
+        {{/if}}
+
+        {{#unless emptyDemoUser}}
         <table>
           <thead>
             <tr>
@@ -185,7 +192,10 @@ limitations under the License.
             {{/each}}
           </tbody>
         </table>
+        {{/unless}}
+
         {{#if isDemoUser}}
+        {{#unless emptyDemoUser}}
           <aside>
             <form id="signup" action="https://sandstorm.us7.list-manage.com/subscribe/post?u=1a036c5ea0fc3c215793748ed&amp;id=5d9399a0af" method="post">
               <p>Join our mailing list for updates<br>
@@ -206,6 +216,7 @@ limitations under the License.
               <p>Connect with us</p>
             </div>
           </aside>
+        {{/unless}}
         {{/if}}
       </div>
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -195,28 +195,28 @@ limitations under the License.
         {{/unless}}
 
         {{#if isDemoUser}}
-        {{#unless emptyDemoUser}}
-          <aside>
-            <form id="signup" action="https://sandstorm.us7.list-manage.com/subscribe/post?u=1a036c5ea0fc3c215793748ed&amp;id=5d9399a0af" method="post">
-              <p>Join our mailing list for updates<br>
-              <input type="email" name="EMAIL" placeholder="e-mail" required><input type="submit" value="&#10003;"></p>
-            </form>
-            <a id="preorder" href="https://sandstorm.io/preorder.html">
-              <span>Early Bird</span>
-              <span>Pre-order Now</span>
-            </a>
-            <div id="social">
-              <ul>
-                <li id="github"><a href="https://github.com/sandstorm-io/sandstorm">Github</a></li>
-                <li id="feed"><a href="https://blog.sandstorm.io/feed.xml">Atom/RSS feed</a></li>
-                <li id="twitter"><a href="https://twitter.com/SandstormIO">Twitter</a></li>
-                <li id="google-plus"><a href="https://google.com/+SandstormIo">Google+</a></li>
-                <li id="facebook"><a href="https://facebook.com/sandstorm.io">Facebook</a></li>
-              </ul>
-              <p>Connect with us</p>
-            </div>
-          </aside>
-        {{/unless}}
+          {{#unless emptyDemoUser}}
+            <aside>
+              <form id="signup" action="https://sandstorm.us7.list-manage.com/subscribe/post?u=1a036c5ea0fc3c215793748ed&amp;id=5d9399a0af" method="post">
+                <p>Join our mailing list for updates<br>
+                <input type="email" name="EMAIL" placeholder="e-mail" required><input type="submit" value="&#10003;"></p>
+              </form>
+              <a id="preorder" href="https://sandstorm.io/preorder.html">
+                <span>Early Bird</span>
+                <span>Pre-order Now</span>
+              </a>
+              <div id="social">
+                <ul>
+                  <li id="github"><a href="https://github.com/sandstorm-io/sandstorm">Github</a></li>
+                  <li id="feed"><a href="https://blog.sandstorm.io/feed.xml">Atom/RSS feed</a></li>
+                  <li id="twitter"><a href="https://twitter.com/SandstormIO">Twitter</a></li>
+                  <li id="google-plus"><a href="https://google.com/+SandstormIo">Google+</a></li>
+                  <li id="facebook"><a href="https://facebook.com/sandstorm.io">Facebook</a></li>
+                </ul>
+                <p>Connect with us</p>
+              </div>
+            </aside>
+          {{/unless}}
         {{/if}}
       </div>
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -171,27 +171,27 @@ limitations under the License.
         {{/if}}
 
         {{#unless emptyDemoUser}}
-        <table>
-          <thead>
-            <tr>
-              <td>Title</td>
-              <td>Last Used</td>
-            </tr>
-          </thead>
-          <tbody>
-            {{#each filteredGrains}}
-              <tr class="grain" data-grainid="{{_id}}">
-                <td>{{title}}</td>
-                <td title="{{lastUsed}}">{{dateString lastUsed}}</td>
-              </tr>
-            {{else}}
+          <table>
+            <thead>
               <tr>
-                <td><i>no files to display...</i></td>
-                <td></td>
+                <td>Title</td>
+                <td>Last Used</td>
               </tr>
-            {{/each}}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {{#each filteredGrains}}
+                <tr class="grain" data-grainid="{{_id}}">
+                  <td>{{title}}</td>
+                  <td title="{{lastUsed}}">{{dateString lastUsed}}</td>
+                </tr>
+              {{else}}
+                <tr>
+                  <td><i>no files to display...</i></td>
+                  <td></td>
+                </tr>
+              {{/each}}
+            </tbody>
+          </table>
         {{/unless}}
 
         {{#if isDemoUser}}

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -362,6 +362,12 @@ if (Meteor.isClient) {
   });
 
   Template.root.helpers({
+    // The shell checks for an emptyDemoUser so it can show a visual
+    // nudge that the user should install an app, create a grain, etc.
+    emptyDemoUser: function() {
+      var hasNoGrains = (Grains.find({userId: Meteor.userId()}).count() == 0);
+      return isDemoUser() && hasNoGrains;
+    },
     filteredGrains: function () {
       var selectedTab = Session.get("selectedTab");
       var userId = Meteor.userId();


### PR DESCRIPTION
For demo users with no grains, point an arrow at "Install apps" and
"New App Instance" if they are looking at an app.

This visually conflicts with the information about the managed hosting
and mailing list signup, so we hide that information until the demo user
has created a grain.

Requesting @kentonv 's review + merge.