### PR TITLE
Ensure tmp/ exists before generating changelog in it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ shell/public/inbox-m.png: icons/inbox.svg
 	@convert -background none -scale 40x40 -negate -evaluate multiply 0.87 $< $@
 
 shell/client/changelog.html: CHANGELOG.md
+	@mkdir -p tmp
 	@echo '<template name="changelog">' > tmp/changelog.html
 	@markdown CHANGELOG.md >> tmp/changelog.html
 	@echo '</template>' >> tmp/changelog.html


### PR DESCRIPTION
This is the smallest possible fix for #524.

Other imaginable fixes include:

* Depending on a dir called `tmp/` which has its own `Makefile` target.
* Adding `tmp/.gitkeep` to the repository so there is always a `tmp/` directory.

I think this is an OK fix. If others have opinions, I'm interested in them, although I'm much more interested in them if the opinions come with their own pull request that supercede this one. (But if people think I should adjust this one, OK.)

Also perhaps @jparyani we should be `git clean -d -x -f -f`-ing from the tests to catch problems like this?