### PR TITLE
Add opt-in passthrough of remote address to ApiSession as X-Real-IP

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -23,6 +23,7 @@ var Http = Npm.require("http");
 var Url = Npm.require("url");
 var Promise = Npm.require("es6-promise").Promise;
 var Capnp = Npm.require("capnp");
+var Net = Npm.require("net");
 
 var ByteStream = Capnp.importSystem("sandstorm/util.capnp").ByteStream;
 var ApiSession = Capnp.importSystem("sandstorm/api-session.capnp").ApiSession;
@@ -936,13 +937,69 @@ Proxy.prototype._callNewWebSession = function (request, userInfo) {
                                 WebSession.typeId, params).session;
 };
 
+var isRfc1918OrLocal = function(address) {
+  if (Net.isIPv4(address)) {
+    quad = address.split(".").map(function(x) { return parseInt(x, 10); });
+    return (quad[0] === 127 || quad[0] === 10 ||
+            (quad[0] === 192 && quad[1] === 168) ||
+            (quad[0] === 172 && quad[1] >= 16 && quad[1] < 32));
+  } else if (Net.isIPv6(address)) {
+    // IPv6 specifies ::1 as localhost and fd:: as reserved for private networks
+    return (address === "::1" || address.indexOf("fd") === 0);
+  } else {
+    // Ignore things that are neither IPv4 nor IPv6
+    return false;
+  }
+};
+
 Proxy.prototype._callNewApiSession = function (request, userInfo) {
   var self = this;
+  var params = {};
+
+  if ("x-sandstorm-passthrough" in request.headers) {
+    var optIns = request.headers["x-sandstorm-passthrough"]
+        .split(',')
+        .map(function(s) { return s.trim(); });
+    // The only currently supported passthrough value is "address", but others could be useful in
+    // the future
+    if (optIns.indexOf("address") !== -1) {
+      // Sadly, we can't use request.socket.remoteFamily because it's not available in the (rather-old)
+      // version of node that comes in the Meteor bundle we're using.  Hence this hackery.
+      var addressToPass = request.socket.remoteAddress;
+      if (isRfc1918OrLocal(addressToPass) && "x-real-ip" in request.headers) {
+        // Allow overriding the socket's remote address with X-Real-IP header if the request comes
+        // from either localhost or an RFC1918 address.  These are not useful for geolocation
+        // anyway.
+        addressToPass = request.headers["x-real-ip"];
+      }
+      if (Net.isIPv4(addressToPass)) {
+        // Map IPv4 addresses in IPv6
+        var v4Int = 0xFFFF00000000 + addressToPass.split(".")
+            .map(function(x) { return parseInt(x, 10); })
+            .reduce(function(a, b) { return 256*a + b; });
+        params.remoteAddress = {
+            lower64: v4Int,
+            upper64: 0
+        };
+      } else if (Net.isIPv6(addressToPass)) {
+        // Because I don't want to parse a v6 address in JS so I can convert it to a bignum so I can
+        // convert it back to a string to stuff it in a uint64_t, we do not support IPv6 for this
+        // feature at present, and instead always send ::1.  Someone can fix this later.
+        params.remoteAddress = {
+            lower64: 1,
+            upper64: 0
+        };
+      }
+    }
+  }
+
+  var serializedParams = Capnp.serialize(ApiSession.Params, params);
 
   // TODO(someday): We are currently falling back to WebSession if we get any kind of error upon
   // calling newSession with an ApiSession._id.
   // Eventually we'll remove this logic once we're sure apps have updated.
-  return this.uiView.newSession(userInfo, makeHackSessionContext(this.grainId), ApiSession.typeId)
+  return this.uiView.newSession(userInfo, makeHackSessionContext(this.grainId), ApiSession.typeId,
+                                serializedParams)
       .then(function (session) {
     return session.session;
   }, function (err) {

--- a/src/sandstorm/api-session.capnp
+++ b/src/sandstorm/api-session.capnp
@@ -19,12 +19,18 @@
 $import "/capnp/c++.capnp".namespace("sandstorm");
 
 using WebSession = import "web-session.capnp";
+using IpAddress = import "ip.capnp".IpAddress;
 
 interface ApiSession @0xc879e379c625cdc7 extends(WebSession.WebSession) {
   # A special case of WebSession but for APIs. It doesn't provide much other
   # than a unique type id that we can identify ApiSessions with
 
   struct Params {
-    # Currently there are no params for api sessions
+    # Normally, we strip the remote address from requests, since most applications shouldn't need
+    # it.  However, for those that benefit from it (like analytics), clients can opt into passing
+    # their IP on to the backend by adding an "X-Sandstorm-Pass-IP: yes" header to their request.
+    # This would be a privacy leak for WebSession, since the grain can give the client scripts which
+    # would send the header, but ApiSession requires a user action, so it's safe here.
+    remoteAddress @0 :IpAddress;
   }
 }

--- a/src/sandstorm/api-session.capnp
+++ b/src/sandstorm/api-session.capnp
@@ -28,9 +28,9 @@ interface ApiSession @0xc879e379c625cdc7 extends(WebSession.WebSession) {
   struct Params {
     # Normally, we strip the remote address from requests, since most applications shouldn't need
     # it.  However, for those that benefit from it (like analytics), clients can opt into passing
-    # their IP on to the backend by adding an "X-Sandstorm-Pass-IP: yes" header to their request.
-    # This would be a privacy leak for WebSession, since the grain can give the client scripts which
-    # would send the header, but ApiSession requires a user action, so it's safe here.
+    # their IP on to the backend by adding an "X-Sandstorm-Passthrough: address" header to their
+    # request.  This would be a privacy leak for WebSession, since the grain can give the client
+    # scripts which would send the header, but ApiSession requires a user action, so it's safe here.
     remoteAddress @0 :IpAddress;
   }
 }

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -29,6 +29,7 @@
 #include <capnp/rpc.capnp.h>
 #include <capnp/schema.h>
 #include <capnp/serialize.h>
+#include <arpa/inet.h>
 #include <unistd.h>
 #include <map>
 #include <unordered_map>
@@ -829,7 +830,7 @@ public:
                  UserInfo::Reader userInfo, SessionContext::Client sessionContext,
                  SessionContextMap& sessionContextMap, kj::String&& sessionId,
                  kj::String&& basePath, kj::String&& userAgent, kj::String&& acceptLanguages,
-                 kj::String&& rootPath, kj::String&& permissions)
+                 kj::String&& rootPath, kj::String&& permissions, kj::Maybe<kj::String> remoteAddress)
       : serverAddr(serverAddr),
         sessionContext(kj::mv(sessionContext)),
         sessionContextMap(sessionContextMap),
@@ -839,7 +840,8 @@ public:
         basePath(kj::mv(basePath)),
         userAgent(kj::mv(userAgent)),
         acceptLanguages(kj::mv(acceptLanguages)),
-        rootPath(kj::mv(rootPath)) {
+        rootPath(kj::mv(rootPath)),
+        remoteAddress(kj::mv(remoteAddress)) {
     if (userInfo.hasUserId()) {
       auto id = userInfo.getUserId();
       KJ_ASSERT(id.size() == 32, "User ID not a SHA-256?");
@@ -968,6 +970,7 @@ private:
   kj::String acceptLanguages;
   kj::String rootPath;
   spk::BridgeConfig::Reader config;
+  kj::Maybe<kj::String> remoteAddress;
 
   kj::String makeHeaders(kj::StringPtr method, kj::StringPtr path,
                          WebSession::Context::Reader context,
@@ -1015,6 +1018,9 @@ private:
       lines.add(kj::str("Host: sandbox"));
     }
     lines.add(kj::str("X-Sandstorm-Session-Id: ", sessionId));
+    KJ_IF_MAYBE(addr, remoteAddress) {
+      lines.add(kj::str("X-Real-IP: ", *addr));
+    }
 
     auto cookies = context.getCookies();
     if (cookies.size() > 0) {
@@ -1295,16 +1301,23 @@ public:
                                    kj::heapString(sessionParams.getUserAgent()),
                                    kj::strArray(sessionParams.getAcceptableLanguages(), ","),
                                    kj::heapString("/"),
-                                   formatPermissions(userPermissions)));
+                                   formatPermissions(userPermissions),
+                                   nullptr));
     } else if (sessionType == capnp::typeId<ApiSession>()) {
       auto userPermissions = params.getUserInfo().getPermissions();
+      auto sessionParams = params.getSessionParams().getAs<ApiSession::Params>();
+      kj::Maybe<kj::String> addr = nullptr;
+      if (sessionParams.hasRemoteAddress()) {
+        addr = addressToString(sessionParams.getRemoteAddress());
+      }
 
       context.getResults(capnp::MessageSize {2, 1}).setSession(
           kj::heap<WebSessionImpl>(serverAddress, params.getUserInfo(), params.getContext(),
                                    sessionContextMap, kj::str(sessionIdCounter++),
                                    kj::heapString(""), kj::heapString(""), kj::heapString(""),
                                    kj::heapString(config.getApiPath()),
-                                   formatPermissions(userPermissions)));
+                                   formatPermissions(userPermissions),
+                                   kj::mv(addr)));
     } else if (sessionType == capnp::typeId<HackEmailSession>()) {
       context.getResults(capnp::MessageSize {2, 1}).setSession(kj::heap<EmailSessionImpl>());
     }
@@ -1323,6 +1336,47 @@ private:
       }
     }
     return kj::strArray(permissionVec, ",");
+  }
+  inline kj::String addressToString(::sandstorm::IpAddress::Reader&& address) {
+    uint64_t lower64 = address.getLower64();
+    uint64_t upper64 = address.getUpper64();
+    if (upper64 == 0 && ((lower64 >> 32) == 0xffff)) {
+      // This is an IPv4 address.
+      char buf[INET_ADDRSTRLEN];
+      memset(buf, 0, INET_ADDRSTRLEN);
+      lower64 &= 0xffffffff;
+      struct in_addr ipv4;
+      ipv4.s_addr = ntohl(uint32_t(lower64));
+      const char* ok = inet_ntop(AF_INET, &ipv4, buf, INET_ADDRSTRLEN);
+      KJ_REQUIRE(ok != NULL, "inet_ntop() failed");
+      kj::String s = kj::heapString(buf);
+      return kj::mv(s);
+    } else {
+      // This is an IPv6 address.
+      char buf[INET6_ADDRSTRLEN];
+      memset(buf, 0, INET6_ADDRSTRLEN);
+      struct in6_addr ipv6;
+      ipv6.s6_addr[0]  = ((upper64 >> 56) & 0xff);
+      ipv6.s6_addr[1]  = ((upper64 >> 48) & 0xff);
+      ipv6.s6_addr[2]  = ((upper64 >> 40) & 0xff);
+      ipv6.s6_addr[3]  = ((upper64 >> 32) & 0xff);
+      ipv6.s6_addr[4]  = ((upper64 >> 24) & 0xff);
+      ipv6.s6_addr[5]  = ((upper64 >> 16) & 0xff);
+      ipv6.s6_addr[6]  = ((upper64 >>  8) & 0xff);
+      ipv6.s6_addr[7]  = ((upper64      ) & 0xff);
+      ipv6.s6_addr[8]  = ((lower64 >> 56) & 0xff);
+      ipv6.s6_addr[9]  = ((lower64 >> 48) & 0xff);
+      ipv6.s6_addr[10] = ((lower64 >> 40) & 0xff);
+      ipv6.s6_addr[11] = ((lower64 >> 32) & 0xff);
+      ipv6.s6_addr[12] = ((lower64 >> 24) & 0xff);
+      ipv6.s6_addr[13] = ((lower64 >> 16) & 0xff);
+      ipv6.s6_addr[14] = ((lower64 >>  8) & 0xff);
+      ipv6.s6_addr[15] = ((lower64      ) & 0xff);
+      const char* ok = inet_ntop(AF_INET6, &ipv6, buf, INET6_ADDRSTRLEN);
+      KJ_REQUIRE(ok != NULL, "inet_ntop() failed");
+      kj::String s = kj::heapString(buf);
+      return kj::mv(s);
+    }
   }
   kj::NetworkAddress& serverAddress;
   SessionContextMap& sessionContextMap;

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -1337,6 +1337,7 @@ private:
     }
     return kj::strArray(permissionVec, ",");
   }
+
   inline kj::String addressToString(::sandstorm::IpAddress::Reader&& address) {
     uint64_t lower64 = address.getLower64();
     uint64_t upper64 = address.getUpper64();
@@ -1378,6 +1379,7 @@ private:
       return kj::mv(s);
     }
   }
+
   kj::NetworkAddress& serverAddress;
   SessionContextMap& sessionContextMap;
   spk::BridgeConfig::Reader config;


### PR DESCRIPTION
While in most cases, we want to avoid exposing a client's IP address to
sandboxed apps, having the option of sharing it is acutely valuable for
analytics apps like Piwik, which benefit substantially from having external IP
addresses for geolocation.

If an authenticated client sends the API endpoint a header:

    X-Sandstorm-Passthrough: address

then we will pass the client's observed IP address as a parameter in the
ApiSession, and sandstorm-http-bridge will pass that to the app's backend as
an X-Real-IP header.

Additionally, if the request to the API endpoint is made from an RFC1918
address, we will substitute the value of an X-Real-IP header, if present, for
the client's address.  This should make things work out-of-the-box for most
simple SSL termination setups, while preventing spoofing of the address seen by
apps by anyone on a separate network from the sandstorm server.

We only allow this for API sessions because doing so for web sessions would
allow a malicious app to serve JS that makes requests back to the app with the
opt-in header, leaking the user's real IP without first requiring user action.
That would break our sandboxing guarantees.