### PR TITLE
Cache viewInfo in a new field in Grains.

### DIFF
--- a/shell/lib/db.js
+++ b/shell/lib/db.js
@@ -81,6 +81,8 @@ Grains = new Mongo.Collection("grains");
 //   title:  Human-readable string title, as chosen by the user.
 //   lastUsed:  Date when the grain was last used by a user.
 //   private: If true, then knowledge of `_id` does not suffice to open this grain.
+//   cachedViewInfo: The JSON-encoded result of `UiView.getViewInfo()`, cached from the most recent
+//                   time a session to this grain was opened.
 //
 // The following fields *might* also exist. These are temporary hacks used to implement e-mail and
 // web publishing functionality without powerbox support; they will be replaced once the powerbox

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -996,7 +996,11 @@ Proxy.prototype.getSession = function (request) {
     this.getConnection();  // make sure we're connected
     var self = this;
     var promise = this.uiView.getViewInfo().then(function (viewInfo) {
-      return self._callNewSession(request, viewInfo);
+      return inMeteor(function() {
+        Grains.update(self.grainId, {$set: {cachedViewInfo: viewInfo}});
+      }).then(function () {
+        return self._callNewSession(request, viewInfo);
+      });
     }, function (error) {
       if (error.kjType === "failed" || error.kjType === "unimplemented") {
         // Method not implemented.


### PR DESCRIPTION
This will allow us to answer questions like "Does Alice have permissions X on grain Y?" without needing to wake up grain Y.

@jparyani and I stumbled upon the need for this nearly simultaneously today.