### PR TITLE
Implement web publishing by RPC rather than filesystem access.

### DIFF
--- a/src/sandstorm/backend.c++
+++ b/src/sandstorm/backend.c++
@@ -493,51 +493,6 @@ private:
   }
 };
 
-kj::Promise<void> BackendImpl::pump(kj::AsyncInputStream& input, ByteStream::Client stream) {
-  auto req = stream.writeRequest(capnp::MessageSize { 2100, 0 });
-  auto orphanage = capnp::Orphanage::getForMessageContaining(
-      kj::implicitCast<ByteStream::WriteParams::Builder>(req));
-  auto orphan = orphanage.newOrphan<capnp::Data>(8192);
-  auto buffer = orphan.get();
-
-  return input.tryRead(buffer.begin(), 1, buffer.size())
-      .then([&input,KJ_MVCAP(stream),KJ_MVCAP(req),KJ_MVCAP(orphan)](size_t n) mutable
-            -> kj::Promise<void> {
-    if (n == 0) {
-      return kj::READY_NOW;
-    }
-
-    orphan.truncate(n);
-    req.adoptData(kj::mv(orphan));
-
-    // TODO(perf): Parallelize writes.
-    return req.send().then([&input,KJ_MVCAP(stream)](auto&&) mutable {
-      return pump(input, kj::mv(stream));
-    });
-  });
-}
-
-kj::Promise<void> BackendImpl::pump(kj::InputStream& input, ByteStream::Client stream) {
-  auto req = stream.writeRequest(capnp::MessageSize { 2100, 0 });
-  auto orphanage = capnp::Orphanage::getForMessageContaining(
-      kj::implicitCast<ByteStream::WriteParams::Builder>(req));
-  auto orphan = orphanage.newOrphan<capnp::Data>(8192);
-  auto buffer = orphan.get();
-
-  size_t n = input.tryRead(buffer.begin(), 1, buffer.size());
-  if (n == 0) {
-    return kj::READY_NOW;
-  }
-
-  orphan.truncate(n);
-  req.adoptData(kj::mv(orphan));
-
-  // TODO(perf): Parallelize writes.
-  return req.send().then([&input,KJ_MVCAP(stream)](auto&&) mutable {
-    return pump(input, kj::mv(stream));
-  });
-}
-
 kj::Promise<void> BackendImpl::uploadBackup(UploadBackupContext context) {
   auto path = kj::str("/var/sandstorm/backups/", context.getParams().getBackupId());
   context.releaseParams();

--- a/src/sandstorm/backend.h
+++ b/src/sandstorm/backend.h
@@ -92,9 +92,6 @@ private:
   static kj::Promise<kj::String> readAll(kj::AsyncInputStream& input,
       kj::Vector<char> soFar = kj::Vector<char>());
 
-  static kj::Promise<void> pump(kj::AsyncInputStream& input, ByteStream::Client stream);
-  static kj::Promise<void> pump(kj::InputStream& input, ByteStream::Client stream);
-
   void taskFailed(kj::Exception&& exception) override;
 };
 

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -73,6 +73,27 @@ interface Supervisor {
   watchLog @7 (backlogAmount :UInt64, stream :Util.ByteStream) -> (handle :Util.Handle);
   # Write the last `backlogAmount` bytes of the grain's debug log to `stream`, and then watch the
   # log for changes, writing them to `stream` as they happen, until `handle` is dropped.
+
+  enum WwwFileStatus {
+    file @0;
+    directory @1;
+    notFound @2;
+  }
+
+  getWwwFileHack @9 (path :Text, stream :Util.ByteStream) -> (status :WwwFileStatus);
+  # Reads a file from under the grain's "/var/www" directory. If the path refers to a regular
+  # file, the contents are written to `stream`, and `status` is returned as `file`. If the path
+  # refers to a directory or is not found, then `stream` is NOT called at all and the method
+  # returns the corresponding status.
+  #
+  # Note that if a Supervisor capability is obtained and used only for `getWwwFileHack()` -- i.e.
+  # `getMainView()` and `restore()` are not called -- then the supervisor will not actually start
+  # the application.
+  #
+  # This method is a temporary hack designed so that Sandstorm's front-end can implement web
+  # publishing -- as defined by HackSessionContext -- without digging directly into the grain's
+  # storage on-disk. Eventually, this mechanism for web publishing will be eliminated entirely
+  # and replaced with a driver and powerbox interactions.
 }
 
 interface SandstormCore {

--- a/src/sandstorm/supervisor.h
+++ b/src/sandstorm/supervisor.h
@@ -22,6 +22,7 @@
 #include <kj/async-io.h>
 #include <capnp/capability.h>
 #include <sandstorm/supervisor.capnp.h>
+#include <kj/io.h>
 
 namespace sandstorm {
 
@@ -120,9 +121,9 @@ private:
   void maybeFinishMountingProc();
   void permanentlyDropSuperuser();
   void enterSandbox();
-  [[noreturn]] void runChild(int apiFd);
+  [[noreturn]] void runChild(int apiFd, kj::AutoCloseFd startEventFd);
 
-  [[noreturn]] void runSupervisor(int apiFd);
+  [[noreturn]] void runSupervisor(int apiFd, kj::AutoCloseFd startEventFd);
 
   class DefaultSystemConnector: public SystemConnector {
   public:

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -30,6 +30,7 @@
 #include <kj/function.h>
 #include <kj/async.h>
 #include <capnp/rpc-twoparty.h>
+#include <sandstorm/util.capnp.h>
 
 namespace kj {
   class UnixEventPort;
@@ -67,6 +68,10 @@ kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExists(
     int dirfd, kj::StringPtr name, int flags, mode_t mode = 0666);
 
 kj::Maybe<kj::String> readLine(kj::BufferedInputStream& input);
+
+kj::Promise<void> pump(kj::AsyncInputStream& input, ByteStream::Client stream);
+kj::Promise<void> pump(kj::InputStream& input, ByteStream::Client stream);
+// Read from `input`, write to `output`, until EOF.
 
 class StructyMessage {
   // Helper for constructing a message to be passed to the kernel composed of a bunch of structs


### PR DESCRIPTION
I've added a hacky method to the Supervisor interface, so that the supervisor can directly serve these files. I also modified the supervisor to delay starting up the app until it receives a getMainView() or restore() call, which requires the app to be running. This allows WWW files to be served without actually starting the app. The overhead of running the supervisor is comparatively small, and is acceptable for the time being until we replace all of this with a driver.

I believe this eliminates the last way that the front-end was reaching directly into grain storage.

This change will make web publishing work correctly on Oasis.

All code in this change will go away as soon as we have web publishing drivers. There are many improvements that could be made otherwise, e.g. caching and range requests, but they aren't worth the effort for throw-away code.