### PR TITLE
Detect architecture before trying to detect userns support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1543,12 +1543,12 @@ sandcats_generate_keys() {
 # Now that the steps exist as functions, run them in an order that
 # would result in a working install.
 assert_usable_kernel
+assert_linux_x86_64
 detect_current_uid
 detect_userns_clone
 assert_userns_clone_works_or_can_be_made_to_work
 handle_args "$@"
 assert_on_terminal
-assert_linux_x86_64
 assert_dependencies
 assert_valid_bundle_file
 detect_init_system


### PR DESCRIPTION
There's no sense trying to run a 64-bit Linux binary if you're not even sure
you're running on 64-bit Linux.  This patch reorders the checks in the
installer script so users get more helpful failure messages, so we prevent
confusing issues like #539.