### PR TITLE
Default role for share-with-app tokens is now 'allAccess'.

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -296,6 +296,7 @@ limitations under the License.
         {{#if roles}}
           Role:
           <select id="api-token-role">
+            <option title="has every app permission" selected=true>all access</option>
             {{#each roles}}
               <option title={{verbPhrase.defaultText}}
                       style="{{#if obsolete}}display:none{{else}}{{/if}}">

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -280,11 +280,9 @@ if (Meteor.isClient) {
       var grainId = this.grainId;
       Session.set("api-token-" + grainId, "pending");
       var roleList = document.getElementById("api-token-role");
-      var assignment;
-      if (roleList) {
-        assignment = {roleId: roleList.selectedIndex};
-      } else {
-        assignment = {none: null};
+      var assignment = {allAccess: null};
+      if (roleList && roleList.selectedIndex > 0) {
+        assignment = {roleId: roleList.selectedIndex - 1};
       }
       Meteor.call("newApiToken", this.grainId, document.getElementById("api-token-petname").value,
                   assignment, false, undefined,


### PR DESCRIPTION
This implements the change discussed in https://github.com/sandstorm-io/sandstorm/pull/443.