### PR TITLE
Clean up offer template argument validation.

### DIFF
--- a/shell/lib/db.js
+++ b/shell/lib/db.js
@@ -473,3 +473,11 @@ allowDevAccounts = function () {
            Meteor.settings.public.allowDevAccounts;
   }
 };
+
+roleAssignmentPattern = {
+  none : Match.Optional(null),
+  allAccess: Match.Optional(null),
+  roleId: Match.Optional(Match.Integer),
+  addPermissions: Match.Optional([Boolean]),
+  removePermissions: Match.Optional([Boolean]),
+};

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -332,11 +332,7 @@ Meteor.methods({
     check(grainId, String);
     check(petname, String);
     check(forSharing, Boolean);
-    check(roleAssignment, {
-      none : Match.Optional(null),
-      allAccess: Match.Optional(null),
-      roleId: Match.Optional(Match.Integer),
-    });
+    check(roleAssignment, roleAssignmentPattern);
     // Meteor bug #3877: we get null here instead of undefined when we
     // explicitly pass in undefined.
     if (destroyIfNotUsedByTime) {

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -586,31 +586,23 @@ if (Meteor.isClient) {
         // the platform, we can ensure that the token is only visible to the
         // shell's origin.
         var call = event.data.renderTemplate;
-        check(call, Object);
+        check(call, {rpcId: String, template: String, petname: Match.Optional(String),
+                     roleAssignment: Match.Optional(roleAssignmentPattern)});
         var rpcId = call.rpcId;
-        check(rpcId, String);
         var template = call.template;
-        check(template, String);
-        var assignment = undefined;
-        if (call.roleId) {
-          check(call.roleId, Match.Integer);
-          assignment = {roleId: call.roleId};
-        } else {
-          assignment = {none: null};
-        }
-        var petname = undefined;
+        var petname = "connected external app";
         if (call.petname) {
-          check(call.petname, String);
           petname = call.petname;
-        } else {
-          petname = "connected external app";
+        }
+        var assignment = {allAccess: null};
+        if (call.roleAssignment) {
+          assignment = call.roleAssignment;
         }
         // Tokens expire by default in 5 minutes from generation date
         var selfDestructTime = Date.now() + (5 * 60 * 1000);
         Meteor.call("newApiToken", currentGrainId, petname, assignment, false,
                     selfDestructTime, function (error, result) {
           if (error) {
-            //Session.set("api-token-" + currentGrainId, undefined);
             window.alert("Failed to create token for offer template.\n" + error);
             console.error(error.stack);
           } else {


### PR DESCRIPTION
This puts `roleAssignment` into its own field. Additionally, it validates `roleAssignment` on the client side, resulting in a better error message if the match fails.

(Unfortunately there's a related issue where Firefox does not report the full exception information when a `Meteor.Error` is thrown from within the event listener callback. (Chrome does just fine.) I think that problem should be dealt with in a separate pull request.)

I couldn't think of a good way to precisely express an exclusive union in a Meteor [pattern](http://docs.meteor.com/#/full/matchpatterns).

Something like the following would work, but it starts to get really verbose:

```
roleAssignmentPattern = Match.OneOf([
 {none : null,
  addPermissions: Match.Optional([Boolean]),
  removePermissions: Match.Optional([Boolean])},
 {allAccess : null,
  addPermissions: Match.Optional([Boolean]),
  removePermissions: Match.Optional([Boolean])},
 {roleId : Match.Integer,
  addPermissions: Match.Optional([Boolean]),
  removePermissions: Match.Optional([Boolean])}]);
```