### PR TITLE
Stop crashing when Meteor.user() is null

### DIFF
--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -190,7 +190,8 @@ if (Meteor.isClient) {
   var formatAccountExpiresIn = function (template, currentDatetime) {
     // TODO(someday): formatInCountdown will set the interval to match account expiration time, and
     // completely overwrite the previous interval for $IN_COUNTDOWN
-    var expires = Meteor.user().expires;
+    var user = Meteor.user() || {};
+    var expires = user.expires || null;
     if (!expires) {
       return null;
     } else {


### PR DESCRIPTION
This affects a purely-cosmetic stacktrace that arises when visiting
https://demo.sandstorm.io/ -- the admin alert wants to show information
about when this user expires, but there is no user yet, so it would
crash with:

```
Exception in template helper: TypeError: Cannot read property expires of null
```

in `formatAccountExpiresIn()`.

It's "purely cosmetic" in that it didn't affect functionality.

Regardless, this fixes that.