### PR TITLE
Hide the admin alert if it's too large for the screen size

### DIFF
--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -57,6 +57,7 @@ body {
   height: 32px;
   text-align: left;
   z-index: 2;
+  white-space: nowrap;
 }
 
 #topbar.light {
@@ -1222,6 +1223,48 @@ table#users-table tr {
   display: none;
 }
 
+#admin-alert-box.small .alert {
+  display: none;
+}
+
+#admin-alert-box.small #admin-alert[data-show="true"] .alert {
+  display: inline-block;
+  position: fixed;
+  left: 0px;
+  top: 32px;
+  width: 100%;
+  z-index: 2;
+}
+
+#admin-alert-box.small #admin-alert-icon {
+  display: inline;
+  background-color: #762f87;
+  color: white;
+  font-size: 20px;
+  font-weight: bold;
+  margin: 0px 2px;
+  padding: 0px 10px;
+  text-align: center;
+  border-radius: 50%;
+  height: 22px;
+  width: 22px;
+  line-height: 22px;
+  cursor: pointer;
+}
+
+#admin-alert-box.small #admin-alert-closer[data-show="true"] {
+  display: block;
+  position: fixed;
+  left: 0px;
+  top: 64px;
+  width: 2000px;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1;
+  -webkit-transition: background-color 200ms;
+  transition: background-color 200ms;
+}
+
 @media screen and (max-width: 1250px) {
   aside {
     position: static;
@@ -1385,45 +1428,11 @@ table#users-table tr {
     font-size: 30px;
   }
 
-  #admin-alert .alert {
-    display: none;
-  }
-
   #admin-alert[data-show="true"] .alert {
-    display: inline-block;
-    position: fixed;
-    left: 0px;
     top: 48px;
-    width: 100%;
   }
-
-  #admin-alert-icon {
-    display: inline;
-    background-color: #762f87;
-    color: white;
-    font-size: 20px;
-    font-weight: bold;
-    margin: 0px 2px;
-    padding: 0px 10px;
-    text-align: center;
-    border-radius: 50%;
-    height: 22px;
-    width: 22px;
-    line-height: 22px;
-    cursor: pointer;
-  }
-
   #admin-alert-closer[data-show="true"] {
-    display: block;
-    position: fixed;
-    left: 0px;
     top: 96px;
-    width: 2000px;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    z-index: 1;
-    -webkit-transition: background-color 200ms;
-    transition: background-color 200ms;
   }
 }
 @media screen and (max-width: 650px) {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -42,15 +42,17 @@ limitations under the License.
   {{else}}
   <div id="topbar-right">
     {{#with adminAlert}}
-      <div id="admin-alert-closer" data-show="{{showTopbar}}"></div>
-      <span id="admin-alert" data-show="{{showTopbar}}">
-        {{#if alertUrl}}
-          <a href="{{alertUrl}}" class="alert {{className}}">{{text}}</a>
-        {{else}}
-          <div class="alert {{className}}">{{text}}</div>
-        {{/if}}
+      <span id="admin-alert-box" class="{{#if adminAlertIsTooLarge}}small{{/if}}">
+        <div id="admin-alert-closer" data-show="{{showTopbar}}"></div>
+        <span id="admin-alert" data-show="{{showTopbar}}">
+          {{#if alertUrl}}
+            <a href="{{alertUrl}}" class="alert {{className}}">{{text}}</a>
+          {{else}}
+            <div class="alert {{className}}">{{text}}</div>
+          {{/if}}
+        </span>
+        <span id="admin-alert-icon">!</span>
       </span>
-      <span id="admin-alert-icon">!</span>
     {{/with}}
     {{#if currentUser}}
       {{> notifications}}


### PR DESCRIPTION
This is ridiculously hacky since there's no good way to do this fully in
CSS.

Ideally, we would measure everything in the topbar's width and subtract
that from the window width to figure out how large the admin alert can
be. For now, we just pick some reasonable estimates.