### PR TITLE
Implement storage quotas.

### DIFF
--- a/shell/client/shell.css
+++ b/shell/client/shell.css
@@ -442,6 +442,21 @@ img {
   cursor: pointer;
 }
 
+#applist-grains .button-box button.over-quota {
+  background-color: #ddd;
+}
+
+#storage-usage {
+  margin: 16px 4px;
+  font-size: 75%;
+  font-weight: bold;
+  color: #777;
+}
+
+#storage-usage.over-quota {
+  color: red;
+}
+
 #app .interstitial-button-box {
   text-align: center;
 }
@@ -784,6 +799,11 @@ input.autoSelect {
   font-size: inherit;
   width: 80%;
   box-sizing: border-box;
+}
+
+#invite input#key-quota {
+  width: 40%;
+  margin-bottom: 8px;
 }
 
 #invite textarea {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -152,7 +152,8 @@ limitations under the License.
                   data-devid="{{_id}}" data-index="{{index}}">{{title}}</button>
             {{else}}
               {{#each actions}}
-                <button class="new-grain-button" data-actionid="{{_id}}">{{title}}</button>
+                <button class="new-grain-button {{#if overQuota}}over-quota{{/if}}"
+                    data-actionid="{{_id}}">{{title}}</button>
               {{/each}}
               <button class="uninstall-app-button" data-appid="{{selectedTab.appId}}">
                 Uninstall</button>
@@ -166,12 +167,26 @@ limitations under the License.
         {{else}}
           {{#if selectedTab.myFiles}}
             <div class="button-box">
-              <button id="install-apps-button">Install apps</button>
-              <button id="upload-app-button">Upload an app</button>
-              <button id="restore-backup-button">Restore a backup</button>
+              <button id="install-apps-button" class="{{#if overQuota}}over-quota{{/if}}">
+                  Install apps</button>
+              <button id="upload-app-button" class="{{#if overQuota}}over-quota{{/if}}">
+                  Upload an app</button>
+              <button id="restore-backup-button" class="{{#if overQuota}}over-quota{{/if}}">
+                  Restore a backup</button>
             </div>
           {{/if}}
         {{/if}}
+
+        {{#unless selectedTab.sharedWithMe}}
+          {{#if quotaEnabled}}
+            <div id="storage-usage" class="{{#if overQuota}}over-quota{{/if}}">{{storageUsage}}
+              {{#with storageQuota}}
+                of {{.}}
+              {{/with}}
+              used
+            </div>
+          {{/if}}
+        {{/unless}}
 
         {{#if filteredGrains}}
           <table>
@@ -576,7 +591,10 @@ limitations under the License.
         if you just want to share your files with them.</p>
       <h3>Create a link:</h3>
       <p>This will create a magic link which you can send to someone.</p>
-      <p style="text-align: center">
+      <p>
+        {{#if quotaEnabled}}
+          Quota: <input id="key-quota" type="text" placeholder="(bytes; blank for none)"><br>
+        {{/if}}
         <input id="key-note" type="text" placeholder="notes, e.g. name of the recipient">
         <button id="create">Create</button></p>
 
@@ -592,6 +610,9 @@ limitations under the License.
       <textarea id="invite-message">Click on the following link to get access to my Sandstorm.io server.
 
 $KEY</textarea></p>
+      {{#if quotaEnabled}}
+        <p>Quota: <input id="invite-quota" type="text" placeholder="(bytes; blank for none)"></p>
+      {{/if}}
       <p><button id="send">Send</button></p>
       </div>
     {{/if}}
@@ -796,6 +817,10 @@ $KEY</textarea></p>
         <td>Username</td>
         <td>Name</td>
         <td>User Class</td>
+        {{#if quotaEnabled}}
+          <td>Quota</td>
+          <td>Used</td>
+        {{/if}}
         <td>Created</td>
         <td>Last Active</td>
         <td>Invited as</td>
@@ -814,6 +839,10 @@ $KEY</textarea></p>
               <option value="guest" selected={{#if userIsGuest}}selected{{/if}}>Guest</option>
             </select>
           </td>
+          {{#if quotaEnabled}}
+            <td>{{userQuota}}</td>
+            <td>{{userStorageUsage}}</td>
+          {{/if}}
           <td title="{{createdAt}}">{{dateString createdAt}}</td>
           <td title="{{lastActive}}">{{dateString lastActive}}</td>
           <td>{{userSignupNote}}</td>

--- a/shell/lib/db.js
+++ b/shell/lib/db.js
@@ -326,7 +326,7 @@ if (Meteor.isServer) {
 
     if (this.userId) {
       return Meteor.users.find({_id: this.userId},
-          {fields: {signupKey: 1, isAdmin: 1, expires: 1}});
+          {fields: {signupKey: 1, isAdmin: 1, expires: 1, quota: 1, storageUsage: 1}});
     } else {
       return [];
     }
@@ -378,6 +378,18 @@ isSignedUpOrDemo = function () {
   } else {
     return false;
   }
+}
+
+isUserOverQuota = function (user) {
+  return Meteor.settings.public.quotaEnabled &&
+         typeof user.quota === "number" &&
+         user.storageUsage && user.storageUsage >= user.quota;
+}
+
+isUserExcessivelyOverQuota = function (user) {
+  return Meteor.settings.public.quotaEnabled &&
+         typeof user.quota === "number" &&
+         user.storageUsage && user.storageUsage >= user.quota * 1.2;
 }
 
 isAdmin = function() {

--- a/shell/server/backup.js
+++ b/shell/server/backup.js
@@ -74,6 +74,10 @@ Meteor.methods({
       throw new Meteor.Error(403, "Unauthorized",
           "Token was not found, or user cannot create grains");
     }
+    if (isUserOverQuota(Meteor.user())) {
+      throw new Meteor.Error(402,
+          "You are out of storage space. Please delete some things and try again.");
+    }
 
     this.unblock();
 

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -733,7 +733,7 @@ if (Meteor.isServer) {
     },
     createSignupKey: function (token, note, quota) {
       check(note, String);
-      check(quota, Match.Optional(Number));
+      check(quota, Match.OneOf(undefined, null, Number));
 
       checkAuth(token);
 
@@ -745,7 +745,7 @@ if (Meteor.isServer) {
     },
     sendInvites: function (token, origin, from, list, subject, message, quota) {
       check([origin, from, list, subject, message], [String]);
-      check(quota, Match.Optional(Number));
+      check(quota, Match.OneOf(undefined, null, Number));
 
       checkAuth(token);
 

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -409,7 +409,16 @@ if (Meteor.isClient) {
     },
     userIsGuest: function () {
       return !this.isAdmin && !this.signupKey;
-    }
+    },
+    userQuota: function () {
+      return (typeof this.quota === "number") ? prettySize(this.quota) : "";
+    },
+    userStorageUsage: function () {
+      return (typeof this.storageUsage === "number") ? prettySize(this.storageUsage) : "";
+    },
+    quotaEnabled: function () {
+      return Meteor.settings.public.quotaEnabled;
+    },
   });
 
   var configureLoginServiceDialogTemplateForService = function (serviceName) {
@@ -491,6 +500,11 @@ if (Meteor.isClient) {
       var list = document.getElementById("invite-emails").value;
       var subject = document.getElementById("invite-subject").value;
       var message = document.getElementById("invite-message").value;
+      var quotaInput = document.getElementById("invite-quota");
+      var quota;
+      if (quotaInput && quotaInput.value.trim() !== "") {
+        quota = parseInt(quotaInput.value);
+      }
 
       var sendButton = event.currentTarget;
       sendButton.disabled = true;
@@ -498,7 +512,7 @@ if (Meteor.isClient) {
       sendButton.textContent = "Sending...";
 
       Meteor.call("sendInvites", state.get("token"), getOrigin(), from, list, subject, message,
-                  function (error, results) {
+                  quota, function (error, results) {
         sendButton.disabled = false;
         sendButton.textContent = oldContent;
         if (error) {
@@ -512,8 +526,13 @@ if (Meteor.isClient) {
     "click #create": function (event) {
       var state = Iron.controller().state;
       var note = document.getElementById("key-note").value;
+      var quotaInput = document.getElementById("key-quota");
+      var quota;
+      if (quotaInput && quotaInput.value.trim() !== "") {
+        quota = parseInt(quotaInput.value);
+      }
 
-      Meteor.call("createSignupKey", state.get("token"), note, function (error, key) {
+      Meteor.call("createSignupKey", state.get("token"), note, quota, function (error, key) {
         if (error) {
           state.set("inviteMessage", { error: error.toString() });
         } else {
@@ -551,7 +570,10 @@ if (Meteor.isClient) {
     url: function () {
       var res = Iron.controller().state.get("inviteMessage");
       return res && res.url;
-    }
+    },
+    quotaEnabled: function () {
+      return Meteor.settings.public.quotaEnabled;
+    },
   });
   var maybeScrollLog = function() {
     var elem = document.getElementById("adminLog");
@@ -715,17 +737,21 @@ if (Meteor.isServer) {
         smtpUrl: smtpUrl
       });
     },
-    createSignupKey: function (token, note) {
+    createSignupKey: function (token, note, quota) {
       check(note, String);
+      check(quota, Match.Optional(Number));
 
       checkAuth(token);
 
       var key = Random.id();
-      SignupKeys.insert({_id: key, used: false, note: note});
+      var content = {_id: key, used: false, note: note};
+      if (typeof quota === "number") content.quota = quota;
+      SignupKeys.insert(content);
       return key;
     },
-    sendInvites: function (token, origin, from, list, subject, message) {
+    sendInvites: function (token, origin, from, list, subject, message, quota) {
       check([origin, from, list, subject, message], [String]);
+      check(quota, Match.Optional(Number));
 
       checkAuth(token);
 
@@ -746,8 +772,10 @@ if (Meteor.isServer) {
         if (email) {
           var key = Random.id();
 
-          SignupKeys.insert({_id: key, used: false, note: "E-mail invite to " + email,
-                             email: email, definitelySent: false});
+          var content = {_id: key, used: false, note: "E-mail invite to " + email,
+                         email: email, definitelySent: false};
+          if (typeof quota === "number") content.quota = quota;
+          SignupKeys.insert(content);
           SandstormEmail.send({
             to: email,
             from: from,

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -416,9 +416,6 @@ if (Meteor.isClient) {
     userStorageUsage: function () {
       return (typeof this.storageUsage === "number") ? prettySize(this.storageUsage) : "";
     },
-    quotaEnabled: function () {
-      return Meteor.settings.public.quotaEnabled;
-    },
   });
 
   var configureLoginServiceDialogTemplateForService = function (serviceName) {
@@ -570,9 +567,6 @@ if (Meteor.isClient) {
     url: function () {
       var res = Iron.controller().state.get("inviteMessage");
       return res && res.url;
-    },
-    quotaEnabled: function () {
-      return Meteor.settings.public.quotaEnabled;
     },
   });
   var maybeScrollLog = function() {

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -447,19 +447,7 @@ if (Meteor.isClient) {
       if (this.sessionId) {
         sizeEntry = GrainSizes.findOne(this.sessionId);
         if (sizeEntry) {
-          var size = sizeEntry.size;
-          var suffix = "B";
-          if (size > 1000000000) {
-            size = size / 1000000000;
-            suffix = "GB";
-          } else if (size > 1000000) {
-            size = size / 1000000;
-            suffix = "MB";
-          } else if (size > 1000) {
-            size = size / 1000;
-            suffix = "kB";
-          }
-          return "(" + size.toPrecision(3) + suffix + ")";
+          return "(" + prettySize(sizeEntry.size) + ")";
         }
       }
       return "";

--- a/shell/shared/install.js
+++ b/shell/shared/install.js
@@ -102,7 +102,7 @@ Meteor.methods({
     check(url, Match.OneOf(String, undefined, null));
 
     if (!packageId.match(/^[a-zA-Z0-9]*$/)) {
-      throw new Meteor.Error(400, "The package name contains illegal characters.");
+      throw new Meteor.Error(400, "The package ID contains illegal characters.");
     }
 
     if (!this.userId) {
@@ -113,6 +113,11 @@ Meteor.methods({
       throw new Meteor.Error(403,
           "Sorry, Sandstorm is in closed alpha. You must receive an alpha key before you " +
           "can install packages.");
+    }
+
+    if (isUserOverQuota(Meteor.user())) {
+      throw new Meteor.Error(402,
+          "You are out of storage space. Please delete some things and try again.");
     }
 
     if (!this.isSimulation) {

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -50,6 +50,23 @@ if (Meteor.isServer) {
 
   Meteor.publish("grainsMenu", function () {
     if (this.userId) {
+      if (Meteor.settings.public.quotaEnabled) {
+        // Hack: Fire off an asynchronous update to the user's storage usage whenever they open the
+        //   front page.
+        // TODO(someday): Implement the ability to reactively subscribe to storage usage from the
+        //   back-end?
+        var userId = this.userId;
+        sandstormBackend.getUserStorageUsage(userId).then(function (results) {
+          inMeteor(function () {
+            Meteor.users.update(userId, {$set: {storageUsage: parseInt(results.size)}});
+          });
+        }).catch(function (err) {
+          if (err.kjType !== "unimplemented") {
+            console.error(err.stack);
+          }
+        });
+      }
+
       return [
         UserActions.find({userId: this.userId}),
         Grains.find({userId: this.userId}),
@@ -315,9 +332,7 @@ if (Meteor.isClient) {
     }
   });
 
-  Tracker.autorun(function () {
-    Meteor.subscribe("credentials");
-  });
+  Meteor.subscribe("credentials");
 
   makeDateString = function (date) {
     // Note: this is also used by grain.js.
@@ -344,6 +359,21 @@ if (Meteor.isClient) {
     return result;
   };
   Template.registerHelper("dateString", makeDateString);
+
+  prettySize = function (size) {
+    var suffix = "B";
+    if (size >= 1000000000) {
+      size = size / 1000000000;
+      suffix = "GB";
+    } else if (size >= 1000000) {
+      size = size / 1000000;
+      suffix = "MB";
+    } else if (size >= 1000) {
+      size = size / 1000;
+      suffix = "kB";
+    }
+    return size.toPrecision(3) + suffix;
+  }
 
   launchAndEnterGrainByPackageId = function(packageId) {
     var action = UserActions.findOne({packageId: packageId});
@@ -478,6 +508,23 @@ if (Meteor.isClient) {
     splashDialog: function() {
       var setting = Settings.findOne("splashDialog");
       return (setting && setting.value) || DEFAULT_SPLASH_DIALOG;
+    },
+
+    quotaEnabled: function() {
+      return Meteor.settings.public.quotaEnabled;
+    },
+
+    storageUsage: function() {
+      return prettySize(Meteor.user().storageUsage || 0);
+    },
+
+    storageQuota: function() {
+      var quota = Meteor.user().quota;
+      return (typeof quota === "number") ? prettySize(quota) : undefined;
+    },
+
+    overQuota: function() {
+      return isUserOverQuota(Meteor.user());
     }
   });
 
@@ -519,11 +566,23 @@ if (Meteor.isClient) {
     },
 
     "click #install-apps-button": function (event) {
-      document.location = "https://sandstorm.io/apps/?host=" + getOrigin();
+      if (isUserOverQuota(Meteor.user())) {
+        // The install process would eventually fail. Alert the user now rather than let them go
+        // pick an app.
+        alert("You are out of storage space. Please delete some things and try again.");
+      } else {
+        document.location = "https://sandstorm.io/apps/?host=" + getOrigin();
+      }
     },
 
     "click #upload-app-button": function (event) {
-      Router.go("uploadForm", {});
+      if (isUserOverQuota(Meteor.user())) {
+        // The install process would eventually fail. Alert the user now rather than let them go
+        // pick an app.
+        alert("You are out of storage space. Please delete some things and try again.");
+      } else {
+        Router.go("uploadForm", {});
+      }
     },
 
     "click #restore-backup-button":  function (event) {

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -360,6 +360,10 @@ if (Meteor.isClient) {
   };
   Template.registerHelper("dateString", makeDateString);
 
+  Template.registerHelper("quotaEnabled", function() {
+    return Meteor.settings.public.quotaEnabled;
+  });
+
   prettySize = function (size) {
     var suffix = "B";
     if (size >= 1000000000) {
@@ -508,10 +512,6 @@ if (Meteor.isClient) {
     splashDialog: function() {
       var setting = Settings.findOne("splashDialog");
       return (setting && setting.value) || DEFAULT_SPLASH_DIALOG;
-    },
-
-    quotaEnabled: function() {
-      return Meteor.settings.public.quotaEnabled;
     },
 
     storageUsage: function() {

--- a/shell/shared/signup.js
+++ b/shell/shared/signup.js
@@ -53,6 +53,9 @@ if (Meteor.isServer) {
       if (keyInfo.email) {
         userFields.signupEmail = keyInfo.email;
       }
+      if ("quota" in keyInfo) {
+        userFields.quota = keyInfo.quota;
+      }
 
       Meteor.users.update(this.userId, {$set: userFields});
       SignupKeys.update(key, {$set: {used: true}});

--- a/src/sandstorm/backend.capnp
+++ b/src/sandstorm/backend.capnp
@@ -74,6 +74,14 @@ interface Backend {
 
   deleteBackup @10 (backupId :Text);
   # Delete a stored backup form disk. Succeeds silently if the backup doesn't exist.
+
+  # ----------------------------------------------------------------------------
+
+  getUserStorageUsage @11 (userId :Text) -> (size :UInt64);
+  # Returns the number of bytes of data in storage attributed to the given user.
+  #
+  # This method is not implemented by the single-machine version of Sandstorm, which does not track
+  # per-user storage quotas.
 }
 
 interface SandstormCoreFactory {


### PR DESCRIPTION
The basic idea here is:
- Admin assigns storage quota to users e.g. at invite time.
- The back-end can determine how much space the user's grains are currently using. (Only on Blackrock, though; regular Sandstorm doesn't have any efficient way to do this.)
- We'll use this to display to the user how much space they are using.
- When the user goes over their quota, we'll stop letting them create new grains.
- When the user goes over 120% of their quota, we'll stop letting them start their existing grains.

@jparyani can you review this?