### PR TITLE
Fix bug in `downstreamTokens()`.

### DIFF
--- a/shell/server/permissions.js
+++ b/shell/server/permissions.js
@@ -303,17 +303,16 @@ downstreamTokens = function(root) {
 
   ApiTokens.find({grainId: grainId}).forEach(function (token) {
     tokensById[token._id] = token;
-    if (token.userId) {
-      if (!tokensBySharer[token.userId]) {
-        tokensBySharer[token.userId] = [];
-      }
-      tokensBySharer[token.userId].push(token);
-    }
     if (token.parentToken) {
       if (!tokensByParent[token.parentToken]) {
         tokensByParent[token.parentToken] = [];
       }
       tokensByParent[token.parentToken].push(token);
+    } else if (token.userId) {
+      if (!tokensBySharer[token.userId]) {
+        tokensBySharer[token.userId] = [];
+      }
+      tokensBySharer[token.userId].push(token);
     }
   });
 


### PR DESCRIPTION
 Now when you revoke a token, users downstream from it will no longer show up in your 'see who has access' view.