### PR TITLE
Fix various things pertaining to sharing.

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -327,14 +327,14 @@ limitations under the License.
         <p>Your existing webkeys:</p>
         <ul>
         {{#each existingTokens}}
-          {{#unless revoked}}
+          {{#if displayToken}}
             <li>
               <span class="token-petname" data-token-id="{{_id}}">
                 {{petname}} ({{dateString created}})
               </span>
               <button class="revoke-token" title="revoke" data-token-id="{{_id}}">revoke</button>
             </li>
-          {{/unless}}
+          {{/if}}
         {{/each}}
         </ul>
       {{/if}}
@@ -410,14 +410,14 @@ limitations under the License.
             <p> Your existing links: </p>
             <ul>
             {{#each existingShareTokens}}
-              {{#unless revoked}}
+              {{#if displayToken}}
                 <li>
                   <span class="token-petname" data-token-id="{{_id}}">
                     {{petname}} ({{dateString created}})
                   </span>
                   <button class="revoke-token" title="revoke" data-token-id="{{_id}}">revoke</button>
                 </li>
-              {{/unless}}
+              {{/if}}
             {{/each}}
             </ul>
           {{else}}

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -148,9 +148,12 @@ checkRequirements = function (requirements) {
       }
     } else if (requirement.permissionsHeld) {
       var p = requirement.permissionsHeld;
+      var vertex = {grain: {_id: p.grainId, userId: p.userId}};
+      if (!mayOpenGrain(vertex)) {
+        return false;
+      }
       var viewInfo = Grains.findOne(p.grainId, {fields: {cachedViewInfo: 1}}).cachedViewInfo;
-      var currentPermissions = grainPermissions({grain: {_id: p.grainId, userId: p.userId}},
-                                                viewInfo || {});
+      var currentPermissions = grainPermissions(vertex, viewInfo || {});
       for (var ii = 0; ii < p.permissions.length; ++ii) {
         if (p.permissions[ii] && !currentPermissions[ii]) {
           return false;

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -148,12 +148,12 @@ checkRequirements = function (requirements) {
       }
     } else if (requirement.permissionsHeld) {
       var p = requirement.permissionsHeld;
-      var vertex = {grain: {_id: p.grainId, userId: p.userId}};
-      if (!mayOpenGrain(vertex)) {
+      var viewInfo = Grains.findOne(p.grainId, {fields: {cachedViewInfo: 1}}).cachedViewInfo;
+      var currentPermissions = grainPermissions({grain: {_id: p.grainId, userId: p.userId}},
+                                                viewInfo || {});
+      if (!currentPermissions) {
         return false;
       }
-      var viewInfo = Grains.findOne(p.grainId, {fields: {cachedViewInfo: 1}}).cachedViewInfo;
-      var currentPermissions = grainPermissions(vertex, viewInfo || {});
       for (var ii = 0; ii < p.permissions.length; ++ii) {
         if (p.permissions[ii] && !currentPermissions[ii]) {
           return false;

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -149,9 +149,12 @@ checkRequirements = function (requirements) {
     } else if (requirement.permissionsHeld) {
       var p = requirement.permissionsHeld;
       var viewInfo = Grains.findOne(p.grainId, {fields: {cachedViewInfo: 1}}).cachedViewInfo;
-      var set = new PermissionSet(grainPermissions(p.grainId, p.userId, viewInfo || {}));
-      if (new PermissionSet(p.permissions).intersect(set)) {
-        return false;
+      var currentPermissions = grainPermissions({grain: {_id: p.grainId, userId: p.userId}},
+                                                viewInfo || {});
+      for (var ii = 0; ii < p.permissions.length; ++ii) {
+        if (p.permissions[ii] && !currentPermissions[ii]) {
+          return false;
+        }
       }
     } else if (requirement.userIsAdmin) {
       if (!isAdminById(requirement.userIsAdmin)) {

--- a/shell/server/permissions.js
+++ b/shell/server/permissions.js
@@ -194,7 +194,8 @@ function collectEdges(vertex) {
 }
 
 grainPermissions = function(vertex, viewInfo) {
-  // Computes the permissions of a vertex.
+  // Computes the permissions of a vertex. If the vertex is not allowed to open the grain,
+  // returns null. Otherwise, returns an array of bools representing the permissions held.
   var edges = collectEdges(vertex);
   if (edges.openerIsOwner) {
     return roleAssignmentPermissions({allAccess: null}, viewInfo).array;
@@ -205,7 +206,7 @@ grainPermissions = function(vertex, viewInfo) {
     return roleAssignmentPermissions({none: null}, viewInfo).array;
   }
   if (edges.grainDoesNotExist || !edges.terminalEdge || edges.disallowedAnonymousAccess) {
-    return [];
+    return null;
   }
 
   var openerUserId = edges.terminalEdge.sharer;
@@ -216,7 +217,6 @@ grainPermissions = function(vertex, viewInfo) {
   // Keeps track of the permissions that the opener receives from each user. The final result of
   // our computation will be stored in permissionsMap[owner].
 
-  permissionsMap[owner] = new PermissionSet();
   var userStack = [openerUserId];
 
   var openerAttenuation = roleAssignmentPermissions({allAccess: null}, viewInfo);
@@ -249,7 +249,11 @@ grainPermissions = function(vertex, viewInfo) {
       });
     }
   }
-  return permissionsMap[owner].array;
+  if (permissionsMap[owner]) {
+    return permissionsMap[owner].array;
+  } else {
+    return null;
+  }
 }
 
 mayOpenGrain = function(vertex) {

--- a/shell/server/permissions.js
+++ b/shell/server/permissions.js
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-PermissionSet = function (array) {
+function PermissionSet(array) {
   // A wrapper around an array of booleans.
 
   if (!array) {

--- a/shell/server/permissions.js
+++ b/shell/server/permissions.js
@@ -102,75 +102,128 @@ function roleAssignmentPermissions(roleAssignment, viewInfo) {
   return result;
 }
 
-function collectEdgesByRecipient(grainId) {
-  // Collects chains of `parentToken` UiView tokens into direct user-to-user edges that are
-  // more convenient for permissions computations. Returns a map where the keys are IDs of
-  // recipient users and the values are lists of objects of the form
-  // `{sharer: <userId>, roleAssignments: <list of role assignments>}`.
-  // The role assignments should be applied in sequence to compute the set of permissions that
-  // flow to a recipient from a sharer.
+function collectEdges(vertex) {
+  // Given a vertex in the sharing graph in the format specified by the `check()` invocation below,
+  // collects the data needed for permissions computations pertaining to that vertex. There are four
+  // self-explanatory special cases for the return value. In order of decreasing precedence, they
+  // are: `{grainDoesNotExist: true}`, `{openerIsOwner: true}`, `{grainIsPublic: true}`, and
+  // `{disallowedAnonymousAccess: true}`. In all other cases, this function returns an object
+  // of the form: `{owner: <userId>, edgesByRecipient: <object>, terminalEdge: Maybe(<object>)}`.
+  // The `owner` field indicates the user who owns the grain. The `edgesByRecipient` field is a map
+  // that coalesces chains of `parentToken` UiView tokens into direct user-to-user edges; its keys
+  // are IDs of recipient users and ites values are lists of "edge" objects of the form
+  // `{sharer: <userId>, roleAssignments: <list of role assignments>}`.  The role assignments
+  // should be applied in sequence to compute the set of permissions that flow to a recipient from
+  // a sharer. The `terminalEdge` field is an edge object representing the link to `vertex` from
+  // the nearest user in the sharing graph. If `vertex` is already a user, then this edge is
+  // trivial and its `roleAssignments` field is an empty list. If `terminalEdge` is not present,
+  // then there is no such link.
   //
   // TODO(someday): Once UiView tokens can have membrane requirements, we'll need to account for
   // them in this computation.
+  check(vertex,
+        Match.OneOf({token: Match.ObjectIncluding({_id: String, grainId: String})},
+                    {grain: Match.ObjectIncluding({_id: String,
+                                                   userId: Match.OneOf(String, null, undefined)})}));
 
-  var edgesByRecipient = {};
+  var grainId;
+  if (vertex.token) {
+    grainId = vertex.token.grainId;
+  } else if (vertex.grain) {
+    grainId = vertex.grain._id;
+  }
+  var grain = Grains.findOne(grainId);
+  if (!grain) {
+    return {grainDoesNotExist: true};
+  }
+
+  if (vertex.grain && grain.userId === vertex.grain.userId) {
+    return {openerIsOwner: true};
+  }
+
+  if (!grain.private) {
+    return {grainIsPublic: true};
+  } else if (vertex.grain && !vertex.grain.userId) {
+    return {disallowedAnonymousAccess: true};
+  }
+
+  var result = {edgesByRecipient: {}, owner: grain.userId};
   var tokensById = {};
   ApiTokens.find({grainId: grainId, revoked: {$ne: true}}).forEach(function(token) {
     tokensById[token._id] = token;
   });
+
+  function computeEdge(token) {
+    var roleAssignments = [];
+    var curToken = token;
+    while (curToken && curToken.parentToken) {
+      // For a `parentToken` provider, no role assignment means don't attenuate.
+      if (curToken.roleAssignment) {
+        roleAssignments.push(curToken.roleAssignment);
+      }
+      curToken = tokensById[curToken.parentToken];
+    }
+    if (curToken && curToken.grainId && curToken.userId) {
+      roleAssignments.push(curToken.roleAssignment);
+      return {sharer: curToken.userId, roleAssignments: roleAssignments};
+    } else {
+      return;
+    }
+  }
+
+  if (vertex.token) {
+    result.terminalEdge = computeEdge(vertex.token);
+  } else if (vertex.grain) {
+    result.terminalEdge = {sharer: vertex.grain.userId, roleAssignments: []};
+  }
+
   for (var id in tokensById) {
     var token = tokensById[id];
-    var roleAssignments = [];
     if (Match.test(token.owner, {user: Match.Any})) {
-      var curToken = token;
-      while (curToken && curToken.parentToken) {
-        // For a `parentToken` provider, no role assignment means don't attenuate.
-        if (curToken.roleAssignment) {
-          roleAssignments.push(curToken.roleAssignment);
+      var edge = computeEdge(token);
+      if (edge) {
+        var recipient = token.owner.user.userId ;
+        if (!result.edgesByRecipient[recipient]) {
+          result.edgesByRecipient[recipient] = [];
         }
-        curToken = tokensById[curToken.parentToken];
-      }
-      if (curToken && curToken.grainId && curToken.userId) {
-        roleAssignments.push(curToken.roleAssignment);
-        var recipient = token.owner.user.userId;
-        var edge = {sharer: curToken.userId, roleAssignments: roleAssignments}
-        if (!edgesByRecipient[recipient]) {
-          edgesByRecipient[recipient] = [];
-        }
-        edgesByRecipient[recipient].push(edge);
+        result.edgesByRecipient[recipient].push(edge);
       }
     }
   }
-  return edgesByRecipient;
+  return result;
 }
 
-function grainPermissionsInternal(grainId, openerUserId, viewInfo) {
-  // Computes the permissions of a user who is opening a grain.
-
-  var grain = Grains.findOne(grainId);
-
-  var owner = grain.userId;
-  if (openerUserId === owner) {
-    // Optimization: return early in this easy and common case.
-    return roleAssignmentPermissions({allAccess: null}, viewInfo);
+grainPermissions = function(vertex, viewInfo) {
+  // Computes the permissions of a vertex.
+  var edges = collectEdges(vertex);
+  if (edges.openerIsOwner) {
+    return roleAssignmentPermissions({allAccess: null}, viewInfo).array;
   }
-
-  if (!grain.private) {
+  if (edges.grainIsPublic) {
     // Grains using the old sharing model always share the default role to anyone who has the
     // grain URL.
-    return roleAssignmentPermissions({none: null}, viewInfo);
+    return roleAssignmentPermissions({none: null}, viewInfo).array;
+  }
+  if (edges.grainDoesNotExist || !edges.terminalEdge || edges.disallowedAnonymousAccess) {
+    return [];
   }
 
-  if (!openerUserId) { return new PermissionSet(); }
+  var openerUserId = edges.terminalEdge.sharer;
+  var edgesByRecipient = edges.edgesByRecipient;
+  var owner = edges.owner;
+
   var permissionsMap = {};
   // Keeps track of the permissions that the opener receives from each user. The final result of
   // our computation will be stored in permissionsMap[owner].
 
-  permissionsMap[openerUserId] = roleAssignmentPermissions({allAccess: null}, viewInfo);
   permissionsMap[owner] = new PermissionSet();
-
   var userStack = [openerUserId];
-  var edgesByRecipient = collectEdgesByRecipient(grainId);
+
+  var openerAttenuation = roleAssignmentPermissions({allAccess: null}, viewInfo);
+  edges.terminalEdge.roleAssignments.forEach(function(roleAssignment) {
+    openerAttenuation.intersect(roleAssignmentPermissions(roleAssignment, viewInfo));
+  });
+  permissionsMap[openerUserId] = openerAttenuation;
 
   while (userStack.length > 0) {
     var recipient = userStack.pop();
@@ -196,38 +249,31 @@ function grainPermissionsInternal(grainId, openerUserId, viewInfo) {
       });
     }
   }
-
-  return permissionsMap[owner];
+  return permissionsMap[owner].array;
 }
 
-apiTokenPermissions = function (token, viewInfo) {
-  var result = grainPermissionsInternal(token.grainId, token.userId, viewInfo);
-  var edge = roleAssignmentPermissions(token.roleAssignment, viewInfo);
-  result.intersect(edge);
-  return result.array;
-}
+mayOpenGrain = function(vertex) {
+  // Determines whether the vertex is allowed to open the grain by searching depth first
+  // for a path of active role assignments leading from the grain owner to the vertex.
 
-grainPermissions = function (grainId, userId, viewInfo) {
-  return grainPermissionsInternal(grainId, userId, viewInfo).array;
-}
-
-mayOpenGrain = function(grainId, userId) {
-  // Determines whether the user is allowed to open the grain by searching depth first
-  // for a path of active role assignments leading from the grain owner to the user.
-
-  var grain = Grains.findOne(grainId);
-  if (!grain) { return false; }
-  if (!grain.private) { return true; }
-  if (!userId) { return false; }
-  var owner = grain.userId;
-  if (userId == owner) {
+  var edges = collectEdges(vertex);
+  if (edges.grainDoesNotExist || edges.disallowedAnonymousAccess) {
+    return false;
+  }
+  if (edges.openerIsOwner || edges.grainIsPublic) {
+    return true;
+  }
+  var edgesByRecipient = edges.edgesByRecipient;
+  var owner = edges.owner;
+  if (!edges.terminalEdge) { return false; }
+  if (owner == edges.terminalEdge.sharer) {
     return true;
   }
 
+  var openerUserId = edges.terminalEdge.sharer;
   var stackedUsers = {};
-  stackedUsers[userId] = true;
-  var userStack = [userId];
-  var edgesByRecipient = collectEdgesByRecipient(grainId);
+  stackedUsers[openerUserId] = true;
+  var userStack = [openerUserId];
 
   while (userStack.length > 0) {
     var recipient = userStack.pop();

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1082,6 +1082,9 @@ Proxy.prototype._callNewSession = function (request, viewInfo) {
       vertex = {grain: {_id: self.grainId, userId: self.userId}};
     }
     var permissions = grainPermissions(vertex, viewInfo);
+    if (!permissions) {
+      throw new Meteor.Error(403, "Unauthorized", "User is not authorized to open this grain.");
+    }
     Sessions.update({_id: self.sessionId},
                     {$set : {"viewInfo": viewInfo, "permissions": permissions}});
     return permissions;

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -468,6 +468,10 @@ if (Meteor.isClient) {
       return Meteor.userId() || !this.oldSharingModel;
     },
 
+    displayToken: function() {
+      return !this.revoked && !this.expiresIfUnused && !this.parentToken;
+    },
+
     path: function () {
       var originalPath = Template.instance().originalPath;
       var grainPath = originalPath.slice(this.rootPath.length);


### PR DESCRIPTION
The biggest change here is that now when you open a child token UiView anonymously, the permissions are correctly computed. I ended up pushing a lot of shared logic in the `collectEdges()` function, which I think makes things nicer and opens the door to further simplifications later. (Eventually I think we'll want to call `collectEdges()` only once per grain-startup request; right now we call it once under `mayOpenGrain()` and once under `grainPermissions()`.)