### PR TITLE
Extend spk manifest format with market metadata.

### DIFF
--- a/src/sandstorm/package.capnp
+++ b/src/sandstorm/package.capnp
@@ -310,7 +310,7 @@ struct Metadata {
     # valid address with someone paying attention to it.
 
     pgpSignature @11 :Data;
-    # PGP signature attesting responsibility for the app ID. This is a binary-format non-detached
+    # PGP signature attesting responsibility for the app ID. This is a binary-format detached
     # signature of the following ASCII message (not including the quotes, and replacing <app-id>
     # with the standard base-32 text format of the app's ID):
     #
@@ -329,6 +329,11 @@ struct Metadata {
     # identity, then you should not give the new maintainer the app's private key; you should force
     # them to create a new key. Sandstorm will not auto-update users to the new version without,
     # at the very least, confirming their approval of the change in authorship.
+
+    pgpPublicKey @14 :Data;
+    # The public key used to create `pgpSignature`, in binary format, e.g. as output by
+    # `gpg --export <email>`. This is included here, rather than looked up from a keyserver, so
+    # that a package signature can be verified down to a key fingerprint in isolation.
   }
 
   description @12 :Text;

--- a/src/sandstorm/package.capnp
+++ b/src/sandstorm/package.capnp
@@ -263,7 +263,7 @@ struct Metadata {
     # Text of the app's license.
 
     notices @6 :Util.LocalizedText;
-    # Contains any third-party copyright notices that the app is required to display, for exmaple
+    # Contains any third-party copyright notices that the app is required to display, for example
     # due to use of third-party open source libraries.
 
     isOpenSource @7 :Bool;


### PR DESCRIPTION
The goal here is that the app market should not need authors to fill in any form; they just upload an spk.

Note that I plan to extend Cap'n Proto with an `embed` keyword, which is like `import` except that it turns the raw contents of the specified file into `Text` or `Data`. Thus things like image files and license text would not actually be specified inside `sandstorm-pkgdef.capnp` but would be embedded from separate files. When the manifest is compiled to binary, those separate files are pulled into it, forming one big Cap'n Proto blob.