### PR TITLE
Exception -> Error

### DIFF
--- a/shell/packages/sandstorm-email/email.js
+++ b/shell/packages/sandstorm-email/email.js
@@ -175,6 +175,6 @@ SandstormEmail.rawSend = function (mc, smtpUrl) {
   if (pool) {
     smtpSend(pool, mc);
   } else {
-    throw new Exception("SMTP pool is misconfigured.");
+    throw new Error("SMTP pool is misconfigured.");
   }
 };


### PR DESCRIPTION
Currently I see this error if I run the tests without email configured:
```
Error sending e-mail: ReferenceError: Exception is not defined
    at Object.SandstormEmail.rawSend (packages/sandstorm-email/email.js:178:1)
    at app/server/drivers/mail.js:276:20
    at app/server/proxy.js:64:17
    at app/server/proxy.js:56:3
    at runWithEnvironment (packages/meteor/dynamics_nodejs.js:108:1)
```
