### PR TITLE
README specifies just clang, rather than (outdated) clang-3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Please install the following:
 On Debian or Ubuntu, you should be able to get all these with:
 
     sudo apt-get install build-essential libcap-dev xz-utils zip \
-        unzip imagemagick strace curl clang-3.4 discount git
+        unzip imagemagick strace curl clang discount git
     curl https://install.meteor.com/ | sh
 
 ### Building / installing the binaries


### PR DESCRIPTION
On Debian stable, clang-3.4 does not provide /usr/bin/clang, only
/usr/bin/clang-3.4.  The "clang" package (which provides /usr/bin/clang) pulls
in clang-3.5, which is even better.

On Ubuntu 14.04 LTS, the "clang" package provides clang-3.4 as /usr/bin/clang,
which is acceptable.