### PR TITLE
Stop double decoding smtp URLs.

### DIFF
--- a/shell/packages/sandstorm-email/email.js
+++ b/shell/packages/sandstorm-email/email.js
@@ -23,8 +23,8 @@ var makePool = function (mailUrlString) {
   var auth = false;
   if (mailUrl.auth) {
     var parts = mailUrl.auth.split(':', 2);
-    auth = {user: parts[0] && decodeURIComponent(parts[0]),
-            pass: parts[1] && decodeURIComponent(parts[1])};
+    auth = {user: parts[0],
+            pass: parts[1]};
   }
 
   var simplesmtp = Npm.require('simplesmtp');


### PR DESCRIPTION
This was causing problems if a % symbol was in the decoded URL.

Fixes #635.