### PR TITLE
Always fchown the admin token to the sandstorm group.

### DIFF
--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1010,11 +1010,9 @@ public:
 
     {
       auto tokenFd = raiiOpen("../var/sandstorm/adminToken",
-          O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
+          O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0640);
       kj::FdOutputStream tokenFile(tokenFd.get());
-      if (runningAsRoot) {
-        KJ_SYSCALL(fchown(tokenFd, config.uids.uid, config.uids.gid));
-      }
+      KJ_SYSCALL(fchown(tokenFd, -1, config.uids.gid));
       tokenFile.write(hexString.begin(), hexString.size());
     }
 


### PR DESCRIPTION
Today, if you do a default development install, SERVER_USER gets configured to a new user "sandstorm". If a non-root user gets added to the "sandstorm" group, they should be allowed to do `sandstorm admin-token` without sudo. Currently, the command succeeds, but it leaves an adminToken file that causes an error when the frontend tries to open it; the user ends up seeing the admin page stuck on "loading...".

This patch fixes that case and preserves the current functionality for the other cases we care about.