### PR TITLE
Add `onlyPopup` parameter to sandstormTopbar

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -580,6 +580,12 @@ body>.popup {
     >*:last-child {
       margin-bottom: 16px;
     }
+
+    &.centered {
+      margin: 0px auto;
+      width: 600px;
+      margin-left: calc(50% - 300px);
+    }
   }
 
   &.account>.frame {

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -73,7 +73,6 @@ body {
 
 // Styles used by the user account settings page
 @import "_account.scss";
-
 // =======================================================================================
 
 a.copy-me {

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -27,27 +27,37 @@ limitations under the License.
 
     <ul class="topbar {{#if _menuExpanded.get}}expanded{{/if}}">
       {{#each items}}
-        <li class="{{name}}">
-          {{#if ./popupTemplate}}
-            <button class="show-popup">
+        {{#if ./onlyPopup}}
+        {{else}}
+          <li class="{{name}}">
+            {{#if ./popupTemplate}}
+              <button class="show-popup">
+                {{> template data.get}}
+              </button>
+            {{else}}
               {{> template data.get}}
-            </button>
-          {{else}}
-            {{> template data.get}}
-          {{/if}}
-        </li>
+            {{/if}}
+          </li>
+        {{/if}}
       {{/each}}
     </ul>
   {{/if}}
 
   {{#with currentPopup}}
     <div class="popup {{name}}">
-      {{#with position}}
-        <div class="frame align-{{align}}" style="{{align}}: {{px}}px">
+      {{#if ./onlyPopup}}
+        <div class="frame centered">
           <button class="close-popup">Close</button>
           {{>popupTemplate ../data.get}}
         </div>
-      {{/with}}
+      {{else}}
+        {{#with position}}
+          <div class="frame align-{{align}}" style="{{align}}: {{px}}px">
+            <button class="close-popup">Close</button>
+            {{>popupTemplateNested ../data.get}}
+          </div>
+        {{/with}}
+      {{/if}}
     </div>
   {{/with}}
 </template>

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -47,7 +47,7 @@ limitations under the License.
       {{#if onlyPopup}}
         <div class="frame centered">
           <button class="close-popup">Close</button>
-          {{>popupTemplate ../data.get}}
+          {{>popupTemplate data.get}}
         </div>
       {{else}}
         {{#with position}}

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -37,7 +37,7 @@ limitations under the License.
               {{> template data.get}}
             {{/if}}
           </li>
-        {{/if}}
+        {{/unless}}
       {{/each}}
     </ul>
   {{/if}}

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -27,8 +27,7 @@ limitations under the License.
 
     <ul class="topbar {{#if _menuExpanded.get}}expanded{{/if}}">
       {{#each items}}
-        {{#if onlyPopup}}
-        {{else}}
+        {{#unless onlyPopup}}
           <li class="{{name}}">
             {{#if ./popupTemplate}}
               <button class="show-popup">

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -27,7 +27,7 @@ limitations under the License.
 
     <ul class="topbar {{#if _menuExpanded.get}}expanded{{/if}}">
       {{#each items}}
-        {{#if ./onlyPopup}}
+        {{#if onlyPopup}}
         {{else}}
           <li class="{{name}}">
             {{#if ./popupTemplate}}
@@ -45,7 +45,7 @@ limitations under the License.
 
   {{#with currentPopup}}
     <div class="popup {{name}}">
-      {{#if ./onlyPopup}}
+      {{#if onlyPopup}}
         <div class="frame centered">
           <button class="close-popup">Close</button>
           {{>popupTemplate ../data.get}}

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -238,7 +238,6 @@ SandstormTopbar.prototype.closePopup = function () {
       if (result === "block") {
         return;
       } else if (result === "remove") {
-        console.log("removing popup");
         delete this._items[item.name];
         this._itemsTracker.changed();
       } else {

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -78,6 +78,11 @@ Template.sandstormTopbar.helpers({
   },
 
   popupTemplate: function () {
+    var item = Template.parentData(1);
+    return item.popupTemplate;
+  },
+
+  popupTemplateNested: function () {
     // Here we need parentData(2) because we've also pushed `position` onto the stack.
     var item = Template.parentData(2);
     return item.popupTemplate;
@@ -233,6 +238,7 @@ SandstormTopbar.prototype.closePopup = function () {
       if (result === "block") {
         return;
       } else if (result === "remove") {
+        console.log("removing popup");
         delete this._items[item.name];
         this._itemsTracker.changed();
       } else {
@@ -253,7 +259,7 @@ SandstormTopbar.prototype.addItem = function (item) {
     name: String,
     // CSS class name of this item. Must be unique.
 
-    template: Template,
+    template: Match.Optional(Template),
     // Template for the item content as rendered in the topbar.
 
     popupTemplate: Match.Optional(Template),
@@ -280,7 +286,18 @@ SandstormTopbar.prototype.addItem = function (item) {
     // space. This function may return some special string values with specific meanings:
     // * "remove": Removes the topbar item, like if close() were called on the result of addItem().
     // * "block": Block the attempt to dismiss the popup.
+
+    onlyPopup: Match.Optional(Boolean),
+    // If this is true, then no icon is shown in the topbar (`template` param is ignored). startOpen
+    // is defaulted to true and onDismiss defaults to closing the popup.
   });
+
+  if (item.onlyPopup) {
+    item.startOpen = item.startOpen || true;
+    item.onDismiss = item.onDismiss || function () { return "remove"; };
+  } else if (!item.template) {
+    throw new Error("template parameter must be supplied unless onlyPopup is true");
+  }
 
   if (!item.popupTemplate && (item.startOpen || item.onDismiss)) {
     throw new Error("can't set startOpen or onDismiss without setting popupTemplate");


### PR DESCRIPTION
This will create a popup in the center of the screen that extends a
caret into the topbar. There will be no icon in the topbar associated
with these items.