### PR TITLE
Make sure not to try opening a share link while logging in.

### DIFF
--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -863,7 +863,7 @@ Router.map(function () {
     },
 
     data: function() {
-      if (!this.ready) {
+      if (!this.ready || Meteor.loggingIn()) {
         return;
       }
       if (Meteor.userId() && !Session.get("visit-token-" + this.params.token)) {


### PR DESCRIPTION
Fixes #605.

The problem was that a user who was in the process of logging in would always immediately request an anonymous session, because `Meteor.userId()` would initially be unset.