### PR TITLE
Permit null as name

### DIFF
--- a/shell/packages/sandstorm-accounts-ui/accounts-ui-methods.js
+++ b/shell/packages/sandstorm-accounts-ui/accounts-ui-methods.js
@@ -26,7 +26,7 @@ Meteor.methods({
   updateProfile: function (profile) {
     // TODO(cleanup): This check also appears in sandstorm-db/users.js.
     check(profile, {
-      name: Match.Optional(Match.OneOf(null, Match.Optional(String))),
+      name: Match.OneOf(null, Match.Optional(String)),
       handle: Match.Optional(ValidHandle),
       pronoun: Match.Optional(Match.OneOf("male", "female", "neutral", "robot")),
     });

--- a/shell/packages/sandstorm-accounts-ui/accounts-ui-methods.js
+++ b/shell/packages/sandstorm-accounts-ui/accounts-ui-methods.js
@@ -26,7 +26,7 @@ Meteor.methods({
   updateProfile: function (profile) {
     // TODO(cleanup): This check also appears in sandstorm-db/users.js.
     check(profile, {
-      name: Match.Optional(String),
+      name: Match.Optional(Match.OneOf(null, Match.Optional(String))),
       handle: Match.Optional(ValidHandle),
       pronoun: Match.Optional(Match.OneOf("male", "female", "neutral", "robot")),
     });

--- a/shell/packages/sandstorm-db/user.js
+++ b/shell/packages/sandstorm-db/user.js
@@ -79,7 +79,7 @@ Accounts.onCreateUser(function (options, user) {
   if (options.profile) {
     // TODO(cleanup): This check also appears in accounts-ui-methods.js.
     check(options.profile, Match.ObjectIncluding({
-      name: Match.Optional(String),
+      name: Match.Optional(Match.OneOf(null, Match.Optional(String))),
       handle: Match.Optional(ValidHandle),
       pronoun: Match.Optional(Match.OneOf("male", "female", "neutral", "robot")),
     }));

--- a/shell/packages/sandstorm-db/user.js
+++ b/shell/packages/sandstorm-db/user.js
@@ -79,7 +79,7 @@ Accounts.onCreateUser(function (options, user) {
   if (options.profile) {
     // TODO(cleanup): This check also appears in accounts-ui-methods.js.
     check(options.profile, Match.ObjectIncluding({
-      name: Match.Optional(Match.OneOf(null, Match.Optional(String))),
+      name: Match.OneOf(null, Match.Optional(String)),
       handle: Match.Optional(ValidHandle),
       pronoun: Match.Optional(Match.OneOf("male", "female", "neutral", "robot")),
     }));


### PR DESCRIPTION
This occurs when a GitHub user attempts to sign in to Sandstorm where
they have no name configured in GitHub, just a username (aka handle).

Close #675