### PR TITLE
WIP app index with `spk publish` command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ IMAGES= \
 # Meta rules
 
 .SUFFIXES:
-.PHONY: all install clean continuous shell-env fast deps bootstrap-ekam deps update-deps test installer-test
+.PHONY: all install clean continuous shell-env fast deps bootstrap-ekam deps update-deps test installer-test app-index-dev
 
 all: sandstorm-$(BUILD).tar.xz
 
@@ -218,3 +218,23 @@ sandstorm-$(BUILD)-fast.tar.xz: bundle
 	@$(call color,docker build)
 	@docker build -t sandstorm .
 	@touch .docker
+
+# ====================================================================
+# app-index.spk
+
+# This is currently really really hacky because spk is not good at using package definition file
+# that is not located at the root of the source tree. In particular it is hard for the package
+# definition file (living in the src tree) to refer to the `app-index` binary (living in the
+# tmp tree).
+#
+# TODO(cleanup): Make spk better so that it can handle this.
+
+app-index.spk: tmp/.ekam-run
+	@cp src/sandstorm/app-index/app-index.capnp tmp/sandstorm/app-index/app-index.capnp
+	@cp src/sandstorm/app-index/review.html tmp/sandstorm/app-index/review.html
+	spk pack -Isrc -Itmp -ptmp/sandstorm/app-index/app-index.capnp:pkgdef app-index.spk
+
+app-index-dev: tmp/.ekam-run
+	@cp src/sandstorm/app-index/app-index.capnp tmp/sandstorm/app-index/app-index.capnp
+	@cp src/sandstorm/app-index/review.html tmp/sandstorm/app-index/review.html
+	spk dev -Isrc -Itmp -ptmp/sandstorm/app-index/app-index.capnp:pkgdef

--- a/src/sandstorm/app-index/app-index.c++
+++ b/src/sandstorm/app-index/app-index.c++
@@ -1,0 +1,449 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <kj/main.h>
+#include <kj/debug.h>
+#include <kj/io.h>
+#include <kj/async-io.h>
+#include <capnp/rpc-twoparty.h>
+#include <capnp/serialize.h>
+#include <capnp/serialize-packed.h>
+#include <capnp/membrane.h>
+#include <capnp/compat/json.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <errno.h>
+#include <ctype.h>
+#include <sodium/crypto_sign.h>
+#include <map>
+
+#include <sandstorm/grain.capnp.h>
+#include <sandstorm/web-session.capnp.h>
+#include <sandstorm/api-session.capnp.h>
+#include <sandstorm/hack-session.capnp.h>
+#include <sandstorm/util.h>
+#include <sandstorm/app-index/app-index.capnp.h>
+#include <sandstorm/spk.h>
+
+#include "indexer.h"
+
+namespace sandstorm {
+namespace appindex {
+
+kj::String htmlEscape(kj::StringPtr text) {
+  kj::Vector<char> result(text.size() + 1);
+  for (char c: text) {
+    switch (c) {
+      case '<': result.addAll(kj::StringPtr("&lt;")); break;
+      case '>': result.addAll(kj::StringPtr("&gt;")); break;
+      case '&': result.addAll(kj::StringPtr("&amp;")); break;
+      default: result.add(c); break;
+    }
+  }
+  result.add('\0');
+  return kj::String(result.releaseAsArray());
+}
+
+template <typename Context>
+void handleError(Context& context, kj::Exception&& e) {
+  KJ_LOG(ERROR, e);
+  auto error = context.getResults().initServerError();
+  error.setDescriptionHtml(kj::str("Error: ", htmlEscape(e.getDescription())));
+}
+
+class SubmissionSession final: public ApiSession::Server {
+public:
+  explicit SubmissionSession(Indexer& indexer): indexer(indexer) {}
+
+  kj::Promise<void> post(PostContext context) override {
+    return kj::evalNow([&]() -> kj::Promise<void> {
+      auto params = context.getParams();
+      auto path = params.getPath();
+      if (path == "upload") {
+        auto content = params.getContent();
+        KJ_REQUIRE(!content.hasEncoding(), "can't accept encoded (e.g. gzipped) upload");
+
+        // Write content to upload stream: a write() followed by a done(), and a getResults().
+        auto stream = indexer.newUploadStream();
+        auto promises = kj::heapArrayBuilder<kj::Promise<void>>(2);
+        auto req1 = stream.writeRequest();
+        req1.setData(content.getContent());
+        promises.add(req1.send().then([](auto&&) {}));
+        promises.add(stream.doneRequest().send().then([](auto&&) {}));
+        promises.add(stream.getResultRequest().send().then([](auto&&) {}));
+
+        context.releaseParams();
+
+        // Return "no content" when getResult() completes.
+        context.initResults().initNoContent();
+        return kj::joinPromises(promises.finish());
+      } else if (path == "status") {
+        auto content = params.getContent();
+        KJ_REQUIRE(!content.hasEncoding(), "POST can't be encoded (e.g. gzipped)");
+
+        capnp::MallocMessageBuilder requestMessage;
+
+        auto origBytes = content.getContent();
+        kj::ArrayInputStream stream(origBytes);
+        requestMessage.setRoot(capnp::PackedMessageReader(stream).getRoot<SubmissionRequest>());
+
+        // Whatever is left in the input is the signature. What ever was consumed from the input is
+        // the request.
+        kj::ArrayPtr<const byte> signature = stream.tryGetReadBuffer();
+        KJ_ASSERT(signature.begin() >= origBytes.begin() && signature.end() <= origBytes.end());
+        kj::ArrayPtr<const byte> requestBytes = kj::arrayPtr(origBytes.begin(), signature.begin());
+
+        auto req = requestMessage.getRoot<SubmissionRequest>();
+
+        // TODO(security): Verify request's webkey hash. Need to know our own webkey, somehow.
+
+        auto packageId = packageIdString(req.getPackageId());
+
+        KJ_REQUIRE(signature.size() == crypto_sign_BYTES, "invalid signature");
+
+        capnp::MallocMessageBuilder response;
+        byte appPublicKey[crypto_sign_PUBLICKEYBYTES];
+        if (indexer.tryGetAppId(packageId, appPublicKey)) {
+          KJ_ASSERT(
+              crypto_sign_verify_detached(signature.begin(),
+                  requestBytes.begin(), requestBytes.size(), appPublicKey) == 0,
+              "signature validation failed");
+
+          bool changed = false;
+          if (req.isSetState()) {
+            auto mutation = req.getSetState();
+            changed = indexer.setSubmissionState(
+                packageId, mutation.getNewState(), mutation.getSequenceNumber());
+          }
+
+          indexer.getSubmissionStatus(packageId, response);
+
+          auto status = response.getRoot<SubmissionStatus>();
+          if (status.isApproved() && changed) {
+            // Force update now!
+            indexer.updateIndex();
+          }
+        } else {
+          response.getRoot<SubmissionStatus>().setNotUploaded();
+        }
+
+        auto status = response.getRoot<SubmissionStatus>();
+        auto outBytes = kj::heapArray<byte>(
+            status.totalSize().wordCount * sizeof(capnp::word) + 128);
+        kj::ArrayOutputStream outStream(outBytes);
+        {
+          // We prefix with a NUL byte to indicate a binary response, because unfortunately the
+          // client tool uses curl with which it is excessively difficult to distinguish error
+          // responses from success. Ugh.
+          auto buffer = outStream.getWriteBuffer();
+          buffer[0] = 0;
+          outStream.write(buffer.begin(), 1);
+        }
+        capnp::writePackedMessage(outStream, response);
+
+        auto httpResponse = context.getResults().initContent();
+        httpResponse.setMimeType("application/octet-stream");
+        httpResponse.initBody().setBytes(outStream.getArray());
+
+        return kj::READY_NOW;
+      } else {
+        auto error = context.getResults().initClientError();
+        error.setStatusCode(WebSession::Response::ClientErrorCode::NOT_FOUND);
+        error.setDescriptionHtml("<html><body><pre>404 not found</pre></body></html>");
+        return kj::READY_NOW;
+      }
+    }).catch_([context](kj::Exception&& e) mutable {
+      handleError(context, kj::mv(e));
+    });
+  }
+
+  kj::Promise<void> postStreaming(PostStreamingContext context) override {
+    auto params = context.getParams();
+    auto path = params.getPath();
+    if (path == "upload") {
+      KJ_REQUIRE(!params.hasEncoding(), "can't accept encoded (e.g. gzipped) upload");
+      context.releaseParams();
+
+      context.getResults(capnp::MessageSize {4,1}).setStream(
+          capnp::membrane(indexer.newUploadStream(), kj::refcounted<RequestStreamMembrane>())
+              .castAs<WebSession::RequestStream>());
+      return kj::READY_NOW;
+    } else {
+      // This should cause the shell to retry using regular post().
+      KJ_UNIMPLEMENTED("postStreaming() only implemented for /upload");
+    }
+  }
+
+private:
+  Indexer& indexer;
+
+  class StreamWrapper final: public WebSession::RequestStream::Server {
+  public:
+    explicit StreamWrapper(AppIndex::UploadStream::Client inner): inner(kj::mv(inner)) {}
+
+  protected:
+    kj::Promise<void> getResponse(GetResponseContext context) override {
+      return kj::evalNow([&]() -> kj::Promise<void> {
+        context.releaseParams();
+        return inner.getResultRequest().send().then([this,context](auto&&) mutable {
+          context.initResults().initNoContent();
+        });
+      }).catch_([context](kj::Exception&& e) mutable {
+        handleError(context, kj::mv(e));
+      });
+    }
+
+  private:
+    AppIndex::UploadStream::Client inner;
+  };
+
+  class RequestStreamMembrane final: public capnp::MembranePolicy, public kj::Refcounted {
+    // Turns an AppIndex::UploadStream into a WebSession::RequestStream. Any ByteStream method
+    // calls pass through, but other calls are redirected to a wrapper.
+  public:
+    kj::Maybe<capnp::Capability::Client> inboundCall(
+        uint64_t interfaceId, uint16_t methodId, capnp::Capability::Client target) override {
+      if (interfaceId != capnp::typeId<ByteStream>()) {
+        return WebSession::RequestStream::Client(
+            kj::heap<StreamWrapper>(target.castAs<AppIndex::UploadStream>()));
+      }
+      return nullptr;
+    }
+
+    kj::Maybe<capnp::Capability::Client> outboundCall(
+        uint64_t interfaceId, uint16_t methodId, capnp::Capability::Client target) override {
+      // Never called.
+      return nullptr;
+    }
+
+    kj::Own<MembranePolicy> addRef() override { return kj::addRef(*this); }
+  };
+};
+
+class ReviewSession final: public WebSession::Server {
+public:
+  ReviewSession(Indexer& indexer, HackSessionContext::Client session, bool canApprove)
+      : indexer(indexer), session(kj::mv(session)), canApprove(canApprove) {}
+
+  kj::Promise<void> get(GetContext context) override {
+    return kj::evalNow([&]() -> kj::Promise<void> {
+      auto path = context.getParams().getPath();
+      if (path == "") {
+        auto content = context.getResults().initContent();
+        content.setMimeType("text/html; charset=utf-8");
+        content.initBody().setBytes(REVIEW_APP_HTML->asBytes());
+      } else if (path == "queue") {
+        auto content = context.getResults().initContent();
+        content.setMimeType("application/json");
+        content.initBody().setBytes(indexer.getReviewQueueJson().asBytes());
+      } else if (path == "public-id") {
+        context.releaseParams();
+        return session.getPublicIdRequest().send().then([context](auto&& result) mutable {
+          auto content = context.getResults().initContent();
+          content.setMimeType("application/json");
+          content.initBody().setBytes(capnp::JsonCodec().encode(result).asBytes());
+        });
+      } else {
+        auto error = context.getResults().initClientError();
+        error.setStatusCode(WebSession::Response::ClientErrorCode::NOT_FOUND);
+        error.setDescriptionHtml("<html><body><pre>404 not found</pre></body></html>");
+      }
+
+      return kj::READY_NOW;
+    }).catch_([context](kj::Exception&& e) mutable {
+      handleError(context, kj::mv(e));
+    });
+  }
+
+  kj::Promise<void> post(PostContext context) override {
+    return kj::evalNow([&]() -> kj::Promise<void> {
+      KJ_REQUIRE(canApprove, "approval permission denied; you can only view the review queue");
+
+      auto params = context.getParams();
+      auto path = params.getPath();
+      KJ_LOG(INFO, path);
+      if (path.startsWith("approve/")) {
+        // TODO(now): Set URL.
+        indexer.approve(path.slice(strlen("approve/")), "");
+        indexer.updateIndex();
+        context.getResults().initNoContent();
+      } else if (path.startsWith("reject/")) {
+        indexer.reject(path.slice(strlen("reject/")),
+            kj::str(params.getContent().getContent().asChars()));
+        context.getResults().initNoContent();
+      } else if (path.startsWith("unapprove/")) {
+        indexer.unapprove(path.slice(strlen("unapprove/")));
+        indexer.updateIndex();
+        context.getResults().initNoContent();
+      } else if (path.startsWith("keybase/")) {
+        // As a temporary hack, we process keybase API results client-side and then upload them
+        // in a non-JSON format.
+        //
+        // TODO(cleanup): Implement a JSON parser that we can run server-side.
+
+        auto fingerprint = path.slice(strlen("keybase/"));
+        KJ_REQUIRE(fingerprint.size() >= 32 && fingerprint.size() <= 128, "bad fingerprint");
+        for (char c: fingerprint) {
+          KJ_REQUIRE(isalnum(c), "bad fingerprint");
+        }
+
+        kj::Vector<kj::String> keys;
+        std::map<kj::StringPtr, kj::Vector<kj::String>> items;
+        auto lines = splitLines(kj::heapString(params.getContent().getContent().asChars()));
+
+        for (auto& line: lines) {
+          size_t colonPos = KJ_REQUIRE_NONNULL(line.findFirst(':'));
+          auto key = kj::heapString(line.slice(0, colonPos));
+          items[key].add(kj::heapString(line.slice(colonPos + 1)));
+          keys.add(kj::mv(key));
+        }
+
+        capnp::MallocMessageBuilder message;
+        auto keybase = message.getRoot<KeybaseIdentity>();
+
+        KJ_REQUIRE(items["username"].size() > 0, "missing username");
+        keybase.setKeybaseHandle(items["username"][0]);
+
+        if (items["name"].size() > 0) {
+          keybase.setName(items["name"][0]);
+        }
+        if (items["picture"].size() > 0 && items["picture"][0].startsWith("http")) {
+          keybase.setPicture(items["picture"][0]);
+        }
+
+#define TO_STRPTR_ARRAY(array) KJ_MAP(s, array) -> capnp::Text::Reader { return s; }
+        keybase.setWebsites(TO_STRPTR_ARRAY(items["proof.generic_web_site"]));
+        keybase.setGithubHandles(TO_STRPTR_ARRAY(items["proof.github"]));
+        keybase.setTwitterHandles(TO_STRPTR_ARRAY(items["proof.twitter"]));
+        keybase.setHackernewsHandles(TO_STRPTR_ARRAY(items["proof.hackernews"]));
+        keybase.setRedditHandles(TO_STRPTR_ARRAY(items["proof.reddit"]));
+#undef TO_STRPTR_ARRAY
+
+        indexer.addKeybaseProfile(fingerprint, message);
+        context.getResults().initNoContent();
+      } else {
+        auto error = context.getResults().initClientError();
+        error.setStatusCode(WebSession::Response::ClientErrorCode::NOT_FOUND);
+        error.setDescriptionHtml("<html><body><pre>404 not found</pre></body></html>");
+      }
+
+      return kj::READY_NOW;
+    }).catch_([context](kj::Exception&& e) mutable {
+      handleError(context, kj::mv(e));
+    });
+  }
+
+private:
+  Indexer& indexer;
+  HackSessionContext::Client session;
+  bool canApprove;  // True if the user has approver permission.
+};
+
+class UiViewImpl final: public UiView::Server {
+public:
+  explicit UiViewImpl(Indexer& indexer): indexer(indexer) {}
+
+  kj::Promise<void> getViewInfo(GetViewInfoContext context) override {
+    context.setResults(APP_INDEX_VIEW_INFO);
+    return kj::READY_NOW;
+  }
+
+  kj::Promise<void> newSession(NewSessionContext context) override {
+    auto params = context.getParams();
+
+    auto userInfo = params.getUserInfo();
+    auto permissions = userInfo.getPermissions();
+    auto hasPermission = [&](uint index) {
+      return index < permissions.size() && permissions[index];
+    };
+
+    UiSession::Client result = nullptr;
+
+    if (params.getSessionType() == capnp::typeId<ApiSession>()) {
+      KJ_REQUIRE(hasPermission(SUBMIT_PERMISSION),
+                 "client does not have permission to submit apps; can't use API");
+      result = kj::heap<SubmissionSession>(indexer);
+    } else if (params.getSessionType() == capnp::typeId<WebSession>()) {
+      KJ_REQUIRE(hasPermission(REVIEW_PERMISSION),
+                 "client does not have permission to review apps; can't use web interface");
+      result = kj::heap<ReviewSession>(
+          indexer, params.getContext().castAs<HackSessionContext>(),
+          hasPermission(APPROVE_PERMISSION));
+    } else {
+      KJ_FAIL_REQUIRE("Unsupported session type.");
+    }
+
+    context.initResults(capnp::MessageSize {4, 1}).setSession(kj::mv(result));
+    return kj::READY_NOW;
+  }
+
+private:
+  Indexer& indexer;
+};
+
+class AppIndexMain {
+public:
+  AppIndexMain(kj::ProcessContext& context): context(context), ioContext(kj::setupAsyncIo()) {
+    kj::_::Debug::setLogLevel(kj::LogSeverity::INFO);
+  }
+
+  kj::MainFunc getMain() {
+    return kj::MainBuilder(context, "Sandstorm App Index",
+                           "Runs the Sandstorm app index.")
+        .addOption({'i', "init"}, KJ_BIND_METHOD(*this, init), "first run")
+        .callAfterParsing(KJ_BIND_METHOD(*this, run))
+        .build();
+  }
+
+  kj::MainBuilder::Validity init() {
+    KJ_SYSCALL(mkdir("/var/packages", 0777));
+    KJ_SYSCALL(mkdir("/var/keybase", 0777));
+    KJ_SYSCALL(mkdir("/var/www", 0777));
+    KJ_SYSCALL(mkdir("/var/www/apps", 0777));
+    KJ_SYSCALL(mkdir("/var/www/images", 0777));
+    KJ_SYSCALL(mkdir("/var/www/packages", 0777));
+    KJ_SYSCALL(mkdir("/var/tmp", 0777));
+    return true;
+  }
+
+  kj::MainBuilder::Validity run() {
+    Indexer indexer;
+
+    // Set up RPC on file descriptor 3.
+    auto stream = ioContext.lowLevelProvider->wrapSocketFd(3);
+    capnp::TwoPartyClient client(*stream, kj::heap<UiViewImpl>(indexer));
+
+    // TODO(soon):  We don't use this, but for some reason the connection doesn't come up if we
+    //   don't do this bootstrap.  Cap'n Proto bug?  v8capnp bug?  Shell bug?
+    client.bootstrap();
+
+    kj::NEVER_DONE.wait(ioContext.waitScope);
+  }
+
+private:
+  kj::ProcessContext& context;
+  kj::AsyncIoContext ioContext;
+};
+
+} // namespace appindex
+} // namespace sandstorm
+
+KJ_MAIN(sandstorm::appindex::AppIndexMain)

--- a/src/sandstorm/app-index/app-index.capnp
+++ b/src/sandstorm/app-index/app-index.capnp
@@ -1,0 +1,175 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xe16c039c931f2a8a;
+# The app index is designed to run inside a Sandstorm grain, where it maintains the following
+# directory structure:
+#
+# /var/
+#   packages/
+#     <packageId>/   Info about a specific package.
+#       spk          Raw SPK file (immutable).
+#       metadata     Serialized Package.VerifiedInfo (immutable).
+#       status       Serialized SubmissionStatus (mutable).
+#   keybase/
+#     <keyId>        Serialized KeybaseIdentity for a person.
+#   www/
+#     apps/
+#       index        GZIP-JSON of AppIndexForMatker.
+#       <appId>      GZIP-JSON of AppDetailsForMarket for given app.
+#     images/
+#       <imageId>    An image.
+#     packages/
+#       <packageId>  Hard link to released SPK.
+#   tmp/             Temp files staged to be moved elsewhere or deleted.
+#
+# TODO(cleanup): Currently we actually append file extensions like .json, .svg, and .png to the
+#   stuff under www, because Sandstorm web publishing depends on it. Eventually we should fix
+#   web publishing then remove the unnecessary extensions. Note that to keep code changes minimal,
+#   the JSON files list imageIds that include the extensions. The client must know to add ".json",
+#   though. Note also that we do NOT add ".spk" to packages currently, because there's no
+#   particular need.
+
+$import "/capnp/c++.capnp".namespace("sandstorm::appindex");
+
+using Package = import "/sandstorm/package.capnp";
+using Grain = import "/sandstorm/grain.capnp";
+using Util = import "/sandstorm/util.capnp";
+
+struct AppIndexForMarket {
+  # Type containing the index of all apps, downloaded by the market at startup.
+
+  apps @0 :List(App);
+
+  struct App {
+    appId @0 :Package.AppId;
+    name @1 :Text;      # title
+    version @2 :Text;   # marketing version
+    packageId @3 :Package.PackageId;
+    imageId @4 :Text;   # Image found at: /images/<imageId>
+    webLink @5 :Text;
+    codeLink @6 :Text;
+    isOpenSource @7 :Bool;
+    categories @8 :List(Text);
+    author @9 :Identity;
+    struct Identity {
+      name @0 :Text;
+      keybaseUsername @1 :Text;
+      picture @2 :Text;
+      githubUsername @3 :Text;
+      twitterUsername @4 :Text;
+      hackernewsUsername @5 :Text;
+      redditUsername @6 :Text;
+    }
+    shortDescription @10 :Text;
+  }
+}
+
+struct AppDetailsForMarket {
+  # Type containing detailed information downloaded by the app market when the user browses to a
+  # specific app page.
+
+  description @0 :Text;
+
+  screenshots @1 :List(Screenshot);
+  struct Screenshot {
+    imageId @0 :Text;      # Image found at: /images/<imageId>
+    width @1 :UInt32;
+    height @2 :UInt32;
+  }
+
+  license @2 :Text;     # name only
+  createdAt @3 :Text;   # date like "2014-08-21T09:19:29.761Z"
+}
+
+struct KeybaseIdentity {
+  # Social identities verified using Keybase.
+  #
+  # Unfortunately, Keybase apparently verifies handles and not user IDs for Github, Twitter, etc.
+  # These services allow users to change their handles. Hopefully, Keybase users will not change
+  # their handles.
+
+  keybaseHandle @0 :Text;
+  name @1 :Text;
+  picture @2 :Text;
+
+  websites @3 :List(Text);
+  githubHandles @4 :List(Text);
+  twitterHandles @5 :List(Text);
+  hackernewsHandles @6 :List(Text);
+  redditHandles @7 :List(Text);
+}
+
+# ========================================================================================
+
+struct CategoryTable {
+  categories @0 :List(Package.Category);
+}
+
+const appIndexViewInfo :Grain.UiView.ViewInfo = (
+  permissions = [(name = "approve", title = (defaultText = "approve"),
+                  description = (defaultText = "allows approving apps")),
+                 (name = "review", title = (defaultText = "review"),
+                  description = (defaultText = "allows viewing the submission queue")),
+                 (name = "submit", title = (defaultText = "submit"),
+                  description = (defaultText = "allows submitting apps"))],
+  roles = [(title = (defaultText = "approver"),
+            permissions = [true, true, false],
+            verbPhrase = (defaultText = "can approve"),
+            default = true),
+           (title = (defaultText = "reviewer"),
+            permissions = [false, true, false],
+            verbPhrase = (defaultText = "can review")),
+           (title = (defaultText = "submitter"),
+            permissions = [false, false, true],
+            verbPhrase = (defaultText = "can submit"))]
+);
+
+const approvePermission :UInt32 = 0;
+const reviewPermission :UInt32 = 1;
+const submitPermission :UInt32 = 2;
+
+const reviewAppHtml :Text = embed "review.html";
+
+const pkgdef :Package.PackageDefinition = (
+  id = "ghze43a24vg5rck3w5kegeuhu1hy52nh17j8qm7vf40ekc3r5z3h",
+
+  manifest = (
+    appTitle = (defaultText = "Sandstorm App Index"),
+    appVersion = 0,
+    appMarketingVersion = (defaultText = "0.0.0"),
+
+    actions = [
+      ( title = (defaultText = "New Sandstorm App Index"),
+        command = (argv = ["/app-index", "--init"])
+      )
+    ],
+    continueCommand = (argv = ["/app-index"])
+  ),
+
+  fileList = "app-index-sandstorm-files.list",
+
+  sourceMap = (
+    searchPath = [
+      ( packagePath = "app-index", sourcePath = "app-index" ),
+      ( sourcePath = "/",    # Then search the system root directory.
+        hidePaths = [ "home", "proc", "sys" ]
+      )
+    ]
+  ),
+
+  alwaysInclude = ["app-index"]
+);

--- a/src/sandstorm/app-index/category-table.c++
+++ b/src/sandstorm/app-index/category-table.c++
@@ -1,0 +1,106 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sandstorm/app-index/app-index.capnp.h>
+#include <kj/main.h>
+#include <capnp/message.h>
+#include <capnp/serialize.h>
+#include <capnp/schema.capnp.h>
+#include <capnp/schema-loader.h>
+#include <capnp/dynamic.h>
+#include <unistd.h>
+#include <kj/debug.h>
+
+namespace sandstorm {
+namespace appindex {
+
+class CategoryTableMain {
+  // Main class for a simple program that produces a SparseData from an input sparse file.
+  // The output is written as a single-segment message (no leading segment table).
+
+public:
+  CategoryTableMain(kj::ProcessContext& context): context(context) {}
+
+  kj::MainFunc getMain() {
+    return kj::MainBuilder(context, "unknown version",
+                           "Build a table of category metadata from package.capnp. Actually "
+                           "this operates as a code generator plugin, but the output is a "
+                           "serialized CategoryTable.")
+        .callAfterParsing(KJ_BIND_METHOD(*this, run))
+        .build();
+  }
+
+  kj::MainBuilder::Validity run() {
+    capnp::ReaderOptions options;
+    options.traversalLimitInWords = 1 << 30;  // Don't limit.
+    capnp::StreamFdMessageReader reader(STDIN_FILENO, options);
+    auto request = reader.getRoot<capnp::schema::CodeGeneratorRequest>();
+
+    capnp::SchemaLoader loader;
+    for (auto node: request.getNodes()) {
+      loader.load(node);
+    }
+
+    kj::Vector<CategoryInfo> categories;
+
+    capnp::Schema categorySchema = loader.get(capnp::typeId<spk::Category>());
+    for (auto nested: categorySchema.getProto().getNestedNodes()) {
+      capnp::Schema child = loader.get(nested.getId());
+      auto proto = child.getProto();
+      if (proto.isConst()) {
+        auto annotations = proto.getAnnotations();
+        KJ_ASSERT(annotations.size() == 1);
+        auto annotation = annotations[0];
+        KJ_ASSERT(annotation.getId() == 0x8d51dd236606d205ull);
+        auto value = annotation.getValue();
+        KJ_ASSERT(value.isStruct());
+
+        categories.add(CategoryInfo {
+          child.asConst().as<uint64_t>(),
+          nested.getName(),
+          value.getStruct().getAs<spk::Category::Metadata>()
+        });
+      }
+    }
+
+    capnp::MallocMessageBuilder result;
+    auto builder = result.initRoot<CategoryTable>().initCategories(categories.size());
+    for (auto i: kj::indices(categories)) {
+      auto item = builder[i];
+      item.setId(categories[i].id);
+      item.setName(categories[i].name);
+      item.setMetadata(categories[i].metadata);
+    }
+
+    capnp::writeMessageToFd(STDOUT_FILENO, result);
+
+    return true;
+  }
+
+private:
+  kj::ProcessContext& context;
+
+  struct CategoryInfo {
+    uint64_t id;
+    kj::StringPtr name;
+    spk::Category::Metadata::Reader metadata;
+  };
+};
+
+}  // namespace appindex
+}  // namespace sandstorm
+
+KJ_MAIN(sandstorm::appindex::CategoryTableMain)

--- a/src/sandstorm/app-index/category-table.capnp
+++ b/src/sandstorm/app-index/category-table.capnp
@@ -1,0 +1,19 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xe25ce39cd469ebc8;
+
+const categoryTable :import "app-index.capnp".CategoryTable = embed "category-table.data";

--- a/src/sandstorm/app-index/category-table.ekam-rule
+++ b/src/sandstorm/app-index/category-table.ekam-rule
@@ -1,0 +1,48 @@
+#! /bin/sh
+#
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+echo findProvider canonical:sandstorm/app-index/category-table
+read MKTABLE
+
+if test "$MKTABLE" = ""; then
+  echo "error:  couldn't find category-table." >&2
+  exit 1
+fi
+
+echo findProvider special:ekam-interceptor
+read INTERCEPTOR
+
+if test "$INTERCEPTOR" = ""; then
+  echo "error:  couldn't find intercept.so." >&2
+  exit 1
+fi
+
+echo findProvider file:compiler/capnp
+read CAPNP
+
+if test "$CAPNP" = ""; then
+  echo "error:  couldn't find capnp." >&2
+  exit 1
+fi
+
+echo newOutput sandstorm/app-index/category-table.data
+read OUTPUT
+
+LD_PRELOAD=$INTERCEPTOR $CAPNP compile -I. -o$MKTABLE sandstorm/package.capnp 3>&1 4<&0 >$OUTPUT

--- a/src/sandstorm/app-index/indexer.h
+++ b/src/sandstorm/app-index/indexer.h
@@ -1,0 +1,70 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SANDSTORM_APPINDEX_INDEXER_H_
+#define SANDSTORM_APPINDEX_INDEXER_H_
+
+#include <kj/common.h>
+#include <sandstorm/util.capnp.h>
+#include <sandstorm/util.h>
+#include <sandstorm/app-index/submit.capnp.h>
+
+namespace sandstorm {
+namespace appindex {
+
+class Indexer: public AppIndex::Server {
+public:
+  void addKeybaseProfile(kj::StringPtr fingerprint, capnp::MallocMessageBuilder& message);
+
+  bool tryGetAppId(kj::StringPtr packageId, byte appId[32]);
+
+  void approve(kj::StringPtr packageId, kj::StringPtr url);
+  void unapprove(kj::StringPtr packageId);
+  void reject(kj::StringPtr packageId, kj::StringPtr reason);
+  bool setSubmissionState(kj::StringPtr packageId, SubmissionState state, uint64_t sequence);
+  // Modify the status of some package.
+
+  void getSubmissionStatus(kj::StringPtr packageId, capnp::MessageBuilder& output);
+
+  void updateIndex();
+  // Rebuild the main index.
+
+  kj::String getReviewQueueJson();
+
+  AppIndex::Submission::Client getSubmission(spk::PackageId::Reader packageId);
+  // Temporary interface allowing caller to get access to Submission capability. Only callable
+  // in-process. The caller is expected to verify signatures by checking the app ID. Eventually
+  // this will be replaced by a Cap'n Proto interface.
+
+  AppIndex::UploadStream::Client newUploadStream();
+
+protected:
+  // implements AppIndex -------------------------------------------------------
+  kj::Promise<void> upload(UploadContext context) override;
+
+private:
+  class UploadStreamImpl;
+
+  kj::String writeIcon(spk::Metadata::Icon::Reader icon);
+  kj::String writeScreenshot(spk::Metadata::Screenshot::Reader screenshot);
+  kj::String writeImage(kj::ArrayPtr<const byte> data, kj::StringPtr extension);
+  kj::Array<capnp::Text::Reader> categoryNames(capnp::List<uint64_t>::Reader categoryIds);
+};
+
+} // namespace appindex
+} // namespace sandstorm
+
+#endif // SANDSTORM_APPINDEX_INDEXER_H_

--- a/src/sandstorm/app-index/review.html
+++ b/src/sandstorm/app-index/review.html
@@ -1,0 +1,322 @@
+<html>
+  <head>
+    <style type="text/css">
+      body {
+        font-family: "Trebuchet MS", sans-serif;
+      }
+      table {
+        border-collapse: collapse;
+        border-top: 2px solid black;
+        border-bottom: 2px solid black;
+      }
+      td {
+        padding: 8px;
+        border-bottom: 1px solid #888;
+        white-space: pre-wrap;
+        overflow-x: auto;
+        max-width: 1000px;
+        word-wrap: break-word;
+      }
+      td:first-child {
+        font-weight: bold;
+      }
+    </style>
+    <script type="text/javascript">
+      // XMLHttpRequest's API is annoying. $.ajax() is easier except that its error handling makes
+      // no sense.
+      //
+      // I based this somewhat on:
+      //   https://plus.google.com/u/0/+JeffreyYasskin/posts/XjWc5oGs3dP
+      //
+      // (He just happened to post this on the same day I needed it.)
+      function fetch(url, options) {
+        options = options || {};
+        return new Promise(function(resolve, reject) {
+          var xhr = new XMLHttpRequest();
+          xhr.onload = function () {
+            if (xhr.status >= 400) {
+              reject(new Error("XHR returned status " + xhr.status + ":\n" + xhr.responseText));
+            } else {
+              resolve(xhr);
+            }
+          };
+          xhr.onerror = function(e) {
+            reject(new Error("XHR failed: " + (options.method || "get") + " " + url));
+          };
+          if (options.hasOwnProperty('responseType'))
+            xhr.responseType = options.responseType;
+          var method = 'get';
+          if (options.hasOwnProperty('method'))
+            method = options.method;
+          xhr.open(method, url)
+          var data = undefined;
+          if (options.hasOwnProperty('data'))
+            data = options.data;
+          xhr.send(data);
+        });
+      }
+
+      function doGet(url) {
+        return fetch(url);
+      }
+      function doPost(url, data) {
+        return fetch(url, { method: "post", data: data });
+      }
+      function doPut(url, data) {
+        return fetch(url, { method: "put", data: data });
+      }
+      function doDelete(url) {
+        return fetch(url, { method: "delete" });
+      }
+
+      function textElement(tag, content) {
+        var elem = document.createElement(tag);
+        elem.appendChild(document.createTextNode(content));
+        return elem;
+      }
+      function parentElement(tag) {
+        var elem = document.createElement(tag);
+        Array.prototype.slice.call(arguments, 1).forEach(elem.appendChild.bind(elem));
+        return elem;
+      }
+
+      function mergeObject(output, input, prefix) {
+        for (var field in input) {
+          var name = field === "" ? prefix : prefix + "." + field;
+          output[name] = input[field];
+        }
+      }
+
+      var fieldHandlers = {
+        svg: function (data) {
+          var img = document.createElement("img");
+          img.src = "data:image/svg+xml;utf8," + data;
+          return img;
+        },
+
+        packageId: function (id) {
+          var span = textElement("span", id + " ");
+
+          var button = textElement("button", "approve");
+          button.addEventListener("click", function (event) {
+            event.preventDefault();
+            event.stopPropagation();
+            doPost("/approve/" + id).then(function () {
+              console.log("approved:", id);
+              document.location.reload();
+            }, function (err) {
+              alert(err.stack);
+            });
+          });
+          span.appendChild(button);
+
+          var reject = textElement("button", "reject");
+          reject.addEventListener("click", function (event) {
+            var reason = window.prompt("reason:");
+            if (reason) {
+              event.preventDefault();
+              event.stopPropagation();
+              doPost("/reject/" + id, reason).then(function () {
+                console.log("rejected:", id);
+                document.location.reload();
+              }, function (err) {
+                alert(err.stack);
+              });
+            }
+          });
+          span.appendChild(reject);
+
+          return span;
+        },
+
+        authorPgpKeyFingerprint: function (fp) {
+          var div = document.createElement("div");
+          div.appendChild(textElement("p", fp));
+
+          if (fp.match(/^[0-9A-F]{40}$/)) {
+            doGet("https://keybase.io/_/api/1.0/user/lookup.json?key_fingerprint=" + fp +
+                  "&fields=pictures,profile,proofs_summary").then(function (xhr) {
+              var data = JSON.parse(xhr.responseText);
+              if (data.them.length == 0) {
+                div.appendChild(textElement("p", "(no Keybase match)"));
+                return;
+              }
+
+              var upload = [];
+              var them = data.them[0];
+
+              upload.push("username:" + them.basics.username);
+              var url = "https://keybase.io/" + them.basics.username;
+              var link = textElement("a", url);
+              link.href = url;
+              link.target = "_blank";
+              div.appendChild(parentElement("p", link));
+
+              if (them.profile && them.profile.full_name) {
+                upload.push("name:" + them.profile.full_name.replace("\n", ""));
+                div.appendChild(textElement("p", them.profile.full_name));
+              }
+
+              if (them.pictures && them.pictures.primary) {
+                upload.push("picture:" + them.pictures.primary.url);
+                var img = document.createElement("img");
+                img.src = them.pictures.primary.url;
+                div.appendChild(parentElement("p", img));
+              }
+
+              function addProof(name, obj) {
+                var value = obj.nametag;
+                var url = obj.service_url;
+                upload.push("proof." + name + ":" + value);
+                var link = textElement("a", value);
+                if (url.slice(0, 4) == "http") link.href = url;
+                link.target = "_blank";
+                div.appendChild(parentElement("p", document.createTextNode(name + ": "), link));
+              }
+
+              if (them.proofs_summary && them.proofs_summary.by_proof_type) {
+                var proofs = them.proofs_summary.by_proof_type;
+
+                for (var type in proofs) {
+                  var proofSet = proofs[type];
+                  for (var i in proofSet) {
+                    var proof = proofSet[i];
+                    if (proof.nametag && proof.service_url) {
+                      addProof(type, proof);
+                    }
+                  }
+                }
+              }
+
+              doPost("/keybase/" + fp, upload.join("\n"));
+            }).catch(function (err) {
+              div.appendChild(textElement("pre", err.stack));
+            });
+          }
+
+          return div;
+        }
+      };
+
+      function renderJson(value) {
+        var type = typeof value;
+        if (value === null) {
+          return {"": textElement("code", "null")};
+        } else if (type === "boolean" || type === "number") {
+          return {"": textElement("code", value.toString())};
+        } else if (type === "string") {
+          return {"": textElement("span", value)};
+        } else if (value instanceof Array) {
+          var complex = false;
+          var rendered = value.map(function (element) {
+            var rendered = renderJson(element);
+            var keys = Object.keys(rendered);
+            if (keys.length !== 1 || keys[0] !== "" || rendered[""].tagName === "DIV") {
+              complex = true;
+            }
+            return rendered;
+          });
+
+          if (complex) {
+            var div = document.createElement("div");
+            for (var i = 0; i < rendered.length; i++) {
+              div.appendChild(renderTable(rendered[i]));
+            }
+            return {"": div};
+          } else {
+            var element = document.createElement("span");
+            element.appendChild(document.createTextNode("["));
+            for (var i = 0; i < rendered.length; i++) {
+              if (i > 0) {
+                element.appendChild(document.createTextNode(", "));
+              }
+              element.appendChild(rendered[i][""]);
+            }
+            element.appendChild(document.createTextNode("]"));
+            return {"": element};
+          }
+        } else if (typeof value === "object") {
+          var result = {};
+          for (var field in value) {
+            if (field in fieldHandlers) {
+              result[field] = fieldHandlers[field](value[field]);
+            } else {
+              mergeObject(result, renderJson(value[field]), field);
+            }
+          }
+          return result;
+        } else {
+          return {"": textElement("code", "????")};
+        }
+      }
+
+      function renderTable(fields) {
+        var tblBody = document.createElement("tbody");
+        for (fieldName in fields) {
+          var row = document.createElement("tr");
+          row.appendChild(textElement("td", fieldName));
+          row.appendChild(parentElement("td", fields[fieldName]));
+          tblBody.appendChild(row);
+        }
+
+        var tbl = document.createElement("table");
+        tbl.appendChild(tblBody);
+        return tbl;
+      }
+
+      function renderQueue(queue) {
+        queue.forEach(function (app) {
+          var section = document.createElement("section");
+          section.appendChild(renderTable(renderJson(app)));
+          document.body.appendChild(section);
+        });
+      }
+
+      function fetchQueue() {
+        return doGet("/queue").then(function (xhr) {
+          renderQueue(JSON.parse(xhr.responseText));
+        }).catch(function (err) {
+          alert(err.message);
+          throw err;
+        });
+      }
+
+      function fetchPublicId() {
+        return doGet("/public-id").then(function (xhr) {
+          var info = JSON.parse(xhr.responseText);
+          var link = document.getElementById("public-url");
+          link.textContent = info.autoUrl;
+          link.href = info.autoUrl;
+          link.target = "_blank";
+        }).catch(function (err) {
+          alert(err.message);
+          throw err;
+        });
+      }
+
+      function unapprove(form, event) {
+        event.preventDefault();
+        var packageId = form.packageId.value;
+        form.reset();
+        doPost("/unapprove/" + packageId).then(function (xhr) {
+          document.location.reload();
+        }, function (err) {
+          alert(err.stack);
+        })
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Review apps</h1>
+
+    <p>Index at: <a id="public-url"></a></p>
+
+    <form onsubmit="unapprove(this, event);">
+      Unapprove: <input placeholder="package ID" name="packageId">
+    </form>
+
+    <h2>Queue:</h2>
+
+    <script type="text/javascript">fetchQueue(); fetchPublicId();</script>
+  </body>
+</html>

--- a/src/sandstorm/app-index/submit.capnp
+++ b/src/sandstorm/app-index/submit.capnp
@@ -1,0 +1,143 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xbb368e3a12c66692;
+
+$import "/capnp/c++.capnp".namespace("sandstorm::appindex");
+
+using Package = import "/sandstorm/package.capnp";
+using Util = import "/sandstorm/util.capnp";
+
+interface AppIndex {
+  upload @0 () -> (stream :UploadStream);
+
+  interface UploadStream extends(Util.ByteStream) {
+    getResult @0 ();
+  }
+
+  interface Submission {
+    # Represents a particular package that has been submitted. Only given out to those who prove
+    # they possess the app's private key.
+
+    checkStatus @0 () -> (status :SubmissionStatus);
+    setState @1 (state :SubmissionState);
+  }
+}
+
+# ========================================================================================
+# Temporary HTTP app request API
+#
+# Because we don't have cross-internet encrypted Cap'n Proto yet, currently the spk tool
+# communicates with the app server over HTTPS. The interaction works like this:
+#
+#     POST /upload
+#
+# Uploads an app package. Must do this first. Returns status code 200 if successful or status
+# 400 with a human-readable error explanation if the app was immediately rejected. Possible
+# rejection reasons include:
+# - The upload was not a Sandstorm package file.
+# - The package signature was invalid.
+# - The PGP signature was invalid.
+# - No contact email was provided.
+# - The package version was not greater than the last published version of the app.
+#
+#     POST /status
+#
+# Posts a capnp-encoded, signed SubmissionRequest. Returns a capnp-encoded SubmissionStatus.
+
+enum SubmissionState {
+  # The state of an app submission, as set by the author.
+
+  ignore @0;    # Author wants app index to ignore this spk for now (default state).
+  review @1;    # Author is ready for spk to be reviewed by admins, but not published.
+  publish @2;   # Author wants spk to be published as soon as it has passed review.
+}
+
+struct SubmissionRequest {
+  # Sent in a POST request after initial upload.
+  #
+  # The POST body is a packed-encoded SubmissionRequest, followed by an ed25519 detached signature
+  # of the preceding bytes generated using libsodium's crypto_sign_detached() with the app's
+  # private key. This proves that the request really came from the app author.
+  #
+  # WARNING: This protocol is probably BAD CRYPTO. It is intended as a stopgap until a Cap'n Proto
+  # crypto transport exists, at which point we can do something better. Note that this crypto is
+  # not intended to avoid the need for HTTPS with server authentication (though it is roughly
+  # intended to avoid the need for HTTPS client authentication, since we'd rather authenticate
+  # based on app key). If this crypto is totally broken, the worst case is someone can publish
+  # or un-publish a package they don't build.
+
+  packageId @0 :Package.PackageId;
+
+  union {
+    checkStatus @1 :Void;
+    # Just check the status of this package.
+
+    setState :group {
+      newState @2 :SubmissionState;
+      # Update the submission state of the package.
+
+      sequenceNumber @4 :UInt64;
+      # A number which must be monotonically increasing for each SubmissionRequest sent for the
+      # same package to the same index. It is acceptable to skip numbers in the sequence, therefore
+      # you can use a timestamp as a sequence number.
+    }
+  }
+
+  appIndexWebkeyHash @3 :Data;
+  # Blake2b hash prefix of the webkey (endpoint#token) to which this request was intended to be
+  # submitted. Meant to prevent one app index from forwarding requests to some other app index
+  # behind the developer's back. Preferably at least 16 bytes, but any prefix is accepted (more
+  # bytes protects the client better).
+}
+
+struct SubmissionStatus {
+  # The reply to HTTP PUT and POST requests to /submit/<packageId> is either a packed-encoded
+  # SubmissionStatus or an error.
+
+  requestState @0 :SubmissionState;
+
+  union {
+    pending @1 :Void;
+    # The app submission is pending. Updates will be emailed to the contact address listed
+    # in the package metadata. (However, if `requestState` is `ignore`, no updates will be sent
+    # as no review will occur.)
+
+    needsUpdate @2 :Text;
+    # Human reviewers decided that the app cannot be published yet for reasons described in the
+    # text. Generally these are cosmetic issues, e.g. "the description text is incomplete" or
+    # "this submission appears to be a duplicate". Sandstorm does not outright reject apps and
+    # does not place any restrictions on what functionality apps may implement, other than the
+    # technical restrictions implemented by the platform and a general "no exploits" policy.
+    #
+    # The author must upload a new package resolving the issues. Therefore, once a submission hits
+    # the "needsUpdate" state, it is permanent.
+
+    approved @3 :Text;
+    # The app is approved for publishing. If `requestState` is `publish`, then the app has been
+    # published. The text is the URL where the app is / will be published.
+
+    notUploaded @5 :Void;
+    # The requested package is not present on the server. You must upload it first.
+  }
+
+  publishDate @4 :Int64 = 0;
+  # Unix time at which app was first published -- i.e. the first time `requestState` was `publish`
+  # *and* `approved` was set. If zero, this has never happened.
+
+  nextSequenceNumber @6 :UInt64 = 0;
+  # The next SubmissionRequest that modifies the status must use a sequenceNumber of at least this.
+}

--- a/src/sandstorm/package.capnp
+++ b/src/sandstorm/package.capnp
@@ -453,7 +453,7 @@ struct OsiLicenseInfo {
   # Whether or not you are required to provide a `codeUrl` when specifying this license.
 }
 
-annotation osiInfo(enumerant) :OsiLicenseInfo;
+annotation osiInfo @0x9476412d0315d869 (enumerant) :OsiLicenseInfo;
 # Annotation applied to each item in the OpenSourceLicense enum.
 
 enum OpenSourceLicense {

--- a/src/sandstorm/spk.h
+++ b/src/sandstorm/spk.h
@@ -33,7 +33,7 @@ kj::String unpackSpk(int spkfd, kj::StringPtr outdir, kj::StringPtr tmpdir);
 void verifySpk(int spkfd, int tmpfile, spk::VerifiedInfo::Builder output);
 // Temporarily uncompress the spk, check its signature, and fill in `output` with relevant info.
 
-kj::String appIdString(spk::PackageId::Reader appId);
+kj::String appIdString(spk::AppId::Reader appId);
 kj::String packageIdString(spk::PackageId::Reader packageId);
 
 }  // namespace sandstorm

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -152,9 +152,12 @@ kj::String readAll(int fd);
 kj::String readAll(kj::StringPtr name);
 // Read entire contents of a named file to a String.
 
-kj::Array<kj::String> splitLines(kj::String input);
+kj::Array<byte> readAllBytes(int fd);
+// Read entire contents of the file descirptor to a byte array.
+
+kj::Array<kj::String> splitLines(kj::StringPtr input);
 // Split the input into lines, trimming whitespace, and ignoring blank lines or lines that start
-// with #. Consumes the input string.
+// with #.
 
 kj::Vector<kj::ArrayPtr<const char>> split(kj::ArrayPtr<const char> input, char delim);
 // Split the char array on an arbitrary delimiter character.


### PR DESCRIPTION
The app index is itself a Sandstorm app. It presents an API through which apps can be submitted (with the new `spk publish` being the client to this API) and presents a review interface to the admin. Once apps are approved, they are published via web publishing such that the app market client can download and display the index, and Sandstorm servers can install packages from the index.

Currently `spk publish` only works with a webkey pointing to an app index instance, but once we have a standard one up we'll embed the webkey directly into the spk source code.

This code is generally not done and is kind of messy at present, but it basically works.