### PR TITLE
Add new "open grain" UI

### DIFF
--- a/shell/.meteor/packages
+++ b/shell/.meteor/packages
@@ -24,5 +24,6 @@ sandstorm-db
 sandstorm-identicons
 sandstorm-ui-topbar
 sandstorm-ui-applist
+sandstorm-ui-grainlist
 fourseven:scss
 sandstorm-tabs

--- a/shell/.meteor/versions
+++ b/shell/.meteor/versions
@@ -72,6 +72,7 @@ sandstorm-email@0.1.0
 sandstorm-identicons@0.1.0
 sandstorm-tabs@0.1.0
 sandstorm-ui-applist@0.1.0
+sandstorm-ui-grainlist@0.1.0
 sandstorm-ui-topbar@0.1.0
 service-configuration@1.0.4
 session@1.1.0

--- a/shell/client/_grainlist.scss
+++ b/shell/client/_grainlist.scss
@@ -1,0 +1,47 @@
+.grain-list {
+  overflow: auto;
+  padding: 0px 32px;
+  >input.search-bar {
+    font-size: 16pt;
+    width: 100%;
+  }
+  >table {
+    width: 100%;
+    padding: 0;
+    margin: 8px 0 0 0;
+    border-collapse: collapse;
+    background-color: rgba(255, 255, 255, 0.5);
+    >thead>tr {
+      font-weight: 600;
+      border-bottom: 1px solid #aaa;
+      >td.td-app-icon {
+        padding-left: 16px;
+      }
+    }
+    >tbody>tr {
+      width: 100%;
+      height: 32px;
+      border-bottom: 1px solid #ddd;
+      >td {
+        cursor: pointer;
+        &.td-app-icon {
+          >img.app-icon {
+            width: 24px;
+            height: 24px;
+          }
+          width: 48px;
+          padding-left: 16px;
+        }
+        &.grain-name {
+          width: 400px;
+        }
+      }
+      &.grain {
+        cursor: pointer;
+        &:hover {
+          background-color: #f0f0f0;
+        }
+      }
+    }
+  }
+}

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -617,6 +617,12 @@ limitations under the License.
   </div>
 </template>
 
+<template name="selectGrain">
+  <div class="main-content">
+    {{> sandstormGrainList}}
+  </div>
+</template>
+
 <template name="_grainSpinner">
   <!-- This is a terrible hack to center this thing. The styles shold go in css, but it's
     arguably more confusing to put them there when all they're doing is this archaic pattern to

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -171,10 +171,14 @@ img {
   margin-bottom: 0;
 }
 
+// old app list
 @import "_applist-apps.scss";
+// old grain list (by application)
 @import "_applist-grains.scss";
 // new app list (unified)
 @import "_applist.scss";
+// new grainlist (unified)
+@import "_grainlist.scss";
 
 #storage-usage {
   margin: 16px 4px;

--- a/shell/lib/db-deprecated.js
+++ b/shell/lib/db-deprecated.js
@@ -73,6 +73,7 @@ if (Meteor.isServer) {
 }
 
 globalAppList = new SandstormAppList(globalDb);
+globalGrainList = new SandstormGrainList(globalDb);
 
 if (Meteor.isClient) {
   globalTopbar = new SandstormTopbar({

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -585,6 +585,12 @@ SandstormDb = function () {
   this.currentUserGrains = function currentUserGrains (query, aggregations) {
     return this.userGrains(Meteor.userId(), query, aggregations);
   };
+  this.userApiTokens = function userApiTokens (user) {
+    return this.collections.apiTokens.find({'owner.user.userId': user});
+  };
+  this.currentUserApiTokens = function currentUserApiTokens () {
+    return this.userApiTokens(Meteor.userId());
+  };
   this.userActions = function userActions (user, query, aggregations) {
     var filteredQuery = { $and: [ {userId: user}, query ] };
     return this.collections.userActions.find(filteredQuery, aggregations);

--- a/shell/packages/sandstorm-ui-applist/applist.js
+++ b/shell/packages/sandstorm-ui-applist/applist.js
@@ -153,15 +153,14 @@ SandstormAppList = function(db) {
       // N.B.: calls into shell.js.  TODO: refactor
       return appNameFromActionName(action.title);
     };
-    var orClauseFor = function (searchString) {
+    var andClauseFor = function (searchString) {
       var searchKeys = searchString.split(" ").filter(function(k) { return k != "";});
       var searchRegexes = searchKeys.map(function(key) {
-         return { "appTitle": { $regex: key , $options: 'i' } };
-      }).concat(searchKeys.map(function(key) {
-         return { "title": { $regex: key , $options: 'i' } };
-      }));
-      var orClause = searchRegexes.length > 0 ? { $or: searchRegexes} : {};
-      return orClause;
+         return {$or: [{ "appTitle": { $regex: key , $options: 'i' } },
+                       { "title": { $regex: key , $options: 'i' } }]};
+      });
+      var andClause = searchRegexes.length > 0 ? { $and: searchRegexes } : {};
+      return andClause;
     };
     var actionToTemplateObject = function(action) {
       var title = appTitleForAction(action);
@@ -177,8 +176,8 @@ SandstormAppList = function(db) {
       return result;
     };
     var matchActions = function (searchString, sortOrder) {
-        var orClause = orClauseFor(searchString);
-        var actions = db.currentUserActions(orClause, { sort: sortOrder } );
+        var andClause = andClauseFor(searchString);
+        var actions = db.currentUserActions(andClause, { sort: sortOrder } );
         return actions;
     };
     var nounFromAction = function (action, appTitle) {

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.html
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.html
@@ -1,0 +1,32 @@
+<template name="sandstormGrainList">
+  <div class="grain-list">
+    <h2>Grains</h2>
+    <input class="search-bar" type="text" placeholder="search" value="{{ searchText }}" />
+    <table class="grain-list-table">
+      <thead>
+        <tr>
+            <td class="td-app-icon">App</td>
+            <td class="grain-name">Name</td>
+            <td>Last Activity</td>
+            {{!-- Collaborators, size TODO
+            <td>Collaborators</td>
+            <td>Size</td>
+            --}}
+        </tr>
+      </thead>
+      <tbody>
+        {{#each filteredSortedGrains}}
+        <tr class="grain" data-grainid="{{ _id }}">
+          <td class="td-app-icon"><img class="app-icon" src="{{ iconSrc }}" title="{{appTitle}}"></td>
+          <td class="grain-name"><a href="{{ pathFor route='grain' grainId=_id }}">{{title}}</a></td>
+          <td>{{dateString lastUsed}}</td>
+          {{!-- Collaborators, size TODO
+          <td>TODO: collaborators</td>
+          <td>{{ size }}</td>
+          --}}
+        </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.js
@@ -1,0 +1,196 @@
+SandstormGrainList = function (db) {
+  this._filter = new ReactiveVar("");
+  this._staticHost = db.makeWildcardHost('static');
+  var ref = this;
+  if (Meteor.isServer) {
+    // Publish _id, packageId, and lastUsed for grains that you have an API token for.
+    Meteor.publish('sharedGrainInfo', function() {
+      // TODO: figure out what to do for not-logged-in users viewing a grain with a sharing link.
+      // For now, return an empty set for non-logged-in users.
+      if (!this.userId) { return []; }
+      var self = this;
+      var grainRefcounts = {};
+      var grainSubs = {};
+      var refGrain = function (grainId) {
+        if (grainRefcounts[grainId] === undefined) {
+          grainRefcounts[grainId] = 0;
+          var thisGrainQuery = db.collections.grains.find({_id: grainId});
+          var thisGrainSub = thisGrainQuery.observe({
+            added: function(grain) {
+              self.added("grains", grain._id, {
+                packageId: grain.packageId,
+                lastUsed: grain.lastUsed,
+              });
+            },
+            removed: function(grain) {
+              self.removed("grains", grain._id);
+            },
+            updated: function(oldGrain, newGrain) {
+              if (oldGrain.packageId !== newGrain.packageId || oldGrain.lastUsed !== newGrain.lastUsed) {
+                self.changed("grains", newGrain._id, {
+                  packageId: newGrain.packageId,
+                  lastUsed: newGrain.lastUsed,
+                });
+              }
+            }
+          });
+          grainSubs[grainId] = thisGrainSub;
+        }
+        grainRefcounts[grainId] = grainRefcounts[grainId] + 1;
+      };
+      var unrefGrain = function (grainId) {
+        grainRefcounts[grainId] = grainRefcounts[grainId] - 1;
+        if (grainRefcounts[grainId] === 0) {
+          delete grainRefcounts[grainId];
+          var sub = grainSubs[grainId];
+          delete grainSubs[grainId];
+          sub.stop();
+        }
+      };
+
+      var apiTokens = db.collections.apiTokens.find({'owner.user.userId': this.userId});
+      var apiTokensHandle = apiTokens.observe({
+        added: function(newToken) {
+          refGrain(newToken.grainId);
+        },
+        removed: function(oldToken) {
+          unrefGrain(oldToken.grainId);
+        },
+        updated: function(oldToken, newToken) {
+          if (oldToken.grainId !== newToken.grainId) {
+            unrefGrain(oldToken.grainId);
+            refGrain(newToken.grainId);
+          }
+        }
+      });
+      this.onStop(function () {
+        apiTokensHandle.stop();
+        var cleanupSubs = function(subs) {
+          var ids = Object.keys(subs);
+          for (var i = 0 ; i < ids.length ; i++) {
+            var id = ids[i];
+            subs[id].stop();
+            delete subs[id];
+          }
+        };
+        cleanupSubs(grainSubs);
+      });
+      self.ready();
+    });
+  }
+  if (Meteor.isClient) {
+    var compileMatchFilter = function (searchString) {
+      // split up searchString into an array of regexes, use them to match against item
+      var searchKeys = searchString.toLowerCase()
+          .split(" ")
+          .filter(function(k) { return k != "";});
+      return function matchFilter(item) {
+        // special case: no text in filter should pass all items
+        if (searchKeys.length === 0) return true;
+        // Keep any item that matches any given substring
+        var haystack = item.title.toLowerCase();
+        for (var i = 0 ; i < searchKeys.length ; i++) {
+          if (haystack.indexOf(searchKeys[i]) !== -1) {
+            return true;
+          }
+        }
+        return false;
+      };
+    };
+    var mapGrainsToTemplateObject = function (grains) {
+      // Do package lookup all at once, rather than doing N queries for N grains
+      var packageIds = _.chain(grains)
+          .pluck('packageId')
+          .uniq()
+          .value();
+      var packages = db.collections.packages.find({ _id: { $in: packageIds } }).fetch();
+      var packagesById = _.indexBy(packages, '_id');
+      return grains.map(function(grain) {
+        var pkg = packagesById[grain.packageId];
+        var iconSrc = pkg ? iconSrcForPackage(pkg, 'grain', ref._staticHost) : "";
+        var appTitle = (pkg && pkg.manifest && pkg.manifest.appTitle && pkg.manifest.appTitle.defaultText) || "";
+        return {
+          _id: grain._id,
+          title: grain.title,
+          appTitle: appTitle,
+          lastUsed: grain.lastUsed,
+          size: "0kb",
+          iconSrc: iconSrc,
+        };
+      });
+    };
+    var mapApiTokensToTemplateObject = function (apiTokens) {
+      var tokensForGrain = _.groupBy(apiTokens, 'grainId');
+      var grainIdsForApiTokens = Object.keys(tokensForGrain);
+      var sharedGrains = db.collections.grains.find({_id: {$in: grainIdsForApiTokens}}).fetch();
+      var packageIds = _.chain(sharedGrains)
+          .pluck('packageId')
+          .uniq()
+          .value();
+      var packages = db.collections.packages.find({ _id: { $in: packageIds } }).fetch();
+      var packagesById = _.indexBy(packages, '_id');
+      return sharedGrains.map(function(grain) {
+        var pkg = packagesById[grain.packageId];
+        var iconSrc = pkg ? iconSrcForPackage(pkg, 'grain', ref._staticHost) : "";
+        var appTitle = (pkg && pkg.manifest && pkg.manifest.appTitle && pkg.manifest.appTitle.defaultText) || "";
+        // It's theoretically possible to have multiple API tokens for the same grain.
+        // Pick one arbitrarily to assign the grain petname from.
+        var token = tokensForGrain[grain._id][0];
+        return {
+          _id: grain._id,
+          title: token.owner.user.title,
+          appTitle: appTitle,
+          lastUsed: grain.lastUsed,
+          iconSrc: iconSrc,
+        };
+      });
+    };
+    var filteredSortedGrains = function() {
+        var grains = db.currentUserGrains({}, {}).fetch();
+        var itemsFromGrains = mapGrainsToTemplateObject(grains);
+        var apiTokens = db.currentUserApiTokens().fetch();
+        var itemsFromSharedGrains = mapApiTokensToTemplateObject(apiTokens);
+        var filter = compileMatchFilter(ref._filter.get());
+        return _.chain([itemsFromGrains, itemsFromSharedGrains])
+            .flatten()
+            .filter(filter)
+            .sortBy('lastUsed') // TODO: allow sorting by other columns
+            .reverse()
+            .value();
+    };
+    Template.sandstormGrainList.helpers({
+      filteredSortedGrains: filteredSortedGrains,
+      searchText: function() {
+        return ref._filter.get();
+      }
+    });
+    Template.sandstormGrainList.onCreated(function () {
+      Template.instance().subscribe("grainsMenu");
+      Template.instance().subscribe("userPackages");
+      Template.instance().subscribe("sharedGrainInfo");
+    });
+    Template.sandstormGrainList.events({
+      "click tr": function(event) {
+        var grainId = event.currentTarget.getAttribute('data-grainid');
+        Router.go("grain", {grainId: grainId});
+      },
+      // We use keyup rather than keypress because keypress's event.target.value will not have
+      // taken into account the keypress generating this event, so we'll miss a letter to filter by
+      "keyup .search-bar": function(event) {
+        ref._filter.set(event.target.value);
+      },
+      "keypress .search-bar": function(event) {
+        if (event.keyCode == 13) {
+          // Enter pressed.  If a single grain is shown, open it.
+          var grains = filteredSortedGrains();
+          if (grains.length == 1) {
+            // Unique grain found with current filter.  Activate it!
+            var grainId = grains[0]._id;
+            // router.go grain/grainId?
+            Router.go("grain", {grainId: grainId});
+          }
+        }
+      }
+    });
+  }
+};

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.js
@@ -2,19 +2,30 @@ SandstormGrainList = function (db) {
   this._filter = new ReactiveVar("");
   this._staticHost = db.makeWildcardHost('static');
   var ref = this;
+  // TODO(cleanup): Separate into separate files for client and server. Note that the server side
+  //   can grab the database in method and publish implementations as `this.connection.sandstormDb`,
+  //   so perhaps it's not necessary to construct a SandstormAppList object on the server.
+  // TODO(cleanup): Don't do Meteor.publish, Template.x.{helpers,events}, etc. in constructor code
+  //   since these things cannot be executed multiple times.
   if (Meteor.isServer) {
     // Publish _id, packageId, and lastUsed for grains that you have an API token for.
     Meteor.publish('sharedGrainInfo', function() {
-      // TODO: figure out what to do for not-logged-in users viewing a grain with a sharing link.
-      // For now, return an empty set for non-logged-in users.
+      // Non-logged-in users don't get a "shared with me" list.
+      // TODO(someday): Maybe store a list of tokens in localStorage client-side?
       if (!this.userId) { return []; }
+
+      // TODO(perf): This is possibly really inefficient to create a new subscription for each
+      //   grain. Fortunately we only need it for "shared with me" grains, but if someday users
+      //   have thousansd of grains shared with them this could get really slow. Need something
+      //   better.
       var self = this;
       var grainRefcounts = {};
       var grainSubs = {};
       var refGrain = function (grainId) {
-        if (grainRefcounts[grainId] === undefined) {
+        if (!(grainId in grainRefcounts)) {
           grainRefcounts[grainId] = 0;
-          var thisGrainQuery = db.collections.grains.find({_id: grainId});
+          var thisGrainQuery = db.collections.grains.find(
+              grainId, {fields: {packageId: 1, lastUsed: 1}});
           var thisGrainSub = thisGrainQuery.observe({
             added: function(grain) {
               self.added("grains", grain._id, {
@@ -26,7 +37,8 @@ SandstormGrainList = function (db) {
               self.removed("grains", grain._id);
             },
             updated: function(oldGrain, newGrain) {
-              if (oldGrain.packageId !== newGrain.packageId || oldGrain.lastUsed !== newGrain.lastUsed) {
+              if (oldGrain.packageId !== newGrain.packageId ||
+                  oldGrain.lastUsed !== newGrain.lastUsed) {
                 self.changed("grains", newGrain._id, {
                   packageId: newGrain.packageId,
                   lastUsed: newGrain.lastUsed,
@@ -36,11 +48,10 @@ SandstormGrainList = function (db) {
           });
           grainSubs[grainId] = thisGrainSub;
         }
-        grainRefcounts[grainId] = grainRefcounts[grainId] + 1;
+        ++grainRefcounts[grainId];
       };
       var unrefGrain = function (grainId) {
-        grainRefcounts[grainId] = grainRefcounts[grainId] - 1;
-        if (grainRefcounts[grainId] === 0) {
+        if (--grainRefcounts[grainId] === 0) {
           delete grainRefcounts[grainId];
           var sub = grainSubs[grainId];
           delete grainSubs[grainId];
@@ -48,6 +59,11 @@ SandstormGrainList = function (db) {
         }
       };
 
+      // TODO(now): TODO(security): This reveals information (package ID, last activity time, and
+      //   existence) of REVOKED tokens. Computing whether or not tokens have been revoked is
+      //   probably too inefficient to do here. In fact, revealing package ID even to non-revoked
+      //   sharees is arguably wrong since the package could be private, and having the package ID
+      //   is sufficient to install the app.
       var apiTokens = db.collections.apiTokens.find({'owner.user.userId': this.userId});
       var apiTokensHandle = apiTokens.observe({
         added: function(newToken) {
@@ -83,18 +99,16 @@ SandstormGrainList = function (db) {
       // split up searchString into an array of regexes, use them to match against item
       var searchKeys = searchString.toLowerCase()
           .split(" ")
-          .filter(function(k) { return k != "";});
+          .filter(function(k) { return k !== "";});
       return function matchFilter(item) {
-        // special case: no text in filter should pass all items
-        if (searchKeys.length === 0) return true;
-        // Keep any item that matches any given substring
+        // Keep any item that matches all substrings
         var haystack = item.title.toLowerCase();
         for (var i = 0 ; i < searchKeys.length ; i++) {
-          if (haystack.indexOf(searchKeys[i]) !== -1) {
-            return true;
+          if (haystack.indexOf(searchKeys[i]) === -1) {
+            return false;
           }
         }
-        return false;
+        return true;
       };
     };
     var mapGrainsToTemplateObject = function (grains) {
@@ -107,8 +121,9 @@ SandstormGrainList = function (db) {
       var packagesById = _.indexBy(packages, '_id');
       return grains.map(function(grain) {
         var pkg = packagesById[grain.packageId];
-        var iconSrc = pkg ? iconSrcForPackage(pkg, 'grain', ref._staticHost) : "";
-        var appTitle = (pkg && pkg.manifest && pkg.manifest.appTitle && pkg.manifest.appTitle.defaultText) || "";
+        var iconSrc = pkg ? Identicon.iconSrcForPackage(pkg, 'grain', ref._staticHost) : "";
+        var appTitle = (pkg && pkg.manifest && pkg.manifest.appTitle &&
+                        pkg.manifest.appTitle.defaultText) || "";
         return {
           _id: grain._id,
           title: grain.title,
@@ -131,8 +146,9 @@ SandstormGrainList = function (db) {
       var packagesById = _.indexBy(packages, '_id');
       return sharedGrains.map(function(grain) {
         var pkg = packagesById[grain.packageId];
-        var iconSrc = pkg ? iconSrcForPackage(pkg, 'grain', ref._staticHost) : "";
-        var appTitle = (pkg && pkg.manifest && pkg.manifest.appTitle && pkg.manifest.appTitle.defaultText) || "";
+        var iconSrc = pkg ? Identicon.iconSrcForPackage(pkg, 'grain', ref._staticHost) : "";
+        var appTitle = (pkg && pkg.manifest && pkg.manifest.appTitle &&
+                        pkg.manifest.appTitle.defaultText) || "";
         // It's theoretically possible to have multiple API tokens for the same grain.
         // Pick one arbitrarily to assign the grain petname from.
         var token = tokensForGrain[grain._id][0];
@@ -180,10 +196,10 @@ SandstormGrainList = function (db) {
         ref._filter.set(event.target.value);
       },
       "keypress .search-bar": function(event) {
-        if (event.keyCode == 13) {
+        if (event.keyCode === 13) {
           // Enter pressed.  If a single grain is shown, open it.
           var grains = filteredSortedGrains();
-          if (grains.length == 1) {
+          if (grains.length === 1) {
             // Unique grain found with current filter.  Activate it!
             var grainId = grains[0]._id;
             // router.go grain/grainId?

--- a/shell/packages/sandstorm-ui-grainlist/package.js
+++ b/shell/packages/sandstorm-ui-grainlist/package.js
@@ -1,0 +1,30 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Package.describe({
+  summary: "Sandstorm UI grain list",
+  version: "0.1.0"
+});
+
+Package.onUse(function (api) {
+  api.use(["check", "reactive-var", "reload", "templating", "tracker", "sandstorm-db", "sandstorm-identicons", "underscore"], "client");
+  // For the "userPackages" collection.  Perhaps that should move elsewhere.
+  api.use(["sandstorm-ui-applist"], ["server"]);
+  api.addFiles(["grainlist.html", "grainlist.js"], "client");
+  api.addFiles(["grainlist.js"], "server");
+  api.export("SandstormGrainList");
+});
+

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1059,6 +1059,9 @@ Router.map(function () {
   this.route("newGrain", {
     path: "/grain/new",
   });
+  this.route("selectGrain", {
+    path: "/grain",
+  });
   this.route("grain", {
     path: "/grain/:grainId/:path(.*)?",
 


### PR DESCRIPTION
Like the "new grain" UI, this is exposed at a route, but not linked by default.  The path to try out is `/grain`.

Depends on #688 for the crazy server-side reactive publish, icon helpers, and other fun helpers.