### PR TITLE
Prevent the role select element from getting too big.

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -639,7 +639,7 @@ body>.popup {
       text-transform: uppercase;
     }
     .share-token-role {
-      max-width: 40%;
+      width: 40%;
     }
     table .share-token-role {
       max-width: 160px;

--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -639,7 +639,7 @@ body>.popup {
       text-transform: uppercase;
     }
     .share-token-role {
-      max-width: 45%;
+      max-width: 40%;
     }
     table .share-token-role {
       max-width: 160px;


### PR DESCRIPTION
[The change here](https://github.com/sandstorm-io/sandstorm/commit/51347e50f49b93c1d67a7d29c3c645a93aa9f322#diff-f41c8458d337dd4e150b2ed41c120dc1R687) allows the following to happen:

<img width="398" alt="too-big" src="https://cloud.githubusercontent.com/assets/495768/9308777/fbd8fb26-44d3-11e5-98e6-7f9d1140c1c1.png">

This patch fixes it.