### PR TITLE
Add type="button" to profile upload button

### DIFF
--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -95,7 +95,7 @@ limitations under the License.
     <span class="details">E-mail address for service-related notifications.</span>
   </li>
   <li class="picture">
-    <label>Picture: <button><img src="{{picture}}" alt="Upload picture"></button></label>
+    <label>Picture: <button type="button"><img src="{{picture}}" alt="Upload picture"></button></label>
     <input type="hidden" name="picture" value="{{picture}}">
     <span class="details">This picture will be shown to other users to help identify you. Suggested dimensions: 512x512. Max size: 64 KiB.</span>
   </li>


### PR DESCRIPTION
This prevents confusion when it's embedded in a form. Without this,
pressing enter on any input in the form will trigger a click event on
this button.