### PR TITLE
Fixes topbar popups being slightly off-center from their icon

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -475,11 +475,11 @@ body>.popup {
       }
 
       &.align-left::before {
-        left: 42px;
+        left: 41px;
       }
 
       &.align-right::before {
-        right: 42px;
+        right: 41px;
       }
     }
 


### PR DESCRIPTION
We need to account for the 1 pixel border that will result in a 42px
offset