### PR TITLE
Add a grain container div above the grain frame... 

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -109,28 +109,30 @@ limitations under the License.
         sure that adding or removing grains from teh open grain list does not cause other grains'
         iframes to be re-rendered, losing state. --}}
   {{#with unpackedGrainState}}
-  {{#if error}}
-    <pre>{{error}}</pre>
-  {{else}}
-  {{#if appOrigin}}
-    {{!-- Selenium requires iframes to have an id in order to select them. id="grain-frame" is only
-          used for testing purposes. --}}
-    <iframe data-grainid="{{grainId}}" id="grain-frame" class="grain-frame {{#if active}}active-grain{{else}}inactive-grain{{/if}}" src="{{appOrigin}}/_sandstorm-init?sessionid={{sessionId}}&path={{path}}{{hash}}"></iframe>
-    {{#if hasNotLoaded}}
+    <div class="grain-container {{#if active}}active-grain{{else}}inactive-grain{{/if}}">
+    {{#if error}}
+      <pre>{{error}}</pre>
+    {{else}}
+    {{#if appOrigin}}
+      {{!-- Selenium requires iframes to have an id in order to select them. id="grain-frame" is only
+            used for testing purposes. --}}
+      <iframe data-grainid="{{grainId}}" id="grain-frame" class="grain-frame" src="{{appOrigin}}/_sandstorm-init?sessionid={{sessionId}}&path={{path}}{{hash}}"></iframe>
+      {{#if hasNotLoaded}}
+        {{> _grainSpinner}}
+      {{/if}}
+    {{else}}
+    {{#if interstitial}}
+      <div class="interstitial-button-box">
+        <p>This grain was shared by someone who is not in your contacts.</p>
+        <button class="redeem-token-button" data-token="{{token}}">Reveal your Identity</button>
+        <button class="incognito-button" data-token="{{token}}">Open in Incognito Mode</button>
+      </div>
+    {{else}}
       {{> _grainSpinner}}
     {{/if}}
-  {{else}}
-  {{#if interstitial}}
-    <div class="interstitial-button-box">
-      <p>This grain was shared by someone who is not in your contacts.</p>
-      <button class="redeem-token-button" data-token="{{token}}">Reveal your Identity</button>
-      <button class="incognito-button" data-token="{{token}}">Open in Incognito Mode</button>
+    {{/if}}
+    {{/if}}
     </div>
-  {{else}}
-    {{> _grainSpinner}}
-  {{/if}}
-  {{/if}}
-  {{/if}}
   {{/with}}
 </template>
 

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -310,14 +310,7 @@ svg {
   margin-top: 0;
 }
 
-iframe.grain-frame {
-  border: none;
-  padding: 0;
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  display: block;
-  position: absolute;
+div.grain-container {
   &.active-grain {
     z-index: 0;
     background: white;
@@ -326,6 +319,16 @@ iframe.grain-frame {
     z-index: -2;
     display: none;
   }
+}
+
+iframe.grain-frame {
+  border: none;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  display: block;
+  position: absolute;
 }
 
 body.ios iframe.grain-frame {

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -72,7 +72,7 @@ Template.sandstormTopbar.helpers({
       return {
         grainId: grain.grainId(),
         active: grain.isActive(),
-        title: grain.title(),
+        title: grain.title() || "(unknown grain)",
         grainLink: grain.route(),
         iconSrc: grain.iconSrc(),
         appTitle: grain.appTitle(),


### PR DESCRIPTION
...so that errors, loading spinners, and interstitials only get shown when their corresponding grain is selected.

Also, display "unknown grain" in the navbar for /shared/ links that are still on the incognito interstitial and thus have no title yet.