### PR TITLE
Fix typo in error handling.

### DIFF
--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -283,7 +283,7 @@ GrainView.prototype._openGrainSession = function () {
       console.log("openSession error");
       self._error = error.message;
       self._status = "error";
-      self.dep.changed();
+      self._dep.changed();
     } else {
       // result is an object containing sessionId, initial title, and grainId.
       console.log("openSession success");


### PR DESCRIPTION
This was causing the incognito interstitial to appear in some cases where an error message ought to have appeared.