### PR TITLE
Fix grain title issues for shared grains and public grains.

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -425,7 +425,7 @@ limitations under the License.
 
 <template name="shareWithOthers">
   <h4 class="share-with-others">Share with others</h4>
-  {{#if grain.oldSharingModel}}
+  {{#if grain.isOldSharingModel}}
     <p>This grain uses the old sharing model. You can share it by copy/pasting the URL from the
        location bar.</p>
     {{#if grain.isOwner}}


### PR DESCRIPTION
  1. Fixes the Share button for old-sharing-model (i.e. public) grains.
  2. Fixes grain-title-setting for shared grains, and adds a prompt that better explains what's happening.
  3. Gets rid of the `Grains.allow()` rule, in favor of Meteor methods `privatizeGrain()` and `updateGrainTitle()`
  4. Shows the correct title for public grains opened by non-owners.
  5. Deletes some obsolete `showMenu` stuff.