### PR TITLE
Make main-content have a default foreground and background color

### DIFF
--- a/shell/client/_colors.scss
+++ b/shell/client/_colors.scss
@@ -29,10 +29,13 @@ $topbar-dropdown-foreground-color-hover: #383838;
 $topbar-dropdown-border-color: #c1c1c1;
 
 
+//////// Default colors, which may be reused in other modules
+$default-content-background-color: #efefef;
+$default-content-foreground-color: #191919;
 
 //////// Grain list ("Open...") styles
-$grainlist-background-color: #efefef;
-$grainlist-foreground-color: #191919;
+$grainlist-background-color: $default-content-background-color;
+$grainlist-foreground-color: $default-content-foreground-color;
 
 $grainlist-searchbar-background-color: #ffffff;
 $grainlist-searchbar-outline-color: #9e9e9e;
@@ -49,8 +52,8 @@ $grainlist-table-row-background-color-hover: #e8e8e8;
 $grainlist-table-row-outline-color: #d3d3d3;
 
 ///////// App list ("New...") styles
-$applist-background-color: #efefef;
-$applist-foreground-color: #191919;
+$applist-background-color: $default-content-background-color;
+$applist-foreground-color: $default-content-foreground-color;
 
 $applist-action-text-color: #5d5d5d;
 

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -129,7 +129,8 @@ img {
   left: 0;
   right: 0;
   bottom: 0px;
-  color: black;
+  color: $default-content-foreground-color;
+  background-color: $default-content-background-color;
   overflow: auto;
 
   @media #{$desktop} {


### PR DESCRIPTION
This should fix @kentonv's complaint about "white past the bottom of the grainlist/applist"