### PR TITLE
Fix style on tabs in the share popup.

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -743,6 +743,7 @@ body>.popup {
       padding: 3px;
       width: 45%;
       text-align: center;
+      font-size: 14px; // Size must be the same on mobile and desktop for correct absolute position.
       top: -26px;
       background-position: 15px 2px, left;
       background-size: 20px, 20px;


### PR DESCRIPTION
Currently, the open tab is incorrectly rendered like this is the desktop view:
<img width="400" alt="tabbottom" src="https://cloud.githubusercontent.com/assets/495768/9524513/59fd6efe-4cad-11e5-8331-1dd1cab34bad.png">
and like this in the mobile view:
<img width="658" alt="tabsmobile" src="https://cloud.githubusercontent.com/assets/495768/9524516/61404ab0-4cad-11e5-9e0b-ff1ea9769b5f.png">

This patch fixes both views to look like this:
<img width="393" alt="tabsfixed" src="https://cloud.githubusercontent.com/assets/495768/9524612/bfe66e78-4cad-11e5-863e-a399636479b6.png">


