### PR TITLE
Changes for non-logged-in users

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -216,6 +216,14 @@ body>.topbar {
           filter: none;
           background-color: $topbar-background-color-hover;
         }
+
+        // Allow the LI to feel "disabled", in which case, it does not
+        // visually respond to hover.
+        &.disabled {
+          &:hover {
+            background-color: $topbar-background-color;
+          }
+        }
       }
 
       @media #{$mobile} {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -52,9 +52,18 @@ limitations under the License.
   {{else}}
 
   {{!-- standard topbar items --}}
-  {{#sandstormTopbarItem name="toggle-navbar" topbar=globalTopbar}}
-    <button class="toggle-navbar-button">Sandstorm</button>
-  {{/sandstormTopbarItem}}
+  {{#if currentUser}}
+    {{#sandstormTopbarItem name="toggle-navbar" topbar=globalTopbar}}
+      <button class="toggle-navbar-button">Sandstorm</button>
+      {{/sandstormTopbarItem}}
+  {{else}}
+    {{!-- if the user is not logged in, we will not show the navbar,
+      so we apply the "disabled" class to the li to avoid
+      visually hinting that clicking it would do anything. --}}
+    {{#sandstormTopbarItem name="toggle-navbar disabled" topbar=globalTopbar}}
+      <div class="toggle-navbar-button">Sandstorm</div>
+      {{/sandstormTopbarItem}}
+  {{/if}}
   {{>sandstormTopbarItem name="account" topbar=globalTopbar data=globalAccountsUi
                          template="loginButtons" popupTemplate="loginButtonsPopup"}}
   {{#if currentUser}}

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -16,7 +16,7 @@
       {{/if}}
     {{/if}}
   {{else}}
-    {{#if currentRoute 'shared'}}
+    {{#if isCurrentRoute 'shared'}}
       <a>Don't lose this link! Sign up for free ▾</a>
     {{else}}
       <a>Sign in ▾</a>

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -16,7 +16,11 @@
       {{/if}}
     {{/if}}
   {{else}}
-    <a>Sign in ▾</a>
+    {{#if currentRoute 'shared'}}
+      <a>Don't lose this link! Sign up for free ▾</a>
+    {{else}}
+      <a>Sign in ▾</a>
+    {{/if}}
   {{/if}}
 </template>
 

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -2,6 +2,9 @@
 var loginButtonsSession = Accounts._loginButtonsSession;
 
 var helpers = {
+  currentRoute: function (routeName) {
+    return Router.current().route.getName() == routeName;
+  },
   isDemoUser: function () {
     return this._db.isDemoUser();
   },

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -2,7 +2,7 @@
 var loginButtonsSession = Accounts._loginButtonsSession;
 
 var helpers = {
-  currentRoute: function (routeName) {
+  isCurrentRoute: function (routeName) {
     return Router.current().route.getName() == routeName;
   },
   isDemoUser: function () {

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -41,8 +41,8 @@ limitations under the License.
       {{/each}}
     </ul>
     <ul class="navbar {{#unless showNavbar}}hide-desktop{{/unless}}">
-      <li class="navitem-open-grain {{#if currentRoute 'selectGrain'}}current{{/if}}"><a href="{{pathFor route='selectGrain'}}"><span>Open...</span></a></li>
-      <li class="navitem-create-grain {{#if currentRoute 'newGrain'}}current{{/if}}"><a href="{{pathFor route='newGrain'}}">New...</a></li>
+      <li class="navitem-open-grain {{#if isCurrentRoute 'selectGrain'}}current{{/if}}"><a href="{{pathFor route='selectGrain'}}"><span>Open...</span></a></li>
+      <li class="navitem-create-grain {{#if isCurrentRoute 'newGrain'}}current{{/if}}"><a href="{{pathFor route='newGrain'}}">New...</a></li>
       <ul class="navbar-grains">
         {{#each grains}}
         <li data-grainid="{{grainId}}" class="navitem-grain {{#if active}}current{{/if}}">

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -60,7 +60,7 @@ Template.sandstormTopbar.helpers({
     return _.sortBy(_.values(this._items), function (item) { return -(item.priority || 0); });
   },
 
-  currentRoute: function (routeName) {
+  isCurrentRoute: function (routeName) {
     return Router.current().route.getName() == routeName;
   },
 

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -502,9 +502,21 @@ if (Meteor.isClient) {
   };
   Template.registerHelper("dateString", makeDateString);
   Template.registerHelper("showNavbar", function() {
-    // We also want to show the navbar whenever we've blocked reload, since we cover the toggle
-    // and you'd be unable to switch to other grains before page refresh otherwise.
-    return Session.get("show-navbar") || globalTopbar.isUpdateBlocked();
+    // We show the navbar when:
+    //
+    // - The session indicates we should (i.e., the user clicked on
+    //   the Sandstorm logo in the top-left), or
+    //
+    // - We've blocked reload, since we cover the toggle and
+    //   you'd be unable to switch to other grains before page
+    //   refresh otherwise.
+    //
+    // We actively hide the navbar when:
+    //
+    // - The user is not logged-in. This is because "Open" and "New"
+    //   would have no meaning for a non-logged-in user, and since they
+    //   can't open any new grains, "multi-grain" has no meaning for them.
+    return Meteor.user() && (Session.get("show-navbar") || globalTopbar.isUpdateBlocked());
   });
 
 


### PR DESCRIPTION
Goal:

- [x] When not logged in, see a message saying "Don't lose this link! Sign up for free >>" to encourage people to sign up.

- [x] When not logged in, disable the navbar.

- [x] When not logged in, disable clicking the Sandstorm button in the top-left because normally that would enable/disable the nav bar, but now it would do nothing, since non-logged-in users can't see the nav bar.

Status:

* Ready for review.