### PR TITLE
Remove color rule from %hamburger-menu-item

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -152,7 +152,6 @@ body>.topbar {
       background-size: 32px 32px;
       background-repeat: no-repeat;
       background-color: transparent;
-      color: black;
       text-align: left;
       padding-left: 48px;
       font-size: 14pt;


### PR DESCRIPTION
This commit removes "color: black;" from hamburger-menu-item.

Only a few items remain black, such as one's username, since other
items seem to have extra styling that overrides this rule.

But black text on a (nearly) black background doesn't make much sense
anyway. So this commit simply removes that style rule.