### PR TITLE
Use max-width not width on form.account-profile-editor

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -583,7 +583,7 @@ body>.main-content>.account {
 }
 
 form.account-profile-editor {
-  width: 500px;
+  max-width: 500px;
   height: auto;
   background-color: white;
   padding: 0 16px;

--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -604,7 +604,7 @@ form.account-profile-editor {
 
       input[type="text"], input[type="email"], select {
         display: block;
-        width: 300px;
+        max-width: 300px;
         float: right;
         box-sizing: border-box;
         font-size: inherit;


### PR DESCRIPTION
This allows it to scale nicely when the browser window is not very wide.

@kentonv it's usually best to only add `width:` rules if you know that the browser is going to be that wide (`@media desktop...`) or to use `max-width`. I prefer the latter generally.