### PR TITLE
Open and New now align with the start of the icon, rather than the start of the grain title

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -479,6 +479,11 @@ body>.topbar {
             background-color: $topbar-background-color-active;
             color: $topbar-foreground-color-active;
           }
+          // Make the "Open" and "New" verbs align with the start
+          // of the app icon.
+          a {
+            padding-left: 4px;
+          }
         }
       }
     }


### PR DESCRIPTION
This patchset is @neynah requested and @neynah approved!

The idea is that without this change, it looks like "Open..." and "New..." are missing an icon.