### PR TITLE
Add install-purple.svg to list of SVGs in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ IMAGES= \
     shell/public/github.svg \
     shell/public/google.svg \
     shell/public/install.svg \
+    shell/public/install-purple.svg \
     shell/public/key.svg \
     shell/public/link.svg \
     shell/public/menu.svg \


### PR DESCRIPTION
In #755 @neynah adds a new SVG. This does the right thing (I believe!) for adding it to the Makefile, so we actually distribute it.