### PR TITLE
Don't use the main-content class for first signup, as grainview special-cases it.

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -592,7 +592,8 @@ body>.main-content>.account {
   }
 }
 
-#first-sign-in.main-content {
+.first-sign-in-main-content {
+  z-index: 1;
   h1 {
     text-align: center;
   }

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -46,7 +46,7 @@ limitations under the License.
     </div>
   {{else}}
   {{#if firstLogin}}
-    <div id="first-sign-in" class="main-content">
+    <div class="first-sign-in-main-content">
       {{> sandstormAccountsFirstSignIn accountSettingsUi}}
     </div>
   {{else}}
@@ -104,11 +104,12 @@ limitations under the License.
     {{>billingPrompt}}
   {{/with}}
 
-  <div class="main-content {{#if showNavbar}}show-navbar{{/if}}">
-    {{> yield}}
-  </div>
-
   {{/if}}
+  <div class="main-content {{#if showNavbar}}show-navbar{{/if}}">
+    {{#unless firstLogin}}
+      {{> yield}}
+    {{/unless}}
+  </div>
   {{/with}}
 </template>
 

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -122,7 +122,7 @@ img {
   vertical-align: middle;
 }
 
-.main-content {
+.main-content, .first-sign-in-main-content {
   margin: 0;
   padding: 0;
   position: fixed;


### PR DESCRIPTION
Currently, if you still need to confirm your profile but you visit a grain or a shared link, the grainview gets rendered below the profile prompt (scroll down and you'll see it!) and then gets destroyed once the profile prompt is dismissed. The problem is that grainviews attach themselves to the first `.main-content` element they see, and the profile prompt was also using `.main-content`. This somewhat hacky fix works around the problem. With this change, we render the grain *behind* the profile prompt, where it is not visible. I've verified that even when grains are very tall (e.g. a MediaWiki with lots of content on the front page) they don't peek out from behind the profile prompt. (I don't fully understand why not, but hey, it works!) 