### PR TITLE
Make iframes have white backgrounds

### DIFF
--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -334,6 +334,7 @@ iframe.grain-frame {
   margin: 0;
   display: block;
   position: absolute;
+  background-color: white;
 }
 
 body.ios .main-content {


### PR DESCRIPTION
Some apps like Acronymy don't set a background, so it's nice if we make it the
default browser background color.