### PR TITLE
Fix @-sign in 'handle' field of account-settings page.

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -654,21 +654,20 @@ form.account-profile-editor {
         border: 1px solid #c00;
       }
 
-      &.handle {
-        label::after {
-          content: "@";
-          float: right;
-          margin-right: -20px;
-          font-family: monospace;
-          padding-top: 2px;
-          color: #888;
-          position: relative;
-          z-index: 1;
-        }
-
+      &.handle .input-container {
+        position: relative;
         input[type="text"] {
-          padding-left: 1em;
+          font-size: 12pt;
           font-family: monospace;
+          padding-left: 1em;
+        }
+        .background-text {
+          font-size: 12pt;
+          font-family: monospace;
+          color: #888;
+          position: absolute;
+          top: 3px;
+          left: 4px;
         }
       }
 

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -70,8 +70,11 @@ limitations under the License.
   </li>
   <li class="handle">
     <label>Handle:
-      <input type="text" name="handle" value="{{handle}}" placeholder="handle"
-             pattern="^[a-z_][a-z0-9_]*$" required>
+      <div class="input-container">
+        <input type="text" name="handle" value="{{handle}}" placeholder="handle"
+               pattern="^[a-z_][a-z0-9_]*$" required>
+        <div class="background-text">@</div>
+      </div>
     </label>
     <span class="details">Your preferred handle or "username", for use in apps that use handles (often, chat apps). This is only your first choice; an app may make you rename if someone has already taken this name within the specific grain.</span>
   </li>


### PR DESCRIPTION
In Firefox, this currently looks like:
<img width="134" alt="broken-at" src="https://cloud.githubusercontent.com/assets/495768/9548473/b1e1a362-4d6e-11e5-9894-2631133fffe9.png">

After this patch, it looks like:
<img width="144" alt="unbroken-at" src="https://cloud.githubusercontent.com/assets/495768/9548481/beeb79fc-4d6e-11e5-9526-d38df6827896.png">

I've also verified that it looks good in Chrome and Safari.