### PR TITLE
Include the query and fragment directly in the path.

### DIFF
--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -1,26 +1,26 @@
 var counter = 0;
 
-GrainView = function GrainView(grainId, path, query, hash, token, parentElement) {
+GrainView = function GrainView(grainId, path, token, parentElement) {
+  // `path` starts with a slash and includes the query and fragment.
+  //
   // Owned grains:
-  // grainId, path, query, hash, dep.
+  // grainId, path, dep.
   //   callback sets error, openingSession on failure,
   //                 grainId, sessionId, sessionSub on success.
   //
   // Sturdyref ApiTokens:
-  // grainId, path, query, hash, dep.
+  // grainId, path, dep.
   //   callback sets error, openingSession on failure
   //                 grainId, sessionId, sessionSub on success.
   //
   // Token-only sessions:
-  // grainId, token, path, query, hash, dep
+  // grainId, token, path, dep
   //   callback sets error, openingSession on failure
   //                 grainId, sessionId, title, and session Sub on success
 
   this._grainId = grainId;
   this._originalPath = path;
-  this._path = this._originalPath;
-  this._originalQuery = query;
-  this._originalHash = hash;
+  this._path = path;
   this._token = token;
 
   this._status = "closed";
@@ -333,18 +333,7 @@ GrainView.prototype._openApiTokenSession = function () {
         console.log("openSessionFromApiToken redirectToGrain");
         self._grainId = result.redirectToGrain;
         self._dep.changed();
-        // Make sure to carry over any within-grain path.
-        var routeParams = { grainId: result.redirectToGrain };
-        if (self._originalPath) {
-          routeParams.path = self._originalPath;
-        }
-        var urlParams = {};
-        if (self._originalQuery) {
-          urlParams.query = self._originalQuery;
-        }
-        if (self._originalHash) {
-          urlParams.hash = self._originalHash;
-        }
+
         // We should remove this tab from the tab list, since the /grain/<grainId> route
         // will set up its own tab for this grain.  There could even already be a tab open, if the
         // user reuses a /shared/ link.
@@ -358,7 +347,7 @@ GrainView.prototype._openApiTokenSession = function () {
         }
 
         // OK, go to the grain.
-        return Router.go("grain", routeParams, urlParams);
+        return Router.go("/grain/" + result.redirectToGrain + self._path);
       } else {
         // We are viewing this via just the /shared/ link, either as an anonymous user on in our
         // incognito mode (since we'd otherwise have redeemed the token and been redirected).

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -126,7 +126,7 @@ limitations under the License.
     {{#if appOrigin}}
       {{!-- Selenium requires iframes to have an id in order to select them. id="grain-frame" is only
             used for testing purposes. --}}
-      <iframe data-grainid="{{grainId}}" id="grain-frame" class="grain-frame" src="{{appOrigin}}/_sandstorm-init?sessionid={{sessionId}}&path={{path}}{{hash}}"></iframe>
+      <iframe data-grainid="{{grainId}}" id="grain-frame" class="grain-frame" src="{{appOrigin}}/_sandstorm-init?sessionid={{sessionId}}&path={{originalPath}}"></iframe>
       {{#if hasNotLoaded}}
         {{> _grainSpinner}}
       {{/if}}

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -280,7 +280,6 @@ if (Meteor.isClient) {
 
   Template.layout.events({
     "click .incognito-button": function (event) {
-      console.log("incognito button clicked");
       console.log(event);
       var grains = globalGrains.get();
       var token = event.currentTarget.getAttribute("data-token");
@@ -296,7 +295,6 @@ if (Meteor.isClient) {
     },
 
     "click .redeem-token-button": function (event) {
-      console.log("redeem button clicked");
       console.log(event);
       var grains = globalGrains.get();
       var token = event.currentTarget.getAttribute("data-token");
@@ -628,11 +626,6 @@ if (Meteor.isClient) {
     "currentGrain": function() {
       return getActiveGrain(globalGrains.get());
     }
-  });
-
-  Template.grain.onCreated(function () {
-    this.originalPath = window.location.pathname + window.location.search;
-    this.originalHash = window.location.hash;
   });
 
   Template.grainView.helpers({
@@ -1148,7 +1141,6 @@ if (Meteor.isClient) {
 }
 
 function makeGrainIdActive(grainId) {
-  console.log("making grain " + grainId + " active");
   var grains = globalGrains.get();
   for (var i = 0 ; i < grains.length ; i++) {
     var grain = grains[i];
@@ -1206,13 +1198,11 @@ function mapGrainStateToTemplateData(grainState) {
     appOrigin: grainState.origin(),
     hasNotLoaded: !(grainState.hasLoaded()),
     sessionId: grainState.sessionId(),
-    path: encodeURIComponent(grainState._originalPath || ""), //TODO: cleanup
-    hash: grainState._originalHash || "", // TODO: cleanup
+    originalPath: grainState._originalPath,
     interstitial: grainState.shouldShowInterstitial(),
     token: grainState.token(),
     viewInfo: grainState.viewInfo(),
   };
-  console.log(templateData);
   return templateData;
 }
 
@@ -1262,9 +1252,7 @@ Router.map(function () {
       this.state.set("beforeActionHookRan", true);
 
       var grainId = this.params.grainId;
-      var path = "/" + (this.params.path || "");
-      var query = this.params.query;
-      var hash = this.params.hash;
+      var path = "/" + (this.params.path || "") + window.location.search + window.location.hash;
       var grains = globalGrains.get();
       var grainIndex = grainIdToIndex(grains, grainId);
       if (grainIndex == -1) {
@@ -1275,8 +1263,7 @@ Router.map(function () {
           var mainContentElement = document.querySelector("body>.main-content");
           if (mainContentElement) {
             var grains = globalGrains.get();
-            var grainToOpen = new GrainView(grainId, path, query, hash, undefined,
-                mainContentElement);
+            var grainToOpen = new GrainView(grainId, path, undefined, mainContentElement);
             grainToOpen.openSession();
             grainIndex = grains.push(grainToOpen) - 1;
             globalGrains.set(grains);
@@ -1327,8 +1314,7 @@ Router.map(function () {
       this.state.set("beforeActionHookRan", true);
 
       var token = this.params.token;
-      var path = "/" + (this.params.path || "");
-      var query = this.params.query;
+      var path = "/" + (this.params.path || "") + window.location.search + window.location.hash;
       var hash = this.params.hash;
 
       var tokenInfo = TokenInfo.findOne({_id: token});
@@ -1341,8 +1327,7 @@ Router.map(function () {
             var mainContentElement = document.querySelector("body>.main-content");
             if (mainContentElement) {
               var grains = globalGrains.get();
-              var grainToOpen = new GrainView(grainId, path, query, hash, token,
-                                              mainContentElement);
+              var grainToOpen = new GrainView(grainId, path, token, mainContentElement);
               grainToOpen.openSession();
               grainIndex = grains.push(grainToOpen) - 1;
               globalGrains.set(grains);


### PR DESCRIPTION
This forwards the query and fragment to the grain iframe.