### PR TITLE
Add caret to navbar-toggling button when logged in

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -54,7 +54,7 @@ limitations under the License.
   {{!-- standard topbar items --}}
   {{#if currentUser}}
     {{#sandstormTopbarItem name="toggle-navbar" topbar=globalTopbar}}
-      <button class="toggle-navbar-button">Sandstorm</button>
+      <button class="toggle-navbar-button">Sandstorm ▾</button>
       {{/sandstormTopbarItem}}
   {{else}}
     {{!-- if the user is not logged in, we will not show the navbar,


### PR DESCRIPTION
In the longer future, this could perhaps be the small arrow below the logo.  My
attempts to produce something that looked good with the arrow below the logo
were unsuccessful - the space is cluttered, and the arrow isn't recognizable as a
"toggle something" dropdown.