### PR TITLE
Use GrainView.route() when going to an already open GrainView.

### DIFF
--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -233,7 +233,7 @@ Template.sandstormTopbar.events({
       grains.splice(closeIndex, 1);
       grains[newActiveIndex].setActive(true);
       topbar._grains.set(grains);
-      Router.go("grain", {grainId: grains[newActiveIndex].grainId()});
+      Router.go(grains[newActiveIndex].route());
     } else {
       grains.splice(closeIndex, 1);
       topbar._grains.set(grains);

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -344,7 +344,7 @@ if (Meteor.isClient) {
             grains.splice(activeIndex, 1);
             grains[newActiveIndex].setActive(true);
             globalGrains.set(grains);
-            Router.go("grain", {grainId: grains[newActiveIndex].grainId()});
+            Router.go(grains[newActiveIndex].route());
           }
         }
       } else {
@@ -359,7 +359,7 @@ if (Meteor.isClient) {
             grains.splice(activeIndex, 1);
             grains[newActiveIndex].setActive(true);
             globalGrains.set(grains);
-            Router.go("grain", {grainId: grains[newActiveIndex].grainId()});
+            Router.go(grains[newActiveIndex].route());
           }
         }
       }


### PR DESCRIPTION
... otherwise, when we close or delete or forget a grain, the newly-focused grain doesn't get its path set properly.