### PR TITLE
grain log contents: max-height -> height

### DIFF
--- a/shell/client/_grainlog.scss
+++ b/shell/client/_grainlog.scss
@@ -5,7 +5,7 @@
   line-height: 32px;
 }
 .grainlog-contents {
-  max-height: calc(100% - 32px);
+  height: calc(100% - 32px);
   overflow: auto;
   >pre {
     margin: 8px;


### PR DESCRIPTION
Currently, a horizontal scrollbar can appear *above* the bottom of the window:

<img width="703" alt="scrollbar" src="https://cloud.githubusercontent.com/assets/495768/9571316/a04af3ea-4f69-11e5-823b-3b2b1709613f.png">

This fixes the problem by giving the div a fixed height.