### PR TITLE
Make title keyboard-focusable and give close buttons a title

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -220,7 +220,7 @@ limitations under the License.
 </template>
 
 <template name="grainTitle">
-  <span class="editable" title="Rename" id="grainTitle">{{title}}</span>
+  <span class="editable" title="Rename" id="grainTitle" tabindex="0">{{title}}</span>
 </template>
 <template name="grainDeleteButton">
   <button class="grain-button" title="Delete" id="deleteGrain">Delete</button>

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -48,7 +48,7 @@ limitations under the License.
         <li data-grainid="{{grainId}}" class="navitem-grain {{#if active}}current{{/if}}">
           <div class="app-icon" style="background-image: url('{{iconSrc}}');" title="{{appTitle}}" alt="{{appTitle}}"></div>
           <a href="{{grainLink}}">{{title}}</a>
-          <button class="close-button"></button>
+          <button class="close-button" title="Close {{title}}"></button>
         </li>
         {{/each}}
       </ul>

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -310,18 +310,29 @@ if (Meteor.isClient) {
     },
   });
 
+  var promptNewTitle = function() {
+    var grain = getActiveGrain(globalGrains.get());
+    if (grain) {
+      var prompt = "Set new title:";
+      if (!grain.isOwner()) {
+        prompt = "Set a new personal title: (does not change the owner's title for this grain)";
+      }
+      var title = window.prompt(prompt, grain.title());
+      if (title) {
+        grain.setTitle(title);
+      }
+    }
+  };
   Template.grainTitle.events({
     "click": function (event) {
-      var grain = getActiveGrain(globalGrains.get());
-      if (grain) {
-        var prompt = "Set new title:";
-        if (!grain.isOwner()) {
-          prompt = "Set a new personal title: (does not change the owner's title for this grain)";
-        }
-        var title = window.prompt(prompt, grain.title());
-        if (title) {
-          grain.setTitle(title);
-        }
+      promptNewTitle();
+    },
+    "keydown": function (event) {
+      if ((event.keyCode === 13) || (event.keyCode === 32)) {
+        // Allow space or enter to trigger renaming the grain - Firefox doesn't treat enter on the
+        // focused element as click().
+        promptNewTitle();
+        event.preventDefault();
       }
     },
   });


### PR DESCRIPTION
This should fix a regression in the new UI where grain were not renameable by keyboard users because you couldn't keyboard-focus the <span> you'd need to click to change the grain title.

I also added a title to the sidebar buttons to make it clearer that 1) they are close buttons, and 2) which grain they will close.

Big thanks to @ndarilek for the bug report.