### PR TITLE
Construct proxies lazily on request

### DIFF
--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -50,6 +50,7 @@ GrainView.prototype.destroy = function () {
   // rendering the iframe forever, even if it is no longer linked into the page DOM.
 
   Blaze.remove(this._blazeView);
+  if (this._grainSizeSub) this._grainSizeSub.stop();
 }
 
 GrainView.prototype.isActive = function () {
@@ -89,7 +90,7 @@ GrainView.prototype._isUsingAnonymously = function () {
 }
 
 GrainView.prototype.size = function () {
-  var size = GrainSizes.findOne(this._sessionId);
+  var size = GrainSizes.findOne(this._grainId);
   return size && size.size;
 }
 
@@ -295,7 +296,8 @@ GrainView.prototype._openGrainSession = function () {
           self._dep.changed();
         }
       });
-      self._grainSizeSub = Meteor.subscribe("grainSize", result.sessionId);
+      if (self._grainSizeSub) self._grainSizeSub.stop();
+      self._grainSizeSub = Meteor.subscribe("grainSize", result.grainId);
       self._dep.changed();
     }
   });

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -347,23 +347,27 @@ Meteor.startup(function () {
   WebApp.httpServer.removeAllListeners('upgrade');
 
   WebApp.httpServer.on('upgrade', function(req, socket, head) {
-    try {
+    Promise.resolve(undefined).then(function () {
       if (isSandstormShell(req.headers.host.split(":")[0])) {
         // Go on to Meteor.
         for (var ii = 0; ii < meteorUpgradeListeners.length; ++ii) {
           meteorUpgradeListeners[ii](req, socket, head);
         }
+        return true;
       } else {
         var id = matchWildcardHost(req.headers.host);
         if (id) {
-          if (!tryProxyUpgrade(id, req, socket, head)) {
-            socket.destroy();
-          }
+          return tryProxyUpgrade(id, req, socket, head);
+        } else {
+          return false;
         }
       }
-    } catch (err) {
+    }).then(function (handled) {
+      if (!handled) socket.destroy();
+    }).catch(function (err) {
       console.error("WebSocket event handler failed:", err.stack);
-    }
+      socket.destroy();
+    });
   });
 
   // BlackrockPayments is only defined in the Blackrock build of Sandstorm.
@@ -392,41 +396,50 @@ Meteor.startup(function () {
       }
 
       // Try to route the request to a session.
-      if (tryProxyRequest(id, req, res)) {
-        return;
-      }
-
-      publicIdPromise = Promise.resolve(id);
+      publicIdPromise = tryProxyRequest(id, req, res)
+          .then(function (handled) {
+        if (handled) {
+          return null;
+        } else {
+          return id;
+        }
+      });
     } else {
       // Not a wildcard host. Perhaps it is a custom host.
       publicIdPromise = lookupPublicIdFromDns(hostname);
     }
 
     publicIdPromise.then(function (publicId) {
-      var handler = staticHandlers[publicId];
-      if (handler) {
-        return handler;
-      } else {
-        // We don't have a handler for this publicId, so look it up in the grain DB.
-        return inMeteor(function () {
-          var grain = Grains.findOne({publicId: publicId}, {fields: {_id: 1}});
-          if (!grain) {
-            throw new Meteor.Error(404, "No such grain for public ID: " + publicId);
-          }
-          var grainId = grain._id;
+      if (publicId) {
+        return Promise.resolve(undefined).then(function () {
+          var handler = staticHandlers[publicId];
+          if (handler) {
+            return handler;
+          } else {
+            // We don't have a handler for this publicId, so look it up in the grain DB.
+            return inMeteor(function () {
+              var grain = Grains.findOne({publicId: publicId}, {fields: {_id: 1}});
+              if (!grain) {
+                throw new Meteor.Error(404, "No such grain for public ID: " + publicId);
+              }
+              var grainId = grain._id;
 
-          return staticHandlers[publicId] = wwwHandlerForGrain(grainId);
+              return staticHandlers[publicId] = wwwHandlerForGrain(grainId);
+            });
+          }
+        }).then(function (handler) {
+          handler(req, res, function (err) {
+            if (err) {
+              next(err);
+            } else {
+              res.writeHead(404, { "Content-Type": "text/plain" });
+              res.end("404 not found: " + req.url);
+            }
+          });
         });
+      } else {
+        return Promise.resolve(undefined);
       }
-    }).then(function (handler) {
-      handler(req, res, function (err) {
-        if (err) {
-          next(err);
-        } else {
-          res.writeHead(404, { "Content-Type": "text/plain" });
-          res.end("404 not found: " + req.url);
-        }
-      });
     }).catch(function (err) {
       writeErrorResponse(res, err);
     });

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -599,6 +599,16 @@ var getProxyForHostId = function (hostId) {
           return undefined;
         }
 
+        var apiToken;
+        if (session.hashedToken) {
+          apiToken = ApiTokens.findOne({_id: session.hashedToken});
+          // We don't have to fully validate the API token here because if it changed the session
+          // would have been deleted.
+          if (!apiToken) {
+            throw new Meteor.Error(410, "ApiToken has been deleted");
+          }
+        }
+
         var grain = Grains.findOne(session.grainId);
         if (!grain) {
           // Grain was deleted, I guess.
@@ -615,6 +625,7 @@ var getProxyForHostId = function (hostId) {
 
         var proxy = new Proxy(grain._id, grain.userId, session._id, hostId,
                               user && user._id === grain._id, user, null, false);
+        if (apiToken) proxy.apiToken = apiToken;
 
         proxiesByHostId[hostId] = proxy;
 

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -870,7 +870,7 @@ tryProxyRequest = function (hostId, req, res) {
 
       res.writeHead(204, accessControlHeaders);
       res.end();
-      return true;
+      return Promise.resolve(true);
     }
 
     var responseHeaders = {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -936,7 +936,6 @@ tryProxyRequest = function (hostId, req, res) {
     }
     return Promise.resolve(true);
   } else {
-    var proxy = proxiesByHostId[hostId];
     return getProxyForHostId(hostId).then(function (proxy) {
       if (proxy) {
         proxy.requestHandler(req, res);

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -645,6 +645,12 @@ var getProxyForHostId = function (hostId) {
 
         proxiesByHostId[hostId] = proxy;
 
+        if (!Sessions.findOne(session._id)) {
+          // Oops, race: The session was destroyed while we were constructing thhe proxy. Better
+          // unregister it in case the main session observer already observed this change.
+          delete proxiesByHostId[hostId];
+        }
+
         return proxy;
       });
     }
@@ -767,6 +773,12 @@ getProxyForApiToken = function (token) {
         }
 
         proxiesByApiToken[hashedToken] = proxy;
+
+        if (!ApiTokens.findOne(hashedToken)) {
+          // Oops, race: The token was deleted while we were constructing thhe proxy. Better
+          // unregister it in case the main token observer already observed this change.
+          delete proxiesByApiToken[hashedToken];
+        }
 
         return proxy;
       });


### PR DESCRIPTION
This change refactors proxy.js such that `Proxy` objects are constructed lazily on first request rather than proactively.

This will make it easier to run multiple front-ends, since it's not necessary to specifically hit the one that has the Proxy object you're looking for. It would generally be nice if all requests for the same session arrive at the same front-end instance (to avoid creating multiple WebSessions for the same grain host), but this is not strictly necessary.

@dwrensha, please review. Note that I have attempted to organize my commits into bite-sized chunks. :)