### PR TITLE
Make periodic server-side actions replica-safe.

### DIFF
--- a/shell/packages/accounts-email-token/package.js
+++ b/shell/packages/accounts-email-token/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use(["underscore", "random", "templating", "iron:router"]);
+  api.use(["underscore", "random", "templating", "iron:router", "sandstorm-db"]);
   api.use("accounts-base", ["client", "server"]);
   // Export Accounts (etc) to packages using this one.
   api.imply("accounts-base", ["client", "server"]);

--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -12,7 +12,7 @@ var cleanupExpiredTokens = function() {
 
 Meteor.startup(cleanupExpiredTokens);
 // Tokens can actually last up to 2 * TOKEN_EXPIRATION_MS
-Meteor.setInterval(cleanupExpiredTokens, TOKEN_EXPIRATION_MS);
+SandstormDb.periodicCleanup(TOKEN_EXPIRATION_MS, cleanupExpiredTokens);
 
 var checkToken = function (user, token) {
   var found = false;

--- a/shell/packages/sandstorm-db/migrations.js
+++ b/shell/packages/sandstorm-db/migrations.js
@@ -4,6 +4,8 @@
 // side-effects, we should be careful to make sure all migrations are
 // idempotent and safe to accidentally run multiple times.
 
+var Future = Npm.require("fibers/future");
+
 var updateLoginStyleToRedirect = function() {
   var configurations = Package["service-configuration"].ServiceConfiguration.configurations;
   ["google", "github"].forEach(function(serviceName) {
@@ -158,24 +160,45 @@ var MIGRATIONS = [
 ];
 
 function migrateToLatest() {
-  var applied = Migrations.findOne({_id: "migrations_applied"});
-  var start;
-  if (!applied) {
-    // Migrations table is not yet seeded with a value.  This means it has
-    // applied 0 migrations.  Persist this.
-    Migrations.insert({_id: "migrations_applied", value: 0});
-    start = 0;
-  } else {
-    start = applied.value;
-  }
-  console.log("Migrations applied: " + start + "/" + MIGRATIONS.length);
+  if (Meteor.settings.replicaNumber) {
+    // This is a replica. Wait for the first replica to perform migrations.
 
-  for (var i = start ; i < MIGRATIONS.length ; i++) {
-    // Apply migration i, then record that migration i was successfully run.
-    console.log("Applying migration " + (i+1));
-    MIGRATIONS[i]();
-    Migrations.update({_id: "migrations_applied"}, {$set: {value: i+1}});
-    console.log("Applied migration " + (i+1));
+    console.log("Waiting for migrations on replica zero...");
+
+    var done = new Future();
+    var change = function (doc) {
+      console.log("Migrations applied elsewhere: " + doc.value + "/" + MIGRATIONS.length);
+      if (doc.value >= MIGRATIONS.length) done.return();
+    }
+    var observer = Migrations.find({_id: "migrations_applied"}).observe({
+      added: change,
+      changed: change
+    });
+
+    done.wait();
+    observer.stop();
+    console.log("Migrations have completed on replica zero.");
+
+  } else {
+    var applied = Migrations.findOne({_id: "migrations_applied"});
+    var start;
+    if (!applied) {
+      // Migrations table is not yet seeded with a value.  This means it has
+      // applied 0 migrations.  Persist this.
+      Migrations.insert({_id: "migrations_applied", value: 0});
+      start = 0;
+    } else {
+      start = applied.value;
+    }
+    console.log("Migrations applied: " + start + "/" + MIGRATIONS.length);
+
+    for (var i = start ; i < MIGRATIONS.length ; i++) {
+      // Apply migration i, then record that migration i was successfully run.
+      console.log("Applying migration " + (i+1));
+      MIGRATIONS[i]();
+      Migrations.update({_id: "migrations_applied"}, {$set: {value: i+1}});
+      console.log("Applied migration " + (i+1));
+    }
   }
 }
 

--- a/shell/server/backup.js
+++ b/shell/server/backup.js
@@ -32,13 +32,13 @@ function cleanupToken(tokenId) {
 
 Meteor.startup(function () {
   // Cleanup tokens every TOKEN_CLEANUP_MINUTES
-  Meteor.setInterval(function () {
+  SandstormDb.periodicCleanup(TOKEN_CLEANUP_TIMER, function () {
     var queryDate = new Date(Date.now() - TOKEN_CLEANUP_TIMER);
 
     FileTokens.find({timestamp: {$lt: queryDate}}).forEach(function (token) {
       cleanupToken(token._id);
     });
-  }, TOKEN_CLEANUP_TIMER);
+  });
 });
 
 Meteor.methods({

--- a/shell/server/drivers/mail.js
+++ b/shell/server/drivers/mail.js
@@ -272,7 +272,7 @@ hackSendEmail = function (session, email) {
       update: {$inc: {dailySentMailCount: 1}},
       fields: {dailySentMailCount: 1}
     });
-    if (user.dailySentMailCount > DAILY_LIMIT) {
+    if (user.dailySentMailCount >= DAILY_LIMIT) {
       throw new Error(
           "Sorry, you've reached your e-mail sending limit for today. Currently, Sandstorm " +
           "limits each user to " + DAILY_LIMIT + " e-mails per day for spam control reasons. " +

--- a/shell/server/drivers/mail.js
+++ b/shell/server/drivers/mail.js
@@ -32,12 +32,19 @@ var HOSTNAME = ROOT_URL.hostname;
 var DAILY_LIMIT = 50;
 var RECIPIENT_LIMIT = 20;
 
-var dailySendCounts = {};
-// Maps user IDs to counts of the number of e-mails they have sent today.
-
 var CLIENT_TIMEOUT = 15000; // 15s
 
-Meteor.setInterval(function () { dailySendCounts = {}; }, 86400);
+// Every day, reset all per-user sent counts to zero.
+// TODO(cleanup): Consider a more granular approach. For example, each user could have a timer
+//   after which their count will reset. We'd only check the timer when that user is trying to
+//   send a new message. This avoids a global query.
+if (!Meteor.settings.replicaNumber) {  // only first replica
+  SandstormDb.periodicCleanup(86400000, function () {
+    Meteor.users.update({dailySentMailCount: {$exists: true}},
+                        {$unset: {dailySentMailCount: ""}},
+                        {multi: true});
+  });
+}
 
 Meteor.startup(function() {
   var SANDSTORM_SMTP_PORT = parseInt(process.env.SANDSTORM_SMTP_PORT, 10) || 30025;
@@ -260,11 +267,12 @@ hackSendEmail = function (session, email) {
       });
     }
 
-    if (!(this.userId in dailySendCounts)) {
-      dailySendCounts[this.userId] = 0;
-    }
-    var sentToday = ++dailySendCounts[this.userId];
-    if (sentToday > DAILY_LIMIT) {
+    var user = Meteor.users.findAndModify({
+      query: {_id: session.userId},
+      update: {$inc: {dailySentMailCount: 1}},
+      fields: {dailySentMailCount: 1}
+    });
+    if (user.dailySentMailCount > DAILY_LIMIT) {
       throw new Error(
           "Sorry, you've reached your e-mail sending limit for today. Currently, Sandstorm " +
           "limits each user to " + DAILY_LIMIT + " e-mails per day for spam control reasons. " +

--- a/shell/server/permissions.js
+++ b/shell/server/permissions.js
@@ -462,7 +462,7 @@ var cleanupSelfDestructing = function() {
 
 // Make self-destructing tokens actually self-destruct, so they don't
 // clutter the token list view.
-Meteor.setInterval(cleanupSelfDestructing, 60 * 1000);
+SandstormDb.periodicCleanup(5 * 60 * 1000, cleanupSelfDestructing);
 
 Meteor.methods({
   transitiveShares: function(grainId) {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -570,13 +570,13 @@ Meteor.startup(function () {
   });
 });
 
-// Kill off proxies idle for >~5 minutes.
-var TIMEOUT_MS = 300000;
+// Kill off proxies idle for >~3 minutes.
+var TIMEOUT_MS = 180000;
 function gcSessions() {
   var now = new Date().getTime();
   Sessions.remove({timestamp: {$lt: (now - TIMEOUT_MS)}});
 }
-Meteor.setInterval(gcSessions, 60000);
+SandstormDb.periodicCleanup(TIMEOUT_MS, gcSessions);
 
 // Try to restore sessions on server restart.
 Meteor.startup(function () {

--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -204,7 +204,7 @@ if (Meteor.isServer) {
       return packageCursor;
     });
 
-    Meteor.setInterval(cleanupExpiredUsers, DEMO_EXPIRATION_MS);
+    SandstormDb.periodicCleanup(DEMO_EXPIRATION_MS, cleanupExpiredUsers);
   } else {
     // Just run once, in case the config just changed from allowing demos to prohibiting them.
     Meteor.setTimeout(cleanupExpiredUsers, DEMO_EXPIRATION_MS + DEMO_GRACE_MS);

--- a/shell/shared/stats.js
+++ b/shell/shared/stats.js
@@ -64,21 +64,24 @@ if (Meteor.isServer) {
     });
   }
 
-  // Wait until 10:00 UTC (2:00 PST / 5:00 EST), then start recording stats every 24 hours.
-  Meteor.setTimeout(function () {
-    Meteor.setInterval(function () {
+  if (!Meteor.settings.replicaNumber) {
+    // Wait until 10:00 UTC (2:00 PST / 5:00 EST), then start recording stats every 24 hours.
+    // (Only on the first replica to avoid conflicts.)
+    Meteor.setTimeout(function () {
+      Meteor.setInterval(function () {
+        recordStats();
+      }, DAY_MS);
+
       recordStats();
-    }, DAY_MS);
+    }, DAY_MS - (Date.now() - 10*60*60*1000) % DAY_MS);
 
-    recordStats();
-  }, DAY_MS - (Date.now() - 10*60*60*1000) % DAY_MS);
-
-  Meteor.startup(function () {
-    if (StatsTokens.find().count() === 0) {
-      StatsTokens.remove({});
-      StatsTokens.insert({_id: Random.id(22)});
-    }
-  });
+    Meteor.startup(function () {
+      if (StatsTokens.find().count() === 0) {
+        StatsTokens.remove({});
+        StatsTokens.insert({_id: Random.id(22)});
+      }
+    });
+  }
 
   Meteor.methods({
     regenerateStatsToken: function () {


### PR DESCRIPTION
Most uses of Meteor.setInterval were registering "cleanup" events, e.g. removing expired tokens. For a multi-replica system, we probably want these events to fire more often, because more data is being generated. So we stagger them according to replica number.

A couple uses of setInterval were non-cleanup, e.g. stat collection and daily mail limit enforcement. These need to be limited to running only on the first replica.

This change also fixes the mail rate limiter code to store limits in Mongo rather than in-memory, since the latter won't work when there are multiple replicas.

@jparyani, please review.