### PR TITLE
Change tab title to always put grainTitle first, if possible

### DIFF
--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -153,7 +153,7 @@ GrainView.prototype.frameTitle = function () {
   var grainTitle = this.title();
   // Actually set the values
   if (appTitle && grainTitle) {
-    return appTitle + " · " + grainTitle + " · Sandstorm";
+    return grainTitle + " · " + appTitle + " · Sandstorm";
   } else if (grainTitle) {
     return grainTitle + " · Sandstorm";
   } else {


### PR DESCRIPTION
Steps to reproduce:

* Open about 5 Etherpad grains in different browser tabs

Expected behavior:

* I can tell them apart.

Actual behavior:

* They all start with "Etherpad" and that's all I see.

![etherpad-etherpad-etherpad](https://cloud.githubusercontent.com/assets/25457/9666720/a18bc8cc-522c-11e5-8191-daac1f772939.png)

This change:

* Make the grainTitle first, giving me more control over the title in my tab bar.

(BTW I think @ocdtrekkie would like this pull request.)

Testing done:

* Ran `./run-dev.sh` on my laptop and confirmed that the title uses the the grain title first.

![documetn1-2-3](https://cloud.githubusercontent.com/assets/25457/9666757/e2b10e84-522c-11e5-8b84-325662deca02.png)
