### PR TITLE
When user logs out, clear open grain list and redirect to root page

### DIFF
--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -44,6 +44,12 @@ Template.loginButtonsPopup.events({
     Meteor.logout(function () {
       loginButtonsSession.closeDropdown();
       topbar.closePopup();
+      var openGrains = globalGrains.get();
+      openGrains.forEach(function(grain) {
+        grain.destroy();
+      });
+      globalGrains.set([]);
+      Router.go("root");
     });
   }
 });


### PR DESCRIPTION
A suggested change from @neynah per user studies. 

Now you won't see "403 Unauthorized" in grain frames, and instead you'll see
the expected login UI.