### PR TITLE
Fix a bug when highlighting an app in the app list

### DIFF
--- a/shell/packages/sandstorm-ui-applist/applist-client.js
+++ b/shell/packages/sandstorm-ui-applist/applist-client.js
@@ -229,14 +229,14 @@ Template.sandstormAppList.onRendered(function () {
   // Scroll to highlighted app, if any.
   if (this.data._highlight) {
     var self = this;
-    var auto = this.autorun(function () {
+    this.autorun(function (computation) {
       if (self.subscriptionsReady()) {
         var item = self.findAll(".highlight")[0];
         if (item) {
           item.focus();
           item.scrollIntoView();
         }
-        auto.stop();
+        computation.stop();
       }
     });
   } else {


### PR DESCRIPTION
Template instances have a function `autorun` that does not return the computation, but passes it as an arg to the inner function.