### PR TITLE
Update a previously-overlooked usage of mayOpenGrain().

### DIFF
--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -410,7 +410,7 @@ SandstormPermissions.createNewApiToken = function (db, userId, grainId, petname,
   // Meteor bug #3877: we get null here instead of undefined when we
   // explicitly pass in undefined.
   check(expiresIfUnusedDuration, Match.OneOf(undefined, null, Number));
-  check(rawParentToken, Match.Optional(String));
+  check(rawParentToken, Match.OneOf(undefined, null, String));
 
   var parentToken;
   if (rawParentToken) {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -737,7 +737,7 @@ getProxyForApiToken = function (token) {
           proxy = new Proxy(tokenInfo.grainId, grain.userId, null, null, false, null, null, true);
         }
 
-        if (!mayOpenGrain({token: tokenInfo})) {
+        if (!SandstormPermissions.mayOpenGrain(globalDb, {token: tokenInfo})) {
           // Note that only public grains may be opened without a user ID.
           throw new Meteor.Error(403, "Unauthorized.");
         }


### PR DESCRIPTION
Also, get offer templates to work again. For some reason, Meteor is now translating
`undefined` into `null` for `rawParentToken`.