### PR TITLE
Sort apps in the app list case-insensitively

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -681,17 +681,8 @@ if (Meteor.isServer) {
 // Below this point are newly-written or refactored functions.
 
 _.extend(SandstormDb.prototype, {
-  // TODO(cleanup): These methods shouldn't take a raw mongo queries or "aggregations" as inputs.
-  //   We want methods corresponding to each kind of query that is performed in practice. Letting
-  //   the caller pass an arbitrary query and aggregations is problematic because:
-  //   - We can't type-check them to prevent Mongo injections.
-  //   - It defeats the purpose of clearly seeing what kinds of queries we need to support, and
-  //     therefore what kind of indexes we might need.
-  //   - It doesn't make it any easier for us to substitute a non-Mongo database in the future.
-  //   - If the caller is just going to pass in a match-all query, we may be forcing Mongo into
-  //     a slower path by using $and.
   userGrains: function userGrains (user) {
-    return this.collections.grains.find({ userId: user}, {});
+    return this.collections.grains.find({ userId: user});
   },
 
   currentUserGrains: function currentUserGrains () {
@@ -712,7 +703,7 @@ _.extend(SandstormDb.prototype, {
   },
 
   userActions: function userActions (user) {
-    return this.collections.userActions.find({userId: user}, {});
+    return this.collections.userActions.find({userId: user});
   },
 
   currentUserActions: function currentUserActions () {

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -690,13 +690,12 @@ _.extend(SandstormDb.prototype, {
   //   - It doesn't make it any easier for us to substitute a non-Mongo database in the future.
   //   - If the caller is just going to pass in a match-all query, we may be forcing Mongo into
   //     a slower path by using $and.
-  userGrains: function userGrains (user, query, aggregations) {
-    var filteredQuery = { $and: [ { userId: user}, query ] };
-    return this.collections.grains.find(filteredQuery, aggregations);
+  userGrains: function userGrains (user) {
+    return this.collections.grains.find({ userId: user}, {});
   },
 
-  currentUserGrains: function currentUserGrains (query, aggregations) {
-    return this.userGrains(Meteor.userId(), query, aggregations);
+  currentUserGrains: function currentUserGrains () {
+    return this.userGrains(Meteor.userId());
   },
 
   getGrain: function getGrain (grainId) {
@@ -712,13 +711,12 @@ _.extend(SandstormDb.prototype, {
     return this.userApiTokens(Meteor.userId());
   },
 
-  userActions: function userActions (user, query, aggregations) {
-    var filteredQuery = { $and: [ {userId: user}, query ] };
-    return this.collections.userActions.find(filteredQuery, aggregations);
+  userActions: function userActions (user) {
+    return this.collections.userActions.find({userId: user}, {});
   },
 
-  currentUserActions: function currentUserActions (query, aggregations) {
-    return this.userActions(Meteor.userId(), query, aggregations);
+  currentUserActions: function currentUserActions () {
+    return this.userActions(Meteor.userId());
   },
 
   getPlan: function (id) {

--- a/shell/packages/sandstorm-ui-applist/applist-server.js
+++ b/shell/packages/sandstorm-ui-applist/applist-server.js
@@ -33,7 +33,7 @@ Meteor.publish("userPackages", function() {
   };
 
   // package source 1: packages referred to by actions
-  var actions = db.userActions(this.userId, {}, {});
+  var actions = db.userActions(this.userId);
   var actionsHandle = actions.observe({
     added: function(newAction) {
       refPackage(newAction.packageId);
@@ -44,7 +44,7 @@ Meteor.publish("userPackages", function() {
   });
 
   // package source 2: packages referred to by grains directly
-  var grains = db.userGrains(this.userId, {}, {});
+  var grains = db.userGrains(this.userId);
   var grainsHandle = grains.observe({
     added: function(newGrain) {
       refPackage(newGrain.packageId);


### PR DESCRIPTION
Fixes #846.

I took the liberty of cleaning up the methods I'd introduced in db.js to be
less Mongo-specific and to do matching and sorting in client code, rather than
using minimongo's limited capabilities for this (especially given the
complicated backwards-compatibility logic for appTitle and friends).