### PR TITLE
Support listening on multiple ports, speaking HTTPS if requested

### DIFF
--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -1,12 +1,107 @@
-// This file is used by Sandstorm to monkey-patch certain classes/functions in Nodejs
-// Specifically, we're changing http.Server.listen to listen on fd=3 instead of the normal
-// parameters. This is fine to do globally, since there's only ever one http server in meteor.
-var http = require('http');
-var net = require('net');
+// Typically, Meteor binds to one port and speaks HTTP.
+//
+// For Sandstorm, `run-bundle` has already bound a number of TCP ports
+// for us and passed them in as file descriptors starting at #3. So
+// this file runs before Meteor starts, monkey-patching the node world
+// so that, along with pre-meteor.js, we create the the right
+// HTTP+HTTPS services.
 
-var oldListen = http.Server.prototype._oldListen = http.Server.prototype.listen;
-http.Server.prototype.listen = function (port, host, cb) {
-  oldListen.call(this, {fd: 3}, cb);
+var fs = require('fs');
+var http = require('http');
+var https = require('https');
+var net = require('net');
+var url = require('url');
+
+function sandstorm_main() {
+  monkeypatchHttpAndHttps();
+
+  // Delegate to Meteor.
+  require("./main.js");
 }
 
-require("./main.js");
+function monkeypatchHttpAndHttps() {
+  // Monkey-patch the HTTP object's listen() function so if Meteor
+  // calls it, then we listen on FD #3.
+  var oldListen = http.Server.prototype.listen;
+  http.Server.prototype.listen = function (port, host, cb) {
+    // Overridable by passing e.g. {fd: 4} as port.
+    if (typeof port == 'object') {
+      return oldListen.call(this, port, host, cb);
+    }
+    return oldListen.call(this, {fd: 3}, cb);
+  }
+
+  // When Meteor calls createServer(), if we are in HTTPS mode, give it a HTTPS server.
+  //
+  // Passing a second argument of `true` allows us to call the real
+  // createServer directly in pre-meteor.js.
+  var originalHttpCreateServer = http.createServer;
+  var fakeHttpCreateServer = function(requestListener, calledBySandstorm) {
+    if (calledBySandstorm) {
+      return originalHttpCreateServer(requestListener);
+    }
+
+    function getHttpsOptions() {
+      var basePath = '/var/sandcats/https/' + (
+        url.parse(process.env.ROOT_URL).hostname);
+      var files = fs.readdirSync(basePath);
+      // The key files in this directory are named 0 1 2 3 etc., and
+      // metadata about the key is available in e.g. 0.csr. So find
+      // the most recent numbered file, then pull metadata out.
+
+      var keyFilesDescending = files.filter(function (filename) {
+        return filename.match(/^[0-9]*$/);
+      }).sort(function (a, b) {
+        return (parseInt(a) < parseInt(b));
+      }).reverse();
+
+      var result = {};
+      var nowUnixTimestamp = new Date() / 1000;
+      for (var i = 0; i < keyFilesDescending.length; i++) {
+        var keyFilename = basePath + '/' + keyFilesDescending[i];
+        var metadataFilename = keyFilename + '.response-json';
+        var metadata = JSON.parse(fs.readFileSync(metadataFilename));
+
+        // If this certificate isn't valid yet, keep looping, hoping
+        // to find one that is valid.
+        var notBefore = metadata['notBefore'];
+        if (notBefore && (notBefore < nowUnixTimestamp)) {
+          continue;
+        }
+
+        result['ca'] = metadata['ca'];
+        result['key'] = fs.readFileSync(keyFilename, 'utf-8');
+        result['cert'] = metadata['cert'];
+        return result;
+      }
+    };
+
+    if (process.env.HTTPS_PORT) {
+      var httpsServer = https.createServer(getHttpsOptions(), requestListener);
+      // Meteor calls httpServer.setTimeout() to set a default socket
+      // timeout. Since the method is not available on the nodejs
+      // v0.10.x https server object, we ignore it entirely for now.
+      //
+      // TODO(soon): Run slowloris against this to make sure it is
+      // safe to ignore.
+      //
+      // Note that upon actually receiving a connection, Meteor
+      // adjusts the timeouts, so setTimeout only the socket before
+      // the HTTP message got parsed.
+      httpsServer.setTimeout = function() {};
+
+      // When Meteor calls .listen() we bind to FD #3 and speak HTTPS.
+      var oldListen = https.Server.prototype.listen;
+      httpsServer.listen = function (port, host, cb) {
+        oldListen.call(this, {fd: 3}, cb);
+      }
+      return httpsServer;
+    } else {
+      return originalHttpCreateServer(requestListener);
+    }
+  }
+
+  http.createServer = fakeHttpCreateServer;
+}
+
+sandstorm_main();

--- a/shell/run-dev.sh
+++ b/shell/run-dev.sh
@@ -22,6 +22,21 @@ fi
 
 . $SANDSTORM_HOME/sandstorm.conf
 
+# If HTTPS_PORT is specified, then probably the BASE_URL contains HTTPS_PORT
+# as well, and run-dev.sh does not know how to listen on HTTPS, so tell the
+# user to disable that.
+if [ -n "${HTTPS_PORT:-}" ] ; then
+  echo "Please remove the HTTPS_PORT= line in your Sandstorm configuration" >&2
+  echo "since run-dev.sh does not support HTTPS." >&2
+fi
+
+# If PORT specifies two ports to listen on, this script only listens on the
+# first, since it calls Meteor directly, and Meteor has no ability to listen
+# on multiple ports.
+if [[ "${PORT:-}" =~ ^(.*?), ]] ; then
+  PORT=${BASH_REMATCH[1]} >&2
+fi
+
 if [ "$SERVER_USER" != "$USER" ]; then
   echo "Please change your Sandstorm installation to be owned by your own user" >&2
   echo "account. E.g. run as root:" >&2

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -408,7 +408,7 @@ Meteor.startup(function () {
     // first non-HTTPS port. The "true" argument here means skip our
     // monkeypatching.
     if ((i === 0) && (process.env.HTTPS_PORT)) {
-      alternatePortServer = Http.createServer(redirectToMeteorAndServeStaticPublishing, true);
+      alternatePortServer = Http.createServer(redirectToMeteorOrServeStaticPublishing, true);
     } else {
       alternatePortServer = Http.createServer(redirectToMeteorOrBust, true);
     }
@@ -502,7 +502,7 @@ Meteor.startup(function () {
     });
   };
 
-  WebApp.rawConnectHandlers.use(serveMeteorAndStaticPublishing);
+  WebApp.rawConnectHandlers.use(serveMeteorOrStaticPublishing);
 });
 
 var errorTxtMapping = {};

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -205,6 +205,33 @@ struct UserIds {
   kj::Array<gid_t> groups;
 };
 
+kj::Array<uint> parsePorts(kj::Maybe<uint> httpsPort, kj::StringPtr portList) {
+  auto portsSplitOnComma = split(portList, ',');
+  size_t numHttpPorts = portsSplitOnComma.size();
+  size_t numHttpsPorts;
+  kj::Array<uint> result;
+
+  // If the configuration has a https port, then add it first.
+  KJ_IF_MAYBE(portNumber, httpsPort) {
+    numHttpsPorts = 1;
+    result = kj::heapArray<uint>(numHttpsPorts + numHttpPorts);
+    result[0] = *portNumber;
+  } else {
+    numHttpsPorts = 0;
+    result = kj::heapArray<uint>(numHttpsPorts + numHttpPorts);
+  }
+
+  for (size_t i = 0; i < portsSplitOnComma.size(); i++) {
+    KJ_IF_MAYBE(portNumber, parseUInt(trim(portsSplitOnComma[i]), 10)) {
+      result[i + numHttpsPorts] = *portNumber;
+    } else {
+      KJ_FAIL_REQUIRE("invalid config value PORT", portList);
+    }
+  }
+
+  return kj::mv(result);
+}
+
 kj::Maybe<UserIds> getUserIds(kj::StringPtr name) {
   // We can't use getpwnam() in a statically-linked binary, so we shell out to id(1).  lol.
 
@@ -900,7 +927,8 @@ private:
   // Alternate main function we'll use depending on the program name.
 
   struct Config {
-    uint port = 3000;
+    kj::Maybe<uint> httpsPort;
+    kj::Array<uint> ports;
     uint mongoPort = 3001;
     UserIds uids;
     kj::String bindIp = kj::str("127.0.0.1");
@@ -1200,6 +1228,10 @@ private:
     config.uids.uid = getuid();
     config.uids.gid = getgid();
 
+    // Store the PORT and HTTPS_PORT values in variables here so we can
+    // process them at the end.
+    kj::Maybe<kj::String> maybePortValue = nullptr;
+
     auto lines = splitLines(readAll("../sandstorm.conf"));
     for (auto& line: lines) {
       auto equalsPos = KJ_ASSERT_NONNULL(line.findFirst('='), "Invalid config line", line);
@@ -1213,12 +1245,14 @@ private:
         } else {
           KJ_FAIL_REQUIRE("invalid config value SERVER_USER", value);
         }
-      } else if (key == "PORT") {
-        KJ_IF_MAYBE(p, parseUInt(value, 10)) {
-          config.port = *p;
-        } else {
-          KJ_FAIL_REQUIRE("invalid config value PORT", value);
+      } else if (key == "HTTPS_PORT") {
+          KJ_IF_MAYBE(p, parseUInt(value, 10)) {
+            config.httpsPort = *p;
+          } else {
+            KJ_FAIL_REQUIRE("invalid config value HTTPS_PORT", value);
         }
+      } else if (key == "PORT") {
+          maybePortValue = kj::mv(value);
       } else if (key == "MONGO_PORT") {
         KJ_IF_MAYBE(p, parseUInt(value, 10)) {
           config.mongoPort = *p;
@@ -1268,6 +1302,17 @@ private:
           KJ_FAIL_REQUIRE("invalid config value SMTP_LISTEN_PORT", value);
         }
       }
+    }
+
+    // Now process the PORT setting, since the actual value in config.ports
+    // depends on if HTTPS_PORT was provided at any point in reading the
+    // config file.
+    //
+    // Outer KJ_IF_MAYBE so we only run this code if the config file contained
+    // a PORT= declaration.
+    KJ_IF_MAYBE(portValue, maybePortValue) {
+      auto ports = parsePorts(config.httpsPort, *portValue);
+      config.ports = kj::mv(ports);
     }
 
     if (runningAsRoot) {
@@ -1671,9 +1716,7 @@ private:
     return result;
   }
 
-  pid_t startNode(const Config& config) {
-    Subprocess process([&]() -> int {
-      // Create a listening socket for the meteor app on fd=3
+  void bindSocketToFd(const Config& config, uint port, uint targetFdNum) {
       int sockFd;
       KJ_SYSCALL(sockFd = socket(PF_INET, SOCK_STREAM | SOCK_NONBLOCK, IPPROTO_TCP));
 
@@ -1684,7 +1727,7 @@ private:
       sockaddr_in sa;
       memset(&sa, 0, sizeof sa);
       sa.sin_family = AF_INET;
-      sa.sin_port = htons(config.port);
+      sa.sin_port = htons(port);
       int rc = inet_pton(AF_INET, config.bindIp.cStr(), &(sa.sin_addr));
       // If ipv4 address parsing fails, try ipv6
       if (rc == 0) {
@@ -1695,10 +1738,19 @@ private:
       KJ_SYSCALL(bind(sockFd, reinterpret_cast<sockaddr *>(&sa), sizeof sa));
       KJ_SYSCALL(listen(sockFd, 511)); // 511 is what node uses as its default backlog
 
-      if (sockFd != 3) {
+      if (sockFd != targetFdNum) {
         // dup socket to correct fd.
-        KJ_SYSCALL(dup2(sockFd, 3));
+        KJ_SYSCALL(dup2(sockFd, targetFdNum));
         KJ_SYSCALL(close(sockFd));
+      }
+}
+
+  pid_t startNode(const Config& config) {
+    Subprocess process([&]() -> int {
+      // Create a listening socket for the meteor app on fd=3 and up
+      uint socketFdStart = 3;
+      for (size_t i = 0; i < config.ports.size(); i++) {
+        bindSocketToFd(config, config.ports[i], i + socketFdStart);
       }
 
       dropPrivs(config.uids);
@@ -1719,7 +1771,11 @@ private:
             true));
       }
 
-      KJ_SYSCALL(setenv("PORT", kj::str(config.port).cStr(), true));
+      KJ_SYSCALL(setenv("PORT", kj::strArray(config.ports, ",").cStr(), true));
+      KJ_IF_MAYBE(httpsPort, config.httpsPort) {
+        KJ_SYSCALL(setenv("HTTPS_PORT", kj::str(*httpsPort).cStr(), true));
+      }
+
       KJ_SYSCALL(setenv("SANDSTORM_SMTP_PORT", kj::str(config.smtpListenPort).cStr(), true));
       KJ_SYSCALL(setenv("MONGO_URL",
           kj::str("mongodb://", authPrefix, "127.0.0.1:", config.mongoPort,
@@ -1730,11 +1786,21 @@ private:
         KJ_SYSCALL(setenv("MAIL_URL", config.mailUrl.cStr(), true));
       }
       if (config.rootUrl == nullptr) {
-        if (config.port == 80) {
-          KJ_SYSCALL(setenv("ROOT_URL", kj::str("http://", config.bindIp).cStr(), true));
+        kj::String scheme;
+        uint defaultPort;
+
+        if (config.httpsPort == nullptr) {
+          scheme = kj::str("http://");
+          defaultPort = 80;
+        } else {
+          scheme = kj::str("https://");
+          defaultPort = 443;
+        }
+        if (config.ports[0] == defaultPort) {
+          KJ_SYSCALL(setenv("ROOT_URL", kj::str(scheme, config.bindIp).cStr(), true));
         } else {
           KJ_SYSCALL(setenv("ROOT_URL",
-              kj::str("http://", config.bindIp, ":", config.port).cStr(), true));
+              kj::str(scheme, config.bindIp, ":", config.ports[0]).cStr(), true));
         }
       } else {
         KJ_SYSCALL(setenv("ROOT_URL", config.rootUrl.cStr(), true));
@@ -2042,6 +2108,18 @@ private:
     if (access("../var/sandcats", F_OK) == 0) {
         setOwnerGroupAndMode(kj::str("../var/sandcats"), 0700, config.uids.uid, config.uids.gid);
     }
+
+    // Same issue with https directory & its subdirectories.
+    kj::String httpsBaseDir = kj::str("../var/sandcats/https");
+    if (access(httpsBaseDir.cStr(), F_OK) == 0) {
+      setOwnerGroupAndMode(httpsBaseDir, 0700, config.uids.uid, config.uids.gid);
+
+      kj::Array<kj::String> entries = listDirectory(kj::str(httpsBaseDir));
+      for (size_t i = 0; i < entries.size(); i++) {
+        setOwnerGroupAndMode(kj::str(httpsBaseDir, "/", entries[i]), 0700, config.uids.uid, config.uids.gid);
+      }
+    }
+
     // var/sandcats/{register-log,id_rsa{,.pub,private_combined}} should each be 0640, with corrected
     // owner/group
     static const char* const files[] = {"register-log", "id_rsa", "id_rsa.pub", "id_rsa.private_combined"};


### PR DESCRIPTION
Changes:

* Adjust run-bundle to listen on multiple ports and pass their sockets over.

* Adjust meteor-bundle-main.js to optionally rebind http.createServer() to
  return a HTTPS server.

* Adjust pre-meteor.js to handle secondary HTTP services.

* Adjust default ROOT_URL to be https:// if HTTPS is enabled.

* Adjust run-bundle & install.sh to fix permissions problems in https dir.