### PR TITLE
Do not default to fetching HTTPS certificates

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -164,7 +164,7 @@ DEFAULT_UPDATE_CHANNEL="dev"
 DEFAULT_SERVER_USER="sandstorm"
 SANDCATS_BASE_DOMAIN="${OVERRIDE_SANDCATS_BASE_DOMAIN:-sandcats.io}"
 ALLOW_DEV_ACCOUNTS="false"
-SANDCATS_GETCERTIFICATE="yes"
+SANDCATS_GETCERTIFICATE="no"
 
 # Define functions for each stage of the install process.
 


### PR DESCRIPTION
Luckily this only ever caused people to see fun messages printed out and a slightly slower installer, it didn't cause them to actually _get_ broken HTTPS.