### PR TITLE
Support serving HTTPS if configured to do so and listening on multiple ports

### DIFF
--- a/docs/administering/ssl.md
+++ b/docs/administering/ssl.md
@@ -1,3 +1,139 @@
+<!--
+
+(Using an HTML comment to comment out documentation that we want users not
+to see, but that I want to write right now.
+
+## Sandstorm and HTTPS
+
+### Automatic HTTPS for Sandcats.io users (PROPOSED)
+
+**NOTE**: This section documents PROPOSED NEW behavior of Sandstorm, not behavior that works today.
+
+For new Sandstorm installations, HTTPS is (in the future) enabled by
+default. Sandstorm listens on port 443 for HTTPS connections and port
+80 for HTTP connections.
+
+When HTTPS mode is enabled (by setting the `HTTPS_PORT` configuration
+option), the Sandstorm software (in the future) uses port 443 for all
+traffic to the Sandstorm shell. If any requests come in on port 80,
+Sandstorm serves a HTTP redirect.
+
+Sandstorm grains can publish static content to the web on whatever
+domain the user wants. Since the Sandstorm software can't currently
+get a valid HTTPS certificate for all domain names, it serves static
+publishing content over HTTP as well as HTTPS.
+
+#### Enabling HTTPS for an existing Sandstorm server
+
+**NOTE**: This section documents PROPOSED NEW behavior of Sandstorm, not behavior that works today.
+
+If you are using the `sandcats.io` DNS service, you can (in the
+future) migrate from running Sandstorm on port 6080 (perhaps with a
+reverse-proxy) to having Sandstorm own port 443 (HTTPS) and port 80
+(HTTP).
+
+In this example, we presume your server is on
+_example.sandcats.io_. We also assume your Sandstorm server runs on
+port 6080 currently.
+
+This process will require reconfiguring any OAuth login providers like
+Google or GitHub, so it may take you up to thirty minutes to complete.
+
+First, enable HTTPS by (in the future) by modifying your Sandstorm
+configuration file (`sudo nano -w /opt/sandstorm/sandstorm.conf`) to add a
+`HTTPS_PORT=` configuration value as follows.
+
+```bash
+HTTPS_PORT=443
+```
+
+Now, stop and start Sandstorm:
+
+```bash
+sudo sandstorm stop
+sudo sandstorm start
+```
+
+Sandstorm will continue to operate as before on port 6080. In
+addition, Sandstorm will log a message in
+`/opt/sandstorm/var/log/sandstorm.log` indicating it is retrieving a
+HTTPS certificate for you to use. This process can take about two
+minutes. You can read that log by running:
+
+```bash
+sudo tail -f /opt/sandstorm/var/log/sandstorm.log
+```
+
+Once you see a message indicating `Sandstorm has successfully received
+a HTTPS certificate`, it is safe to reconfigure Sandstorm to use HTTPS
+by default. To do that, make the following changes to your
+`sandstorm.conf` file.
+
+```bash
+PORT=80,6080
+HTTPS_PORT=443
+BASE_URL=https://example.sandcats.io
+WILDCARD_HOST=*.example.sandcats.io
+```
+
+If you chose the default HTTPS port (443), you do not need to specify
+a port number in the `BASE_URL` or `WILDCARD_HOST`. We recommend this
+configuration with multiple `PORT=` values so that Sandstorm listens
+on two standard ports, 443 (HTTPS) and 80 (HTTP), and still listens on
+port 6080 in case anyone else links to your server on port 6080.
+
+Having made these changes, you will need to restart Sandstorm.
+
+```bash
+sudo sandstorm stop
+sudo sandstorm start
+```
+
+You can now visit your
+
+*NOTE* that if you had Google or GitHub login enabled (or other OAuth
+providers), the change in `BASE_URL` means that you need to
+reconfigure those services. You can log into Sandstorm in a special admin
+mode by running:
+
+```bash
+sudo sandstorm admin-token
+```
+
+and follow the prompts to configure Google and/or GitHub login
+again. Once you have saved those settings, sign in via the top-right
+corner of Sandstorm.
+
+**Congratulations!** You're now using HTTPS, also known as TLS and
+SSL.
+
+### How multiple ports affect the shell, grains, and static publishing
+
+When HTTPS is enabled, Sandstorm (in the future) serves its interface
+(the shell and all grains) over HTTPS only. If such a request destined
+on any other port, Sandstorm responds with a HTTP redirect to the
+HTTPS version.
+
+Sandstorm serves (in the future) static publishing content on HTTPS as
+well as HTTP (ports 6080 and 80 in the above configuration). This way,
+if you use WordPress or other publishing apps on Sandstorm, visitors
+can reach those sites even if you do not have a valid HTTPS
+certificate for those domain names.
+
+This will result in duplicate content, where the same web pages are
+available on port 80 and 6080. Based on our understanding of [how
+duplicate content is handled by search
+engines](https://support.google.com/webmasters/answer/66359?hl=en),
+this will not be a problem for your site's ranking. In the long run,
+consider turning off port 6080 by removing it from the `PORT=` line.
+If you think the Sandstorm code should support something more
+complicated involving (for example) HTTP redirects, please file a bug
+so we can make sure we're serving your needs.
+
+-->
+
+## Self-hosted HTTPS with a custom certificate authority
+
 The following is a process for self-hosted instances of Sandstorm to use SSL with sandcats.io DNS. These steps create a Certificate Authority (CA), corresponding CA Certificate, and the private and public keys for the `[anything].sandcats.io` and `*.[anything].sandcats.io` domains.
 
 **Note**: Web browsers will display a big red certificate error when you try to connect to this install. This tutorial is appropriate if you are OK with reconfiguring web browsers to trust a custom certificate authority that you will create during this tutorial. For automatically-trusted SSL configuration, you will need to buy a certificate from a certificate authority.

--- a/docs/administering/ssl.md
+++ b/docs/administering/ssl.md
@@ -144,18 +144,18 @@ The following is a process for self-hosted instances of Sandstorm to use SSL wit
 
 
 2. **Add the following to the end of the copied `openssl.cnf` file:**
-        
+
         [req]
         req_extensions = v3_req
-        
+
         [ v3_req ]
-        
+
         # Extensions to add to a certificate request
-        
+
         basicConstraints = CA:FALSE
         keyUsage = nonRepudiation, digitalSignature, keyEncipherment
         subjectAltName = @alt_names
-        
+
         [alt_names]
         DNS.1 = [your-domain-name].sandcats.io
         DNS.2 = *.[your-domain-name].sandcats.io
@@ -163,41 +163,41 @@ The following is a process for self-hosted instances of Sandstorm to use SSL wit
 3. **Create the Certificate Authority (CA) Key:**
 
         openssl genrsa -out rootCA.key 4096
-    `rootCA.key` is the file for the Certificate Authority (CA) key.  
-    _  
+    `rootCA.key` is the file for the Certificate Authority (CA) key.
+    _
 
 4. **Sign the Certificate Authority (CA) Key and Create Certificate Authority (CA) certificate (Expires in 10 years):**
 
         openssl req -x509 -new -nodes -key rootCA.key -days 3650 -out rootCA.pem
 
-    `rootCA.pem` is the file for the Certificate Authority (CA) certificate  
-    _  
+    `rootCA.pem` is the file for the Certificate Authority (CA) certificate
+    _
 
 5. **Create Sandstorm Device Private Key:**
 
         openssl genrsa -out sandstorm.key 4096
 
-    `sandstorm.key` is the Sandstorm Device Private Key  
+    `sandstorm.key` is the Sandstorm Device Private Key
     _
 
 6. **Create Sandstorm Device Certificate Signing Request (CSR) using the copied and edited openssl.cnf file:**
 
         openssl req -new -key sandstorm.key -out sandstorm.csr -config openssl.cnf
 
-    `sandstorm.csr` is the Sandstorm Device Certificate Signing Request (CSR)  
+    `sandstorm.csr` is the Sandstorm Device Certificate Signing Request (CSR)
     _
 
 7. **Create and sign the Sandstorm Certificate (Expire in 2 years):**
 
         openssl x509 -req -in sandstorm.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out sandstorm.crt -days 730 -extensions v3_req -extfile openssl.cnf
 
-    `sandstorm.crt` is the Sandstorm Certificate  
+    `sandstorm.crt` is the Sandstorm Certificate
     _
 
-8. **Import the Certificate Authority (CA) Certificate (`rootCA.pem`) into the browser's that will be using Sandstorm. Some browsers may load grains without this step and ask users to add a security excpetion in order to fully load grains.**  
+8. **Import the Certificate Authority (CA) Certificate (`rootCA.pem`) into the browser's that will be using Sandstorm. Some browsers may load grains without this step and ask users to add a security excpetion in order to fully load grains.**
 _
 
-9. **Copy (FTP/SSH) the Sandstorm Certificate and Sandstorm Private Key to the nginx ssl directory, it may be `/etc/nginx/ssl`**.  
+9. **Copy (FTP/SSH) the Sandstorm Certificate and Sandstorm Private Key to the nginx ssl directory, it may be `/etc/nginx/ssl`**.
 _
 
 10. **Change these lines in your nginx conf file to reflect the new Sandstorm Certificate and Private Key filenames**:
@@ -211,8 +211,8 @@ _
 
 12. **Restart Sandstorm:**
 
-        sudo sandstorm restart 
-    or  
+        sudo sandstorm restart
+    or
 
         sudo /opt/sandstorm/sandstorm restart
 

--- a/install.sh
+++ b/install.sh
@@ -1580,6 +1580,9 @@ sandcats_configure_https() {
 
   chmod 0600 "$LOG_PATH"
 
+  # Make sure the Sandstorm service can read these files.
+  chown "$SERVER_USER":"$SERVER_USER" "$HTTPS_CONFIG_DIR/"*
+
   if [ "200" = "$HTTP_STATUS" ]
   then
     # Say something nice to the user.

--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -97,7 +97,7 @@ function monkeypatchHttpAndHttps() {
       // timeout. Since the method is not available on the nodejs
       // v0.10.x https server object, we ignore it entirely for now.
       //
-      // TODO(soon): Run slowloris against this to make sure it is
+      // TODO(security): Run slowloris against this to make sure it is
       // safe to ignore.
       //
       // Note that upon actually receiving a connection, Meteor

--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -12,7 +12,7 @@ var https = require('https');
 var net = require('net');
 var url = require('url');
 
-function sandstorm_main() {
+function sandstormMain() {
   monkeypatchHttpAndHttps();
 
   // Delegate to Meteor.
@@ -116,4 +116,4 @@ function monkeypatchHttpAndHttps() {
   http.createServer = fakeHttpCreateServer;
 }
 
-sandstorm_main();
+sandstormMain();

--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -66,8 +66,9 @@ function monkeypatchHttpAndHttps() {
         try {
           var metadata = JSON.parse(fs.readFileSync(metadataFilename));
         } catch (e) {
-          // If somehow the metadata has the wrong permissions,
-          // attempt to continue.
+          // If the key metadata has the wrong permissions due to an
+          // installer bug that went out during September, then skip
+          // those keys and attempt to continue.
           if (e.code === 'EACCES') {
             console.log("Skipping unreadable HTTPS key information file:", metadataFilename);
             continue;

--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -66,10 +66,13 @@ function monkeypatchHttpAndHttps() {
         try {
           var metadata = JSON.parse(fs.readFileSync(metadataFilename));
         } catch (e) {
-          // If the key metadata has the wrong permissions due to an
-          // installer bug that went out during September, then skip
-          // those keys and attempt to continue.
-          if (e.code === 'EACCES') {
+          // Ignore EACCESS: The key metadata may have bad permissions
+          // due to an installer bug that went out during September.
+          //
+          // Ignore ENOENT: If we created a key+csr but the server
+          // hasn't given us a signed certificate yet, the response-json
+          // won't exist.
+          if ((e.code === 'EACCES') || (e.code == 'ENOENT')) {
             console.log("Skipping unreadable HTTPS key information file:", metadataFilename);
             continue;
           } else {

--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -1,12 +1,107 @@
-// This file is used by Sandstorm to monkey-patch certain classes/functions in Nodejs
-// Specifically, we're changing http.Server.listen to listen on fd=3 instead of the normal
-// parameters. This is fine to do globally, since there's only ever one http server in meteor.
-var http = require('http');
-var net = require('net');
+// Typically, Meteor binds to one port and speaks HTTP.
+//
+// For Sandstorm, `run-bundle` has already bound a number of TCP ports
+// for us and passed them in as file descriptors starting at #3. So
+// this file runs before Meteor starts, monkey-patching the node world
+// so that, along with pre-meteor.js, we create the the right
+// HTTP+HTTPS services.
 
-var oldListen = http.Server.prototype._oldListen = http.Server.prototype.listen;
-http.Server.prototype.listen = function (port, host, cb) {
-  oldListen.call(this, {fd: 3}, cb);
+var fs = require('fs');
+var http = require('http');
+var https = require('https');
+var net = require('net');
+var url = require('url');
+
+function sandstorm_main() {
+  monkeypatchHttpAndHttps();
+
+  // Delegate to Meteor.
+  require("./main.js");
 }
 
-require("./main.js");
+function monkeypatchHttpAndHttps() {
+  // Monkey-patch the HTTP object's listen() function so if Meteor
+  // calls it, then we listen on FD #3.
+  var oldListen = http.Server.prototype.listen;
+  http.Server.prototype.listen = function (port, host, cb) {
+    // Overridable by passing e.g. {fd: 4} as port.
+    if (typeof port == 'object') {
+      return oldListen.call(this, port, host, cb);
+    }
+    return oldListen.call(this, {fd: 3}, cb);
+  }
+
+  // When Meteor calls createServer(), if we are in HTTPS mode, give it a HTTPS server.
+  //
+  // Passing a second argument of `true` allows us to call the real
+  // createServer directly in pre-meteor.js.
+  var originalHttpCreateServer = http.createServer;
+  var fakeHttpCreateServer = function(requestListener, calledBySandstorm) {
+    if (calledBySandstorm) {
+      return originalHttpCreateServer(requestListener);
+    }
+
+    function getHttpsOptions() {
+      var basePath = '/var/sandcats/https/' + (
+        url.parse(process.env.ROOT_URL).hostname);
+      var files = fs.readdirSync(basePath);
+      // The key files in this directory are named 0 1 2 3 etc., and
+      // metadata about the key is available in e.g. 0.csr. So find
+      // the most recent numbered file, then pull metadata out.
+
+      var keyFilesDescending = files.filter(function (filename) {
+        return filename.match(/^[0-9]*$/);
+      }).sort(function (a, b) {
+        return (parseInt(a) < parseInt(b));
+      }).reverse();
+
+      var result = {};
+      var nowUnixTimestamp = new Date() / 1000;
+      for (var i = 0; i < keyFilesDescending.length; i++) {
+        var keyFilename = basePath + '/' + keyFilesDescending[i];
+        var metadataFilename = keyFilename + '.response-json';
+        var metadata = JSON.parse(fs.readFileSync(metadataFilename));
+
+        // If this certificate isn't valid yet, keep looping, hoping
+        // to find one that is valid.
+        var notBefore = metadata['notBefore'];
+        if (notBefore && (notBefore < nowUnixTimestamp)) {
+          continue;
+        }
+
+        result['ca'] = metadata['ca'];
+        result['key'] = fs.readFileSync(keyFilename, 'utf-8');
+        result['cert'] = metadata['cert'];
+        return result;
+      }
+    };
+
+    if (process.env.HTTPS_PORT) {
+      var httpsServer = https.createServer(getHttpsOptions(), requestListener);
+      // Meteor calls httpServer.setTimeout() to set a default socket
+      // timeout. Since the method is not available on the nodejs
+      // v0.10.x https server object, we ignore it entirely for now.
+      //
+      // TODO(soon): Run slowloris against this to make sure it is
+      // safe to ignore.
+      //
+      // Note that upon actually receiving a connection, Meteor
+      // adjusts the timeouts, so setTimeout only the socket before
+      // the HTTP message got parsed.
+      httpsServer.setTimeout = function() {};
+
+      // When Meteor calls .listen() we bind to FD #3 and speak HTTPS.
+      var oldListen = https.Server.prototype.listen;
+      httpsServer.listen = function (port, host, cb) {
+        oldListen.call(this, {fd: 3}, cb);
+      }
+      return httpsServer;
+    } else {
+      return originalHttpCreateServer(requestListener);
+    }
+  }
+
+  http.createServer = fakeHttpCreateServer;
+}
+
+sandstorm_main();

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -583,8 +583,8 @@ matchWildcardHost = function(host) {
   var prefix = wildcardHost[0];
   var suffix = wildcardHost[1];
 
-  // We ignore everything after the first : character to be agnostic
-  // as to what port a request came in on.
+  // We remove everything after the first ":" character so that our
+  // comparison logic ignores port numbers.
   suffix = suffix.split(":")[0];
   host = host.split(":")[0];
 

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -582,6 +582,12 @@ matchWildcardHost = function(host) {
 
   var prefix = wildcardHost[0];
   var suffix = wildcardHost[1];
+
+  // We ignore everything after the first : character to be agnostic
+  // as to what port a request came in on.
+  suffix = suffix.replace(/:.*/, "");
+  host = host.replace(/:.*/, "");
+
   if (host.lastIndexOf(prefix, 0) >= 0 &&
       host.indexOf(suffix, -suffix.length) >= 0 &&
       host.length >= prefix.length + suffix.length) {

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -585,8 +585,8 @@ matchWildcardHost = function(host) {
 
   // We ignore everything after the first : character to be agnostic
   // as to what port a request came in on.
-  suffix = suffix.replace(/:.*/, "");
-  host = host.replace(/:.*/, "");
+  suffix = suffix.split(":")[0];
+  host = host.split(":")[0];
 
   if (host.lastIndexOf(prefix, 0) >= 0 &&
       host.indexOf(suffix, -suffix.length) >= 0 &&

--- a/shell/run-dev.sh
+++ b/shell/run-dev.sh
@@ -22,6 +22,21 @@ fi
 
 . $SANDSTORM_HOME/sandstorm.conf
 
+# If HTTPS_PORT is specified, then probably the BASE_URL contains HTTPS_PORT
+# as well, and run-dev.sh does not know how to listen on HTTPS, so tell the
+# user to disable that.
+if [ -n "${HTTPS_PORT:-}" ] ; then
+  echo "Please remove the HTTPS_PORT= line in your Sandstorm configuration" >&2
+  echo "since run-dev.sh does not support HTTPS." >&2
+fi
+
+# If PORT specifies two ports to listen on, this script only listens on the
+# first, since it calls Meteor directly, and Meteor has no ability to listen
+# on multiple ports.
+if [[ "${PORT:-}" =~ ^(.*?), ]] ; then
+  PORT=${BASH_REMATCH[1]} >&2
+fi
+
 if [ "$SERVER_USER" != "$USER" ]; then
   echo "Please change your Sandstorm installation to be owned by your own user" >&2
   echo "account. E.g. run as root:" >&2

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -474,7 +474,6 @@ Meteor.startup(function () {
       // Not a wildcard host. Perhaps it is a custom host.
       if (allowStaticPublishing) {
         publicIdPromise = lookupPublicIdFromDns(hostname);
-        console.log("YAY I GUESS");
       } else {
         res.writeHead(404, {"Content-Type": "text/plain"});
         res.end("404 not found: Resource not available.");

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -423,9 +423,9 @@ Meteor.startup(function () {
     // first non-HTTPS port. The "true" argument here means skip our
     // monkeypatching.
     if ((i === 0) && (process.env.HTTPS_PORT)) {
-      alternatePortServer = Http.createServer(redirectToMeteorOrServeStaticPublishing, true);
+      alternatePortServer = Http.createServerForSandstorm(redirectToMeteorOrServeStaticPublishing);
     } else {
-      alternatePortServer = Http.createServer(redirectToMeteorOrBust, true);
+      alternatePortServer = Http.createServerForSandstorm(redirectToMeteorOrBust);
     }
     alternatePortServer.listen({fd: i + 4});
   }

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -385,8 +385,7 @@ Meteor.startup(function () {
   // Bind listeners to FD #4 and higher, if we are supposed to be
   // listening on multiple ports.
   function getNumberOfAlternatePorts() {
-    var numCommas = (process.env.PORT.match(/,/g) || {}).length;
-    var numPorts = numCommas + 1;
+    var numPorts = process.env.PORTS.split(",").length;
     var numAlternatePorts = numPorts - 1;
     return numAlternatePorts;
   };

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -408,7 +408,7 @@ Meteor.startup(function () {
     // first non-HTTPS port. The "true" argument here means skip our
     // monkeypatching.
     if ((i === 0) && (process.env.HTTPS_PORT)) {
-      alternatePortServer = Http.createServer(redirectToMeteorAndServeStaticPublishing, true);
+      alternatePortServer = Http.createServer(redirectToMeteorOrServeStaticPublishing, true);
     } else {
       alternatePortServer = Http.createServer(redirectToMeteorOrBust, true);
     }
@@ -502,7 +502,7 @@ Meteor.startup(function () {
     });
   };
 
-  WebApp.rawConnectHandlers.use(serveMeteorAndStaticPublishing);
+  WebApp.rawConnectHandlers.use(serveMeteorOrStaticPublishing);
 });
 
 var errorTxtMapping = {};

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -389,7 +389,7 @@ Meteor.startup(function () {
   // They are bound to FD #4 and higher.
 
   function getNumberOfAlternatePorts() {
-    var numPorts = process.env.PORTS.split(",").length;
+    var numPorts = process.env.PORT.split(",").length;
     var numAlternatePorts = numPorts - 1;
     return numAlternatePorts;
   };

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -570,7 +570,7 @@ function lookupPublicIdFromDns(hostname) {
           "If you got here after trying to log in via OAuth (e.g. through Github or Google),<br>\n" +
           "the problem is probably that the OAuth callback URL was set wrong. You need to<br>\n" +
           "update it through the respective login provider's management console.</p>";
-        error.httpErrorCode = err.code === "ENOTFOUND" ? 404 : 500;
+        error.httpErrorCode = (_.contains(["ENOTFOUND", "ENODATA"], err.code)) ? 404 : 500;
         reject(error);
       } else if (records.length !== 1) {
         reject(new Error("Host 'sandstorm-www." + hostname + "' must have exactly one TXT record."));

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -205,6 +205,33 @@ struct UserIds {
   kj::Array<gid_t> groups;
 };
 
+kj::Array<uint> parsePorts(kj::Maybe<uint> httpsPort, kj::StringPtr portList) {
+  auto portsSplitOnComma = split(portList, ',');
+  size_t numHttpPorts = portsSplitOnComma.size();
+  size_t numHttpsPorts;
+  kj::Array<uint> result;
+
+  // If the configuration has a https port, then add it first.
+  KJ_IF_MAYBE(portNumber, httpsPort) {
+    numHttpsPorts = 1;
+    result = kj::heapArray<uint>(numHttpsPorts + numHttpPorts);
+    result[0] = *portNumber;
+  } else {
+    numHttpsPorts = 0;
+    result = kj::heapArray<uint>(numHttpsPorts + numHttpPorts);
+  }
+
+  for (size_t i = 0; i < portsSplitOnComma.size(); i++) {
+    KJ_IF_MAYBE(portNumber, parseUInt(trim(portsSplitOnComma[i]), 10)) {
+      result[i + numHttpsPorts] = *portNumber;
+    } else {
+      KJ_FAIL_REQUIRE("invalid config value PORT", portList);
+    }
+  }
+
+  return kj::mv(result);
+}
+
 kj::Maybe<UserIds> getUserIds(kj::StringPtr name) {
   // We can't use getpwnam() in a statically-linked binary, so we shell out to id(1).  lol.
 
@@ -900,7 +927,8 @@ private:
   // Alternate main function we'll use depending on the program name.
 
   struct Config {
-    uint port = 3000;
+    kj::Maybe<uint> httpsPort;
+    kj::Array<uint> ports;
     uint mongoPort = 3001;
     UserIds uids;
     kj::String bindIp = kj::str("127.0.0.1");
@@ -1200,6 +1228,10 @@ private:
     config.uids.uid = getuid();
     config.uids.gid = getgid();
 
+    // Store the PORT and HTTPS_PORT values in variables here so we can
+    // process them at the end.
+    kj::Maybe<kj::String> maybePortValue = nullptr;
+
     auto lines = splitLines(readAll("../sandstorm.conf"));
     for (auto& line: lines) {
       auto equalsPos = KJ_ASSERT_NONNULL(line.findFirst('='), "Invalid config line", line);
@@ -1213,12 +1245,14 @@ private:
         } else {
           KJ_FAIL_REQUIRE("invalid config value SERVER_USER", value);
         }
-      } else if (key == "PORT") {
-        KJ_IF_MAYBE(p, parseUInt(value, 10)) {
-          config.port = *p;
-        } else {
-          KJ_FAIL_REQUIRE("invalid config value PORT", value);
+      } else if (key == "HTTPS_PORT") {
+          KJ_IF_MAYBE(p, parseUInt(value, 10)) {
+            config.httpsPort = *p;
+          } else {
+            KJ_FAIL_REQUIRE("invalid config value HTTPS_PORT", value);
         }
+      } else if (key == "PORT") {
+          maybePortValue = kj::mv(value);
       } else if (key == "MONGO_PORT") {
         KJ_IF_MAYBE(p, parseUInt(value, 10)) {
           config.mongoPort = *p;
@@ -1268,6 +1302,17 @@ private:
           KJ_FAIL_REQUIRE("invalid config value SMTP_LISTEN_PORT", value);
         }
       }
+    }
+
+    // Now process the PORT setting, since the actual value in config.ports
+    // depends on if HTTPS_PORT was provided at any point in reading the
+    // config file.
+    //
+    // Outer KJ_IF_MAYBE so we only run this code if the config file contained
+    // a PORT= declaration.
+    KJ_IF_MAYBE(portValue, maybePortValue) {
+      auto ports = parsePorts(config.httpsPort, *portValue);
+      config.ports = kj::mv(ports);
     }
 
     if (runningAsRoot) {
@@ -1671,9 +1716,7 @@ private:
     return result;
   }
 
-  pid_t startNode(const Config& config) {
-    Subprocess process([&]() -> int {
-      // Create a listening socket for the meteor app on fd=3
+  void bindSocketToFd(const Config& config, uint port, uint targetFdNum) {
       int sockFd;
       KJ_SYSCALL(sockFd = socket(PF_INET, SOCK_STREAM | SOCK_NONBLOCK, IPPROTO_TCP));
 
@@ -1684,7 +1727,7 @@ private:
       sockaddr_in sa;
       memset(&sa, 0, sizeof sa);
       sa.sin_family = AF_INET;
-      sa.sin_port = htons(config.port);
+      sa.sin_port = htons(port);
       int rc = inet_pton(AF_INET, config.bindIp.cStr(), &(sa.sin_addr));
       // If ipv4 address parsing fails, try ipv6
       if (rc == 0) {
@@ -1695,10 +1738,19 @@ private:
       KJ_SYSCALL(bind(sockFd, reinterpret_cast<sockaddr *>(&sa), sizeof sa));
       KJ_SYSCALL(listen(sockFd, 511)); // 511 is what node uses as its default backlog
 
-      if (sockFd != 3) {
+      if (sockFd != targetFdNum) {
         // dup socket to correct fd.
-        KJ_SYSCALL(dup2(sockFd, 3));
+        KJ_SYSCALL(dup2(sockFd, targetFdNum));
         KJ_SYSCALL(close(sockFd));
+      }
+}
+
+  pid_t startNode(const Config& config) {
+    Subprocess process([&]() -> int {
+      // Create a listening socket for the meteor app on fd=3 and up
+      uint socketFdStart = 3;
+      for (size_t i = 0; i < config.ports.size(); i++) {
+        bindSocketToFd(config, config.ports[i], i + socketFdStart);
       }
 
       dropPrivs(config.uids);
@@ -1719,7 +1771,11 @@ private:
             true));
       }
 
-      KJ_SYSCALL(setenv("PORT", kj::str(config.port).cStr(), true));
+      KJ_SYSCALL(setenv("PORT", kj::strArray(config.ports, ",").cStr(), true));
+      KJ_IF_MAYBE(httpsPort, config.httpsPort) {
+        KJ_SYSCALL(setenv("HTTPS_PORT", kj::str(*httpsPort).cStr(), true));
+      }
+
       KJ_SYSCALL(setenv("SANDSTORM_SMTP_PORT", kj::str(config.smtpListenPort).cStr(), true));
       KJ_SYSCALL(setenv("MONGO_URL",
           kj::str("mongodb://", authPrefix, "127.0.0.1:", config.mongoPort,
@@ -1730,11 +1786,21 @@ private:
         KJ_SYSCALL(setenv("MAIL_URL", config.mailUrl.cStr(), true));
       }
       if (config.rootUrl == nullptr) {
-        if (config.port == 80) {
-          KJ_SYSCALL(setenv("ROOT_URL", kj::str("http://", config.bindIp).cStr(), true));
+        kj::String scheme;
+        uint defaultPort;
+
+        if (config.httpsPort == nullptr) {
+          scheme = kj::str("http://");
+          defaultPort = 80;
+        } else {
+          scheme = kj::str("https://");
+          defaultPort = 443;
+        }
+        if (config.ports[0] == defaultPort) {
+          KJ_SYSCALL(setenv("ROOT_URL", kj::str(scheme, config.bindIp).cStr(), true));
         } else {
           KJ_SYSCALL(setenv("ROOT_URL",
-              kj::str("http://", config.bindIp, ":", config.port).cStr(), true));
+              kj::str(scheme, config.bindIp, ":", config.ports[0]).cStr(), true));
         }
       } else {
         KJ_SYSCALL(setenv("ROOT_URL", config.rootUrl.cStr(), true));
@@ -2042,6 +2108,18 @@ private:
     if (access("../var/sandcats", F_OK) == 0) {
         setOwnerGroupAndMode(kj::str("../var/sandcats"), 0700, config.uids.uid, config.uids.gid);
     }
+
+    // Same issue with https directory & its subdirectories.
+    kj::String httpsBaseDir = kj::str("../var/sandcats/https");
+    if (access(httpsBaseDir.cStr(), F_OK) == 0) {
+      setOwnerGroupAndMode(httpsBaseDir, 0700, config.uids.uid, config.uids.gid);
+
+      kj::Array<kj::String> entries = listDirectory(kj::str(httpsBaseDir));
+      for (size_t i = 0; i < entries.size(); i++) {
+        setOwnerGroupAndMode(kj::str(httpsBaseDir, "/", entries[i]), 0700, config.uids.uid, config.uids.gid);
+      }
+    }
+
     // var/sandcats/{register-log,id_rsa{,.pub,private_combined}} should each be 0640, with corrected
     // owner/group
     static const char* const files[] = {"register-log", "id_rsa", "id_rsa.pub", "id_rsa.private_combined"};

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1246,10 +1246,10 @@ private:
           KJ_FAIL_REQUIRE("invalid config value SERVER_USER", value);
         }
       } else if (key == "HTTPS_PORT") {
-          KJ_IF_MAYBE(p, parseUInt(value, 10)) {
-            config.httpsPort = *p;
-          } else {
-            KJ_FAIL_REQUIRE("invalid config value HTTPS_PORT", value);
+        KJ_IF_MAYBE(p, parseUInt(value, 10)) {
+          config.httpsPort = *p;
+        } else {
+          KJ_FAIL_REQUIRE("invalid config value HTTPS_PORT", value);
         }
       } else if (key == "PORT") {
           maybePortValue = kj::mv(value);
@@ -1717,33 +1717,33 @@ private:
   }
 
   void bindSocketToFd(const Config& config, uint port, uint targetFdNum) {
-      int sockFd;
-      KJ_SYSCALL(sockFd = socket(PF_INET, SOCK_STREAM | SOCK_NONBLOCK, IPPROTO_TCP));
+    int sockFd;
+    KJ_SYSCALL(sockFd = socket(PF_INET, SOCK_STREAM | SOCK_NONBLOCK, IPPROTO_TCP));
 
-      // Enable SO_REUSEADDR so that `sandstorm restart` doesn't take minutes to succeed.
-      int optval = 1;
-      KJ_SYSCALL(setsockopt(sockFd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)));
+    // Enable SO_REUSEADDR so that `sandstorm restart` doesn't take minutes to succeed.
+    int optval = 1;
+    KJ_SYSCALL(setsockopt(sockFd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)));
 
-      sockaddr_in sa;
-      memset(&sa, 0, sizeof sa);
-      sa.sin_family = AF_INET;
-      sa.sin_port = htons(port);
-      int rc = inet_pton(AF_INET, config.bindIp.cStr(), &(sa.sin_addr));
-      // If ipv4 address parsing fails, try ipv6
-      if (rc == 0) {
-        rc = inet_pton(AF_INET6, config.bindIp.cStr(), &(sa.sin_addr));
-        KJ_REQUIRE(rc == 1, "Bind IP is an invalid IP address:", config.bindIp);
-      }
+    sockaddr_in sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sin_family = AF_INET;
+    sa.sin_port = htons(port);
+    int rc = inet_pton(AF_INET, config.bindIp.cStr(), &(sa.sin_addr));
+    // If ipv4 address parsing fails, try ipv6
+    if (rc == 0) {
+      rc = inet_pton(AF_INET6, config.bindIp.cStr(), &(sa.sin_addr));
+      KJ_REQUIRE(rc == 1, "Bind IP is an invalid IP address:", config.bindIp);
+    }
 
-      KJ_SYSCALL(bind(sockFd, reinterpret_cast<sockaddr *>(&sa), sizeof sa));
-      KJ_SYSCALL(listen(sockFd, 511)); // 511 is what node uses as its default backlog
+    KJ_SYSCALL(bind(sockFd, reinterpret_cast<sockaddr *>(&sa), sizeof sa));
+    KJ_SYSCALL(listen(sockFd, 511)); // 511 is what node uses as its default backlog
 
-      if (sockFd != targetFdNum) {
-        // dup socket to correct fd.
-        KJ_SYSCALL(dup2(sockFd, targetFdNum));
-        KJ_SYSCALL(close(sockFd));
-      }
-}
+    if (sockFd != targetFdNum) {
+      // dup socket to correct fd.
+      KJ_SYSCALL(dup2(sockFd, targetFdNum));
+      KJ_SYSCALL(close(sockFd));
+    }
+  }
 
   pid_t startNode(const Config& config) {
     Subprocess process([&]() -> int {

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1786,14 +1786,14 @@ private:
         KJ_SYSCALL(setenv("MAIL_URL", config.mailUrl.cStr(), true));
       }
       if (config.rootUrl == nullptr) {
-        kj::String scheme;
+        kj::StringPtr scheme;
         uint defaultPort;
 
         if (config.httpsPort == nullptr) {
-          scheme = kj::str("http://");
+          scheme = "http://";
           defaultPort = 80;
         } else {
-          scheme = kj::str("https://");
+          scheme = "https://";
           defaultPort = 443;
         }
         if (config.ports[0] == defaultPort) {


### PR DESCRIPTION
Changes:

* Adjust run-bundle to listen on multiple ports and pass their sockets over.

* Adjust meteor-bundle-main.js to optionally rebind http.createServer() to
  return a HTTPS server.

* Adjust pre-meteor.js to handle secondary HTTP services.

* Adjust default ROOT_URL to be https:// if HTTPS is enabled.

* Adjust run-bundle & install.sh to fix permissions problems in https dir.

* Adjust install.sh to create the HTTPS keys with permissions that are readable by Sandstorm.

* Serve static publishing on the first HTTPS port as well as the first HTTP port, even for custom user domain names.

* Adjust run-dev.sh to do something reasonable when multiple ports are defined.