### PR TITLE
We don't provide a font-weight: 300, so don't use it

### DIFF
--- a/shell/client/_about.scss
+++ b/shell/client/_about.scss
@@ -60,7 +60,6 @@
     >p {
       font-size: 120%;
       line-height: 150%;
-      font-weight: 300;
       @media (max-width: 1300px) {
         line-height: inherit;
         margin-top: 0;
@@ -248,7 +247,6 @@
       }
       font-size: 120%;
       line-height: 150%;
-      font-weight: 300;
       @media (max-width: 1300px) {
         line-height: inherit;
         margin-top: 0;

--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -1066,8 +1066,6 @@ body>.popup.billing-prompt>.frame {
 
       >p {
         font-size: 10pt;
-        font-weight: 300;
-
         >a {
           text-decoration: none;
           font-weight: 600;


### PR DESCRIPTION
These are falling back to the default font-weight: normal - might as well
remove them if we're not using Source Sans Pro Light.