### PR TITLE
Fix some low-hanging usability fruit

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -300,22 +300,18 @@ body>.topbar {
 
       background-image: url("/share.svg");
       background-repeat: no-repeat;
-      background-position: 8px center;
-
       @media #{$desktop} {
-        background-position: left;
-        background-color: #762f87;
+        background-position: 2px center;
         color: #cccccc; // Have the text match the icon.
                         // This is the single place the button text is visible.
-        padding-left: 32px;
+        padding-left: 36px;
         padding-right: 8px;
         height: 32px;
         line-height: 28px;
         font-size: 12pt;
-
-        &:hover {
-          background-color: lighten(#762f87, 8);
-        }
+      }
+      @media #{$mobile} {
+        background-position: 10px center;
       }
     }
 
@@ -437,11 +433,6 @@ body>.topbar {
           >a {
             padding: 0 8px;
             display: block;
-
-            &.highlight {
-              background-color: #762f87;
-              color: white;
-            }
           }
         }
       }

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -289,7 +289,7 @@ limitations under the License.
 </template>
 
 <template name="grainShareButton">
-  Share
+  Share access
 </template>
 
 <template name="whoHasAccess">

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -16,11 +16,7 @@
       {{/if}}
     {{/if}}
   {{else}}
-    {{#if isCurrentRoute 'shared'}}
-      <a class="highlight">Save this link ▾</a>
-    {{else}}
-      <a>Sign in ▾</a>
-    {{/if}}
+    <a>Sign in ▾</a>
   {{/if}}
 </template>
 


### PR DESCRIPTION
* Users generally interpret "Share" to mean "Share on social media",
  especially with the icon we provided.  We mean to communicate something else:
  that this is how you grant access to this grain.

* "Save this link" has no information scent for signing in.  Revert to "Sign in".