### PR TITLE
Cryptographically verify updates to Sandstorm proper.

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -81,8 +81,12 @@ git push origin "$TAG_NAME"
 
 echo "**** Pushing build $BUILD ****"
 
+# Create signature used to verify updates.
+tmp/sandstorm/update-tool sign ~/.sandstorm-update-keyring $TARBALL > $TARBALL.update-sig
+
 echo $BUILD > tmp/$CHANNEL
 gce-ss copy-files $TARBALL fe:/var/www/dl.sandstorm.io
+gce-ss copy-files $TARBALL.update-sig fe:/var/www/dl.sandstorm.io
 gce-ss copy-files tmp/$CHANNEL fe:/var/www/install.sandstorm.io
 gce-ss copy-files install.sh fe:/var/www/install.sandstorm.io
 

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1883,8 +1883,9 @@ private:
     // Verify signature.
     {
       context.warning("Checking signature...");
-      KJ_ON_SCOPE_FAILURE(
-          context.warning("*** SIGNATURE CHECK FAILED: please notify security@sandstorm.io ***"));
+      KJ_ON_SCOPE_FAILURE(context.warning(
+          "*** Aborting update because signature check failed! Most likely this is due to a "
+          "network glitch, but if you suspect an attack, notify security@sandstorm.io."));
 
       // Download and parse signature file for this update.
       capnp::StreamFdMessageReader signatureMessage(

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -24,7 +24,9 @@
 #include <capnp/serialize.h>
 #include <capnp/compat/json.h>
 #include <sandstorm/package.capnp.h>
+#include <sandstorm/update-tool.capnp.h>
 #include <sodium/randombytes.h>
+#include <sodium/crypto_sign_ed25519.h>
 #include <stdlib.h>
 #include <signal.h>
 #include <limits.h>
@@ -290,7 +292,17 @@ public:
     }
   }
 
-  ~CurlRequest() {
+  explicit CurlRequest(kj::StringPtr url, int outFd): url(kj::heapString(url)) {
+    KJ_SYSCALL(pid = fork());
+    if (pid == 0) {
+      KJ_SYSCALL(dup2(outFd, STDOUT_FILENO));
+      KJ_SYSCALL(execlp("curl", "curl", isatty(STDERR_FILENO) ? "-f" : "-fs",
+                        url.cStr(), EXEC_END_ARGS), url);
+      KJ_UNREACHABLE;
+    }
+  }
+
+  ~CurlRequest() noexcept(false) {
     if (pid == 0) return;
 
     // Close the pipe first, in case the child is waiting for that.
@@ -1861,17 +1873,55 @@ private:
       return false;
     }
 
-    // Start http request to download bundle.
+    // Download bundle to temporary file.
     auto url = kj::str("https://dl.sandstorm.io/sandstorm-", targetBuild, ".tar.xz");
+    auto file = openTemporary("/var/tmp/sandstorm-update");
     context.warning(kj::str("Downloading: ", url));
-    auto download = kj::heap<CurlRequest>(url);
-    int fd = download->getPipe();
-    unpackUpdate(fd, kj::mv(download), targetBuild);
+    CurlRequest(url, file);
+    KJ_SYSCALL(lseek(file, 0, SEEK_SET));
+
+    // Verify signature.
+    {
+      context.warning("Checking signature...");
+      KJ_ON_SCOPE_FAILURE(
+          context.warning("*** SIGNATURE CHECK FAILED: please notify security@sandstorm.io ***"));
+
+      // Download and parse signature file for this update.
+      capnp::StreamFdMessageReader signatureMessage(
+          CurlRequest(kj::str(url, ".update-sig")).getPipe());
+      auto sigs = signatureMessage.getRoot<UpdateSignature>().getSignatures();
+
+      // Always verify using the *last* key in updatePublicKeys, as it is the most recent.
+      uint keyIndex = UPDATE_PUBLIC_KEYS->size() - 1;
+      PublicSigningKey::Reader key = (*UPDATE_PUBLIC_KEYS)[keyIndex];
+      KJ_ASSERT(sigs.size() > keyIndex,
+          "signature is missing the most recent signing key");
+      Signature::Reader signature = sigs[keyIndex];
+
+      // mmap the file and check the signature.
+      MemoryMapping mapping(file, "(update tarball)");
+      capnp::Data::Reader data = mapping;
+      KJ_ASSERT(crypto_sign_ed25519_verify_detached(
+          structToBytes(signature, crypto_sign_ed25519_BYTES),
+          data.begin(), data.size(),
+          structToBytes(key, crypto_sign_ed25519_PUBLICKEYBYTES)) == 0,
+          "signature is invalid");
+
+      context.warning("Signature is valid.");
+    }
+
+    unpackUpdate(file, targetBuild);
+
     return true;
   }
 
-  void unpackUpdate(int bundleFd, kj::Maybe<kj::Own<CurlRequest>> curlRequest = nullptr,
-                    uint expectedBuild = 0) {
+  const byte* structToBytes(capnp::AnyStruct::Reader reader, size_t size) {
+    auto data = reader.getDataSection();
+    KJ_REQUIRE(data.size() >= size);
+    return data.begin();
+  }
+
+  void unpackUpdate(int bundleFd, uint expectedBuild = 0) {
     char tmpdir[] = "../downloading.XXXXXX";
     if (mkdtemp(tmpdir) != tmpdir) {
       KJ_FAIL_SYSCALL("mkdtemp", errno);
@@ -1885,9 +1935,6 @@ private:
       KJ_SYSCALL(execlp("tar", "tar", "Jxo", EXEC_END_ARGS));
       KJ_UNREACHABLE;
     }
-
-    // Make sure to report CURL status before tar status.
-    curlRequest = nullptr;
 
     int tarStatus;
     KJ_SYSCALL(waitpid(tarPid, &tarStatus, 0));

--- a/src/sandstorm/update-tool.c++
+++ b/src/sandstorm/update-tool.c++
@@ -1,0 +1,234 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <kj/main.h>
+#include <sandstorm/update-tool.capnp.h>
+#include "version.h"
+#include <capnp/serialize.h>
+#include "util.h"
+#include <sodium/crypto_sign_ed25519.h>
+#include <sodium/randombytes.h>
+#include <capnp/pretty-print.h>
+
+namespace sandstorm {
+
+class UpdateToolMain {
+  // Main class for a program used to sign updates.
+
+public:
+  UpdateToolMain(kj::ProcessContext& context): context(context) {}
+
+  kj::MainFunc getMain() {
+    return kj::MainBuilder(context, "Sandstorm version " SANDSTORM_VERSION,
+                           "Tool used to sign Sandstorm updates.")
+        .addSubCommand("sign", KJ_BIND_METHOD(*this, getSignMain), "sign an update")
+        .addSubCommand("verify", KJ_BIND_METHOD(*this, getVerifyMain), "verify an update")
+        .addSubCommand("add", KJ_BIND_METHOD(*this, getAddMain), "create a new key")
+        .addSubCommand("list", KJ_BIND_METHOD(*this, getListMain), "list public keys")
+        .build();
+  }
+
+  kj::MainFunc getSignMain() {
+    return kj::MainBuilder(context, "Sandstorm version " SANDSTORM_VERSION,
+                           "Sign a file with each key in the keyring and output the signature "
+                           "list to stdout.")
+        .expectArg("<keyring>", KJ_BIND_METHOD(*this, loadKeyring))
+        .expectArg("<file>", KJ_BIND_METHOD(*this, doSign))
+        .build();
+  }
+
+  kj::MainBuilder::Validity loadKeyring(kj::StringPtr arg) {
+    // The keyring file is actually 100% random. Every 32 bytes is a seed used to generate a
+    // keypair.
+
+    auto bytes = readAllBytes(raiiOpen(arg, O_RDONLY));
+    if (bytes == nullptr) return "file is empty";
+
+    size_t count = bytes.size() / crypto_sign_ed25519_SEEDBYTES;
+    if (bytes.size() % crypto_sign_ed25519_SEEDBYTES != 0) return "invalid keyring";
+
+    auto publicKeys = *UPDATE_PUBLIC_KEYS;
+
+    auto builder = kj::heapArrayBuilder<PrivateKey>(count);
+    for (size_t i = 0; i < count; i++) {
+      byte publicKey[crypto_sign_ed25519_PUBLICKEYBYTES];
+      KJ_ASSERT(crypto_sign_ed25519_seed_keypair(publicKey, builder.add().key,
+          bytes.begin() + i * crypto_sign_ed25519_SEEDBYTES) == 0);
+
+      if (i < publicKeys.size()) {
+        if (memcmp(publicKey, structToBytes(publicKeys[i], crypto_sign_ed25519_PUBLICKEYBYTES),
+                   crypto_sign_ed25519_PUBLICKEYBYTES) != 0) {
+          return kj::str("keyring does not match public key #", i);
+        }
+      }
+    }
+
+    if (count < publicKeys.size()) {
+      return kj::str("keyring is missing keys starting at #", count);
+    }
+
+    if (count > publicKeys.size()) {
+      context.warning(kj::str(
+          "WARNING: keyring contains keys than are not yet listed in updatePublicKeys"));
+    }
+
+    keyring = builder.finish();
+
+    return true;
+  }
+
+  kj::MainBuilder::Validity doSign(kj::StringPtr arg) {
+    auto bundle = raiiOpen(arg, O_RDONLY);
+    MemoryMapping mapping(bundle, arg);
+    capnp::Data::Reader data = mapping;
+
+    capnp::MallocMessageBuilder output;
+    auto signatures = output.getRoot<UpdateSignature>().initSignatures(keyring.size());
+
+    for (auto i: kj::indices(keyring)) {
+      KJ_ASSERT(crypto_sign_ed25519_detached(
+          structToBytes(signatures[i], crypto_sign_ed25519_BYTES),
+          nullptr, data.begin(), data.size(), keyring[i].key) == 0);
+    }
+
+    capnp::writeMessageToFd(STDOUT_FILENO, output);
+
+    context.exit();
+  }
+
+  kj::MainFunc getVerifyMain() {
+    return kj::MainBuilder(context, "Sandstorm version " SANDSTORM_VERSION,
+                           "Verify <file> against the signature read from standard input.")
+        .expectArg("<file>", KJ_BIND_METHOD(*this, doVerify))
+        .build();
+  }
+
+  kj::MainBuilder::Validity doVerify(kj::StringPtr arg) {
+    auto bundle = raiiOpen(arg, O_RDONLY);
+    MemoryMapping mapping(bundle, arg);
+    capnp::Data::Reader data = mapping;
+
+    capnp::StreamFdMessageReader signatureMessage(STDIN_FILENO);
+    auto signatures = signatureMessage.getRoot<UpdateSignature>().getSignatures();
+    auto keys = *UPDATE_PUBLIC_KEYS;
+
+    for (auto i: kj::indices(keys)) {
+      if (i >= signatures.size()) {
+        context.error(kj::str("key ", i, ": NO SIGNATURE"));
+        continue;
+      } else if (crypto_sign_ed25519_verify_detached(
+          structToBytes(signatures[i], crypto_sign_ed25519_BYTES),
+          data.begin(), data.size(),
+          structToBytes(keys[i], crypto_sign_ed25519_PUBLICKEYBYTES)) == 0) {
+        context.warning(kj::str("key ", i, ": PASS"));
+      } else {
+        context.error(kj::str("key ", i, ": FAIL"));
+      }
+    }
+
+    if (keys.size() < signatures.size()) {
+      context.warning(kj::str(
+          "signature has ", signatures.size() - keys.size(), " additional keys."));
+    }
+
+    context.exit();
+  }
+
+  kj::MainFunc getAddMain() {
+    return kj::MainBuilder(context, "Sandstorm version " SANDSTORM_VERSION,
+                           "Add a new key to <keyring>.")
+        .expectArg("<keyring>", KJ_BIND_METHOD(*this, doAdd))
+        .build();
+  }
+
+  kj::MainBuilder::Validity doAdd(kj::StringPtr arg) {
+    if (access(arg.cStr(), F_OK) == 0) {
+      // Verify that this keyring looks right.
+      auto loadResult = loadKeyring(arg);
+      if (loadResult.getError() != nullptr) return loadResult;
+    }
+
+    // Add a new key seed.
+    byte random[crypto_sign_ed25519_SEEDBYTES];
+    randombytes(random, sizeof(random));
+    kj::FdOutputStream(raiiOpen(arg, O_WRONLY | O_APPEND | O_CREAT, 0600))
+        .write(random, sizeof(random));
+
+    // Write key.
+    capnp::MallocMessageBuilder message;
+    auto key = message.getRoot<PublicSigningKey>();
+    memcpy(structToBytes(kj::cp(key), sizeof(random)), random, sizeof(random));
+    printKey(key);
+    context.exitInfo("*** Don't forget to back up the keyring! ***");
+  }
+
+  kj::MainFunc getListMain() {
+    return kj::MainBuilder(context, "Sandstorm version " SANDSTORM_VERSION,
+                           "List public keys for keys in <keyring>, or compiled keys if "
+                           "<keyring> is not provided.")
+        .expectOptionalArg("<keyring>", KJ_BIND_METHOD(*this, loadKeyring))
+        .callAfterParsing(KJ_BIND_METHOD(*this, doList))
+        .build();
+  }
+
+  kj::MainBuilder::Validity doList() {
+    if (keyring == nullptr) {
+      for (auto key: *UPDATE_PUBLIC_KEYS) printKey(key);
+    } else {
+      capnp::MallocMessageBuilder message;
+      auto keys = message.getRoot<capnp::AnyPointer>()
+          .initAs<capnp::List<PublicSigningKey>>(keyring.size());
+      for (auto i: kj::indices(keyring)) {
+        KJ_ASSERT(crypto_sign_ed25519_sk_to_pk(
+            structToBytes(keys[i], crypto_sign_ed25519_PUBLICKEYBYTES), keyring[i].key) == 0);
+      }
+      for (auto key: keys) printKey(key);
+    }
+    context.exit();
+  }
+
+private:
+  kj::ProcessContext& context;
+
+  struct PrivateKey {
+    byte key[crypto_sign_ed25519_SECRETKEYBYTES];
+  };
+  kj::Array<PrivateKey> keyring;
+
+  const byte* structToBytes(capnp::AnyStruct::Reader reader, size_t size) {
+    auto data = reader.getDataSection();
+    KJ_REQUIRE(data.size() == size);
+    return data.begin();
+  }
+
+  byte* structToBytes(capnp::AnyStruct::Builder builder, size_t size) {
+    auto data = builder.getDataSection();
+    KJ_REQUIRE(data.size() == size);
+    return data.begin();
+  }
+
+  void printKey(PublicSigningKey::Reader key) {
+    auto str = kj::str("(key0 = 0x", kj::hex(key.getKey0()), ", "
+                        "key1 = 0x", kj::hex(key.getKey1()), ", "
+                        "key2 = 0x", kj::hex(key.getKey2()), ", "
+                        "key3 = 0x", kj::hex(key.getKey3()), "),\n");
+    kj::FdOutputStream(STDOUT_FILENO).write(str.begin(), str.size());
+  }
+};
+
+}  // namespace sandstorm
+
+KJ_MAIN(sandstorm::UpdateToolMain)

--- a/src/sandstorm/update-tool.capnp
+++ b/src/sandstorm/update-tool.capnp
@@ -1,0 +1,54 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0x96c3fff3f4beb8fe;
+# This file contains schemas relevant to the Sandstorm self-updater.
+
+$import "/capnp/c++.capnp".namespace("sandstorm");
+
+struct PublicSigningKey {
+  key0 @0 :UInt64;
+  key1 @1 :UInt64;
+  key2 @2 :UInt64;
+  key3 @3 :UInt64;
+  # ed25519 public key.
+}
+
+struct Signature {
+  sig0 @0 :UInt64;
+  sig1 @1 :UInt64;
+  sig2 @2 :UInt64;
+  sig3 @3 :UInt64;
+  sig4 @4 :UInt64;
+  sig5 @5 :UInt64;
+  sig6 @6 :UInt64;
+  sig7 @7 :UInt64;
+}
+
+const updatePublicKeys :List(PublicSigningKey) = [
+  # List of public keys with which Sandstorm updates are signed. The last key in this list should
+  # be used to verify updates. When we "rotate" keys, we actually add a new key, but keep signing
+  # with the old keys as well, so that existing servers can update.
+
+  (key0 = 0x5a2d999e727ba977, key1 = 0x83cea6e0708ccf63, key2 = 0xdf70ccedc4be19bc, key3 = 0x81087ee2db417366),
+];
+
+struct UpdateSignature {
+  # Format of a signature file.
+
+  signatures @0 :List(Signature);
+  # Signatures corresponding to each key in updatePublicKeys.
+}

--- a/src/sodium/crypto_sign_ed25519
+++ b/src/sodium/crypto_sign_ed25519
@@ -1,1 +1,1 @@
-../../deps/libsodium/src/libsodium/crypto_sign/ed25519/ref10
+../../deps/libsodium/src/libsodium/crypto_sign/ed25519


### PR DESCRIPTION
Updates are signed using ed25519 via libsodium. We don't use gpg for updates because it would be an extra dependency and it's hard to use correctly. (OTOH we have to use gpg for install verification since we need to bootstrap from tools people have; see pull request #901.)

The strategy is as follows:
- We maintain a list of signing keys, which for now has only one element.
- The public keys in this list are compiled directly into the Sandstorm binary.
- Private keys are kept in a keyring file.
- Every time we want to "rotate" the key, we actually add a new key to the list, and use it to sign future updates.
- Each update is shipped with a signature file containing signatures using *every* key in the list.
- Sandstorm, when updating, checks the signature file for a signature using the most-recent key it knows about.

The scheme makes it painless to rotate keys, since rotating keys will never prevent old versions from updating.

In the event of a compromise of the update signing key, the update system is reduced to relying on HTTPS for integrity until a new release is pushed with a new key added -- which would be almost a non-event, honestly.

In the event that the private signing key becomes inaccessible to us, it will become impossible to update existing clients without manual user intervention -- which would be catastrophic.

Therefore, we should err on the side of keeping many copies of the private key.