### PR TITLE
Use export-minimal to get smallest GPG keyring

### DIFF
--- a/docs/developing/publishing-apps.md
+++ b/docs/developing/publishing-apps.md
@@ -27,7 +27,7 @@ If you do it correctly, `cat pgp-signature | gpg` should print out the statement
 
 To verify your signature, you also need to export your public key and include it in your app package. You can run the following command, where `<key-id>` is a PGP key ID or a username associated with the key:
 
-`gpg --export <key-id> > pgp-keyring`
+`gpg --export <key-id> --export-options export-minimal > pgp-keyring`
 
 ## Add required metadata
 


### PR DESCRIPTION
Micro-benchmark results on my personal key.

```
$ gpg --export --export-options export-minimal '97225E589D6B9E01533C485EEC4B033C70096AD1' | wc -c
8118
```

```
$ gpg --export '97225E589D6B9E01533C485EEC4B033C70096AD1' | wc -c
78782
```

Realistically this only affects people (like me) who have a lot of signatures
on their key. But I think it's smart to document it the export-minimal way
to help those who do.