### PR TITLE
Refresh cert as needed

### DIFF
--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -119,7 +119,7 @@ function monkeypatchHttpAndHttps() {
           } else {
             // Sometimes the server gives us a 0-byte response,
             // presumably due to a connection getting reset?.
-            console.error("Got exception reading JSON from server. Dazed and confused, but trying to continue.", e);
+            console.error("Got exception reading JSON from file:", metadataFilename, "Dazed and confused, but trying to continue.", e);
             continue;
           }
         }

--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -66,9 +66,9 @@ function monkeypatchHttpAndHttps() {
       var files = fs.readdirSync(basePath);
       if ((files.indexOf(keyBasename) == -1) ||
           (files.indexOf(certBasename) == -1)) {
-        // Otherwise, we generate them synchronously. This could slow down the
-        // first startup of a HTTPS-enabled Sandstorm.
-        console.log("Generating default HTTPS key for use with non-SNI clients.");
+        // Generate them synchronously. This could slow down the first
+        // start of a HTTPS-enabled Sandstorm.
+        console.log("Generating default HTTPS key for use with non-SNI clients. Expect a 45 second delay.");
 
         // Generate 2048-bit key.
         var keys = forge.pki.rsa.generateKeyPair({bits: 2048});
@@ -120,9 +120,7 @@ function monkeypatchHttpAndHttps() {
       // and if the time is greater than nextRekeyTime, then call this
       // function again.
       //
-      // If nextRekeyTime is null, then the caller should not bother
-      // calling this function, since it means this function has no
-      // knowledge of other keys that will become valid.
+      // If nextRekeyTime is null, it means we have only one key.
       var basePath = '/var/sandcats/https/' + (
         url.parse(process.env.ROOT_URL).hostname);
       var files = fs.readdirSync(basePath);

--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -66,7 +66,7 @@ function monkeypatchHttpAndHttps() {
       // Indication ("SNI").
 
       // If we're lucky, we already have the files.
-      var hostname = 'for-clients-without-sni.sandstorm-requires-sni.invalid';
+      var hostname = 'client-does-not-support-sni.sandstorm-requires-sni.invalid';
       var basePath = makeHttpsDir(hostname);
       var keyBasename = "0.key";
       var certBasename = "0.crt";

--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -119,7 +119,8 @@ function monkeypatchHttpAndHttps() {
           } else {
             // Sometimes the server gives us a 0-byte response,
             // presumably due to a connection getting reset?.
-            console.error("Got exception reading JSON from file:", metadataFilename, "Dazed and confused, but trying to continue.", e);
+            console.error("Got exception reading JSON from file:", metadataFilename,
+                          "Dazed and confused, but trying to continue.", e);
             continue;
           }
         }

--- a/shell/.meteor/packages
+++ b/shell/.meteor/packages
@@ -26,4 +26,5 @@ sandstorm-permissions
 sandstorm-ui-topbar
 sandstorm-ui-applist
 sandstorm-ui-grainlist
+meteor-node-forge
 fourseven:scss

--- a/shell/.meteor/versions
+++ b/shell/.meteor/versions
@@ -48,6 +48,7 @@ livedata@1.0.13
 localstorage@1.0.3
 logging@1.0.7
 meteor@1.1.6
+meteor-node-forge@0.0.0
 meteor-platform@1.2.2
 minifiers@1.1.5
 minimongo@1.0.8

--- a/shell/packages/meteor-node-forge/import.js
+++ b/shell/packages/meteor-node-forge/import.js
@@ -1,0 +1,1 @@
+this.forge = Npm.require("node-forge");

--- a/shell/packages/meteor-node-forge/package.js
+++ b/shell/packages/meteor-node-forge/package.js
@@ -1,0 +1,7 @@
+Npm.depends({
+    'node-forge': '0.6.34'
+});
+
+Package.on_use(function (api) {
+    api.add_files('import.js', 'server');
+});

--- a/shell/server/sandcats.js
+++ b/shell/server/sandcats.js
@@ -20,8 +20,8 @@ var fs = Npm.require("fs");
 var dgram = Npm.require("dgram");
 var Url = Npm.require("url");
 
-var SANDCATS_HOSTNAME = Meteor.settings && Meteor.settings.public &&
-                          Meteor.settings.public.sandcatsHostname;
+var SANDCATS_HOSTNAME = (Meteor.settings && Meteor.settings.public &&
+                         Meteor.settings.public.sandcatsHostname || "sandcats-dev.sandstorm.io");
 var SANDCATS_VARDIR = (SANDSTORM_ALTHOME || "") + "/var/sandcats";
 
 var ROOT_URL = Url.parse(process.env.ROOT_URL);
@@ -82,7 +82,17 @@ function performSandcatsRequest(path, hostname, postData, errorCallback, respons
       "Content-Type": "application/x-www-form-urlencoded"
     }
   };
+
+  console.log("Submitting certificate request for host",
+              postData.rawHostname, "where the request has length",
+              postData.certificateSigningRequest.length);
   var post_data = querystring.stringify(postData);
+  if ((SANDCATS_HOSTNAME === "sandcats-dev.sandstorm.io") &&
+      ! process.env.NODE_TLS_REJECT_UNAUTHORIZED) {
+    console.log("You are using the Sandcats dev server but have full HTTPS " +
+                "certificate checking enabled. Probably you will get an HTTPS " +
+                "error. Proceeding anyway.");
+  }
   var req = https.request(options, responseCallback);
   req.write(post_data);
   req.end();
@@ -93,17 +103,158 @@ function performSandcatsRequest(path, hostname, postData, errorCallback, respons
   return req;
 }
 
-if (SANDCATS_HOSTNAME) {
-  Meteor.startup(function () {
-    var i = HOSTNAME.lastIndexOf(SANDCATS_HOSTNAME);
-    if (i < 0) {
-      console.error("SANDCATS_BASE_DOMAIN is configured but your HOSTNAME doesn't appear to contain it:",
-                    SANDCATS_HOSTNAME, HOSTNAME);
-    } else {
-      var oneMinute = 60 * 1000;
-      // All Sandcats installs need dyndns updating.
-      SANDCATS_NAME = HOSTNAME.slice(0, i - 1);
-      Meteor.setInterval(pingUdp, oneMinute);
-    }
-  });
+generateKeyAndCsr = function(commonName) {
+  // This function relies on the this.forge object created by the
+  // meteor-node-forge package.
+  check(commonName, String);
+
+  // Generate key pair. Using Meteor.wrapAsync because forge supports
+  // a synchronous as well as an asynchronous API, and the synchronous
+  // one blocks for a while.
+  var wrappedGenerateKeyPair = Meteor.wrapAsync(this.forge.pki.rsa.generateKeyPair);
+
+  // I could pick an `e`[xponent] value for the resulting RSA key, but
+  // I will refrain.
+  var keys = wrappedGenerateKeyPair({bits: 2048});
+
+  // Create a certificate request (CSR).
+  var csr = this.forge.pki.createCertificationRequest();
+  csr.publicKey = keys.publicKey;
+  csr.setSubject([{
+    name: 'commonName',
+    value: commonName
+  }]);
+  csr.sign(keys.privateKey);
+  console.log("generateKeyAndCsr created new key & certificate request for", commonName);
+  return {privateKeyAsPem: this.forge.pki.privateKeyToPem(keys.privateKey),
+          csrAsPem: this.forge.pki.certificationRequestToPem(csr)};
+};
+
+storeNewKeyAndCsr = function(hostname, basePath) {
+  // We use the current JS time (like UNIX timestamp but in
+  // milliseconds) as the key number. Note that the keyNumber is
+  // intended to be an opaque identifier; the only important thing is
+  // that it increases numerically over time. We use the current time
+  // just as a simplistic way to pick a filename that probably no one
+  // else has created yet.
+  var keyNumber = new Date().getTime();
+  var keyFilename = basePath + "/" + keyNumber;
+  var csrFilename = keyFilename + ".csr";
+  var responseFilename = keyFilename + ".response-json";
+  var keyAndCsr = generateKeyAndCsr(hostname);
+  fs.writeFileSync(keyFilename, keyAndCsr.privateKeyAsPem,
+                   {'mode': 0400});
+  fs.writeFileSync(csrFilename, keyAndCsr.csrAsPem);
+  console.log("storeNewKeyAndCsr successfully saved key and certificate request to",
+              keyFilename, "and", csrFilename, "respectively of length",
+              keyAndCsr.privateKeyAsPem.length, "and",
+              keyAndCsr.csrAsPem.length);
+  return {csrFilename: csrFilename,
+          keyFilename: keyFilename,
+          responseFilename: responseFilename};
 }
+
+renewHttpsCertificateIfNeeded = function() {
+  function renewHttpsCertificate() {
+    var hostname = Url.parse(process.env.ROOT_URL).hostname;
+    var basePath = '/var/sandcats/https/' + (
+      hostname);
+    var filenames = storeNewKeyAndCsr(hostname, basePath);
+
+    var errorCallback = function (err) {
+      console.error("Error while renewing HTTPS certificate (will continue to retry)", err);
+    };
+
+    var responseCallback = function (res) {
+      if (res.statusCode == 200) {
+        // Save the response, chunk by chunk, then store it on disk
+        // for later use.
+        var responseBody = "";
+        res.on('data', function (chunk) {
+          responseBody += chunk;
+        });
+        res.on('end', function() {
+          // For sanity, make sure it parses as JSON, since we're
+          // going to need it to do that.
+          try {
+            JSON.parse(responseBody);
+          } catch (e) {
+            console.error("JSON parse error receiving new HTTPS certificate. Discarding:",
+                          responseBody,
+                          "due to exception:",
+                          e);
+            // Overwrite the responseBody with the empty JSON object
+            // and continue with the process of saving it to disk.
+            responseBody = "{}";
+          }
+
+          fs.writeFile(filenames.responseFilename, responseBody, function(err) {
+            if (err) {
+              return console.error("Failure while saveing new HTTPS certificate to",
+                                   filenames.responseFilename,
+                                   "will continue to retry. Exception was:",
+                                   err);
+            }
+          });
+
+          // Tell Sandcats that now is a good time to update its info
+          // about which keys are available.
+          if (! global.sandcats) {
+            console.error("When getting new certificate, could not find callback to request re-keying! Certs will probably become invalid soon.");
+          } else {
+            // Call the sandcats rekeying function.
+            global.sandcats.rekey();
+            // That's that.
+            console.log("Successfully renewed HTTPS certificate into",
+                        filenames.responseFilename);
+          }
+        });
+      } else {
+        console.log("Received HTTP error while renewing certificate (will keep retrying)",
+                    res.statusCode);
+        res.on('data', function (chunk) {
+          console.log("Error response contained information", chunk.toString('utf-8'));
+        });
+      }
+    };
+
+    var wrappedReadFile = Meteor.wrapAsync(fs.readFile);
+
+    performSandcatsRequest("/getcertificate", SANDCATS_HOSTNAME, {
+      rawHostname: SANDCATS_NAME,
+      certificateSigningRequest: wrappedReadFile(filenames.csrFilename, 'utf-8')
+    }, errorCallback, responseCallback);
+  }
+
+  // TODO: Actually check timestamps.
+  return renewHttpsCertificate();
+}
+
+initializeSandcats = function() {
+  var i = HOSTNAME.lastIndexOf(SANDCATS_HOSTNAME);
+  if (i < 0) {
+    console.error("SANDCATS_BASE_DOMAIN is configured but your HOSTNAME doesn't appear to contain it:",
+                  SANDCATS_HOSTNAME, HOSTNAME);
+  } else {
+    var oneMinute = 60 * 1000;
+    var oneHour = 60 * oneMinute;
+    var randomIntervalZeroToOneHour = Math.random() * oneHour;
+    // All Sandcats installs need dyndns updating.
+    SANDCATS_NAME = HOSTNAME.slice(0, i - 1);
+    Meteor.setInterval(pingUdp, oneMinute);
+    // If process.env.HTTPS_PORT is set, we need to auto-refresh our HTTPS certificate.
+    if (process.env.HTTPS_PORT) {
+      // Always do a HTTPS certificate update check on Sandstorm start.
+      renewHttpsCertificateIfNeeded();
+
+      // After that's done, schedule it for every approx 1-2 hours in
+      // the future.
+      Meteor.setInterval(renewHttpsCertificateIfNeeded,
+                         oneHour + randomIntervalZeroToOneHour);
+    }
+  }
+}
+
+if (SANDCATS_HOSTNAME) {
+  Meteor.startup(initializeSandcats);
+};

--- a/shell/server/sandcats.js
+++ b/shell/server/sandcats.js
@@ -23,7 +23,7 @@ var dgram = Npm.require("dgram");
 var Url = Npm.require("url");
 
 var SANDCATS_HOSTNAME = (Meteor.settings && Meteor.settings.public &&
-                         Meteor.settings.public.sandcatsHostname || "sandcats-dev.sandstorm.io");
+                         Meteor.settings.public.sandcatsHostname);
 var SANDCATS_VARDIR = (SANDSTORM_ALTHOME || "") + "/var/sandcats";
 
 var ROOT_URL = Url.parse(process.env.ROOT_URL);

--- a/shell/server/sandcats.js
+++ b/shell/server/sandcats.js
@@ -28,7 +28,7 @@ var ROOT_URL = Url.parse(process.env.ROOT_URL);
 var HOSTNAME = ROOT_URL.hostname;
 var SANDCATS_NAME; // Look at `startup` below to see where this is set
 
-function updateSandcats() {
+function updateSandcatsIp() {
   var options = {
     hostname: SANDCATS_HOSTNAME,
     path: "/update",
@@ -68,7 +68,7 @@ function pingUdp() {
   message = new Buffer(SANDCATS_NAME + " " + secret);
   socket.on("message", function (buf) {
     if (buf.toString() === secret) {
-      updateSandcats();
+      updateSandcatsIp();
     } else {
       console.error("Received unexpected response in UDP sandcats ping:", buf.toString());
     }

--- a/shell/server/sandcats.js
+++ b/shell/server/sandcats.js
@@ -228,14 +228,8 @@ Sandcats.renewHttpsCertificateIfNeeded = function() {
     }, errorCallback, responseCallback);
   }
 
-  // We only want to fetch a new certificate if such an action is
-  // needed. The strategy is that if we're on a certificate right now,
-  // and there is no nextRekeyTime available, then we should get a
-  // fresh cert.
-  if (global.sandcats.hasNextRekeyTime()) {
-    return;
-  } else {
-    console.log("renewHttpsCertificateIfNeeded: Happily choosing to renew certificate because we found no rekey time.");
+  if (global.sandcats.shouldGetAnotherCertificate()) {
+    console.log("renewHttpsCertificateIfNeeded: Happily choosing to renew certificate.");
     return renewHttpsCertificate();
   }
 }

--- a/shell/server/sandcats.js
+++ b/shell/server/sandcats.js
@@ -190,14 +190,14 @@ Sandcats.renewHttpsCertificateIfNeeded = function() {
             responseBody = "{}";
           }
 
-          fs.writeFile(filenames.responseFilename, responseBody, function(err) {
-            if (err) {
-              return console.error("Failure while saveing new HTTPS certificate to",
-                                   filenames.responseFilename,
-                                   "will continue to retry. Exception was:",
-                                   err);
-            }
-          });
+          try {
+            fs.writeFileSync(filenames.responseFilename, responseBody, "utf-8");
+          } catch (err) {
+            return console.error("Failure while saveing new HTTPS certificate to",
+                                 filenames.responseFilename,
+                                 "will continue to retry. Exception was:",
+                                 err);
+          }
 
           // Tell Sandcats that now is a good time to update its info
           // about which keys are available.


### PR DESCRIPTION
I believe this is ready to merge. It achieves the following:

* When we have either 0 valid certificates, or 1 valid certificate that expires 3 or fewer days from now, then we get a new cert.

Implementation details:

* In the face of multiple certificates being valid, pick one in a reasonable way.

* It outright denies access to all non-SNI clients by giving them an invalid cert. (@jparyani you might find that amusing.)

* It only calls `.listen()` on the HTTPS socket (fd 3) if a key is available.

Out of scope for this pull request (to be handled tomorrow):

* Deal with clock skew.