### PR TITLE
Fix clang 3.7 compilation errors.

### DIFF
--- a/src/sandstorm/backend.c++
+++ b/src/sandstorm/backend.c++
@@ -240,7 +240,7 @@ kj::Promise<void> BackendImpl::deleteGrain(DeleteGrainContext context) {
   if (iter != supervisors.end()) {
     shutdownPromise = iter->second.promise.addBranch()
         .then([context](Supervisor::Client client) mutable {
-      return client.shutdownRequest().send().then([](auto) {});
+      return client.shutdownRequest().send().then([](auto) { return; });
     }).then([]() -> kj::Promise<void> {
       return KJ_EXCEPTION(FAILED, "expected shutdown() to throw disconnected exception");
     }, [](kj::Exception&& e) -> kj::Promise<void> {

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -201,7 +201,7 @@ public:
         auto request = responseStream.writeRequest();
         auto dst = request.initData(body.size());
         memcpy(dst.begin(), body.begin(), body.size());
-        taskSet.add(request.send().then([](auto x){}));
+        taskSet.add(request.send().then([](auto x){ return; }));
         body.resize(0);
       }
 
@@ -420,7 +420,7 @@ private:
         KJ_FAIL_ASSERT("Failed to parse HTTP response from sandboxed app.", error);
       } else if (messageComplete || actual == 0) {
         // The parser is done or the stream has closed.
-        taskSet.add(responseStream.doneRequest().send().then([](auto x){}));
+        taskSet.add(responseStream.doneRequest().send().then([](auto x){ return; }));
         return kj::READY_NOW;
       } else {
         taskSet.add(pumpStreamInternal(kj::mv(stream)));
@@ -554,7 +554,7 @@ private:
       auto request = responseStream.writeRequest();
       auto dst = request.initData(data.size());
       memcpy(dst.begin(), data.begin(), data.size());
-      taskSet.add(request.send().then([](auto x){}));
+      taskSet.add(request.send().then([](auto x){ return; }));
     } else {
       body.addAll(data);
     }
@@ -626,7 +626,7 @@ public:
     auto request = clientStream.sendBytesRequest(
         capnp::MessageSize { data.size() / sizeof(capnp::word) + 8, 0 });
     request.setMessage(data);
-    tasks.add(request.send().then([](auto response) {}));
+    tasks.add(request.send().then([](auto response) { return; }));
   }
 
 protected:

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1590,7 +1590,7 @@ public:
     req.setOwner(owner);
     req.setRequirements(requirements);
     return req.send().then([context](auto args) mutable {
-      context.getResults().setSturdyRef(args.getToken());
+      return context.getResults().setSturdyRef(args.getToken());
     });
   }
 
@@ -1623,7 +1623,7 @@ public:
       req.setOwner(owner);
       // TODO(someday): Set requirements. This will require membranes to work properly.
       return req.send().then([context](auto response) mutable {
-        context.getResults().setSturdyRef(response.getToken());
+        return context.getResults().setSturdyRef(response.getToken());
       });
      });
   }
@@ -1684,12 +1684,12 @@ public:
 
     kj::Promise<void> cancel(CancelContext context) override {
       cancel();
-      return ongoingNotification.cancelRequest().send().then([](auto args) {});
+      return ongoingNotification.cancelRequest().send().then([](auto args) { return; });
     }
 
     kj::Promise<void> save(SaveContext context) override {
       return wakelockSet.save(ongoingNotification).then([context] (auto args) mutable {
-        context.getResults().setSturdyRef(args.getToken());
+        return context.getResults().setSturdyRef(args.getToken());
       });
     }
   private:
@@ -1773,7 +1773,7 @@ public:
     grainOwner.setGrainId(grainId);
     grainOwner.setSaveLabel(args.getLabel());
     return req.send().then([this, context](auto args) mutable {
-      context.getResults().setToken(args.getSturdyRef());
+      return context.getResults().setToken(args.getSturdyRef());
     });
   }
 
@@ -1782,14 +1782,14 @@ public:
     req.setToken(context.getParams().getToken());
     req.setRequiredPermissions(context.getParams().getRequiredPermissions());
     return req.send().then([context](auto args) mutable {
-      context.getResults().setCap(args.getCap());
+      return context.getResults().setCap(args.getCap());
     });
   }
 
   kj::Promise<void> drop(DropContext context) override {
     auto req = sandstormCore.dropRequest();
     req.setToken(context.getParams().getToken());
-    return req.send().then([](auto args) {});
+    return req.send().then([](auto args) { return; });
   }
 
 //  kj::Promise<void> deleted(DeletedContext context) override {
@@ -1843,6 +1843,7 @@ public:
       return req.send().then([this, context](auto args) mutable {
         SANDSTORM_LOG("Grain has enabled backgrounding.");
         context.getResults().setHandle(kj::heap<WakelockHandle>(args.getSturdyRef(), *this));
+        return;
       });
     });
   }
@@ -1853,7 +1854,7 @@ private:
     req.setToken(sturdyRef);
     // TODO(someday): Handle failures for drop? Currently, if the the frontend never drops the
     // notification or calls cancel on it, then this handle will essentially leak.
-    tasks.add(req.send().then([](auto args) {}));
+    tasks.add(req.send().then([](auto args) { return; }));
   }
 
   void taskFailed(kj::Exception&& exception) override {
@@ -1957,7 +1958,7 @@ public:
         auto req = mainView.restoreRequest();
         req.setObjectId(objectId.getAppRef());
         return req.send().then([this, params, context](auto args) mutable {
-          context.getResults().setCap(kj::heap<SaveWrapper>(
+          return context.getResults().setCap(kj::heap<SaveWrapper>(
             args.getCap().template castAs<AppPersistent<>>(), params.getRequirements(), params.getParentToken(), sandstormCore));
         });
       }
@@ -2096,7 +2097,7 @@ private:
         }
         req.adoptData(kj::mv(orphan));
 
-        tasks.add(req.send().then([](auto) {}));
+        tasks.add(req.send().then([](auto) { return; }));
 
         if (done) break;
       }


### PR DESCRIPTION
I get a bunch of errors like the following when I try `make continuous` with clang 3.7:

```
compile: sandstorm/sandstorm-http-bridge.c++
  In file included from /ekam-provider/canonical/sandstorm/sandstorm-http-bridge.c++:25:
  In file included from /ekam-provider/c++header/kj/async-io.h:29:
  In file included from /ekam-provider/c++header/kj/async.h:670:
  /ekam-provider/c++header/kj/async-inl.h:314:12: error: no matching function for call to 'from'
      return PtmfHelper::from<ReturnType, Decay<Func>, ParamTypes...>(
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /ekam-provider/c++header/kj/async-inl.h:353:45: note: in instantiation of function template specialization 'kj::_::GetFunctorStartAddress<capnp::Response<sandstorm::ByteStream::
    WriteResults> &&>::apply<(lambda at /ekam-provider/canonical/sandstorm/sandstorm-http-bridge.c++:204:41) &>' requested here
              GetFunctorStartAddress<DepT&&>::apply(func)),
                                              ^
  /ekam-provider/c++header/kj/memory.h:344:21: note: in instantiation of member function 'kj::_::TransformPromiseNode<kj::_::Void, capnp::Response<sandstorm::ByteStream::WriteResults>, 
    (lambda at /ekam-provider/canonical/sandstorm/sandstorm-http-bridge.c++:204:41), kj::_::PropagateException>::TransformPromiseNode' requested here
    return Own<T>(new T(kj::fwd<Params>(params)...), _::HeapDisposer<T>::instance);
                      ^
  /ekam-provider/c++header/kj/async-inl.h:757:7: note: in instantiation of function template specialization 'kj::heap<kj::_::TransformPromiseNode<kj::_::Void, capnp::Response<sandstorm:
    :ByteStream::WriteResults>, (lambda at /ekam-provider/canonical/sandstorm/sandstorm-http-bridge.c++:204:41), kj::_::PropagateException>, kj::Own<kj::_::PromiseNode>, (lambda at /
    ekam-provider/canonical/sandstorm/sandstorm-http-bridge.c++:204:41), kj::_::PropagateException>' requested here
        heap<_::TransformPromiseNode<ResultT, _::FixVoid<T>, Func, ErrorFunc>>(
        ^
  /ekam-provider/canonical/sandstorm/sandstorm-http-bridge.c++:204:36: note: in instantiation of function template specialization 'kj::Promise<capnp::Response<sandstorm::ByteStream::
    WriteResults> >::then<(lambda at /ekam-provider/canonical/sandstorm/sandstorm-http-bridge.c++:204:41), kj::_::PropagateException>' requested here
          taskSet.add(request.send().then([](auto x){}));
                                     ^
  /ekam-provider/c++header/kj/async-inl.h:277:21: note: candidate function [with R = void, C = (lambda at /ekam-provider/canonical/sandstorm/sandstorm-http-bridge.c++:204:41), P = <
    capnp::Response<sandstorm::ByteStream::WriteResults> &&>] not viable: no overload of 'operator()' matching 'void ((lambda at /ekam-provider/canonical/sandstorm/sandstorm-http-bridge
    .c++:204:41)::*)(NoInfer<capnp::Response<sandstorm::ByteStream::WriteResults> &&>)' for 1st argument
    static PtmfHelper from(R (C::*p)(NoInfer<P>...)) { BODY; }
                      ^
  /ekam-provider/c++header/kj/async-inl.h:279:21: note: candidate function [with R = void, C = (lambda at /ekam-provider/canonical/sandstorm/sandstorm-http-bridge.c++:204:41), P = <
    capnp::Response<sandstorm::ByteStream::WriteResults> &&>] not viable: no overload of 'operator()' matching 'void ((lambda at /ekam-provider/canonical/sandstorm/sandstorm-http-bridge
```


After this patch, the compilation succeeds.

I'm puzzled about the root cause here. How could adding these return statements change anything?

I think that, if possible, KJ should be updated so that this patch isn't necessary. I'm too intimidated to play around with the template magic there, though.