### PR TITLE
Typo "Sandstorm" -> "Sandcats"

### DIFF
--- a/docs/administering/sandcats.md
+++ b/docs/administering/sandcats.md
@@ -68,7 +68,7 @@ prompts.
 
 # Disabling the sandcats service
 
-If you want to run Sandstorm without the Sandstorm service, remove the
+If you want to run Sandstorm without the Sandcats service, remove the
 
 ```bash
 SANDCATS_BASE_DOMAIN=...


### PR DESCRIPTION
This looks like a typo... "run Sandstorm without the Sandstorm service"