### PR TITLE
Use *.hostname as commonName in CSR

### DIFF
--- a/shell/server/sandcats.js
+++ b/shell/server/sandcats.js
@@ -143,7 +143,8 @@ Sandcats.storeNewKeyAndCsr = function(hostname, basePath) {
   var keyFilename = basePath + "/" + keyNumber;
   var csrFilename = keyFilename + ".csr";
   var responseFilename = keyFilename + ".response-json";
-  var keyAndCsr = generateKeyAndCsr(hostname);
+  var withWildcard = '*.' + hostname;
+  var keyAndCsr = generateKeyAndCsr(withWildcard);
   fs.writeFileSync(keyFilename, keyAndCsr.privateKeyAsPem,
                    {'mode': 0400});
   fs.writeFileSync(csrFilename, keyAndCsr.csrAsPem);


### PR DESCRIPTION
This is one piece of the puzzle for actually getting wildcard certs
from GlobalSign.

The other piece of the puzzle is a `sandcats.io`-side code change that
changes how we request wildcards via the GlobalSign SOAP API. That code
is already tested & deployed.