### PR TITLE
Fix more bad installer-tests strings

### DIFF
--- a/installer-tests/install-without-root.t
+++ b/installer-tests/install-without-root.t
@@ -47,8 +47,7 @@ Setup complete. To start your server now, run:
 sandstorm start
 Once that's done, visit this link to configure it:
   http://local.sandstorm.io:6080/admin/
-NOTE: This token expires in 15 minutes.
-You can generate a new configuration URL by running 'sandstorm admin-token' from the command line
+NOTE: This URL expires in 15 minutes.
 
 To learn how to control the server, run:
 help


### PR DESCRIPTION
The `installer-tests` now run cleanly for me on my laptop.