### PR TITLE
split user IDs into account IDs and identity IDs: take 2

### DIFF
--- a/shell/.meteor/packages
+++ b/shell/.meteor/packages
@@ -21,6 +21,8 @@ browser-policy
 
 reactive-var
 sandstorm-db
+sandstorm-backend
+sandstorm-accounts-merge
 sandstorm-identicons
 sandstorm-permissions
 sandstorm-ui-topbar

--- a/shell/.meteor/versions
+++ b/shell/.meteor/versions
@@ -64,9 +64,11 @@ reactive-var@1.0.5
 reload@1.1.3
 retry@1.0.3
 routepolicy@1.0.5
+sandstorm-accounts-merge@0.1.0
 sandstorm-accounts-oauth@1.1.4
 sandstorm-accounts-packages@0.1.0
 sandstorm-accounts-ui@0.1.0
+sandstorm-backend@0.1.0
 sandstorm-db@0.1.0
 sandstorm-email@0.1.0
 sandstorm-identicons@0.1.0

--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -22,19 +22,22 @@ GrainView = function GrainView(grainId, path, token, parentElement) {
   this._originalPath = path;
   this._path = path;
   this._token = token;
-
   this._status = "closed";
-  this._revealIdentity = new ReactiveVar(undefined); // set to true or false to make explicit
+  this._dep = new Tracker.Dependency();
+
+  this._userIdentity = new ReactiveVar(undefined);
+  // `false` means incognito; `undefined` means we still need to decide whether to reveal
+  // an identity.
 
   if (token) {
     if (!Meteor.userId()) {
-      this._revealIdentity.set(false);
+      this.doNotRevealIdentity();
     } else if (this._isIdentityAlreadyRevealedToOwner()) {
-      this._revealIdentity.set(true);
+      this.revealIdentity();
     }
+  } else {
+    this.revealIdentity();
   }
-
-  this._dep = new Tracker.Dependency();
 
   // We manage our Blaze view directly in order to get more control over when iframes get
   // re-rendered. E.g. if we were to instead use a template with {{#each grains}} iterating over
@@ -106,10 +109,9 @@ GrainView.prototype.title = function () {
     var grain = Grains.findOne({_id: this._grainId});
     return grain && grain.title;
   } else if (!this._isUsingAnonymously()) {
-    var identity = SandstormDb.getUserIdentities(Meteor.user())[0];
     // Case 2.
     var apiToken = ApiTokens.findOne({grainId: this._grainId,
-                                      "owner.user.identityId": identity.id},
+                                      "owner.user.identityId": this._userIdentity.get().id},
                                      {sort: {created: 1}});
     return apiToken && apiToken.owner && apiToken.owner.user && apiToken.owner.user.title;
   } else {
@@ -132,9 +134,9 @@ GrainView.prototype.appTitle = function () {
     return pkg && pkg.manifest && pkg.manifest.appTitle && pkg.manifest.appTitle.defaultText;
   } else if (!this._isUsingAnonymously()) {
     // Case 2
-    var identity = globalDb.getUserIdentities(Meteor.userId())[0];
-    var token = ApiTokens.findOne({grainId: this._grainId, 'owner.user.identityId': identity.id},
-                                     {sort: {created: 1}});
+    var token = ApiTokens.findOne({grainId: this._grainId,
+                                   'owner.user.identityId': this._userIdentity.get().id},
+                                  {sort: {created: 1}});
     return (token && token.owner && token.owner.user && token.owner.user.denormalizedGrainMetadata &&
       token.owner.user.denormalizedGrainMetadata.appTitle.defaultText);
     // TODO(someday) - shouldn't use defaultText
@@ -212,8 +214,10 @@ GrainView.prototype.sessionId = function () {
 }
 
 GrainView.prototype.setTitle = function (newTitle) {
-  Meteor.call("updateGrainTitle", this._grainId, newTitle);
   this._title = newTitle;
+  if (this._userIdentity.get()) {
+    Meteor.call("updateGrainTitle", this._grainId, newTitle, this._userIdentity.get().id);
+  }
   this._dep.changed();
 }
 
@@ -229,14 +233,50 @@ GrainView.prototype.depend = function () {
   this._dep.depend();
 }
 
-GrainView.prototype.setRevealIdentity = function (revealIdentity) {
-  this._revealIdentity.set(revealIdentity);
+GrainView.prototype.revealIdentity = function () {
+  if (!Meteor.user()) {
+    throw new Error("Cannot reveal identity if not logged in.");
+  }
+  var identities = SandstormDb.getUserIdentities(Meteor.user());
+  var identityIds = identities.map(function(x) { return x.id; });
+  var identity = identities[0];
+  // Choose a plausible identity.
+  var grain = Grains.findOne(this._grainId);
+  if (grain && identityIds.indexOf(grain.identityId) != -1) {
+    identity = _.findWhere(identities, {id: grain.identityId});
+  } else {
+    var token = ApiTokens.findOne({"owner.user.identityId": {$in: identityIds}});
+    if (token) {
+      identity = _.findWhere(identities, {id: token.owner.user.identityId});
+    }
+  }
+  this._userIdentity.set(identity);
+  this._dep.changed();
+}
+
+GrainView.prototype.doNotRevealIdentity = function () {
+  this._userIdentity.set(false);
   this._dep.changed();
 }
 
 GrainView.prototype.shouldRevealIdentity = function () {
   this._dep.depend();
-  return this._revealIdentity.get();
+  return !!this._userIdentity.get();
+}
+
+GrainView.prototype.identity = function () {
+  this._dep.depend();
+  return this._userIdentity.get() || null;
+}
+
+GrainView.prototype.identityId = function () {
+  this._dep.depend();
+  var identity = this._userIdentity.get();
+  if (identity) {
+    return identity.id;
+  } else {
+    return null;
+  }
 }
 
 GrainView.prototype._isIdentityAlreadyRevealedToOwner = function () {
@@ -262,8 +302,8 @@ GrainView.prototype.shouldShowInterstitial = function () {
     return false;
   }
 
-  // If we have explictly set _revealIdentity, we don't need to show the interstitial.
-  if (this._revealIdentity.get() !== undefined) {
+  // If we have explictly set _userIdentity, we don't need to show the interstitial.
+  if (this._userIdentity.get() !== undefined) {
     return false;
   }
   // If we are not logged in, we don't need to show the interstitial - we'll go incognito by default.
@@ -311,7 +351,8 @@ GrainView.prototype._addSessionObserver = function (sessionId) {
 
 GrainView.prototype._openGrainSession = function () {
   var self = this;
-  Meteor.call("openSession", self._grainId, self._sessionSalt, function(error, result) {
+  var identityId = self.identityId();
+  Meteor.call("openSession", self._grainId, identityId, self._sessionSalt, function(error, result) {
     if (error) {
       console.error("openSession error", error);
       self._error = error.message;
@@ -350,13 +391,15 @@ function onceConditionIsTrue(condition, continuation) {
 
 GrainView.prototype._openApiTokenSession = function () {
   var self = this;
-  function condition() { return self._revealIdentity.get() !== undefined; }
+  function condition() { return self._userIdentity.get() !== undefined; }
   onceConditionIsTrue(condition, function () {
+    var identityId = self.identityId();
     var openSessionArg = {
       token: self._token,
-      incognito: !self._revealIdentity.get(),
+      incognito: !identityId,
     };
-    Meteor.call("openSessionFromApiToken", openSessionArg, self._sessionSalt, function(error, result) {
+    Meteor.call("openSessionFromApiToken", openSessionArg, identityId, self._sessionSalt,
+                function(error, result) {
       if (error) {
         console.log("openSessionFromApiToken error");
         self._error = error.message;

--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -106,8 +106,10 @@ GrainView.prototype.title = function () {
     var grain = Grains.findOne({_id: this._grainId});
     return grain && grain.title;
   } else if (!this._isUsingAnonymously()) {
+    var identity = SandstormDb.getUserIdentities(Meteor.user())[0];
     // Case 2.
-    var apiToken = ApiTokens.findOne({grainId: this._grainId, "owner.user.userId": Meteor.userId()},
+    var apiToken = ApiTokens.findOne({grainId: this._grainId,
+                                      "owner.user.identityId": identity.id},
                                      {sort: {created: 1}});
     return apiToken && apiToken.owner && apiToken.owner.user && apiToken.owner.user.title;
   } else {
@@ -130,7 +132,8 @@ GrainView.prototype.appTitle = function () {
     return pkg && pkg.manifest && pkg.manifest.appTitle && pkg.manifest.appTitle.defaultText;
   } else if (!this._isUsingAnonymously()) {
     // Case 2
-    var token = ApiTokens.findOne({grainId: this._grainId, 'owner.user.userId': Meteor.userId()},
+    var identity = globalDb.getUserIdentities(Meteor.userId())[0];
+    var token = ApiTokens.findOne({grainId: this._grainId, 'owner.user.identityId': identity.id},
                                      {sort: {created: 1}});
     return (token && token.owner && token.owner.user && token.owner.user.denormalizedGrainMetadata &&
       token.owner.user.denormalizedGrainMetadata.appTitle.defaultText);
@@ -181,7 +184,6 @@ GrainView.prototype.hasLoaded = function () {
   if (this._hasLoaded) {
     return true;
   }
-
   var session = Sessions.findOne({_id: this._sessionId});
   // TODO(soon): this is a hack to cache hasLoaded. Consider moving it to an autorun.
   this._hasLoaded = session && session.hasLoaded;

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -313,7 +313,7 @@ limitations under the License.
             <td> added by
               <ul>
                 {{#each shares}}
-                  <li>{{displayName userId}}</li>
+                  <li>{{displayName identityId}}</li>
                 {{/each}}
               </ul>
             </td>
@@ -895,7 +895,7 @@ limitations under the License.
     <thead>
       <tr>
         <td>Service</td>
-        <td>Username</td>
+        <td>Handle</td>
         <td>Name</td>
         <td>User Class</td>
         {{#if quotaEnabled}}
@@ -910,9 +910,11 @@ limitations under the License.
     <tbody>
       {{#each users}}
         <tr>
-          <td>{{userService}}</td>
-          <td>{{userName}}</td>
-          <td>{{profile.name}}</td>
+          {{#with userIdentity}}
+            <td>{{service}}</td>
+            <td>{{handle}}</td>
+            <td>{{name}}</td>
+          {{/with}}
           <td>
             <select class="user-class" name="select">
               <option value="admin" selected={{#if userIsAdmin}}selected{{/if}}>Admin</option>

--- a/shell/packages/sandstorm-accounts-merge/accounts-merge-client.js
+++ b/shell/packages/sandstorm-accounts-merge/accounts-merge-client.js
@@ -1,0 +1,36 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Accounts.onLogin(function() {
+  var oldLoginToken = sessionStorage.getItem("mergeAccountsLoginToken");
+  sessionStorage.removeItem("mergeAccountsLoginToken");
+
+  if (oldLoginToken) {
+    Meteor.call("mergeWithAccount", oldLoginToken, function (err, result) {
+      console.log("merged!");
+      if (err) {
+        throw new Error("error: " + err);
+      }
+      Meteor.loginWithToken(oldLoginToken);
+    });
+  }
+});
+
+SandstormAccountsMerge.mergeWithGoogle = function () {
+  var oldLoginToken = Accounts._storedLoginToken();
+  sessionStorage.setItem("mergeAccountsLoginToken", oldLoginToken);
+  Meteor.loginWithGoogle();
+}

--- a/shell/packages/sandstorm-accounts-merge/accounts-merge-client.js
+++ b/shell/packages/sandstorm-accounts-merge/accounts-merge-client.js
@@ -14,13 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 Accounts.onLogin(function() {
   var oldLoginToken = sessionStorage.getItem("mergeAccountsLoginToken");
   sessionStorage.removeItem("mergeAccountsLoginToken");
 
   if (oldLoginToken) {
     Meteor.call("mergeWithAccount", oldLoginToken, function (err, result) {
-      console.log("merged!");
       if (err) {
         throw new Error("error: " + err);
       }
@@ -34,3 +34,4 @@ SandstormAccountsMerge.mergeWithGoogle = function () {
   sessionStorage.setItem("mergeAccountsLoginToken", oldLoginToken);
   Meteor.loginWithGoogle();
 }
+

--- a/shell/packages/sandstorm-accounts-merge/accounts-merge-common.js
+++ b/shell/packages/sandstorm-accounts-merge/accounts-merge-common.js
@@ -1,0 +1,17 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+SandstormAccountsMerge = {};

--- a/shell/packages/sandstorm-accounts-merge/accounts-merge-server.js
+++ b/shell/packages/sandstorm-accounts-merge/accounts-merge-server.js
@@ -123,6 +123,7 @@ Meteor.methods({
 });
 
 SandstormAccountsMerge.registerObservers = function (db, backend) {
+  // TODO(before enabling merging): make these handlers robust to exceptions.
 
   Meteor.users.find({"merging.status": "pending"}).observe({
     added: function(losingUser) {
@@ -185,6 +186,7 @@ SandstormAccountsMerge.registerObservers = function (db, backend) {
       // Transfer grain storage to new owner.
       // Note: We don't parallelize this because it can cause some contention in the Blackrock
       //   back-end.
+      // TODO(before enabling): make this robust to mid-transfer server crashes.
       grains.forEach(function (grain) {
         return waitPromise(backend.cap().transferGrain(grain.userId, grain._id, winningUserId));
       });
@@ -230,6 +232,7 @@ SandstormAccountsMerge.registerObservers = function (db, backend) {
       // Transfer grain storage to new owner.
       // Note: We don't parallelize this because it can cause some contention in the Blackrock
       //   back-end.
+      // TODO(before enabling): make this robust to mid-transfer server crashes.
       grains.forEach(function (grain) {
         return waitPromise(backend.cap().transferGrain(grain.userId, grain._id, destUserId));
       });

--- a/shell/packages/sandstorm-accounts-merge/accounts-merge-server.js
+++ b/shell/packages/sandstorm-accounts-merge/accounts-merge-server.js
@@ -28,6 +28,8 @@ waitPromise = function (promise) {
 
 Meteor.methods({
   mergeWithAccount: function (token) {
+    throw new Meteor.Error(400, "Accounts merging turned off for now. Needs more testing.");
+
     check(token, String);
     if (!this.userId) {
       throw new Meteor.Error(403, "Cannot merge accounts if not logged in.");
@@ -72,6 +74,8 @@ Meteor.methods({
   },
 
   unmergeToAccount: function (destUserId) {
+    throw new Meteor.Error(400, "Accounts unmerging turned off for now. Needs more testing.");
+
     check(destUserId, String);
     if (!this.userId) {
       throw new Meteor.Error(403, "Cannot merge accounts if not logged in.");

--- a/shell/packages/sandstorm-accounts-merge/accounts-merge-server.js
+++ b/shell/packages/sandstorm-accounts-merge/accounts-merge-server.js
@@ -1,0 +1,237 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var Future = Npm.require("fibers/future");
+
+promiseToFuture = function (promise) {
+  var result = new Future();
+  promise.then(result.return.bind(result), result.throw.bind(result));
+  return result;
+}
+
+waitPromise = function (promise) {
+  return promiseToFuture(promise).wait();
+}
+
+Meteor.methods({
+  mergeWithAccount: function (token) {
+    check(token, String);
+    if (!this.userId) {
+      throw new Meteor.Error(403, "Cannot merge accounts if not logged in.");
+    }
+    var hashed = Accounts._hashLoginToken(token);
+    var winningUser = Meteor.users.findOne({"services.resume.loginTokens.hashedToken": hashed});
+
+    if (!winningUser) {
+      throw new Meteor.Error(404, "No account found for token: " + token);
+    }
+
+    var losingUser = Meteor.user();
+
+    if (losingUser.merging) {
+      throw new Meteor.Error(400, "Account is already being merged.");
+    }
+
+    // We need to verify that we can actually do the merge.
+    // For now, this means that there is at most one instance of each service
+    // in the two identities arrays.
+    var servicesPresent = {};
+    function verifyUnique(service) {
+      if (service in servicesPresent) {
+        throw new Meteor.Error(400, "Cannot merge accounts with duplicate service: " + service);
+      }
+      servicesPresent[service] = true;
+    }
+    winningUser.identities.forEach(function(identity) {
+      verifyUnique(identity.service);
+    });
+    losingUser.identities.forEach(function(identity) {
+      verifyUnique(identity.service);
+    });
+
+    // assert that there are no other pending merges?
+    Meteor.users.update(losingUser._id,
+                        {$set: {merging: {destinationUserId: winningUser._id, status: "pending",
+                                          sourceIdentities: losingUser.identities,
+                                          sourceServices: losingUser.services}},
+                         $unset: {identities: 1, services: 1}});
+
+  },
+
+  unmergeToAccount: function (destUserId) {
+    check(destUserId, String);
+    if (!this.userId) {
+      throw new Meteor.Error(403, "Cannot merge accounts if not logged in.");
+    }
+    var sourceUser = Meteor.user();
+    if (!sourceUser.mergedUsers || sourceUser.mergedUsers.indexOf(destUserId) == -1) {
+      throw new Meteor.Error(403, "Current user was never merged with user " + destUserId);
+    }
+
+    // Now look up the destination user to figure out which identities and services
+    // to restore.
+
+    var destUser = Meteor.users.findOne(destUserId);
+
+    /// what if the status is still pending? Then we abort.
+    var oldServices = destUser.merging && destUser.merging.status === "done" &&
+        destUser.merging.sourceServices;
+
+    if (!oldServices) {
+      throw new Meteor.Error(400, "Cannot unmerge");
+    }
+    var oldIdentities = {};
+    var servicesToRemove = {};
+    destUser.merging.sourceIdentities.forEach(function(identity) {
+      oldIdentities[identity.id] = identity;
+      servicesToRemove["services." + identity.service] = 1;
+    });
+
+    var sourceIdentities = sourceUser.identities.filter(function (identity) {
+      return identity.id in oldIdentities;
+    });
+
+    // TODO what about the case when there are multiple email identities
+    // in a single emailToken service?
+
+    // what about quota, login?
+    Meteor.users.update(sourceUser._id,
+                        {$set: {unmerging: {destinationUserId: destUserId, status: "pending",
+                                            sourceIdentities: sourceIdentities,
+                                            sourceServices: oldServices}},
+                         $unset: servicesToRemove,
+                         $pull: {identities: {id: {$in: Object.keys(oldIdentities)}},
+                                 mergedUsers: destUserId} });
+  }
+});
+
+SandstormAccountsMerge.registerObservers = function (db, backend) {
+
+  Meteor.users.find({"merging.status": "pending"}).observe({
+    added: function(losingUser) {
+      console.log("merging user " + JSON.stringify(sourceUser));
+      var winningUserId = losingUser.merging.destinationUserId;
+      var winningUser = Meteor.users.findOne(winningUserId);
+
+      if (winningUser.mergedUsers.indexOf(losingUser._id) == -1) {
+        // Now let's construct a modifier that will update the new user.
+        var fieldsToSet = {};
+        var identitiesToPush = [];
+        losingUser.merging.sourceIdentities.forEach(function(identity) {
+          identitiesToPush.push(identity);
+          if (identity.service === "dev") {
+            fieldsToSet.devName = losingUser.devName;
+          } else if (identity.service === "demo") {
+            fieldsToSet.expires = losingUser.expires;
+          } else if (identity.service === "github") {
+            fieldsToSet["services.github"] = losingUser.merging.sourceServices.github;
+          } else if (identity.service === "google") {
+            fieldsToSet["services.google"] = losingUser.merging.sourceServices.google;
+          } else if (identity.service === "emailToken") {
+            fieldsToSet["services.emailToken"] = losingUser.merging.sourceServices.emailToken;
+          }
+        });
+
+        var modifier = {$push: {identities: {$each: identitiesToPush},
+                                mergedUsers: losingUser._id}};
+        if (Object.keys(fieldsToSet).length > 0) {
+          modifier["$set"] = fieldsToSet;
+        }
+        Meteor.users.update({_id: winningUserId}, modifier);
+      }
+
+      db.collections.notifications.update({userId: losingUser._id},
+                                          {$set: {userId: winningUserId}},
+                                          {multi: true});
+
+      db.collections.userActions.find({userId: losingUser._id}).forEach(function (action) {
+        var newAction = _.omit(action, "_id");
+        newAction.userId = winningUserId;
+        db.collections.userActions.upsert({userId: winningUserId, packageId: action.packageId,
+                                           title: action.title, nounPhrase: action.nounPhrase,
+                                           command: action.command},
+                                          {$set: newAction});
+      });
+
+      var grains = Grains.find({userId: losingUser._id}).fetch();
+
+      db.collections.grains.update({userId: losingUser._id},
+                                   {$set: {userId: winningUserId}}, {multi: true});
+
+      // Force all grains to shut down.
+      grains.map(function (grain) {
+        return backend.shutdownGrain(grain._id, losingUser._id, false);
+      }).forEach(function (promise) {
+        waitPromise(promise);
+      });
+
+      // Transfer grain storage to new owner.
+      // Note: We don't parallelize this because it can cause some contention in the Blackrock
+      //   back-end.
+      grains.forEach(function (grain) {
+        return waitPromise(backend.cap().transferGrain(grain.userId, grain._id, winningUserId));
+      });
+
+      var result = Meteor.users.update(losingUser._id, {$unset: {devName: 1, expires: 1},
+                                                        $set: {"merging.status": "done"}});
+
+    },
+  });
+
+  Meteor.users.find({"unmerging.status": "pending"}).observe({
+    added: function(sourceUser) {
+      console.log("unmerging user " + JSON.stringify(sourceUser));
+      var destUserId = sourceUser.unmerging.destinationUserId;
+      var servicesSetter = {};
+      for (var key in sourceUser.unmerging.sourceServices) {
+        servicesSetter["services." + key] = sourceUser.unmerging.sourceServices[key];
+      }
+
+      var destUser = Meteor.users.findOne(destUserId);
+      if (destUser.merging) {
+        Meteor.users.update(destUserId,
+                            {$push: {identities: {$each: sourceUser.unmerging.sourceIdentities}},
+                             $unset: {merging: 1},
+                             $set: servicesSetter});
+      }
+
+      var sourceIdentityIds = sourceUser.unmerging.sourceIdentities.map(function (x) { return x.id; });
+
+      var grains = Grains.find({userId: sourceUser._id, identityId: {$in: sourceIdentityIds}}).fetch();
+
+      db.collections.grains.update({userId: sourceUser._id, identityId: {$in: sourceIdentityIds}},
+                                   {$set: {userId: destUserId}},
+                                   {multi: true});
+
+      // Force all grains to shut down.
+      grains.map(function (grain) {
+        return backend.shutdownGrain(grain._id, sourceUser._id, false);
+      }).forEach(function (promise) {
+        waitPromise(promise);
+      });
+
+      // Transfer grain storage to new owner.
+      // Note: We don't parallelize this because it can cause some contention in the Blackrock
+      //   back-end.
+      grains.forEach(function (grain) {
+        return waitPromise(backend.cap().transferGrain(grain.userId, grain._id, destUserId));
+      });
+
+      var result = Meteor.users.update(sourceUser._id, {$unset: {"unmerging": 1}});
+    },
+  });
+
+}

--- a/shell/packages/sandstorm-accounts-merge/package.js
+++ b/shell/packages/sandstorm-accounts-merge/package.js
@@ -1,0 +1,29 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Package.describe({
+  summary: "Sandstorm package for merging user accounts.",
+  version: "0.1.0"
+});
+
+Package.onUse(function (api) {
+  api.use(["accounts-base", "sandstorm-db"], ["client", "server"]);
+  api.addFiles(["accounts-merge-common.js"], ["client", "server"]);
+  api.addFiles(["accounts-merge-client.js"], "client");
+  api.addFiles(["accounts-merge-server.js"], "server");
+  api.export("SandstormAccountsMerge");
+});
+

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -83,7 +83,7 @@ limitations under the License.
   <li class="email">
     <label>E-mail:
       <input type="email" name="email" data-verified-email="{{verifiedEmail}}"
-             value="{{emailSuggestion verifiedEmail unverifiedEmail}}"
+             value="{{emailSuggestion unverifiedEmail verifiedEmail}}"
              placeholder="email address" required>
     </label>
     <span class="details">E-mail address for service-related notifications.</span>

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -80,12 +80,14 @@ limitations under the License.
     </label>
     <span class="details">Your preferred handle or "username", for use in apps that use handles (often, chat apps). This is only your first choice; an app may make you rename if someone has already taken this name within the specific grain.</span>
   </li>
-  {{#if verifiedEmail}}
   <li class="email">
-    E-mail:<p>{{verifiedEmail}}</p>
-    <span class="details">E-mail address attached to this identity.</span>
+    <label>E-mail:
+      <input type="email" name="email" data-verified-email="{{verifiedEmail}}"
+             value="{{emailSuggestion verifiedEmail unverifiedEmail}}"
+             placeholder="email address" required>
+    </label>
+    <span class="details">E-mail address for service-related notifications.</span>
   </li>
-  {{/if}}
   <li class="picture">
     <label>Picture: <button type="button"><img src="{{pictureUrl}}" alt="Upload picture"></button></label>
     <input type="hidden" name="picture" value="{{pictureUrl}}">

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -26,7 +26,7 @@ limitations under the License.
 
   <section class="profile">
     {{#each identities}}
-      <form class="account-profile-editor">
+      <form class="account-profile-editor" data-identity-id="{{id}}">
         <h3>Profile</h3>
         <ul>
           {{>_accountProfileEditor}}
@@ -48,7 +48,7 @@ limitations under the License.
 <template name="sandstormAccountsFirstSignIn">
   <h1>Confirm your profile</h1>
   {{#with mainIdentity}}
-    <form class="account-profile-editor"><ul>
+    <form class="account-profile-editor" data-identity-id="{{id}}"><ul>
       {{>_accountProfileEditor}}
       {{#with termsAndPrivacy}}
         <li class="terms">
@@ -80,15 +80,15 @@ limitations under the License.
     </label>
     <span class="details">Your preferred handle or "username", for use in apps that use handles (often, chat apps). This is only your first choice; an app may make you rename if someone has already taken this name within the specific grain.</span>
   </li>
+  {{#if verifiedEmail}}
   <li class="email">
-    <label>E-mail:
-      <input type="email" name="email" value="{{email}}" placeholder="email address" required>
-    </label>
-    <span class="details">E-mail address for service-related notifications.</span>
+    E-mail:<p>{{verifiedEmail}}</p>
+    <span class="details">E-mail address attached to this identity.</span>
   </li>
+  {{/if}}
   <li class="picture">
-    <label>Picture: <button type="button"><img src="{{picture}}" alt="Upload picture"></button></label>
-    <input type="hidden" name="picture" value="{{picture}}">
+    <label>Picture: <button type="button"><img src="{{pictureUrl}}" alt="Upload picture"></button></label>
+    <input type="hidden" name="picture" value="{{pictureUrl}}">
     <span class="details">This picture will be shown to other users to help identify you. Suggested dimensions: 512x512. Max size: 64 KiB.</span>
   </li>
   <li class="pronoun">

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -53,6 +53,10 @@ var helpers = {
 
   db: function () {
     return Template.instance().data._db;
+  },
+
+  emailSuggestion: function(verifiedEmail, unverifiedEmail) {
+    return verifiedEmail || unverifiedEmail;
   }
 };
 
@@ -101,6 +105,15 @@ var submitProfileForm = function (event, cb) {
     return;
   }
 
+  if (!form.email.value) {
+    alert("You must enter an email.");
+    return;
+  }
+
+  if (form.email.value !== form.email.getAttribute("data-verified-email")) {
+    newProfile.unverifiedEmail = form.email.value;
+  }
+
   if (!newProfile.handle.match(/^[a-z_][a-z0-9_]*$/)) {
     // TODO(soon): Reject bad keystrokes in real-time.
     alert("Invalid handle. Handles must contain only English letters, digits, and " +
@@ -112,7 +125,6 @@ var submitProfileForm = function (event, cb) {
     if (err) {
       alert("Error updating profile: " + err.message);
     } else if (cb) {
-      console.log(cb);
       cb();
     }
   });

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -90,18 +90,14 @@ var submitProfileForm = function (event, cb) {
   }
 
   var newProfile = {
+    id: form.getAttribute("data-identity-id"),
     name: form.nameInput.value,
     handle: form.handle.value,
     pronoun: form.pronoun.value,
-    email: form.email.value,
   };
 
   if (!newProfile.name) {
     alert("You must enter a name.");
-    return;
-  }
-  if (!newProfile.email) {
-    alert("You must enter an email.");
     return;
   }
 

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -55,8 +55,8 @@ var helpers = {
     return Template.instance().data._db;
   },
 
-  emailSuggestion: function(verifiedEmail, unverifiedEmail) {
-    return verifiedEmail || unverifiedEmail;
+  emailSuggestion: function(unverifiedEmail, verifiedEmail) {
+    return unverifiedEmail || verifiedEmail;
   }
 };
 

--- a/shell/packages/sandstorm-accounts-ui/accounts-ui-methods.js
+++ b/shell/packages/sandstorm-accounts-ui/accounts-ui-methods.js
@@ -26,21 +26,20 @@ Meteor.methods({
   updateProfile: function (profile) {
     // TODO(cleanup): This check also appears in sandstorm-db/users.js.
     check(profile, {
+      id: String,
       name: String,
       handle: ValidHandle,
       pronoun: Match.OneOf("male", "female", "neutral", "robot"),
-      email: String
     });
 
     if (!this.userId) {
       throw new Meteor.Error(403, "not logged in");
     }
 
-    Meteor.users.update(this.userId, {$set: {
-      "profile.name": profile.name,
-      "profile.handle": profile.handle,
-      "profile.pronoun": profile.pronoun,
-      "profile.email": profile.email,
+    Meteor.users.update({_id: this.userId, "identities.id": profile.id}, {$set: {
+      "identities.$.name": profile.name,
+      "identities.$.handle": profile.handle,
+      "identities.$.pronoun": profile.pronoun,
       "hasCompletedSignup": true
     }});
   },
@@ -80,3 +79,4 @@ if (Meteor.isServer) {
     },
   });
 }
+

--- a/shell/packages/sandstorm-accounts-ui/accounts-ui-methods.js
+++ b/shell/packages/sandstorm-accounts-ui/accounts-ui-methods.js
@@ -30,18 +30,25 @@ Meteor.methods({
       name: String,
       handle: ValidHandle,
       pronoun: Match.OneOf("male", "female", "neutral", "robot"),
+      unverifiedEmail: Match.Optional(String)
     });
 
     if (!this.userId) {
       throw new Meteor.Error(403, "not logged in");
     }
 
-    Meteor.users.update({_id: this.userId, "identities.id": profile.id}, {$set: {
+    var newValues = {
       "identities.$.name": profile.name,
       "identities.$.handle": profile.handle,
       "identities.$.pronoun": profile.pronoun,
       "hasCompletedSignup": true
-    }});
+    };
+
+    if (profile.unverifiedEmail) {
+      newValues["identities.$.unverifiedEmail"] = profile.unverifiedEmail
+    }
+
+    Meteor.users.update({_id: this.userId, "identities.id": profile.id}, {$set: newValues});
   },
 
   testFirstSignup: function (profile) {
@@ -79,4 +86,3 @@ if (Meteor.isServer) {
     },
   });
 }
-

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -63,14 +63,8 @@ var displayName = function () {
   if (!user)
     return '';
 
-  if (user.profile && user.profile.name)
-    return user.profile.name;
-  if (user.username)
-    return user.username;
-  if (user.emails && user.emails[0] && user.emails[0].address)
-    return user.emails[0].address;
-
-  return '';
+  var mainIdentity = _.findWhere(user.identities, {main: true});
+  return mainIdentity ? mainIdentity.name : "Name Unknown";
 };
 
 Template.loginButtons.helpers({

--- a/shell/packages/sandstorm-backend/package.js
+++ b/shell/packages/sandstorm-backend/package.js
@@ -1,0 +1,27 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Package.describe({
+  summary: "Sandstorm package for interacting with the backend.",
+  version: "0.1.0"
+});
+
+Package.onUse(function (api) {
+  api.use(["accounts-base", "sandstorm-db", "sandstorm-permissions"], ["server"]);
+  api.addFiles(["sandstorm-backend.js"], ["server"]);
+  api.export("SandstormBackend");
+});
+

--- a/shell/packages/sandstorm-backend/sandstorm-backend.js
+++ b/shell/packages/sandstorm-backend/sandstorm-backend.js
@@ -1,0 +1,322 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var Capnp = Npm.require("capnp");
+var Backend = Capnp.importSystem("sandstorm/backend.capnp").Backend;
+var Crypto = Npm.require("crypto");
+var Future = Npm.require("fibers/future");
+var Promise = Npm.require("es6-promise").Promise;
+
+var inMeteorInternal = Meteor.bindEnvironment(function (callback) {
+  callback();
+});
+
+inMeteor = function (callback) {
+  // Calls the callback in a Meteor context.  Returns a Promise for its result.
+  return new Promise(function (resolve, reject) {
+    inMeteorInternal(function () {
+      try {
+        resolve(callback());
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+promiseToFuture = function (promise) {
+  var result = new Future();
+  promise.then(result.return.bind(result), result.throw.bind(result));
+  return result;
+}
+
+waitPromise = function (promise) {
+  return promiseToFuture(promise).wait();
+}
+
+SANDSTORM_ALTHOME = Meteor.settings && Meteor.settings.home;
+
+SandstormBackend = function(db, backendCap) {
+  this._db = db;
+  this.runningGrains = {};
+  this._backendCap = backendCap
+}
+
+SandstormBackend.prototype.cap = function() {
+  return this._backendCap;
+}
+
+SandstormBackend.prototype.shutdownGrain = function (grainId, ownerId, keepSessions) {
+  if (!keepSessions) {
+    Sessions.remove({grainId: grainId});
+    delete this.runningGrains[grainId];
+  }
+
+  var grain = this._backendCap.getGrain(ownerId, grainId).supervisor;
+  return grain.shutdown().then(function () {
+    grain.close();
+    throw new Error("expected shutdown() to throw disconnected");
+  }, function (err) {
+    grain.close();
+    if (err.kjType !== "disconnected") {
+      throw err;
+    }
+  });
+}
+
+SandstormBackend.prototype.deleteGrain = function (grainId, ownerId) {
+  // We leave it up to the caller if they want to actually wait, but some don't so we report
+  // exceptions.
+  return this._backendCap.deleteGrain(ownerId, grainId).catch(function (err) {
+    console.error("problem deleting grain " + grainId + ":", err.message);
+    throw err;
+  });
+}
+
+
+SandstormBackend.prototype.openGrain = function (grainId, isRetry) {
+  // Create a Cap'n Proto connection to the given grain. Note that this function does not actually
+  // verify that the connection succeeded. Instead, if an RPC call to the connection fails, check
+  // shouldRestartGrain(). If it returns true, call continueGrain() and then openGrain()
+  // again with isRetry = true, and then retry.
+  //
+  // Must be called in a Meteor context.
+
+  if (isRetry) {
+    // Since this is a retry, try starting the grain even if we think it's already running.
+    return this._continueGrain(grainId);
+  } else {
+    // Start the grain if it is not running.
+    var runningGrain = this.runningGrains[grainId];
+    if (runningGrain) {
+      return waitPromise(runningGrain);
+    } else {
+      return this._continueGrain(grainId);
+    }
+  }
+}
+
+SandstormBackend.shouldRestartGrain = function (error, retryCount) {
+  // Given an error thrown by an RPC call to a grain, return whether or not it makes sense to try
+  // to restart the grain and retry. `retryCount` is the number of times that the request has
+  // already gone through this cycle (should be zero for the first call).
+
+  return error.kjType === "disconnected" && retryCount < 1;
+}
+
+SandstormBackend.prototype.maybeRetryUseGrain = function (grainId, cb, retryCount, err) {
+  var self = this;
+  if (SandstormBackend.shouldRestartGrain(err, retryCount)) {
+    return inMeteor(function () {
+      return cb(self.openGrain(grainId, true).supervisor)
+          .catch(self.maybeRetryUseGrain.bind(undefined, grainId, cb, retryCount + 1));
+    });
+  } else {
+    throw err;
+  }
+}
+
+SandstormBackend.prototype.useGrain = function (grainId, cb) {
+  // This will open a grain for you, handling restarts if needed, and call the passed function with
+  // the supervisor capability as the only parameter. The callback must return a promise that used
+  // the supervisor, so that we can check if a disconnect error occurred, and retry if possible.
+  // This function returns the same promise that your callback returns.
+  //
+  // This function is NOT expected to be run in a meteor context.
+
+  var runningGrain = this.runningGrains[grainId];
+  var self = this;
+  if (runningGrain) {
+    return runningGrain.then(function (grainInfo) {
+      return cb(grainInfo.supervisor);
+    }).catch(self.maybeRetryUseGrain.bind(undefined, grainId, cb, 0));
+  } else {
+    return inMeteor(function () {
+      return cb(self.openGrain(grainId, false).supervisor)
+          .catch(self.maybeRetryUseGrain.bind(undefined, grainId, cb, 0));
+    });
+  }
+}
+
+SandstormBackend.prototype._continueGrain = function(grainId) {
+  var grain = Grains.findOne(grainId);
+  if (!grain) {
+    throw new Meteor.Error(404, "Grain Not Found", "Grain ID: " + grainId);
+  }
+
+  var manifest;
+  var packageId;
+  var devApp = DevApps.findOne({_id: grain.appId});
+  var isDev;
+  if (devApp) {
+    // If a DevApp with the same app ID is currently active, we let it override the installed
+    // package, so that the grain runs using the dev app.
+    manifest = devApp.manifest;
+    packageId = devApp.packageId;
+    isDev = true;
+  } else {
+    var pkg = Packages.findOne(grain.packageId);
+    if (pkg) {
+      manifest = pkg.manifest;
+      packageId = pkg._id;
+    } else {
+      throw new Meteor.Error(500, "Grain's package not installed",
+                             "Package ID: " + grain.packageId);
+    }
+  }
+
+  if (!("continueCommand" in manifest)) {
+    throw new Meteor.Error(500, "Package manifest defines no continueCommand.",
+                           "Package ID: " + packageId);
+  }
+
+  return this._startGrainInternal(
+      packageId, grainId, grain.userId, manifest.continueCommand, false, isDev);
+}
+
+SandstormBackend.prototype._startGrainInternal = function(packageId, grainId, ownerId, command, isNew, isDev) {
+  // Starts the grain supervisor.  Must be executed in a Meteor context.  Blocks until grain is
+  // started. Returns a promise for an object containing two fields: `owner` (the ID of the owning
+  // user) and `supervisor` (the supervisor capability).
+
+  if (isUserExcessivelyOverQuota(Meteor.users.findOne(ownerId))) {
+    throw new Meteor.Error(402, "Cannot start grain because owner's storage is exhausted.");
+  }
+
+  // Ugly: Stay backwards-compatible with old manifests that had "executablePath" and "args" rather
+  //   than just "argv".
+  if ("args" in command) {
+    if (!("argv" in command)) {
+      command.argv = command.args;
+    }
+    delete command.args;
+  }
+  if ("executablePath" in command) {
+    if (!("deprecatedExecutablePath" in command)) {
+      command.deprecatedExecutablePath = command.executablePath;
+    }
+    delete command.executablePath;
+  }
+
+  var whenReady = this._backendCap.startGrain(ownerId, grainId, packageId, command, isNew, isDev)
+      .then(function (results) {
+    return {
+      owner: ownerId,
+      supervisor: results.supervisor
+    };
+  });
+
+  this.runningGrains[grainId] = whenReady;
+  return waitPromise(whenReady);
+}
+
+SandstormBackend.prototype.updateLastActive = function(grainId, userId, identityId) {
+  // Update the lastActive date on the grain, any relevant API tokens, and the user,
+  // and also update the user's storage usage.
+
+  var storagePromise = undefined;
+  if (Meteor.settings.public.quotaEnabled) {
+    storagePromise = globalBackend._backendCap.getUserStorageUsage(userId);
+  }
+
+  var now = new Date();
+  Grains.update(grainId, {$set: {lastUsed: now}});
+  if (userId) {
+    Meteor.users.update(userId, {$set: {lastActive: now}});
+  }
+  if (identityId) {
+    // Update any API tokens that match this user/grain pairing as well
+    var now = new Date();
+    ApiTokens.update({"grainId": grainId, "owner.user.identityId": identityId},
+        {$set: {"owner.user.lastUsed": now }});
+  }
+
+  if (Meteor.settings.public.quotaEnabled) {
+    try {
+      var ownerId = Grains.findOne(grainId).userId;
+      var size = parseInt(waitPromise(storagePromise).size);
+      Meteor.users.update(ownerId, {$set: {storageUsage: size}});
+      // TODO(security): Consider actively killing grains if the user is excessively over quota?
+      //   Otherwise a constantly-active grain could consume arbitrary space without being stopped.
+    } catch (err) {
+      if (err.kjType !== "unimplemented") {
+        console.error("error getting user storage usage:", err.stack);
+      }
+    }
+  }
+}
+
+
+function generateSessionId(grainId, userId, salt) {
+  var sessionParts = [grainId, salt];
+  if (userId) {
+    sessionParts.push(userId);
+  }
+  var sessionInput = sessionParts.join(":");
+  return Crypto.createHash("sha256").update(sessionInput).digest("hex");
+}
+
+SandstormBackend.prototype._openSessionInternal = function (grainId, userId, identityId, title, apiToken, cachedSalt) {
+
+  // Start the grain if it is not running. This is an optimization: if we didn't start it here,
+  // it would start on the first request to the session host, but we'd like to get started before
+  // the round trip.
+  var runningGrain = this.runningGrains[grainId];
+  var grainInfo;
+  if (runningGrain) {
+    grainInfo = waitPromise(runningGrain);
+  } else {
+    grainInfo = this._continueGrain(grainId);
+  }
+
+  this.updateLastActive(grainId, userId, identityId);
+
+  cachedSalt = cachedSalt || Random.id(22);
+  var sessionId = generateSessionId(grainId, userId, cachedSalt);
+  var session = Sessions.findOne({_id: sessionId});
+  if (session) {
+    // TODO(someday): also do some more checks for anonymous sessions (sessions without a userId).
+    if ((session.identityId && session.identityId !== identityId) ||
+        (session.grainId !== grainId)) {
+      var e = new Meteor.Error(500, "Duplicate SessionId");
+      console.error(e);
+      throw e;
+    } else {
+      return {sessionId: session._id, title: title, grainId: grainId, hostId: session.hostId, salt: cachedSalt};
+    }
+  }
+
+  session = {
+    _id: sessionId,
+    grainId: grainId,
+    hostId: Crypto.createHash("sha256").update(sessionId).digest("hex").slice(0, 32),
+    timestamp: new Date().getTime(),
+    hasLoaded: false
+  };
+
+  if (userId) {
+    session.identityId = identityId;
+    session.userId = userId;
+  } else if (apiToken) {
+    session.hashedToken = apiToken._id;
+  } else {
+    // Must be old-style sharing, i.e. !grain.private.
+  }
+
+  Sessions.insert(session);
+
+  return {sessionId: session._id, title: title, grainId: grainId, hostId: session.hostId, salt: cachedSalt};
+}

--- a/shell/packages/sandstorm-backend/sandstorm-backend.js
+++ b/shell/packages/sandstorm-backend/sandstorm-backend.js
@@ -97,14 +97,14 @@ SandstormBackend.prototype.openGrain = function (grainId, isRetry) {
 
   if (isRetry) {
     // Since this is a retry, try starting the grain even if we think it's already running.
-    return this._continueGrain(grainId);
+    return this.continueGrain(grainId);
   } else {
     // Start the grain if it is not running.
     var runningGrain = this.runningGrains[grainId];
     if (runningGrain) {
       return waitPromise(runningGrain);
     } else {
-      return this._continueGrain(grainId);
+      return this.continueGrain(grainId);
     }
   }
 }
@@ -151,7 +151,7 @@ SandstormBackend.prototype.useGrain = function (grainId, cb) {
   }
 }
 
-SandstormBackend.prototype._continueGrain = function(grainId) {
+SandstormBackend.prototype.continueGrain = function(grainId) {
   var grain = Grains.findOne(grainId);
   if (!grain) {
     throw new Meteor.Error(404, "Grain Not Found", "Grain ID: " + grainId);
@@ -183,11 +183,11 @@ SandstormBackend.prototype._continueGrain = function(grainId) {
                            "Package ID: " + packageId);
   }
 
-  return this._startGrainInternal(
+  return this.startGrainInternal(
       packageId, grainId, grain.userId, manifest.continueCommand, false, isDev);
 }
 
-SandstormBackend.prototype._startGrainInternal = function(packageId, grainId, ownerId, command, isNew, isDev) {
+SandstormBackend.prototype.startGrainInternal = function(packageId, grainId, ownerId, command, isNew, isDev) {
   // Starts the grain supervisor.  Must be executed in a Meteor context.  Blocks until grain is
   // started. Returns a promise for an object containing two fields: `owner` (the ID of the owning
   // user) and `supervisor` (the supervisor capability).
@@ -269,7 +269,7 @@ function generateSessionId(grainId, userId, salt) {
   return Crypto.createHash("sha256").update(sessionInput).digest("hex");
 }
 
-SandstormBackend.prototype._openSessionInternal = function (grainId, userId, identityId, title, apiToken, cachedSalt) {
+SandstormBackend.prototype.openSessionInternal = function (grainId, userId, identityId, title, apiToken, cachedSalt) {
 
   // Start the grain if it is not running. This is an optimization: if we didn't start it here,
   // it would start on the first request to the session host, but we'd like to get started before
@@ -279,7 +279,7 @@ SandstormBackend.prototype._openSessionInternal = function (grainId, userId, ide
   if (runningGrain) {
     grainInfo = waitPromise(runningGrain);
   } else {
-    grainInfo = this._continueGrain(grainId);
+    grainInfo = this.continueGrain(grainId);
   }
 
   this.updateLastActive(grainId, userId, identityId);

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -52,6 +52,7 @@ if (Meteor.isServer && process.env.LOG_MONGO_QUERIES) {
 //       handle: String containing the user's preferred handle. Default: first part of email.
 //       picture: _id into the StaticAssets table for the user's picture. Default: identicon.
 //       pronoun: One of "male", "female", "neutral", or "robot". Default: neutral.
+//       unverifiedEmail: Email address specified by the user.
 //       verifiedEmail: Only provided by some services. Cannot be directly edited by the user.
 //       main: True is this is the user's main identity.
 //       allowsLogin: True if the user trusts this identity for account authentication.

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -54,7 +54,7 @@ if (Meteor.isServer && process.env.LOG_MONGO_QUERIES) {
 //       pronoun: One of "male", "female", "neutral", or "robot". Default: neutral.
 //       unverifiedEmail: Email address specified by the user.
 //       verifiedEmail: Only provided by some services. Cannot be directly edited by the user.
-//       main: True is this is the user's main identity.
+//       main: True if this is the user's main identity.
 //       noLogin: True if the user does not trust this identity for account authentication.
 //   services: Object containing login and identity data used by Meteor authentication services.
 //   mergedUsers: Array of User _id strings, representing the accounts that have been merged into this

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -33,10 +33,10 @@ if (Meteor.isServer && process.env.LOG_MONGO_QUERIES) {
 //
 // Note that accounts are not the same thing as identities. An account may have multiple identities
 // attached to it. Identities provide a way to authenticate the user and are also used to present
-// globally unique and stable user indentifiers to grains via `Grain.UserInfo.userId`.
+// globally unique and stable user indentifiers to grains via `Grain.UserInfo.identityId`.
 //
 // Each entry in this collection contains:
-//   _id: Random.
+//   _id: Random string. What we're talking about when we say "User ID" or "Account ID".
 //   createdAt: Date when this entry was added to the collection.
 //   lastActive: Date of the user's most recent interaction with this Sandstorm server.
 //   profile: Object containing profile data editable by the user and visible to other users. May
@@ -268,10 +268,6 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //              still apply. For non-UiView capabilities, `identityId` is never present. Note that
 //              this is NOT the identity against which the `requiredPermissions` parameter of
 //              `SandstormApi.restore()` is checked; that would be `owner.grain.introducerIdentity`.
-//   userInfo:  *DEPRECATED* For API tokens created by the app through HackSessionContext, the
-//              UserInfo struct that should be passed to `newSession()` when exercising this token,
-//              in decoded (JS object) format. This is a temporary hack. `identityId` is never
-//              present when `userInfo` is present.
 //   roleAssignment: If this API token represents a UiView, this field contains a JSON-encoded
 //              Grain.ViewSharingLink.RoleAssignment representing the permissions it carries. These
 //              permissions will be intersected with those held by `identityId` when the view is
@@ -299,8 +295,8 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //              the ApiToken with _id = parentToken, except possibly (if it is a UiView) attenuated
 //              by `roleAssignment` (if present). To facilitate permissions computations, if the
 //              capability is a UiView, then `grainId` is set to the backing grain and `identityId`
-//              is set to the identity that shared the view. None of `userInfo`, `objectId`, or
-//              `frontendRef` are present when `parentToken` is present.
+//              is set to the identity that shared the view. Neither `objectId` nor `frontendRef`
+//              is present when `parentToken` is present.
 //   petname:   Human-readable label for this access token, useful for identifying tokens for
 //              revocation. This should be displayed when visualizing incoming capabilities to
 //              the grain identified by `grainId`.

--- a/shell/packages/sandstorm-db/migrations.js
+++ b/shell/packages/sandstorm-db/migrations.js
@@ -222,9 +222,14 @@ function splitUserIdsIntoAccountIdsAndIdentityIds() {
     ApiTokens.update({"owner.grain.introducerUser": user._id},
                      {$set: {"owner.grain.introducerIdentity": identity.id}},
                      {multi: true});
-    ApiTokens.update({"requirements.permissionsHeld.userId": user._id},
-                     {$set: {"requirements.$.permissionsHeld.identityId": identity.id}},
-                     {multi: true});
+
+    while (ApiTokens.update({"requirements.permissionsHeld.userId": user._id},
+                            {$set: {"requirements.$.permissionsHeld.identityId": identity.id},
+                             $unset: {"requirements.$.permissionsHeld.userId": 1}},
+                            {multi: true}) > 0);
+    // The `$` operatorer modifies the first element in the array that matches the query. Since
+    // there may be many matches, we need to repeat until no documents are modified.
+
   });
 
   ApiTokens.remove({userInfo: {$exists: true}});

--- a/shell/packages/sandstorm-db/migrations.js
+++ b/shell/packages/sandstorm-db/migrations.js
@@ -191,6 +191,34 @@ function verifyAllPgpSignatures() {
   });
 }
 
+function splitUserIdsIntoAccountIdsAndIdentityIds() {
+  Meteor.users.find().forEach(function (user) {
+    var identities = SandstormDb.getUserIdentities(user);
+    if (identities.length != 1) {
+      throw new Error("user has unexpected number of identities: " + JSON.stringify(user));
+    }
+    var service = identities[0].service;
+    var identityId = identities[0].id;
+
+    Meteor.users.update(user._id, {$set: {identityIds: [identityId]}});
+
+    Grains.update({userId: user._id}, {$set: {identityId: identityId}}, {multi: true});
+    Sessions.update({userId: user._id}, {$set: {identityId: identityId}}, {multi: true});
+    ApiTokens.update({userId: user._id},
+                     {$set: {identityId: identityId}},
+                     {multi: true});
+    ApiTokens.update({"owner.user.userId": user._id},
+                     {$set: {"owner.user.identityId": identityId}},
+                     {multi: true});
+    ApiTokens.update({"owner.grain.introducerUser": user._id},
+                     {$set: {"owner.grain.introducerIdentity": identityId}},
+                     {multi: true});
+    ApiTokens.update({"requirements.permissionsHeld.userId": user._id},
+                     {$set: {"requirements.$.permissionsHeld.identityId": identityId}},
+                     {multi: true});
+  });
+}
+
 // This must come after all the functions named within are defined.
 // Only append to this list!  Do not modify or remove list entries;
 // doing so is likely change the meaning and semantics of user databases.
@@ -205,6 +233,7 @@ var MIGRATIONS = [
   removeKeyrings,
   useLocalizedTextInUserActions,
   verifyAllPgpSignatures,
+  splitUserIdsIntoAccountIdsAndIdentityIds
 ];
 
 function migrateToLatest() {

--- a/shell/packages/sandstorm-db/migrations.js
+++ b/shell/packages/sandstorm-db/migrations.js
@@ -179,6 +179,7 @@ function splitUserIdsIntoAccountIdsAndIdentityIds() {
       serviceUserId = user.services.google.id;
     } else if (user.services && "github" in user.services) {
       identity.service = "github";
+      identity.unverifiedEmail = user.services.github.email;
       serviceUserId = user.services.github.id;
     } else if (user.services && "emailToken" in user.services) {
       identity.service = "emailToken";
@@ -201,6 +202,9 @@ function splitUserIdsIntoAccountIdsAndIdentityIds() {
       }
       if (user.profile.pronoun) {
         identity.pronoun = user.profile.pronoun;
+      }
+      if (user.profile.email) {
+        identity.unverifiedEmail = user.profile.email;
       }
     }
     identity.main = true;

--- a/shell/packages/sandstorm-db/migrations.js
+++ b/shell/packages/sandstorm-db/migrations.js
@@ -208,7 +208,6 @@ function splitUserIdsIntoAccountIdsAndIdentityIds() {
       }
     }
     identity.main = true;
-    identity.allowsLogin = true;
 
     Meteor.users.update(user._id, {$set: {identities: [identity]}});
 

--- a/shell/packages/sandstorm-db/migrations.js
+++ b/shell/packages/sandstorm-db/migrations.js
@@ -217,6 +217,11 @@ function splitUserIdsIntoAccountIdsAndIdentityIds() {
                      {$set: {"requirements.$.permissionsHeld.identityId": identityId}},
                      {multi: true});
   });
+
+  ApiTokens.remove({userInfo: {$exists: true}});
+  // We've renamed `Grain.UserInfo.userId` to `Grain.userInfo.identityId`. The only place
+  // that this field could show up in the database was in this deprecated, no-longer-functional
+  // form of API token.
 }
 
 // This must come after all the functions named within are defined.

--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -237,21 +237,23 @@ SandstormDb.getUserIdentities = function (user) {
   var staticHost = httpProtocol + "//" + makeWildcardHost("static");
 
   var result = [];
-  if (user && user.services) {
-    if ("google" in user.services) {
-      result.push(googleIdentity(user, staticHost));
-    }
-    if ("github" in user.services) {
-      result.push(githubIdentity(user, staticHost));
-    }
-    if ("emailToken" in user.services) {
-      result.push(emailIdentity(user, staticHost));
-    }
+  if (user) {
     if ("devName" in user) {
       result.push(devIdentity(user, staticHost));
     }
     if ("expires" in user) {
       result.push(demoIdentity(user, staticHost));
+    }
+    if (user.services) {
+      if ("google" in user.services) {
+        result.push(googleIdentity(user, staticHost));
+      }
+      if ("github" in user.services) {
+        result.push(githubIdentity(user, staticHost));
+      }
+      if ("emailToken" in user.services) {
+        result.push(emailIdentity(user, staticHost));
+      }
     }
   }
   return result;

--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -25,7 +25,7 @@ if (Meteor.isServer) {
     return [
       Meteor.users.find(Meteor.userId,
         {fields: {
-          "profile":1,
+          "identities":1,
           "devName":1,
           "expires":1,
 
@@ -127,94 +127,6 @@ function emailToHandle(email) {
   return filterHandle(base);
 }
 
-function identityId(service, id) {
-  return sha256(service + ":" + id);
-}
-
-function googleIdentity(user, staticHost) {
-  var google = (user.services && user.services.google) || {};
-  var profile = user.profile || {};
-  var id = identityId("google", google.id);
-
-  return {
-    service: "google",
-    id: id,
-    name: profile.name || google.name || "Name Unknown",
-    email: profile.email || google.email,
-    handle: profile.handle || emailToHandle(google.email) ||
-            filterHandle(profile.name || google.name) || "unknown",
-    picture: staticAssetUrl(profile.picture, staticHost) || makeIdenticon(id),
-    pronoun: profile.pronoun || GENDERS[google.gender] || "neutral",
-  }
-}
-
-function githubIdentity(user, staticHost) {
-  var github = (user.services && user.services.github) || {};
-  var profile = user.profile || {};
-  var id = identityId("github", github.id);
-
-  return {
-    service: "github",
-    id: id,
-    name: profile.name || github.username || "Name Unknown",
-    email: profile.email || github.email,
-    handle: profile.handle || filterHandle(github.username) ||
-            filterHandle(profile.name) || "unknown",
-    picture: staticAssetUrl(profile.picture, staticHost) || makeIdenticon(id),
-    pronoun: profile.pronoun,
-  }
-}
-
-function emailIdentity(user, staticHost) {
-  var email = (user.services && user.services.emailToken) || {};
-  var profile = user.profile || {};
-  var id = identityId("email", email.email);
-
-  return {
-    service: "email",
-    id: id,
-    name: profile.name || email.email.split("@")[0] || "Name Unknown",
-    email: profile.email || email.email,
-    handle: profile.handle || emailToHandle(email.email) ||
-            filterHandle(profile.name) || "unknown",
-    picture: staticAssetUrl(profile.picture, staticHost) || makeIdenticon(id),
-    pronoun: profile.pronoun,
-  }
-}
-
-function devIdentity(user, staticHost) {
-  var email = (user.services && user.services.emailToken) || {};
-  var profile = user.profile || {};
-  var name = user.devName.split(" ")[0].toLowerCase();
-  var id = identityId("dev", user.devName);
-
-  return {
-    service: "dev",
-    id: id,
-    name: profile.name || user.devName,
-    handle: profile.handle || filterHandle(name),
-    picture: staticAssetUrl(profile.picture, staticHost) || makeIdenticon(id),
-    pronoun: profile.pronoun ||
-             (_.contains(["alice", "carol", "eve"], name) ? "female" :
-              _.contains(["bob", "dave"], name) ? "male" : "neutral"),
-  }
-}
-
-function demoIdentity(user, staticHost) {
-  var email = (user.services && user.services.emailToken) || {};
-  var profile = user.profile || {};
-  var id = identityId("demo", user._id);
-
-  return {
-    service: "demo",
-    id: id,
-    name: profile.name || "Demo User",
-    handle: profile.handle || "demo",
-    picture: staticAssetUrl(profile.picture, staticHost) || makeIdenticon(id),
-    pronoun: profile.pronoun || "neutral",
-  }
-}
-
 SandstormDb.getVerifiedEmails = function (user) {
   var result = [];
 
@@ -229,32 +141,47 @@ SandstormDb.getVerifiedEmails = function (user) {
   return result;
 }
 
+function fillInDefaults(identity, user) {
+  if (identity.service === "github") {
+    identity.name = identity.name || user.services.github.username || "Name Unknown";
+    identity.handle = identity.handle || filterHandle(user.services.github.username) ||
+        filterHandle(identity.name) || "unknown";
+  } else if (identity.service === "google") {
+    identity.name = identity.name || user.services.google.name || "Name Unknown";
+    identity.handle = identity.handle || emailToHandle(user.services.google.email) ||
+        filterHandle(identity.name) || "unknown";
+    identity.pronoun = identity.pronoun || GENDERS[user.services.google.gender] || "neutral";
+  } else if (identity.service === "emailToken") {
+    identity.name = identity.name || user.services.emailToken.email.split("@")[0] || "Name Unknown";
+    identity.handle = identity.handle || emailToHandle(user.services.emailToken.email) ||
+        filterHandle(identity.name) || "unknown";
+  } else if (identity.service === "dev") {
+    var lowerCaseName = user.devName.split(" ")[0].toLowerCase();
+    identity.name = identity.name || user.devName;
+    identity.handle = identity.handle | filterHandle(lowerCaseName);
+    identity.pronoun = identity.pronoun ||
+        (_.contains(["alice", "carol", "eve"], lowerCaseName) ? "female" :
+         _.contains(["bob", "dave"], lowerCaseName) ? "male" : "neutral");
+  } else if (identity.service === "demo") {
+    identity.name = identity.name || "Demo User";
+    identity.handle = identity.handle || "demo";
+  } else {
+    throw new Error("unrecognized identity service: " + identity.service);
+  }
+
+  identity.pronoun = identity.pronoun || "netural";
+}
+
 SandstormDb.getUserIdentities = function (user) {
   // Given a user object, return all of the user's identities.
   //
   // On the client, must be subscribed "accountIdentities" for the user.
+  if (!user) return [];
 
   var staticHost = httpProtocol + "//" + makeWildcardHost("static");
-
-  var result = [];
-  if (user) {
-    if ("devName" in user) {
-      result.push(devIdentity(user, staticHost));
-    }
-    if ("expires" in user) {
-      result.push(demoIdentity(user, staticHost));
-    }
-    if (user.services) {
-      if ("google" in user.services) {
-        result.push(googleIdentity(user, staticHost));
-      }
-      if ("github" in user.services) {
-        result.push(githubIdentity(user, staticHost));
-      }
-      if ("emailToken" in user.services) {
-        result.push(emailIdentity(user, staticHost));
-      }
-    }
-  }
-  return result;
+  return user.identities.map(function(identity) {
+    identity.pictureUrl = staticAssetUrl(identity.picture, staticHost) || makeIdenticon(identity.id);
+    fillInDefaults(identity, user);
+    return identity;
+  });
 }

--- a/shell/packages/sandstorm-db/user.js
+++ b/shell/packages/sandstorm-db/user.js
@@ -97,6 +97,6 @@ Accounts.onCreateUser(function (options, user) {
       user.profile.picture = assetId;
     }
   }
-
+  user.identityIds = SandstormDb.getUserIdentities(user).map(function (i) { return i.id; });
   return user;
 });

--- a/shell/packages/sandstorm-db/user.js
+++ b/shell/packages/sandstorm-db/user.js
@@ -100,7 +100,6 @@ Accounts.onCreateUser(function (options, user) {
   }
   var identity = _.pick(user.profile, "name", "handle", "pronouns", "picture");
   identity.main = true;
-  identity.allowsLogin = true;
 
   var serviceUserId;
   if ("devName" in user) {
@@ -117,6 +116,9 @@ Accounts.onCreateUser(function (options, user) {
     serviceUserId = user.services.google.id;
   } else if (user.services && "github" in user.services) {
     identity.service = "github";
+    if (user.services.github.email) {
+      identity.unverifiedEmail = user.services.github.email;
+    }
     serviceUserId = user.services.github.id;
   } else if (user.services && "emailToken" in user.services) {
     identity.service = "emailToken";
@@ -138,7 +140,7 @@ Accounts.validateLoginAttempt(function(info) {
       var identities = info.user.identities;
       for (var ii = 0; ii < identities.length; ++ii) {
         if (identities[ii].service === info.type) {
-          return identities[ii].allowsLogin;
+          return !identities[ii].noLogin;
         }
       }
     }

--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -428,7 +428,7 @@ SandstormPermissions.createNewApiToken = function (db, provider, grainId, petnam
   };
 
   if (provider.rawParentToken) {
-    var parentToken = Crypto.createHash("sha256").update(rawParentToken).digest("base64");
+    var parentToken = Crypto.createHash("sha256").update(provider.rawParentToken).digest("base64");
     var parentApiToken = db.collections.apiTokens.findOne(
       {_id: parentToken, grainId: grainId, objectId: {$exists: false}});
     if (!parentApiToken) {

--- a/shell/server/backup.js
+++ b/shell/server/backup.js
@@ -26,7 +26,7 @@ var TOKEN_CLEANUP_TIMER = TOKEN_CLEANUP_MINUTES * 60 * 1000;
 
 function cleanupToken(tokenId) {
   check(tokenId, String);
-  waitPromise(sandstormBackend.deleteBackup(tokenId));
+  waitPromise(globalBackend.cap().deleteBackup(tokenId));
   FileTokens.remove({_id: tokenId});
 }
 
@@ -62,7 +62,7 @@ Meteor.methods({
     var grainInfo = _.pick(grain, "appId", "appVersion", "title");
 
     FileTokens.insert(token);
-    waitPromise(sandstormBackend.backupGrain(token._id, this.userId, grainId, grainInfo));
+    waitPromise(globalBackend.cap().backupGrain(token._id, this.userId, grainId, grainInfo));
 
     return token._id;
   },
@@ -84,7 +84,7 @@ Meteor.methods({
     var grainId = Random.id(22);
 
     try {
-      var grainInfo = waitPromise(sandstormBackend.restoreGrain(
+      var grainInfo = waitPromise(globalBackend.cap().restoreGrain(
           tokenId, this.userId, grainId).catch(function (err) {
             console.error("Unzip failure:", err.message);
             throw new Meteor.Error(500, "Invalid backup file.");
@@ -195,7 +195,7 @@ Router.map(function () {
         }
       };
 
-      waitPromise(sandstormBackend.downloadBackup(this.params.tokenId, stream));
+      waitPromise(globalBackend.cap().downloadBackup(this.params.tokenId, stream));
 
       if (!sawEnd) {
         console.error("backend failed to call done() when downloading backup");
@@ -220,7 +220,7 @@ Router.map(function () {
             _id: Random.id(),
             timestamp: new Date()
           };
-          var stream = sandstormBackend.uploadBackup(token._id).stream;
+          var stream = globalBackend.cap().uploadBackup(token._id).stream;
 
           FileTokens.insert(token);
 

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -40,7 +40,7 @@ function makeNotificationHandle(notificationId, saved) {
 }
 
 function dropWakelock(grainId, wakeLockNotificationId) {
-  waitPromise(useGrain(grainId, function (supervisor) {
+  waitPromise(globalBackend.useGrain(grainId, function (supervisor) {
     return supervisor.drop({wakeLockNotification: wakeLockNotificationId});
   }));
 }
@@ -220,7 +220,7 @@ restoreInternal = function (tokenId, ownerPattern, requirements, parentToken) {
     if (token.objectId.appRef) {
       token.objectId.appRef = new Buffer(token.objectId.appRef);
     }
-    return waitPromise(useGrain(token.grainId, function (supervisor) {
+    return waitPromise(globalBackend.useGrain(token.grainId, function (supervisor) {
       return supervisor.restore(token.objectId, requirements, parentToken);
     }));
   } else if (token.parentToken) {

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -153,7 +153,7 @@ checkRequirements = function (requirements) {
       var p = requirement.permissionsHeld;
       var viewInfo = Grains.findOne(p.grainId, {fields: {cachedViewInfo: 1}}).cachedViewInfo;
       var currentPermissions = SandstormPermissions.grainPermissions(
-        globalDb, {grain: {_id: p.grainId, userId: p.userId}}, viewInfo || {});
+        globalDb, {grain: {_id: p.grainId, identityId: p.identityId}}, viewInfo || {});
       if (!currentPermissions) {
         return false;
       }
@@ -239,11 +239,11 @@ SandstormCoreImpl.prototype.restore = function (sturdyRef, requiredPermissions) 
       tokenValid: hashedSturdyRef
     }];
 
-    if (requiredPermissions && token.owner.grain.introducerUser) {
+    if (requiredPermissions && token.owner.grain.introducerIdentity) {
       requirements.push({
         permissionsHeld: {
           permissions: requiredPermissions,
-          userId: token.owner.grain.introducerUser,
+          identityId: token.owner.grain.introducerIdentity,
           grainId: self.grainId
         }
       });

--- a/shell/server/drivers/mail.js
+++ b/shell/server/drivers/mail.js
@@ -129,7 +129,7 @@ Meteor.startup(function() {
               var grain = Grains.findOne({publicId: publicId}, {fields: {}});
               if (grain) {
                 grainId = grain._id;
-                return openGrain(grainId, retryCount > 0);
+                return globalBackend.openGrain(grainId, retryCount > 0);
               } else {
                 // TODO(someday): We really ought to rig things up so that the "RCPT TO" SMTP command
                 //   fails in this case, but simplesmtp doesn't appear to support that.
@@ -156,7 +156,7 @@ Meteor.startup(function() {
                   .session.castAs(EmailSendPort);
               return session.send(mailMessage);
             }).catch(function (err) {
-              if (shouldRestartGrain(err, retryCount)) {
+              if (SandstormBackend.shouldRestartGrain(err, retryCount)) {
                 return tryDeliver(retryCount + 1);
               } else {
                 throw err;
@@ -268,7 +268,7 @@ hackSendEmail = function (session, email) {
     }
 
     var user = Meteor.users.findAndModify({
-      query: {_id: session.userId},
+      query: {"identities.id": session.identityId},
       update: {$inc: {dailySentMailCount: 1}},
       fields: {dailySentMailCount: 1}
     });

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -314,56 +314,15 @@ HackSessionContextImpl.prototype.getUserAddress = function () {
 };
 
 HackSessionContextImpl.prototype.generateApiToken = function (petname, userInfo, expires) {
-  return inMeteor((function () {
-    var token = Random.secret();
-    var endpointUrl = ROOT_URL.protocol + "//" + makeWildcardHost("api");
-
-    var tokenId = ApiTokens.insert({
-      _id: Crypto.createHash("sha256").update(token).digest("base64"),
-      userInfo: userInfo,
-      grainId: this.grainId,
-      petname: petname,
-      created: new Date(),
-      expires: expires > 0 ? new Date(expires * 1000) : null
-    });
-
-    return [token, endpointUrl, tokenId];
-  }).bind(this));
+  throw new Error("generateApiToken() has been removed. Use offer templates instead.");
 };
 
 HackSessionContextImpl.prototype.listApiTokens = function () {
-  return inMeteor((function () {
-    results = [];
-    ApiTokens.find({grainId: this.grainId, userInfo: {$exists: true}})
-        .forEach(function (token) {
-      if (token.expires && token.expires.getTime() < Date.now()) {
-        // Skip.
-        return;
-      }
-
-      // Hack: When Mongo stores a Buffer, it comes back as some other type.
-      if ("userId" in token.userInfo) {
-        token.userInfo.userId = new Buffer(token.userInfo.userId);
-      }
-      results.push({
-        tokenId: token._id,
-        petname: token.petname,
-        userInfo: token.userInfo
-      });
-    });
-
-    return [results];
-  }).bind(this));
+  throw new Error("listApiTokens() has been removed. Use offer templates instead.");
 };
 
 HackSessionContextImpl.prototype.revokeApiToken = function (tokenId) {
-  return inMeteor((function () {
-    if (ApiTokens.remove({_id: tokenId, grainId: this.grainId, userInfo: {$exists: true}}) === 0) {
-      var err = new Error("No such token.");
-      err.nature = "precondition";
-      throw err;
-    }
-  }).bind(this));
+  throw new Error("revokeApiToken() has been removed. Use offer templates instead.");
 };
 
 HackSessionContextImpl.prototype.getUiViewForEndpoint = function (url) {

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -75,16 +75,16 @@ SessionContextImpl.prototype.offer = function (cap, requiredPermissions) {
 };
 
 Meteor.methods({
-  finishPowerboxRequest: function (webkeyUrl, saveLabel, grainId) {
+  finishPowerboxRequest: function (webkeyUrl, saveLabel, identityId, grainId) {
     check(webkeyUrl, String);
     check(saveLabel, Match.OneOf(undefined, null, String));
+    check(identityId, String);
     check(grainId, String);
 
     var userId = Meteor.userId();
-    if (!userId) {
-      throw new Meteor.Error(403, "User must be logged in to user powerbox.");
+    if (!userId || !globalDb.getIdentityOfUser(identityId, userId)) {
+      throw new Meteor.Error(403, "Not an identity of the current user: " + identityId);
     }
-    var identity = this.connection.sandstormDb.getUserIdentities(userId)[0];
     var parsedWebkey = Url.parse(webkeyUrl.trim());
     if (parsedWebkey.host !== makeWildcardHost("api")) {
       console.log(parsedWebkey.hostname, makeWildcardHost("api"));
@@ -105,7 +105,7 @@ Meteor.methods({
     var castedCap = cap.castAs(SystemPersistent);
     var grainOwner = {
       grainId: grainId,
-      introducerIdentity: identity.id
+      introducerIdentity: identityId
     };
     if (saveLabel) {
       grainOwner.saveLabel = {
@@ -312,15 +312,15 @@ HackSessionContextImpl.prototype.getUserAddress = function () {
   }).bind(this));
 };
 
-HackSessionContextImpl.prototype.generateApiToken = function (petname, userInfo, expires) {
+HackSessionContextImpl.prototype.obsoleteGenerateApiToken = function (petname, userInfo, expires) {
   throw new Error("generateApiToken() has been removed. Use offer templates instead.");
 };
 
-HackSessionContextImpl.prototype.listApiTokens = function () {
+HackSessionContextImpl.prototype.obsoleteListApiTokens = function () {
   throw new Error("listApiTokens() has been removed. Use offer templates instead.");
 };
 
-HackSessionContextImpl.prototype.revokeApiToken = function (tokenId) {
+HackSessionContextImpl.prototype.obsoleteRevokeApiToken = function (tokenId) {
   throw new Error("revokeApiToken() has been removed. Use offer templates instead.");
 };
 

--- a/shell/server/installer.js
+++ b/shell/server/installer.js
@@ -67,7 +67,7 @@ var deletePackageInternal = function (package) {
     var grain = Grains.findOne({packageId:packageId});
     if (!grain && !action) {
       Packages.update({_id:packageId}, {$set: {status:"delete"}, $unset: {shouldCleanup: ""}});
-      waitPromise(sandstormBackend.deletePackage(packageId));
+      waitPromise(globalBackend.cap().deletePackage(packageId));
       Packages.remove(packageId);
 
       // Clean up assets (icon, etc).
@@ -156,7 +156,7 @@ doClientUpload = function (stream) {
   return new Promise(function (resolve, reject) {
     var id = Random.id();
 
-    var backendStream = sandstormBackend.installPackage().stream;
+    var backendStream = globalBackend.cap().installPackage().stream;
     var hasher = Crypto.createHash("sha256");
 
     stream.on("data", function (chunk) {
@@ -402,7 +402,7 @@ AppInstaller.prototype.start = function () {
   return this.wrapCallback(function () {
     this.cleanup();
 
-    sandstormBackend.tryGetPackage(this.packageId)
+    globalBackend.cap().tryGetPackage(this.packageId)
         .then(this.wrapCallback(function(info) {
       if (info.appId) {
         this.appId = info.appId;
@@ -425,7 +425,7 @@ AppInstaller.prototype.doDownload = function () {
   console.log("Downloading app:", this.url);
   this.updateProgress("download");
 
-  this.uploadStream = sandstormBackend.installPackage().stream;
+  this.uploadStream = globalBackend.cap().installPackage().stream;
   return this.doDownloadTo(this.uploadStream);
 }
 

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -152,6 +152,7 @@ Meteor.methods({
         throw new Meteor.Error(404, "Not Found", "No such package is installed.");
       }
     }
+    var userIdentity = this.connection.sandstormDb.getUserIdentities(this.userId)[0];
 
     var grainId = Random.id(22);  // 128 bits of entropy
     Grains.insert({
@@ -160,11 +161,12 @@ Meteor.methods({
       appId: appId,
       appVersion: manifest.appVersion,
       userId: this.userId,
+      identityId: userIdentity.id,
       title: title,
       private: true
     });
     startGrainInternal(packageId, grainId, this.userId, command, true, isDev);
-    updateLastActive(grainId, this.userId);
+    updateLastActive(grainId, this.userId, userIdentity.id);
     return grainId;
   },
 
@@ -173,9 +175,11 @@ Meteor.methods({
     // running.
 
     check(grainId, String);
+    var db = this.connection.sandstormDb;
+    var identity = db.getUserIdentities(this.userId)[0];
     check(cachedSalt, Match.OneOf(undefined, null, String));
-    if (!SandstormPermissions.mayOpenGrain(globalDb,
-                                           {grain: {_id: grainId, userId: this.userId}})) {
+    if (!SandstormPermissions.mayOpenGrain(db,
+                                           {grain: {_id: grainId, identityId: identity.id}})) {
       throw new Meteor.Error(403, "Unauthorized", "User is not authorized to open this grain.");
     }
 
@@ -211,12 +215,12 @@ Meteor.methods({
     // Only provide an app ID if we have no icon asset to provide and need to offer an identicon.
     var appId = appIcon ? undefined : grain.appId;
     var title;
-    if (grain.userId == apiToken.userId) {
+    if (grain.identityId == apiToken.identityId) {
       title = grain.title;
     } else {
-      if (apiToken.userId) {
+      if (apiToken.identityId) {
         var sharerToken = ApiTokens.findOne({grainId: apiToken.grainId,
-                                             "owner.user.userId": apiToken.userId},
+                                             "owner.user.identityId": apiToken.identityId},
                                             {sort : {created : 1}});
         if (sharerToken) {
           title = sharerToken.owner.user.title;
@@ -225,19 +229,20 @@ Meteor.methods({
     }
 
     if (this.userId && !incognito) {
-      if (this.userId != apiToken.userId && this.userId != grain.userId &&
-          !ApiTokens.findOne({'owner.user.userId': this.userId, parentToken: hashedToken })) {
+      var identity = globalDb.getUserIdentities(this.userId)[0];
+      if (identity.id != apiToken.identityId && identity.id != grain.identityId &&
+          !ApiTokens.findOne({'owner.user.identityId': identity.id, parentToken: hashedToken })) {
         // The current user is neither the sharer nor the grain owner,
         // and the current user has not already redeemed this token.
         var now = new Date();
         var grainInfo = { appTitle: appTitle };
         if (appIcon) { grainInfo.icon = appIcon; }
         if (appId) { grainInfo.appId = appId; }
-        var owner = {user: {userId: this.userId, title: title, lastUsed: now,
+        var owner = {user: {identityId: identity.id, title: title, lastUsed: now,
                             denormalizedGrainMetadata: grainInfo}};
         var newToken = {
           grainId: apiToken.grainId,
-          userId: apiToken.userId,
+          identityId: apiToken.identityId,
           parentToken: hashedToken,
           roleAssignment: {allAccess: null},
           petname: apiToken.petname,
@@ -272,7 +277,7 @@ Meteor.methods({
 
       var grainId = session.grainId;
       waitPromise(openGrain(grainId, false).supervisor.keepAlive());
-      updateLastActive(grainId, this.userId);
+      updateLastActive(grainId, this.userId, session.identityId);
       return true;
     } else {
       return false;
@@ -336,6 +341,7 @@ function generateSessionId(grainId, userId, salt) {
 
 function openSessionInternal(grainId, user, title, apiToken, cachedSalt) {
   var userId = user ? user._id : undefined;
+  var identityId = user ? SandstormDb.getUserIdentities(user)[0].id : undefined;
 
   // Start the grain if it is not running. This is an optimization: if we didn't start it here,
   // it would start on the first request to the session host, but we'd like to get started before
@@ -348,14 +354,14 @@ function openSessionInternal(grainId, user, title, apiToken, cachedSalt) {
     grainInfo = continueGrain(grainId);
   }
 
-  updateLastActive(grainId, userId);
+  updateLastActive(grainId, userId, identityId);
 
   cachedSalt = cachedSalt || Random.id(22);
   var sessionId = generateSessionId(grainId, userId, cachedSalt);
   var session = Sessions.findOne({_id: sessionId});
   if (session) {
     // TODO(someday): also do some more checks for anonymous sessions (sessions without a userId).
-    if ((session.userId && session.userId !== userId) ||
+    if ((session.identityId && session.identityId !== identityId) ||
         (session.grainId !== grainId)) {
       var e = new Meteor.Error(500, "Duplicate SessionId");
       console.error(e);
@@ -374,6 +380,7 @@ function openSessionInternal(grainId, user, title, apiToken, cachedSalt) {
   };
 
   if (userId) {
+    session.identityId = identityId;
     session.userId = userId;
   } else if (apiToken) {
     session.hashedToken = apiToken._id;
@@ -386,7 +393,7 @@ function openSessionInternal(grainId, user, title, apiToken, cachedSalt) {
   return {sessionId: session._id, title: title, grainId: grainId, hostId: session.hostId, salt: cachedSalt};
 }
 
-function updateLastActive(grainId, userId) {
+function updateLastActive(grainId, userId, identityId) {
   // Update the lastActive date on the grain, any relevant API tokens, and the user,
   // and also update the user's storage usage.
 
@@ -399,9 +406,11 @@ function updateLastActive(grainId, userId) {
   Grains.update(grainId, {$set: {lastUsed: now}});
   if (userId) {
     Meteor.users.update(userId, {$set: {lastActive: now}});
+  }
+  if (identityId) {
     // Update any API tokens that match this user/grain pairing as well
     var now = new Date();
-    ApiTokens.update({"grainId": grainId, "owner.user.userId": userId},
+    ApiTokens.update({"grainId": grainId, "owner.user.identityId": identityId},
         {$set: {"owner.user.lastUsed": now }});
   }
 
@@ -696,7 +705,7 @@ Meteor.startup(function() {
     // TODO(soon): Only clear sessions and proxies for which the permissions have changed.
     var downstream = SandstormPermissions.downstreamTokens(globalDb, {token: token});
     downstream.push(token);
-    var users = [];
+    var identityIds = [];
     var tokenIds = [];
     downstream.forEach(function (token) {
       var proxy = proxiesByApiToken[token._id];
@@ -706,25 +715,27 @@ Meteor.startup(function() {
       delete proxiesByApiToken[token._id];
       tokenIds.push(token._id);
       if (token.owner && token.owner.user){
-        users.push(token.owner.user.userId);
+        identityIds.push(token.owner.user.identityId);
       }
     });
-    Sessions.find({grainId: token.grainId, $or: [{userId: {$in: users}},
-      {hashedToken: {$in: tokenIds}}]}, {fields: {hostId: 1}}).forEach(function (session) {
+    Sessions.find({grainId: token.grainId,
+                   $or: [{identityId: {$in: identityIds}},
+                         {hashedToken: {$in: tokenIds}}]},
+                  {fields: {hostId: 1}}).forEach(function (session) {
       var proxy = proxiesByHostId[session.hostId];
       if (proxy) {
         proxy.close();
       }
       delete proxiesByHostId[session.hostId];
     });
-    Sessions.remove({grainId: token.grainId, $or: [{userId: {$in: users}},
+    Sessions.remove({grainId: token.grainId, $or: [{identityId: {$in: identityIds}},
                                                    {hashedToken: {$in: tokenIds}}]});
   }
 
   Grains.find().observe({
     changed: function (newGrain, oldGrain) {
       if (oldGrain.private != newGrain.private) {
-        Sessions.remove({grainId: oldGrain._id, userId: {$ne: oldGrain.userId}});
+        Sessions.remove({grainId: oldGrain._id, identityId: {$ne: oldGrain.identityId}});
         ApiTokens.find({grainId: oldGrain._id}).forEach(function(apiToken) {
           delete proxiesByApiToken[apiToken._id];
         });
@@ -1039,6 +1050,7 @@ function Proxy(grainId, ownerId, sessionId, hostId, isOwner, user, userInfo, isA
     }
     var identity = identities[0];
     this.userId = user._id;
+    this.identityId = identity.id;
 
     this.userInfo = {
       displayName: {defaultText: identity.name},
@@ -1272,7 +1284,7 @@ Proxy.prototype._callNewSession = function (request, viewInfo) {
       vertex = {token: self.apiToken};
     } else {
       // (self.userId might be null; this is fine)
-      vertex = {grain: {_id: self.grainId, userId: self.userId}};
+      vertex = {grain: {_id: self.grainId, identityId: self.identityId}};
     }
     var permissions = SandstormPermissions.grainPermissions(globalDb, vertex, viewInfo);
     if (!permissions) {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -676,7 +676,7 @@ var getProxyForHostId = function (hostId) {
         var user = session.userId && Meteor.users.findOne(session.userId);
 
         var proxy = new Proxy(grain._id, grain.userId, session._id, hostId,
-                              user && user._id === grain._id, user, null, false);
+                              user && user._id === grain.userId, user, false);
         if (apiToken) proxy.apiToken = apiToken;
 
         // Only add the proxy to the table if it was not concurrently deleted (which could happen
@@ -804,12 +804,12 @@ getProxyForApiToken = function (token) {
           }
 
           var isOwner = grain.userId === tokenInfo.userId;
-          proxy = new Proxy(tokenInfo.grainId, grain.userId, null, null, isOwner, user, null, true);
+          proxy = new Proxy(tokenInfo.grainId, grain.userId, null, null, isOwner, user, true);
           proxy.apiToken = tokenInfo;
         } else if (tokenInfo.userInfo) {
           throw new Error("API tokens created with arbitrary userInfo no longer supported");
         } else {
-          proxy = new Proxy(tokenInfo.grainId, grain.userId, null, null, false, null, null, true);
+          proxy = new Proxy(tokenInfo.grainId, grain.userId, null, null, false, null, true);
         }
 
         if (!SandstormPermissions.mayOpenGrain(globalDb, {token: tokenInfo})) {
@@ -1016,8 +1016,7 @@ tryProxyRequest = function (hostId, req, res) {
 // Connects to a grain and exports it on a wildcard host.
 //
 
-function Proxy(grainId, ownerId, sessionId, hostId, isOwner, user, userInfo, isApi,
-               supervisor) {
+function Proxy(grainId, ownerId, sessionId, hostId, isOwner, user, isApi, supervisor) {
   this.grainId = grainId;
   this.ownerId = ownerId;
   this.supervisor = supervisor;  // note: optional parameter; we can reconnect
@@ -1035,9 +1034,7 @@ function Proxy(grainId, ownerId, sessionId, hostId, isOwner, user, userInfo, isA
     if (hostId) throw new Error("API proxy sholudn't have hostId");
   }
 
-  if (userInfo) {
-    this.userInfo = userInfo;
-  } else if (user) {
+  if (user) {
     var identities = SandstormDb.getUserIdentities(user);
     if (identities.length !== 1) {
       if (identities.length === 0) {
@@ -1055,7 +1052,7 @@ function Proxy(grainId, ownerId, sessionId, hostId, isOwner, user, userInfo, isA
     this.userInfo = {
       displayName: {defaultText: identity.name},
       preferredHandle: identity.handle,
-      userId: new Buffer(identity.id, "hex")
+      identityId: new Buffer(identity.id, "hex")
     };
     if (identity.picture) this.userInfo.pictureUrl = identity.picture;
     if (identity.pronoun) this.userInfo.pronouns = identity.pronoun;
@@ -1283,7 +1280,7 @@ Proxy.prototype._callNewSession = function (request, viewInfo) {
     if (self.apiToken) {
       vertex = {token: self.apiToken};
     } else {
-      // (self.userId might be null; this is fine)
+      // (self.identityId might be null; this is fine)
       vertex = {grain: {_id: self.grainId, identityId: self.identityId}};
     }
     var permissions = SandstormPermissions.grainPermissions(globalDb, vertex, viewInfo);

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -330,25 +330,8 @@ if (Meteor.isClient) {
     users: function () {
       return Meteor.users.find({}, {sort: {createdAt: 1}});
     },
-    userService: function () {
-      var services = _.without(Object.keys(this.services), "resume");
-      if (services.length === 0) {
-        return "dev";
-      } else {
-        return services[0];
-      }
-    },
-    userName: function () {
-      var services = this.services;
-      if (services.github) {
-        return services.github.username;
-      } else if (services.google) {
-        return services.google.email;
-      } else if (services.emailToken) {
-        return services.emailToken.email;
-      } else {
-        return this.profile && this.profile.name;
-      }
+    userIdentity: function () {
+      return SandstormDb.getUserIdentities(this)[0];
     },
     userSignupNote: function () {
       if (this.signupEmail) {

--- a/shell/shared/devAccounts.js
+++ b/shell/shared/devAccounts.js
@@ -46,7 +46,7 @@ if (allowDevAccounts) {
         }
         // Log them in on this connection.
         return Accounts._loginMethod(this, "createDevAccount", arguments,
-            "devAccounts", function () { return { userId: userId }; });
+            "dev", function () { return { userId: userId }; });
       }
     });
   }

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -25,24 +25,37 @@ if (Meteor.isServer) {
     check(grainId, String);
     var self = this;
 
-    // Alice is allowed to know Bob's display name if Bob has received a UiView from Alice
-    // for *any* grain.
-    var handle = ApiTokens.find({userId: this.userId,
-                                 "owner.user.userId": {$exists: true}}).observe({
-      added: function(token) {
-        var user = Meteor.users.findOne(token.owner.user.userId);
-        if (user) {
-          self.added("displayNames", user._id, {displayName: user.profile.name});
-        }
-      },
-    });
-    this.onStop(function() { handle.stop(); });
+    var result = [Grains.find({_id : grainId, $or: [{userId: this.userId}, {private: {$ne: true}}]},
+                              {fields: {title: 1, userId: 1, identityId: 1, private: 1}})];
+    if (this.userId) {
+      // TODO how will this work with multiple identities?
+      var myIdentity = globalDb.getUserIdentities(this.userId)[0];
+      self.added("displayNames", myIdentity.id, {displayName: myIdentity.name});
 
-    return [Grains.find({_id : grainId, $or: [{userId: this.userId}, {private: {$ne: true}}]},
-                        {fields: {title: 1, userId: 1, private: 1}}),
-            ApiTokens.find({grainId: grainId,
-                            $or : [{"owner.user.userId": this.userId}, {userId: this.userId}]}),
-           ];
+      // Alice is allowed to know Bob's display name if Bob has received a UiView from Alice
+      // for *any* grain.
+      var handle = ApiTokens.find({identityId: myIdentity.id,
+                                   "owner.user.identityId": {$exists: true}}).observe({
+        added: function(token) {
+          var user = Meteor.users.findOne({identityIds: token.owner.user.identityId});
+          if (user) {
+            var identity = _.findWhere(SandstormDb.getUserIdentities(user),
+                                       {id: token.owner.user.identityId});
+            if (identity) {
+              self.added("displayNames", identity.id, {displayName: identity.name});
+            }
+
+          }
+        },
+      });
+      this.onStop(function() { handle.stop(); });
+
+      result.push(ApiTokens.find({grainId: grainId,
+                                  $or : [{"owner.user.identityId": myIdentity.id},
+                                         {identityId: myIdentity.id}]}));
+
+    }
+    return result;
   });
 
   // We allow users to learn package information about a grain they own.
@@ -66,7 +79,6 @@ if (Meteor.isServer) {
 
     return publishThis;
   });
-
 
   Meteor.publish("tokenInfo", function (token) {
     // Allows the client side to map a raw token to its entry in ApiTokens, and the additional
@@ -189,20 +201,22 @@ Meteor.methods({
     check(grainId, String);
 
     if (this.userId) {
-      ApiTokens.remove({grainId: grainId, "owner.user.userId": this.userId});
+      var identity = globalDb.getUserIdentities(this.userId)[0];
+      ApiTokens.remove({grainId: grainId, "owner.user.identityId": identity.id});
     }
   },
   updateGrainTitle: function (grainId, newTitle) {
     check(grainId, String);
     check(newTitle, String);
     if (this.userId) {
+      var identityId = globalDb.getUserIdentities(this.userId)[0].id
       var grain = Grains.findOne(grainId);
       if (grain) {
-        if (this.userId === grain.userId) {
+        if (identityId === grain.identityId) {
           Grains.update(grainId, {$set: {title: newTitle}});
         } else {
           var token = ApiTokens.findOne({grainId: grainId, objectId: {$exists: false},
-                                         "owner.user.userId": this.userId},
+                                         "owner.user.identityId": identityId},
                                         {sort:{created:1}});
           if (token) {
             ApiTokens.update(token._id, {$set: {"owner.user.title": newTitle}});
@@ -694,8 +708,8 @@ if (Meteor.isClient) {
   });
 
   Template.grainPowerboxOfferPopup.events({
-    "click button.dismiss": function (event) {
-      var sessionId = Template.instance().data.sessionId;
+    "click button.dismiss": function (event, instance) {
+      var sessionId = instance.data.sessionId;
       if (sessionId) {
         Meteor.call("finishPowerboxOffer", sessionId, function (err) {
           // TODO(someday): display the error nicely to the user
@@ -810,13 +824,13 @@ if (Meteor.isClient) {
         } else {
           var sharesByRecipient = {};
           downstream.forEach(function (token) {
-            if (Match.test(token.owner, {user: Match.ObjectIncluding({userId: String})})) {
-              var recipient = token.owner.user.userId;
+            if (Match.test(token.owner, {user: Match.ObjectIncluding({identityId: String})})) {
+              var recipient = token.owner.user.identityId;
               if (!sharesByRecipient[recipient]) {
                 sharesByRecipient[recipient] = {recipient: recipient, shares: []};
               }
               var shares = sharesByRecipient[recipient].shares;
-              if (!shares.some(function(share) { return share.userId === token.userId; })) {
+              if (!shares.some(function(share) { return share.identityId === token.identityId; })) {
                 sharesByRecipient[recipient].shares.push(token);
               }
             }
@@ -878,11 +892,15 @@ if (Meteor.isClient) {
 
   Template.whoHasAccessPopup.helpers({
     existingShareTokens: function () {
-      return ApiTokens.find({grainId: Template.instance().grainId, userId: Meteor.userId(),
-                             forSharing: true,
-                             $or: [{owner: {webkey:null}},
-                                   {owner: {$exists: false}}],
-                            }).fetch();
+      if (Meteor.userId()) {
+        var identity = globalDb.getUserIdentities(Meteor.userId())[0];
+        var result = ApiTokens.find({grainId: Template.instance().grainId, identityId: identity.id,
+                               forSharing: true,
+                               $or: [{owner: {webkey:null}},
+                                     {owner: {$exists: false}}],
+                                    }).fetch();
+        return result;
+      }
     },
     getPetname: function () {
       if (this.petname) {
@@ -891,14 +909,12 @@ if (Meteor.isClient) {
         return "Unlabeled Link";
       }
     },
-    displayName: function (userId) {
-      var name = DisplayNames.findOne(userId);
+    displayName: function (identityId) {
+      var name = DisplayNames.findOne(identityId);
       if (name) {
         return name.displayName;
-      } else if (userId === Meteor.userId()) {
-        return Meteor.user().profile.name + " (you)";
       } else {
-        return "Unknown User (" + userId + ")";
+        return "Unknown User (" + identityId.slice(0,16) + ")";
       }
     },
     transitiveShares: function () {

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -87,11 +87,12 @@ if (Meteor.isServer) {
           }
         });
       }
-      var identity = globalDb.getUserIdentities(this.userId)[0]
+      var identityIds = SandstormDb.getUserIdentities(globalDb.getUser(this.userId))
+          .map(function (x) { return x.id; });
       return [
         UserActions.find({userId: this.userId}),
         Grains.find({userId: this.userId}),
-        ApiTokens.find({'owner.user.identityId': identity.id}),
+        ApiTokens.find({'owner.user.identityId': {$in: identityIds}}),
       ];
     } else {
       return [];

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -77,7 +77,7 @@ if (Meteor.isServer) {
         // TODO(someday): Implement the ability to reactively subscribe to storage usage from the
         //   back-end?
         var userId = this.userId;
-        sandstormBackend.getUserStorageUsage(userId).then(function (results) {
+        globalBackend.cap().getUserStorageUsage(userId).then(function (results) {
           inMeteor(function () {
             Meteor.users.update(userId, {$set: {storageUsage: parseInt(results.size)}});
           });
@@ -591,8 +591,10 @@ if (Meteor.isClient) {
     }
     title = "Untitled " + title;
 
+    var identity = _.findWhere(SandstormDb.getUserIdentities(Meteor.user()), {main: true});
+
     // We need to ask the server to start a new grain, then browse to it.
-    Meteor.call("newGrain", packageId, command, title, function (error, grainId) {
+    Meteor.call("newGrain", packageId, command, title, identity.id, function (error, grainId) {
       if (error) {
         console.error(error);
         alert(error.message);

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -32,7 +32,8 @@ if (Meteor.isClient) {
     Meteor.subscribe("grainsMenu"),
     Meteor.subscribe("userPackages"),
     Meteor.subscribe("devApps"),
-    Meteor.subscribe("credentials")
+    Meteor.subscribe("credentials"),
+    Meteor.subscribe("accountIdentities")
   ];
 }
 
@@ -86,11 +87,11 @@ if (Meteor.isServer) {
           }
         });
       }
-
+      var identity = globalDb.getUserIdentities(this.userId)[0]
       return [
         UserActions.find({userId: this.userId}),
         Grains.find({userId: this.userId}),
-        ApiTokens.find({'owner.user.userId': this.userId}),
+        ApiTokens.find({'owner.user.identityId': identity.id}),
       ];
     } else {
       return [];

--- a/src/sandstorm/grain.capnp
+++ b/src/sandstorm/grain.capnp
@@ -566,9 +566,9 @@ struct UserInfo {
   # permissions.  Either way, the application need not worry about permissions changing during a
   # session.
 
-  userId @2 :Data;
+  identityId @2 :Data;
   # A unique, stable identifier for the calling user. This is computed such that a user's ID will
-  # be the same across all Sandstorm servers, and will not collide with any other user ID in the
+  # be the same across all Sandstorm servers, and will not collide with any other identity ID in the
   # world. Therefore, grains transferred between servers can still count on the user IDs being the
   # same and secure (unless the new host is itself malicious, of course, in which case all bets are
   # off).

--- a/src/sandstorm/hack-session.capnp
+++ b/src/sandstorm/hack-session.capnp
@@ -65,45 +65,9 @@ interface HackSessionContext @0xe14c1f5321159b8f
 
   generateApiToken @3 (petname :Text, userInfo :Grain.UserInfo, expires :UInt64 = 0)
       -> (token :Text, endpointUrl :Text, tokenId :Text);
-  # Generates a new API token which can be used to access an HTTP API exported by this application.
-  # The method also returns the URL at which the API is exported.
-  #
-  # To access the API, a client may send requests to `endpointUrl` (or sub-paths thereof) and pass
-  # the following header, replacing <token> with the returned `token`:
-  #
-  #     Authorization: Bearer <token>
-  #
-  # The request will be delivered to the app like a regular web request. However, the request will
-  # contain no cookies, and any cookies in the response will be ignored. Also note that the system
-  # will arrange for `endpointUrl` to accept cross-origin request from any origin, so that
-  # third-party web sites can use XMLHttpRequest to communicate with this API.
-  #
-  # By convention, if you wish to present `endpointUrl` and `token` to the user (e.g. to copy/paste
-  # into a client app), you should do so in the format: "<endpointUrl>#<token>" -- that is,
-  # separate the two by a '#' character, as if the token is a URL "hash" or "fragment". If this
-  # combined URL is loaded directly in the browser, Sandstorm may be able to display something
-  # useful to the user, although this is not the intended usage method.
-  #
-  # `userInfo` contains the `UserInfo` struct which should be passed back to the application
-  # verbatim when this token is used. There is no need to fill this struct with accurate
-  # information as it will only be passed back to the app. You are encouraged to replace the
-  # `userId` field with some sort of token that grants a narrow permission rather than use an
-  # actual user's ID. This is a temporary hack. Eventually, when we have persistent Cap'n Proto
-  # capabilities, we will not use `newSession()` with capability tokens; we will persist and
-  # restore the WebSession capability instead.
-  #
-  # `expires` is a Unix timestamp (seconds since epoch) after which the token should no longer
-  # work. A value of zero (default) indicates no expiration.
-  #
-  # `tokenId` can be used to identify and delete the token in later requests. (We don't use
-  # `token` itself for this because the token is not actually stored by Sandstorm; only a hash
-  # of it is.)
-
   listApiTokens @4 () -> (tokens :List(TokenInfo));
-  # List all tokens that were previously created by `generateApiToken()` and have not yet expired.
-
   revokeApiToken @5 (tokenId :Text);
-  # Revoke (delete) a previously-generated token.
+  # OBSOLETE. Apps that need to present API tokens to users should use offer templates.
 
   getUiViewForEndpoint @8 (url :Text) -> (view :Grain.UiView);
   # There are 3 cases here that are seamlessly handled by the platform

--- a/src/sandstorm/hack-session.capnp
+++ b/src/sandstorm/hack-session.capnp
@@ -63,10 +63,10 @@ interface HackSessionContext @0xe14c1f5321159b8f
   getUserAddress @2 () -> Email.EmailAddress;
   # Returns the address of the owner of the grain.
 
-  generateApiToken @3 (petname :Text, userInfo :Grain.UserInfo, expires :UInt64 = 0)
+  obsoleteGenerateApiToken @3 (petname :Text, userInfo :Grain.UserInfo, expires :UInt64 = 0)
       -> (token :Text, endpointUrl :Text, tokenId :Text);
-  listApiTokens @4 () -> (tokens :List(TokenInfo));
-  revokeApiToken @5 (tokenId :Text);
+  obsoleteListApiTokens @4 () -> (tokens :List(TokenInfo));
+  obsoleteRevokeApiToken @5 (tokenId :Text);
   # OBSOLETE. Apps that need to present API tokens to users should use offer templates.
 
   getUiViewForEndpoint @8 (url :Text) -> (view :Grain.UiView);

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -845,12 +845,12 @@ public:
         acceptLanguages(kj::mv(acceptLanguages)),
         rootPath(kj::mv(rootPath)),
         remoteAddress(kj::mv(remoteAddress)) {
-    if (userInfo.hasUserId()) {
-      auto id = userInfo.getUserId();
-      KJ_ASSERT(id.size() == 32, "User ID not a SHA-256?");
+    if (userInfo.hasIdentityId()) {
+      auto id = userInfo.getIdentityId();
+      KJ_ASSERT(id.size() == 32, "Identity ID not a SHA-256?");
 
       // We truncate to 128 bits to be a little more wieldy. Still 32 chars, though.
-      userId = hexEncode(userInfo.getUserId().slice(0, 16));
+      userId = hexEncode(userInfo.getIdentityId().slice(0, 16));
     }
     sessionContextMap.insert({kj::StringPtr(this->sessionId), this->sessionContext});
   }

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -174,17 +174,20 @@ struct MembraneRequirement {
     # specifies the `_id` of the other ApiToken.
 
     permissionsHeld :group {
-      # This token is valid only as long as some specified user holds some specified set of
+      # This token is valid only as long as some specified identity holds some specified set of
       # permissions on some specified grain.
 
-      userId @1 :Text;
-      # The user who must hold the permissions.
+      identityId @5 :Text;
+      # The identity that must hold the permissions.
 
       grainId @2 :Text;
       # The grain on which the permissions must be held.
 
       permissions @3 :Grain.PermissionSet;
       # The permissions the user must hold on the grain.
+
+      userId @1 :Text;
+      # Deprecated. See `identityId`.
     }
 
     userIsAdmin @4 :Text;
@@ -261,12 +264,15 @@ struct ApiTokenOwner {
       saveLabel @2 :Util.LocalizedText;
       # As passed to `save()` in Sandstorm's Persistent interface.
 
-      introducerUser @5 :Text;
-      # The user ID (`_id` in the users table) of the user whose powerbox action caused the grain
-      # to receive this token. This is the user against which the `requiredPermissions` parameter
+      introducerIdentity @10 :Text;
+      # The identity ID through which a user's powerbox action caused the grain to receive this
+      # token. This is the identity against which the `requiredPermissions` parameter
       # to `restore()` will be checked. This field is only intended to be filled in by the
       # front-end during a powerbox request; a regular `save()` call produces a capability that
       # has no "introducer".
+
+      introducerUser @5 :Text;
+      # Deprecated. See `introducerIdentity`.
     }
 
     internet @3 :AnyPointer;
@@ -281,11 +287,11 @@ struct ApiTokenOwner {
     # Owned by the front-end, i.e. stored in its Mongo database.
 
     user :group {
-      # Owned by a user. If the token represents a UiView, then it will show up in this user's
-      # grain list.
+      # Owned by a user's identity. If the token represents a UiView, then it will show up in this
+      # user's grain list.
 
-      userId @6 :Text;
-      # The ID (`_id` in the users table) of the user who is allowed to restore this token.
+      identityId @11 :Text;
+      # The identity that is allowed to restore this token.
 
       title @7 :Text;
       # Title as chosen by the user.
@@ -296,6 +302,9 @@ struct ApiTokenOwner {
 
       denormalizedGrainMetadata @9 :DenormalizedGrainMetadata;
       # Information needed to show the user an app title and icon in the grain list.
+
+      userId @6 :Text;
+      # Deprecated. See `identityId`.
     }
   }
 }


### PR DESCRIPTION
This changeset performs the database migration to allow us to support multiple identities per account. It also updates all places (I think!) in the code that used to assume there was only one identity per account. Finally, it partially implements account merging and unmerging (with no UI yet), but disables those features for now, until they are more fully implemented and tested.