### PR TITLE
Remove unused jparker:crypto-sha256 dependencies.

### DIFF
--- a/shell/.meteor/versions
+++ b/shell/.meteor/versions
@@ -38,8 +38,6 @@ iron:location@1.0.9
 iron:middleware-stack@1.0.9
 iron:router@1.0.9
 iron:url@1.0.9
-jparker:crypto-core@0.1.0
-jparker:crypto-sha256@0.1.1
 jquery@1.11.3_2
 json@1.0.3
 launch-screen@1.0.2

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -268,7 +268,7 @@ ApiTokens = new Mongo.Collection("apiTokens");
 // `MainView`) -- the fields of type `Data` are API tokens.
 //
 // Each contains:
-//   _id:       A SHA-256 hash of the token.
+//   _id:       A SHA-256 hash of the token, base64-encoded.
 //   grainId:   The grain servicing this API. (Not present if the API isn't serviced by a grain.)
 //   identityId: For UiView capabilities, this is the identity for which the view is attenuated.
 //              That is, the UiView's newSession() method will intersect the requested permissions
@@ -425,7 +425,7 @@ StaticAssets = new Mongo.Collection("staticAssets");
 //
 // Each contains:
 //   _id:       Random ID; will be used in the URL.
-//   hash:      A SHA-256 hash of the data, used to de-dupe.
+//   hash:      A base64-encoded SHA-256 hash of the data, used to de-dupe.
 //   mimeType:  MIME type of the asset, suitable for Content-Type header.
 //   encoding:  Either "gzip" or not present, suitable for Content-Encoding header.
 //   content:   The asset content (byte buffer).

--- a/shell/packages/sandstorm-db/package.js
+++ b/shell/packages/sandstorm-db/package.js
@@ -24,7 +24,7 @@ Npm.depends({ "content-type": "1.0.1" });
 Package.onUse(function (api) {
   api.use(["mongo", "random", "check", "underscore"], ["client", "server"]);
   api.use(["accounts-base", "fongandrew:find-and-modify", "http"], ["server"]);
-  api.use(["jparker:crypto-sha256", "sandstorm-identicons"], ["client"]);
+  api.use(["sandstorm-identicons"], ["client"]);
 
   api.addFiles(["db.js", "profile.js"]);
   api.addFiles(["user.js", "migrations.js"], "server");

--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -16,7 +16,6 @@
 
 var makeIdenticon;
 var httpProtocol;
-var sha256;
 
 if (Meteor.isServer) {
   Meteor.publish("accountIdentities", function () {
@@ -52,11 +51,6 @@ if (Meteor.isServer) {
 
   var Url = Npm.require("url");
   httpProtocol = Url.parse(process.env.ROOT_URL).protocol;
-
-  var Crypto = Npm.require("crypto");
-  sha256 = function (data) {
-    return Crypto.createHash("sha256").update(data).digest("hex");
-  };
 } else {
   var identiconCache = {};
 
@@ -82,10 +76,6 @@ if (Meteor.isServer) {
   }
 
   httpProtocol = window.location.protocol;
-
-  sha256 = function (data) {
-    return CryptoJS.SHA256(data).toString();
-  };
 }
 
 var GENDERS = {male: "male", female: "female", neutral: "neutral", robot: "robot"};

--- a/shell/packages/sandstorm-ui-applist/package.js
+++ b/shell/packages/sandstorm-ui-applist/package.js
@@ -20,7 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use(["check", "reactive-var", "reload", "templating", "tracker", "underscore", "jparker:crypto-sha256", "sandstorm-identicons"], "client");
+  api.use(["check", "reactive-var", "reload", "templating", "tracker", "underscore", "sandstorm-identicons"], "client");
   api.addFiles(["applist-common.js"], ["client","server"]);
   api.addFiles(["applist.html", "applist-client.js"], "client");
   api.addFiles(["applist-server.js"], "server")


### PR DESCRIPTION
After #958, we are no longer actually using the jparker:crypto-sha256 package. Note also that if we just want a function to return a hex-encoded SHA256 in the browser, then the meteor sha package (see https://www.meteor.com/utilities and https://atmospherejs.com/meteor/sha) might be a better choice. (We're already using it in our accounts-email-token package.)

This change also updates some documentation to specify that some hashes in our database are base64-encoded.