### PR TITLE
Add code to fetch Keybase profile information.

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1220,6 +1220,9 @@ if (Meteor.isServer) {
           // Remove potentially Mongo-incompatible stuff. (Currently Keybase returns nothing that
           // this would filter.)
           for (var field in proof) {
+            // Don't allow field names containing '.' or '$'. Also don't allow sub-objects mainly
+            // because I'm too lazy to check the field names recursively (and Keybase doesn't
+            // return any objects anyway).
             if (field.match(/[.$]/) || typeof(proof[field]) === "object") {
               delete proof[field];
             }

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1233,7 +1233,14 @@ if (Meteor.isServer) {
 
         KeybaseProfiles.update(keyFingerprint, {$set: record}, {upsert: true});
       } else {
-        KeybaseProfiles.update(keyFingerprint, {$unset: {profile: ""}}, {upsert: true});
+        // Keybase reports no match, so remove what we know of this user. We don't want to remove
+        // the item entirely from the cache as this will cause us to repeatedly re-fetch the data
+        // from Keybase.
+        //
+        // TODO(someday): We could perhaps keep the proofs if we can still verify them directly,
+        //   but at present we don't have the ability to verify proofs.
+        KeybaseProfiles.update(keyFingerprint,
+            {$unset: {displayName: "", handle: "", proofs: ""}}, {upsert: true});
       }
     });
   };

--- a/shell/server/installer.js
+++ b/shell/server/installer.js
@@ -348,6 +348,10 @@ AppInstaller.prototype.updateProgress = function (status, progress, error, manif
         appId: self.appId,
         authorPgpKeyFingerprint: self.authorPgpKeyFingerprint
       }});
+
+      if (self.authorPgpKeyFingerprint) {
+        globalDb.updateKeybaseProfileAsync(self.authorPgpKeyFingerprint);
+      }
     }).catch (function (err) {
       console.error(err.stack);
     });


### PR DESCRIPTION
We maintain a cache of this information on the Sandstorm server. We force a cache update when a new package is installed by the same author. All fetches are server-to-server and do not identify the user who triggered the fetch (and the cache is shared between users).

@zarvox, care to review?