### PR TITLE
Move fallback logic about packages to SandstormDb static methods

### DIFF
--- a/shell/lib/db-deprecated.js
+++ b/shell/lib/db-deprecated.js
@@ -26,7 +26,7 @@
 globalDb = new SandstormDb();
 
 Packages = globalDb.collections.packages;
-DevApps = globalDb.collections.devApps;
+DevPackages = globalDb.collections.devPackages;
 UserActions = globalDb.collections.userActions;
 Grains = globalDb.collections.grains;
 Contacts = globalDb.collections.contacts;

--- a/shell/packages/sandstorm-backend/sandstorm-backend.js
+++ b/shell/packages/sandstorm-backend/sandstorm-backend.js
@@ -157,26 +157,21 @@ SandstormBackend.prototype.continueGrain = function(grainId) {
     throw new Meteor.Error(404, "Grain Not Found", "Grain ID: " + grainId);
   }
 
-  var manifest;
-  var packageId;
-  var devApp = DevApps.findOne({_id: grain.appId});
+  // If a DevPackage with the same app ID is currently active, we let it override the installed
+  // package, so that the grain runs using the dev app.
+  var devPackage = DevPackages.findOne({_appId: grain.appId});
   var isDev;
-  if (devApp) {
-    // If a DevApp with the same app ID is currently active, we let it override the installed
-    // package, so that the grain runs using the dev app.
-    manifest = devApp.manifest;
-    packageId = devApp.packageId;
+  if (devPackage) {
     isDev = true;
   } else {
     var pkg = Packages.findOne(grain.packageId);
-    if (pkg) {
-      manifest = pkg.manifest;
-      packageId = pkg._id;
-    } else {
+    if (!pkg) {
       throw new Meteor.Error(500, "Grain's package not installed",
                              "Package ID: " + grain.packageId);
     }
   }
+  var manifest = pkg.manifest;
+  var packageId = pkg._id;
 
   if (!("continueCommand" in manifest)) {
     throw new Meteor.Error(500, "Package manifest defines no continueCommand.",

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -97,23 +97,22 @@ Packages = new Mongo.Collection("packages");
 //   authorPgpKeyFingerprint: Verified PGP key fingerprint (SHA-1, hex, all-caps) of the app
 //     packager.
 
-DevApps = new Mongo.Collection("devapps");
-// List of applications currently made available via the dev tools running on the local machine.
+DevPackages = new Mongo.Collection("devpackages");
+// List of packages currently made available via the dev tools running on the local machine.
 // This is normally empty; the only time it is non-empty is when a developer is using the spk tool
 // on the local machine to publish an under-development app to this server. That should only ever
 // happen on developers' desktop machines.
 //
-// While a dev app is published, it automatically appears as installed by every user of the server,
-// and it overrides all packages with the same application ID. If any instances of those packages
-// are currently open, they are killed and reset on publish.
+// While a dev package is published, it automatically appears as installed by every user of the
+// server, and it overrides all packages with the same application ID. If any instances of those
+// packages are currently open, they are killed and reset on publish.
 //
-// When the dev tool disconnects, the app is automatically unpublished, and any open instances
+// When the dev tool disconnects, the package is automatically unpublished, and any open instances
 // are again killed and refreshed.
 //
 // Each contains:
-//   _id:  The application ID string (as with Packages.appId).
-//   appId: The same as _id, included to mimic Packages.appId.
-//   packageId:  The directory name where the dev package is mounted.
+//   _id:  The package ID string (as with Packages._id).
+//   appId: The app ID this package is intended to override (as with Packages.appId).
 //   timestamp:  Time when the package was last updated. If this changes while the package is
 //     published, all running instances are reset. This is used e.g. to reset the app each time
 //     changes are made to the source code.
@@ -701,7 +700,7 @@ SandstormDb = function () {
     //   direct access to the collections.
 
     packages: Packages,
-    devApps: DevApps,
+    devPackages: DevPackages,
     userActions: UserActions,
     grains: Grains,
     contacts: Contacts,

--- a/shell/packages/sandstorm-ui-applist/applist-client.js
+++ b/shell/packages/sandstorm-ui-applist/applist-client.js
@@ -107,16 +107,16 @@ Template.sandstormAppList.helpers({
   },
   devActions: function () {
     var ref = Template.instance().data;
-    var result = ref._db.collections.devApps.find().fetch();
-    var actionList = result.map(function(devapp) {
+    var result = ref._db.collections.devPackages.find().fetch();
+    var actionList = result.map(function(devPackage) {
       var thisAppActions = [];
-      for (var i = 0 ; i < devapp.manifest.actions.length ; i++) {
+      for (var i = 0 ; i < devPackage.manifest.actions.length ; i++) {
         thisAppActions.push({
-          _id: devapp._id,
-          appTitle: SandstormDb.appNameFromPackage(devapp),
-          noun: SandstormDb.nounPhraseForActionAndAppTitle(devapp.manifest.actions[i],
-                  devapp.manifest.appTitle.defaultText),
-          iconSrc: ref._db.iconSrcForPackage(devapp, 'appGrid'),
+          _id: devPackage._id,
+          appTitle: SandstormDb.appNameFromPackage(devPackage),
+          noun: SandstormDb.nounPhraseForActionAndAppTitle(devPackage.manifest.actions[i],
+                  devPackage.manifest.appTitle.defaultText),
+          iconSrc: ref._db.iconSrcForPackage(devPackage, 'appGrid'),
           actionIndex: i
         });
       }
@@ -192,12 +192,12 @@ Template.sandstormAppList.events({
     Meteor.call("deleteUnusedPackages", appId);
   },
   "click .dev-action": function(event, template) {
-    var devId = this._id;
+    var devPackageId = this._id;
     var actionIndex = this.actionIndex;
     // N.B.: this calls into a global in shell.js.
     // TODO(cleanup): refactor into a safer dependency.
     template.appIsLoading.set(true);
-    launchAndEnterGrainByActionId("dev", this._id, this.actionIndex);
+    launchAndEnterGrainByActionId("dev", devPackageId, actionIndex);
   },
   "click button.toggle-uninstall": function(event) {
     var uninstallVar = Template.instance().data._uninstalling;

--- a/shell/packages/sandstorm-ui-applist/applist-server.js
+++ b/shell/packages/sandstorm-ui-applist/applist-server.js
@@ -38,7 +38,7 @@ Meteor.publish("userPackages", function() {
     added: function(newAction) {
       refPackage(newAction.packageId);
     },
-    updated: function(oldAction, newAction) {
+    changed: function(oldAction, newAction) {
       refPackage(newAction.packageId);
     }
   });
@@ -49,7 +49,7 @@ Meteor.publish("userPackages", function() {
     added: function(newGrain) {
       refPackage(newGrain.packageId);
     },
-    updated: function(oldGrain, newGrain) {
+    changed: function(oldGrain, newGrain) {
       refPackage(newGrain.packageId);
     }
   });

--- a/shell/packages/sandstorm-ui-applist/package.js
+++ b/shell/packages/sandstorm-ui-applist/package.js
@@ -20,7 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use(["check", "reactive-var", "reload", "templating", "tracker", "underscore", "sandstorm-identicons", "sandstorm-autoupdate-apps"], "client");
+  api.use(["check", "reactive-var", "reload", "templating", "tracker", "underscore", "sandstorm-db", "sandstorm-autoupdate-apps"], "client");
   api.addFiles(["applist-common.js"], ["client","server"]);
   api.addFiles(["applist.html", "applist-client.js"], "client");
   api.addFiles(["applist-server.js"], "server")

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -27,9 +27,8 @@ var mapGrainsToTemplateObject = function (grains) {
   var packagesById = _.indexBy(packages, '_id');
   return grains.map(function(grain) {
     var pkg = packagesById[grain.packageId];
-    var iconSrc = pkg ? Identicon.iconSrcForPackage(pkg, 'grain', Template.instance().data._staticHost) : "";
-    var appTitle = (pkg && pkg.manifest && pkg.manifest.appTitle &&
-                    pkg.manifest.appTitle.defaultText) || "";
+    var iconSrc = pkg ? db.iconSrcForPackage(pkg, 'grain') : "";
+    var appTitle = pkg ? SandstormDb.appNameFromPackage(pkg) : "";
     return {
       _id: grain._id,
       title: grain.title,
@@ -68,7 +67,7 @@ var mapApiTokensToTemplateObject = function (apiTokens) {
 };
 var filteredSortedGrains = function() {
   var db = Template.instance().data._db;
-  var grains = db.currentUserGrains({}, {}).fetch();
+  var grains = db.currentUserGrains().fetch();
   var itemsFromGrains = mapGrainsToTemplateObject(grains);
   var apiTokens = db.currentUserApiTokens().fetch();
   var itemsFromSharedGrains = mapApiTokensToTemplateObject(apiTokens);
@@ -89,11 +88,11 @@ Template.sandstormGrainList.helpers({
     return Template.instance().data._filter.get();
   },
   myGrainsCount: function () {
-    return Template.instance().data._db.currentUserGrains({}, {}).count();
+    return Template.instance().data._db.currentUserGrains().count();
   },
   hasAnyGrainsCreatedOrSharedWithMe: function() {
     var _db = Template.instance().data._db;
-    return !! (_db.currentUserGrains({}, {}).count() ||
+    return !! (_db.currentUserGrains().count() ||
                _db.currentUserApiTokens().count());
   },
   myGrainsSize: function () {

--- a/shell/server/backup.js
+++ b/shell/server/backup.js
@@ -98,18 +98,17 @@ Meteor.methods({
       // Create variables we'll use for later Mongo query.
       var packageId;
       var appVersion;
-      // DevApps are system-wide, so we do not check the user ID.
-      var devApp = DevApps.findOne({_id: grainInfo.appId});
-
-      if (action) {
+      // DevPackages are system-wide, so we do not check the user ID.
+      var devPackage = DevPackages.findOne({appId: grainInfo.appId});
+      if (devPackage) {
+        // If the dev app package exists, it should override the user action.
+        packageId = devPackage.packageId;
+        appVersion = devPackage.manifest.appVersion;
+      } else if (action) {
         // The app is installed, so we can continue restoring this
         // grain.
         packageId = action.packageId;
         appVersion = action.appVersion;
-      } else if (devApp) {
-        // If the dev app exists, permit this.
-        packageId = devApp.packageId;
-        appVersion = devApp.manifest.appVersion;
       } else {
         // If the package isn't installed at all, bail out.
         deleteGrain(grainId, this.userId);

--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -384,7 +384,7 @@ Router.map(function () {
       var appName = 'missing package';
 
       if (thisPackage) {
-        appName = appNameFromPackage(thisPackage);
+        appName = SandstormDb.appNameFromPackage(thisPackage);
       }
 
       return {

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1408,7 +1408,7 @@ Router.map(function () {
 
     waitOn: function () {
       return [
-        Meteor.subscribe("devApps"),
+        Meteor.subscribe("devPackages"),
         Meteor.subscribe("tokenInfo", this.params.token),
 
         Meteor.subscribe("grainsMenu")

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -31,7 +31,7 @@ if (Meteor.isClient) {
   globalSubs = [
     Meteor.subscribe("grainsMenu"),
     Meteor.subscribe("userPackages"),
-    Meteor.subscribe("devApps"),
+    Meteor.subscribe("devPackages"),
     Meteor.subscribe("credentials"),
     Meteor.subscribe("accountIdentities")
   ];
@@ -107,8 +107,8 @@ if (Meteor.isServer) {
     return Sessions.find({_id: sessionId, $or: [{userId: this.userId}, {userId: null}]});
   });
 
-  Meteor.publish("devApps", function () {
-    return DevApps.find();
+  Meteor.publish("devPackages", function () {
+    return DevPackages.find();
   });
 
   Meteor.publish("notifications", function () {
@@ -567,23 +567,23 @@ if (Meteor.isClient) {
     }
   };
 
-  launchAndEnterGrainByActionId = function(actionId, devId, devIndex) {
-    // Note that this takes a devId and a devIndex as well. If provided,
+  launchAndEnterGrainByActionId = function(actionId, devPackageId, devIndex) {
+    // Note that this takes a devPackageId and a devIndex as well. If provided,
     // they override the actionId.
     var packageId;
     var command;
     var appTitle;
     var nounPhrase;
-    if (devId) {
-      var devApp = DevApps.findOne(devId);
-      if (!devApp) {
-        console.error("no such dev app: ", devId);
+    if (devPackageId) {
+      var devPackage = DevPackages.findOne(devPackageId);
+      if (!devPackage) {
+        console.error("no such dev package: ", devPackageId);
         return;
       }
-      var devAction = devApp.manifest.actions[devIndex];
-      packageId = devApp.packageId;
+      var devAction = devPackage.manifest.actions[devIndex];
+      packageId = devPackageId
       command = devAction.command;
-      appTitle = SandstormDb.appNameFromPackage(devApp);
+      appTitle = SandstormDb.appNameFromPackage(devPackage);
       nounPhrase = SandstormDb.nounPhraseForActionAndAppTitle(devAction, appTitle);
     } else {
       var action = UserActions.findOne(actionId);

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -572,6 +572,7 @@ if (Meteor.isClient) {
     // they override the actionId.
     var packageId;
     var command;
+    var appTitle;
     var nounPhrase;
     if (devId) {
       var devApp = DevApps.findOne(devId);
@@ -582,7 +583,7 @@ if (Meteor.isClient) {
       var devAction = devApp.manifest.actions[devIndex];
       packageId = devApp.packageId;
       command = devAction.command;
-      var appTitle = SandstormDb.appNameFromPackage(devApp);
+      appTitle = SandstormDb.appNameFromPackage(devApp);
       nounPhrase = SandstormDb.nounPhraseForActionAndAppTitle(devAction, appTitle);
     } else {
       var action = UserActions.findOne(actionId);
@@ -594,11 +595,11 @@ if (Meteor.isClient) {
       packageId = action.packageId;
       var pkg = Packages.findOne(packageId);
       command = action.command;
-      var appTitle = SandstormDb.appNameFromPackage(pkg);
+      appTitle = SandstormDb.appNameFromPackage(pkg);
       nounPhrase = SandstormDb.nounPhraseForActionAndAppTitle(action, appTitle);
     }
 
-    var title = "Untitled " + nounPhrase;
+    var title = "Untitled " + appTitle + " " + nounPhrase;
 
     var identity = _.findWhere(SandstormDb.getUserIdentities(Meteor.user()), {main: true});
 

--- a/shell/shared/stats.js
+++ b/shell/shared/stats.js
@@ -285,7 +285,7 @@ if (Meteor.isClient) {
           var p = Packages.findOne({appId: appId, manifest: {$exists: true}},
                                    {sort: {"manifest.appVersion": -1}});
           if (p) {
-            packObj.appTitle = appNameFromPackage(p);
+            packObj.appTitle = SandstormDb.appNameFromPackage(p);
           }
           return packObj;
         })

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -2363,6 +2363,7 @@ private:
     mongoCommand(config, kj::str(
         "db.devapps.insert({"
           "_id:\"", appId, "\","
+          "appId:\"", appId, "\","
           "packageId:\"", pkgId, "\","
           "timestamp:", time(nullptr), ","
           "manifest:", toMongoJson(manifest),

--- a/tests/apps/powerbox.js
+++ b/tests/apps/powerbox.js
@@ -98,7 +98,7 @@ module.exports["Install Powerbox with failing requirements"] = function (browser
   browser
     .init()
     .installApp("http://sandstorm.io/apps/jparyani/powerbox-2.spk", "9d6493e63bc9919de3959fe0c5a131ad", "jm40yaw7zvnxyggqt2dddp5ztt0f5wku7a8wfz8uzn9cjus46ygh")
-    .assert.containsText("#grainTitle", "Untitled SandstormTest");
+    .assert.containsText("#grainTitle", "Untitled PowerboxTest sandstormtest");
 };
 
 module.exports["Test Powerbox with failing requirements"] = function (browser) {

--- a/tests/apps/roundcube.js
+++ b/tests/apps/roundcube.js
@@ -27,7 +27,7 @@ module.exports = {};
 module.exports["Install"] = function (browser) {
   browser
     .installApp("http://sandstorm.io/apps/jparyani/roundcube-6.spk", "373a821a7a9cde5b13258922046fe217", "0qhha1v9ne1p42s5jw7r6qq6rt5tcx80zpg1f5ptsg7ryr4hws1h")
-    .assert.containsText("#grainTitle", "Untitled Roundcube Mailbox");
+    .assert.containsText("#grainTitle", "Untitled Roundcube mailbox");
 };
 
 

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -23,6 +23,9 @@ var utils = require('../utils'),
     very_long_wait = utils.very_long_wait;
 var path = require('path');
 var assetsPath = path.resolve(__dirname, '../assets');
+var expectedHackerCMSButtonText = 'New Hacker CMS site';
+var expectedHackerCMSGrainTitle = 'Untitled Hacker CMS site';
+var expectedEtherpadGrainTitle = 'Untitled Etherpad document';
 
 module.exports = utils.testAllLogins({
   // TODO(soon): Uploading tests are broken. Waiting on refactor of upload input to fix.
@@ -51,7 +54,7 @@ module.exports = utils.testAllLogins({
   //         .waitForElementVisible('#step-confirm', long_wait)
   //         .click('#confirmInstall')
   //         .waitForElementVisible('.new-grain-button', short_wait)
-  //         .assert.containsText('.new-grain-button', 'New Hacker CMS Site');
+  //         .assert.containsText('.new-grain-button', expectedHackerCMSButtonText);
   //     });
   // },
 
@@ -78,7 +81,7 @@ module.exports = utils.testAllLogins({
   //         .assert.containsText('#confirmInstall', 'Upgrade')
   //         .click('#confirmInstall')
   //         .waitForElementVisible('.new-grain-button', short_wait)
-  //         .assert.containsText('.new-grain-button', 'New Hacker CMS Site');
+  //         .assert.containsText('.new-grain-button', expectedHackerCMSButtonText);
   //     });
   // },
 
@@ -105,7 +108,7 @@ module.exports = utils.testAllLogins({
   //         .assert.containsText('#confirmInstall', 'Downgrade')
   //         .click('#confirmInstall')
   //         .waitForElementVisible('.new-grain-button', short_wait)
-  //         .assert.containsText('.new-grain-button', 'New Hacker CMS Site');
+  //         .assert.containsText('.new-grain-button', expectedHackerCMSButtonText);
   //     });
   // },
 
@@ -122,7 +125,7 @@ module.exports = utils.testAllLogins({
     browser
       .click('.app-action[data-app-id="nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh"]')
       .waitForElementVisible('#grainTitle', medium_wait)
-      .assert.containsText('#grainTitle', 'Untitled Hacker CMS Site');
+      .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle);
   },
 
   "Test grain frame" : function (browser) {
@@ -159,7 +162,7 @@ module.exports = utils.testAllLogins({
         browser.switchWindow(windows.value[1]);
       })
       .pause(short_wait)
-      .assert.containsText('.grainlog-title', 'Debug log: Untitled Hacker CMS Site')
+      .assert.containsText('.grainlog-title', 'Debug log: ' + expectedHackerCMSGrainTitle)
       .closeWindow()
       .end();
   },
@@ -170,7 +173,7 @@ module.exports["Test grain anonymous user"] = function (browser) {
     // Upload app as normal user
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
     .waitForElementVisible('#grainTitle', medium_wait)
-    .assert.containsText('#grainTitle', 'Untitled Hacker CMS Site')
+    .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
     .click('.topbar .share > .show-popup')
     .waitForElementVisible('#shareable-link-tab-header', short_wait)
     .click('#shareable-link-tab-header')
@@ -184,7 +187,7 @@ module.exports["Test grain anonymous user"] = function (browser) {
         .pause(short_wait)
         .url(response.value)
         .waitForElementVisible('#grainTitle', medium_wait)
-        .assert.containsText('#grainTitle', 'Untitled Hacker CMS Site')
+        .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
         .frame('grain-frame')
         .waitForElementPresent('#publish', medium_wait)
         .assert.containsText('#publish', 'Publish')
@@ -215,7 +218,7 @@ module.exports["Test roleless sharing"] = function (browser) {
     .click(
       '.app-list>.app-action[data-app-id="nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh"]')
     .waitForElementVisible('#grainTitle', medium_wait)
-    .assert.containsText('#grainTitle', 'Untitled Hacker CMS Site')
+    .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
     .click('.topbar .share > .show-popup')
     .waitForElementVisible("#shareable-link-tab-header", short_wait)
     .click("#shareable-link-tab-header")
@@ -233,7 +236,7 @@ module.exports["Test roleless sharing"] = function (browser) {
         .waitForElementVisible(".redeem-token-button", short_wait)
         .click(".redeem-token-button")
         .waitForElementVisible('#grainTitle', medium_wait)
-        .assert.containsText('#grainTitle', 'Untitled Hacker CMS Site')
+        .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
         .frame('grain-frame')
         .waitForElementPresent('#publish', medium_wait)
         .assert.containsText('#publish', 'Publish')
@@ -252,7 +255,7 @@ module.exports["Test roleless sharing"] = function (browser) {
             .waitForElementVisible(".redeem-token-button", short_wait)
             .click(".redeem-token-button")
             .waitForElementVisible('#grainTitle', medium_wait)
-            .assert.containsText('#grainTitle', 'Untitled Hacker CMS Site')
+            .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
             .frame('grain-frame')
             .waitForElementPresent('#publish', medium_wait)
             .assert.containsText('#publish', 'Publish')
@@ -267,7 +270,7 @@ module.exports["Test roleless sharing"] = function (browser) {
             .loginDevAccount(firstUserName)
             .url(response.value)
             .waitForElementVisible('#grainTitle', medium_wait)
-            .assert.containsText('#grainTitle', 'Untitled Hacker CMS Site')
+            .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
             .click('.topbar .share > .show-popup')
             .click('.popup.share .who-has-access')
             .waitForElementVisible('.popup.who-has-access', medium_wait)
@@ -296,7 +299,7 @@ module.exports["Test role sharing"] = function (browser) {
     .click(
       '.app-list>.app-action[data-app-id="h37dm17aa89yrd8zuqpdn36p6zntumtv08fjpu8a8zrte7q1cn60"]')
     .waitForElementVisible('#grainTitle', medium_wait)
-    .assert.containsText('#grainTitle', 'Untitled Etherpad Document')
+    .assert.containsText('#grainTitle', expectedEtherpadGrainTitle)
     .click('.topbar .share > .show-popup')
     .waitForElementVisible("#shareable-link-tab-header", short_wait)
     .click("#shareable-link-tab-header")
@@ -312,7 +315,7 @@ module.exports["Test role sharing"] = function (browser) {
         .waitForElementVisible(".redeem-token-button", short_wait)
         .click(".redeem-token-button")
         .waitForElementVisible('#grainTitle', medium_wait)
-        .assert.containsText('#grainTitle', 'Untitled Etherpad Document')
+        .assert.containsText('#grainTitle', expectedEtherpadGrainTitle)
         .frame('grain-frame')
         .waitForElementPresent('#editorcontainerbox', medium_wait)
         .frame(null)
@@ -331,7 +334,7 @@ module.exports["Test role sharing"] = function (browser) {
             .waitForElementVisible(".redeem-token-button", short_wait)
             .click(".redeem-token-button")
             .waitForElementVisible('#grainTitle', medium_wait)
-            .assert.containsText('#grainTitle', 'Untitled Etherpad Document')
+            .assert.containsText('#grainTitle', expectedEtherpadGrainTitle)
             .frame('grain-frame')
             .waitForElementPresent('#editorcontainerbox', medium_wait)
             .frame(null)
@@ -363,7 +366,7 @@ module.exports["Test grain incognito interstitial"] = function (browser) {
     .click(
       '.app-list>.app-action[data-app-id="nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh"]')
     .waitForElementVisible('#grainTitle', medium_wait)
-    .assert.containsText('#grainTitle', 'Untitled Hacker CMS Site')
+    .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
     .click('.topbar .share > .show-popup')
     .waitForElementVisible("#shareable-link-tab-header", short_wait)
     .click("#shareable-link-tab-header")
@@ -380,7 +383,7 @@ module.exports["Test grain incognito interstitial"] = function (browser) {
         .waitForElementVisible(".incognito-button", short_wait)
         .click(".incognito-button")
         .waitForElementVisible('#grainTitle', medium_wait)
-        .assert.containsText('#grainTitle', 'Untitled Hacker CMS Site')
+        .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
         .frame('grain-frame')
         .waitForElementPresent('#publish', medium_wait)
         .assert.containsText('#publish', 'Publish')
@@ -390,7 +393,7 @@ module.exports["Test grain incognito interstitial"] = function (browser) {
         .waitForElementVisible(".redeem-token-button", short_wait)
         .click(".redeem-token-button")
         .waitForElementVisible('#grainTitle', medium_wait)
-        .assert.containsText('#grainTitle', 'Untitled Hacker CMS Site')
+        .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
         .frame('grain-frame')
         .waitForElementPresent('#publish', medium_wait)
         .assert.containsText('#publish', 'Publish')


### PR DESCRIPTION
We have a decent amount of logic dealing with backwards-compatibility with app
titles and actions, and guessing values for new manifest fields based on older
ones.  This commit attempts to centralize that logic as some methods on the data
model in the sandstorm-db package.

This commit also add an appId field to devApps, to make accessing them more
like accessing Packages.  This makes dealing with packages that may be dev
packages or installed packages a bit simpler.