### PR TITLE
Remove mongod warning from spk.c++

### DIFF
--- a/src/sandstorm/spk.c++
+++ b/src/sandstorm/spk.c++
@@ -1301,7 +1301,6 @@ private:
           mapping = MemoryMapping(kj::mv(fd), target);
           auto content = orphanage.referenceExternalData(mapping);
           if (stats.st_mode & S_IXUSR) {
-            warnIfMongod(context);
             builder.adoptExecutable(kj::mv(content));
           } else {
             builder.adoptRegular(kj::mv(content));
@@ -1310,7 +1309,6 @@ private:
           // Small file; direct read preferable.
           ::capnp::Data::Builder buf = nullptr;
           if (stats.st_mode & S_IXUSR) {
-            warnIfMongod(context);
             buf = builder.initExecutable(size);
           } else {
             buf = builder.initRegular(size);
@@ -1350,24 +1348,6 @@ private:
     }
 
   private:
-    void warnIfMongod(kj::ProcessContext& context) {
-      if (target.endsWith("/mongod") || target == "mongod") {
-        context.warning(
-          "** WARNING: It looks like your app uses MongoDB. PLEASE verify that the size\n"
-          "**   of a typical instance of your app is reasonable before you distribute\n"
-          "**   it. App instance storage is found in:\n"
-          "**     $SANDSORM_HOME/var/sandstorm/grains/$GRAIN_ID\n"
-          "**   Mongo likes to pre-allocate lots of space, while Sandstorm grains\n"
-          "**   should be small, which can lead to waste. Please consider using\n"
-          "**   Kenton's fork of Mongo that preallocates less data, found here:\n"
-          "**     https://github.com/kentonv/mongo/tree/niscu\n"
-          "**   This warning will disappear if the name of the binary on your disk is\n"
-          "**   something other than \"mongod\" -- you can still map it to the name\n"
-          "**   \"mongod\" inside your package, e.g. with a mapping like:\n"
-          "**     (packagePath=\"usr/bin/mongod\", sourcePath=\"niscud\")");
-      }
-    }
-
     kj::String target;
     // The disk path which should be used to initialize this node.
 


### PR DESCRIPTION
Historically, MongoDB users should be admonished to use
NiscuDB. However, since the creation of meteor-spk, Meteor
apps use NiscuDB (or Mongo 3) which wastes less space
per grain. And since Mongo 3 is going to be increasingly
common, this warning mostly affects people who do not need
to read it.