### PR TITLE
Don't call `topbar.closePopup()` when `topbar` is null.

### DIFF
--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -179,7 +179,7 @@ var loginWithToken = function (email, token, topbar) {
     } else {
       loginButtonsSession.set("inSignupFlow", false);
       loginButtonsSession.closeDropdown();
-      topbar.closePopup();
+      if (topbar) topbar.closePopup();
     }
   });
 };


### PR DESCRIPTION
Currently, if you log in with an email identity from the "loginButtonsDialog" (as opposed to the "loginButtonsPopup", which is rooted on the topbar), the client hits an exception after the login succeeds.

The change here sidesteps the issue in the same way that [`loginResultCallback()`](https://github.com/sandstorm-io/sandstorm/blob/747cd5783a59a570a8195781fe43145eb00dd781/shell/packages/sandstorm-accounts-ui/login_buttons.js#L124) already sidesteps the issue for a related case.

I consider this a temporary hack, as it's really only an accident that `topbar == null` in these cases. I'm going to have to deal with the more general case in my merge-accounts branch, which will be reusing the login buttons in a different context.