### PR TITLE
Adjust some SandstormDb methods to not throw exceptions on null input.

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -753,8 +753,10 @@ if (Meteor.isServer) {
 
 _.extend(SandstormDb.prototype, {
   getUser: function getUser (userId) {
-    check(userId, String);
-    return Meteor.users.findOne(userId);
+    check(userId, Match.OneOf(String, undefined, null));
+    if (userId) {
+      return Meteor.users.findOne(userId);
+    }
   },
 
   getIdentity: function getIdentity (identityId) {
@@ -773,8 +775,9 @@ _.extend(SandstormDb.prototype, {
     return !!Meteor.users.findOne({_id: userId, "identities.id": identityId});
   },
 
-  userGrains: function userGrains (user) {
-    return this.collections.grains.find({ userId: user});
+  userGrains: function userGrains (userId) {
+    check(userId, Match.OneOf(String, undefined, null));
+    return this.collections.grains.find({userId: userId});
   },
 
   currentUserGrains: function currentUserGrains () {
@@ -787,8 +790,8 @@ _.extend(SandstormDb.prototype, {
   },
 
   userApiTokens: function userApiTokens (userId) {
-    check(userId, String);
-    var identityIds = SandstormDb.getUserIdentities(this.getUser(userId))
+    check(userId, Match.OneOf(String, undefined, null));
+    identityIds = SandstormDb.getUserIdentities(this.getUser(userId))
         .map(function (identity) { return identity.id; });
     return this.collections.apiTokens.find({'owner.user.identityId': {$in: identityIds}});
   },


### PR DESCRIPTION
This fixes a regression where, on logout, the javascript console would sometimes display a match failure exception.  The cause was a `check(userId, String)` that I had added to `userApiTokens()` in https://github.com/sandstorm-io/sandstorm/commit/9bd302dbce3ec8bd185c461602c5d61d5d6fc646. The fix proposed here is to adjust the check to allow null values, so that an empty cursor will be returned in that case.