### PR TITLE
run-bundle: bind /etc to /etc.host RO and symlink interesting files

### DIFF
--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -142,7 +142,7 @@ strace tmp/dnstest 2>&1 | grep -o '"/[^"]*"' | tr -d '"' | copyDeps
 cat tmp/etc.list | grep -v '/ld[.]so[.]' | sort | uniq > bundle/etc.list
 
 # Make mount points.
-mkdir -p bundle/{dev,proc,tmp,etc,var}
+mkdir -p bundle/{dev,proc,tmp,etc,etc.host,var}
 touch bundle/dev/{null,zero,random,urandom,fuse}
 
 # Mongo wants these localization files.

--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -138,6 +138,21 @@ __EOF__
 gcc tmp/dnstest.c -o tmp/dnstest
 strace tmp/dnstest 2>&1 | grep -o '"/[^"]*"' | tr -d '"' | copyDeps
 
+# Add some whitelisted entries to etc.list that we always want to include,
+# even if the build machine doesn't necessarily use them.  This helps handle
+# systems that use resolvconf to manage /etc/resolv.conf.
+# We skip copyDeps because it only adds files that exist on this system; we
+# wish to make things work for systems configured differently from the build host.
+cat >> tmp/etc.list << '__EOF__'
+/etc/gai.conf
+/etc/host.conf
+/etc/hosts
+/etc/nsswitch.conf
+/etc/resolvconf
+/etc/resolv.conf
+/etc/services
+__EOF__
+
 # Dedup the etc.list and copy over.  Don't copy the ld.so.x files, though.
 cat tmp/etc.list | grep -v '/ld[.]so[.]' | sort | uniq > bundle/etc.list
 

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1195,9 +1195,9 @@ private:
     auto files = splitLines(readAll("etc.list"));
     for (auto& file: files) {
       auto pathElements = split(file, '/');
-      KJ_REQUIRE(pathElements.size() >= 3, kj::str("Invalid path ", file));
-      KJ_REQUIRE(pathElements[0].size() == 0, kj::str("Relative path given in etc.list: ", file));
-      KJ_REQUIRE(kj::str(pathElements[1]) == "etc", "etc.list asked to symlink in file outside of /etc/");
+      KJ_REQUIRE(pathElements.size() >= 3, "invalid path", file);
+      KJ_REQUIRE(pathElements[0].size() == 0, kj::str("relative path given in etc.list", file));
+      KJ_REQUIRE(kj::str(pathElements[1]) == "etc", "etc.list asked to symlink in file outside of /etc/", file);
       auto etcChild = pathElements[2];
       auto linkTargetAsSeenByLink = kj::str("/etc.host/", etcChild);
       auto linkToCreate = kj::str("./etc/", etcChild);

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1196,7 +1196,7 @@ private:
     for (auto& file: files) {
       auto pathElements = split(file, '/');
       KJ_REQUIRE(pathElements.size() >= 3, "invalid path", file);
-      KJ_REQUIRE(pathElements[0].size() == 0, kj::str("relative path given in etc.list", file));
+      KJ_REQUIRE(pathElements[0].size() == 0,"relative path given in etc.list", file);
       KJ_REQUIRE(kj::str(pathElements[1]) == "etc", "etc.list asked to symlink in file outside of /etc/", file);
       auto etcChild = pathElements[2];
       auto linkTargetAsSeenByLink = kj::str("/etc.host/", etcChild);

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1123,9 +1123,12 @@ private:
 
     // Bind in the host's /etc as /etc.host.
     // As noted in backup.c++, MS_BIND does not respect mount flags on the initial bind, and
-    // we have to issue a remount to set them.
+    // we have to issue a remount to set them.  Because the host /etc may have been mounted nosuid,
+    // nodev, and noexec, we also add those flags here lest mount() think we're trying to remove
+    // them (which would cause mount() to fail)
     KJ_SYSCALL(mount("/etc", "etc.host", nullptr, MS_BIND, nullptr));
-    KJ_SYSCALL(mount("/etc", "etc.host", nullptr, MS_BIND | MS_REMOUNT | MS_RDONLY, nullptr));
+    KJ_SYSCALL(mount("/etc", "etc.host", nullptr,
+                     MS_BIND | MS_REMOUNT | MS_RDONLY | MS_NOSUID | MS_NODEV | MS_NOEXEC, nullptr));
 
     // Mount a tmpfs at /etc and symlink in necessary config files from the host.
     KJ_SYSCALL(mount("tmpfs", "etc", "tmpfs", MS_NOSUID | MS_NOEXEC,


### PR DESCRIPTION
This way, when e.g. `resolv.conf` changes, we won't be using an out-of-date copy.

Fixes #895