### PR TITLE
Mention Sandcats terms of service & privacy policy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -811,7 +811,7 @@ sandcats_configure() {
   # possible time-of-check-time-of-use race.
   echo -n "As a Sandstorm user, you are invited to use a free Internet hostname "
   echo "as a subdomain of sandcats.io,"
-  echo "a free service by the Sandstorm development team."
+  echo "a service operated by the Sandstorm development team."
 
   sandcats_generate_keys
 

--- a/install.sh
+++ b/install.sh
@@ -810,9 +810,16 @@ sandcats_configure() {
   # hostname, and if that succeeds, we are totally done. This avoids a
   # possible time-of-check-time-of-use race.
   echo -n "As a Sandstorm user, you are invited to use a free Internet hostname "
-  echo "as a subdomain of sandcats.io."
+  echo "as a subdomain of sandcats.io,"
+  echo "a free service by the Sandstorm development team."
 
   sandcats_generate_keys
+
+  echo ""
+  echo "Sandcats.io protects your privacy and is subject to terms of use. By using it,"
+  echo "you agree to the terms of service & privacy policy available here:"
+  echo "https://sandcats.io/terms https://sandcats.io/privacy"
+  echo ""
 
   # Having set up the keys, we run the function to register a name
   # with Sandcats. This function handles tail-recursing itself until


### PR DESCRIPTION
Here's how it appears to users:

```
vagrant@localhost:~$ sudo CURL_USER_AGENT=testing OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh
Sandstorm makes it easy to run web apps on your own server. You can have:

1. A full server with automatic setup (press enter to accept this default)
2. A development server, for writing apps.

How are you going to use this Sandstorm install? [1] 
We're going to:

* Install Sandstorm in /opt/sandstorm
* Automatically keep Sandstorm up-to-date
* Configure auto-renewing HTTPS if you use a subdomain of sandcats.io
* Create a service user (sandstorm) that owns Sandstorm's files
* Configure Sandstorm to start on System boot (with sysvinit)

Rest assured that Sandstorm itself won't run as root.
OK to continue? [yes] 
As a Sandstorm user, you are invited to use a free Internet hostname as a subdomain of sandcats.io.

By proceeding, you agree to the Sandcats.io terms of service & privacy policy 
which you can find at https://sandcats.io/.
Choose your desired Sandcats subdomain (alphanumeric, max 20 characters).
Type the word none to skip this step, or help for help.
What *.sandcats-dev.sandstorm.io subdomain would you like? [] 
```

Note the new "By proceeding..." line.

I think this is OK, so I'll self-merge, but @kentonv if you want to suggest text changes to that, let me know.