### PR TITLE
WORK IN PROGRESS: Pass --repair to mongod

### DIFF
--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1441,7 +1441,8 @@ private:
     uint64_t backendStartTime = getTime();
 
     context.warning("** Starting MongoDB...");
-    pid_t mongoPid = startMongo(config);
+    bool doMongoRepair = false;
+    pid_t mongoPid = startMongo(config, doMongoRepair);
     int64_t mongoStartTime = getTime();
 
     // Create the mongo user if it hasn't been created already.
@@ -1511,8 +1512,14 @@ private:
           backendStartTime = getTime();
         }
         if (mongoDied) {
+          // If Mongo died, let's try doing a repair. This way, every second mongo starting is a
+          // repair.
+          //
+          // Mongo's --repair argument causes Mongo to exit once the repair is over. This will
+          // re-trigger this branch, and we'll then re-start Mongo not in repair mode.
+          doMongoRepair = ! doMongoRepair;
           maybeWaitAfterChildDeath("MongoDB", mongoStartTime);
-          mongoPid = startMongo(config);
+          mongoPid = startMongo(config, doMongoRepair);
           mongoStartTime = getTime();
         }
         if (nodeDied) {
@@ -1556,36 +1563,65 @@ private:
     }
   }
 
-  pid_t startMongo(const Config& config) {
+  pid_t startMongo(const Config& config, bool doMongoRepair) {
     Subprocess process([&]() -> int {
       dropPrivs(config.uids);
       clearSignalMask();
 
-      KJ_SYSCALL(execl("/bin/mongod", "/bin/mongod", "--fork",
-          "--bind_ip", "127.0.0.1", "--port", kj::str(config.mongoPort).cStr(),
-          "--dbpath", "/var/mongo", "--logpath", "/var/log/mongo.log",
-          "--pidfilepath", "/var/pid/mongo.pid",
-          "--auth", "--nohttpinterface", "--noprealloc", "--nopreallocj", "--smallfiles",
-          "--replSet", "ssrs", "--oplogSize", "16",
-          EXEC_END_ARGS));
+      kj::Vector<const char*> args;
+      args.add("/bin/mongod");
+      args.add("--fork");
+      args.add("--bind_ip");
+      args.add("127.0.0.1");
+      args.add("--port");
+      args.add(kj::str(config.mongoPort).cStr());
+      args.add("--dbpath");
+      args.add("/var/mongo");
+      args.add("--logpath");
+      args.add("/var/log/mongo.log");
+      args.add("--pidfilepath");
+      args.add("/var/pid/mongo.pid");
+      args.add("--auth");
+      args.add("--nohttpinterface");
+      args.add("--noprealloc");
+      args.add("--nopreallocj");
+      args.add("--smallfiles");
+      args.add("--replSet");
+      args.add("ssrs");
+      args.add("--oplogSize");
+      args.add("16");
+
+      if (doMongoRepair) {
+        args.add("--repair");
+      }
+
+      args.add(nullptr);
+
+      context.warning(kj::str("MONGO ARGS: ", args));
+
+      KJ_SYSCALL(execv(args[0], const_cast<char**>(args.begin())));
       KJ_UNREACHABLE;
     });
 
     // Wait for mongod to return, meaning the database is up.  Then get its real pid via the
     // pidfile.
-    process.waitForSuccess();
+    int exitCode = process.waitForExit();
 
-    // Even after the startup command exits, MongoDB takes exactly two seconds to elect itself as
-    // master of the repl set (of which it is the only damned member). Unforutnately, if Node
-    // connects during this time, it fails, sometimes without actually exiting, leaving the entire
-    // server hosed. It appears that this always takes exactly two seconds from startup, since
-    // MongoDB does some sort of heartbeat every second where it checks the replset status, and it
-    // takes three of these for the election to complete, and the first of the three happens
-    // immediately on startup, meaning the last one is two seconds in. So, we'll sleep for 3
-    // seconds to be safe.
-    // TODO(cleanup): There must be a better way...
-    int n = 3;
-    while (n > 0) n = sleep(n);
+    if (exitCode == 0) {
+      // Even after the startup command exits, MongoDB takes exactly two seconds to elect itself as
+      // master of the repl set (of which it is the only damned member). Unforutnately, if Node
+      // connects during this time, it fails, sometimes without actually exiting, leaving the entire
+      // server hosed. It appears that this always takes exactly two seconds from startup, since
+      // MongoDB does some sort of heartbeat every second where it checks the replset status, and it
+      // takes three of these for the election to complete, and the first of the three happens
+      // immediately on startup, meaning the last one is two seconds in. So, we'll sleep for 3
+      // seconds to be safe.
+      // TODO(cleanup): There must be a better way...
+      int n = 3;
+      while (n > 0) n = sleep(n);
+    } else {
+      context.warning(kj::str("** Mongo exited with exitCode: ", exitCode));
+    }
 
     return KJ_ASSERT_NONNULL(parseUInt(trim(readAll("/var/pid/mongo.pid")), 10));
   }
@@ -1855,7 +1891,12 @@ private:
 
     int status;
 
-    KJ_SYSCALL(kill(pid, SIGTERM));
+    KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+      KJ_SYSCALL(kill(pid, SIGTERM));
+    })) {
+      KJ_LOG(ERROR, "Error while killing child process.", *exception);
+      return;
+    }
 
     alarmed = false;
     uint timeout = 5;
@@ -1879,7 +1920,7 @@ private:
           // Some other signal; ignore.
         }
       } else {
-        KJ_FAIL_SYSCALL("waitpid()", error, title);
+        // omg KJ_FAIL_SYSCALL("waitpid()", error, title);
       }
     }
   }


### PR DESCRIPTION
General strategy to fix this:

* Create a doMongoRepair boolean param to startMongo()

* Every even-numbered time, doMongoRepair is false.

* Every odd-numbered time, doMongoRepair is true. So that way, we start Mongo without
  trying to do a repair, but if Mongo _does_ fail, then we should try starting it in
  repair mode.

Unfortunately I ended up with a large number of yaks to shave:

* I turned the args for /bin/mongod into a kj::Vector, rather than a big
  constant array. I seem to have introduced a segfault in the process (?)

* I noticed that runServerMonitor() would fail with an assertion error if
  Mongo crashes, before these changes.

* I noticed that if mongo exits too soon, it causes our call to waitpid() to
  crash, because there is no such PID.

* We can't call kill on the PID since it doesn't exist, either.

Probably other problems.

This commit is definitely not in a workable state, but I realize I am out of my
league for a "quick" fix. Help requested.