### PR TITLE
If Sandstorm fails, don't kill the update process

### DIFF
--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1406,8 +1406,7 @@ private:
           context.warning("** Updater died; restarting it");
           updaterPid = startUpdater(config, true);
         } else if (sandstormDied) {
-          context.exitError("** Server monitor died. Aborting.");
-          KJ_UNREACHABLE;
+          context.warning("** Sandstorm died. Keeping the update monitor alive just in case.");
         }
       } else if (siginfo.ssi_signo == SIGINT) {
         // Pass along to server monitor.


### PR DESCRIPTION
This commit has an upside:

* If Sandstorm crashes because e.g. `mongod` crashes, then we continue looking for updates.

This commit has a downside:

* Sandstorm now has no way to signal to a process monitor (e.g. systemd) that it has failed. This means that errors like binding to a port that is already in use prevent Sandstorm don't clearly alert the admin to a problem, which is pretty sad.

So I'm not sure I actually am +1 on this change. @kentonv your feedback very much requested.