### PR TITLE
Upgrade nightwatch and capture screenshots on test/assertion failure

### DIFF
--- a/tests/nightwatch.json
+++ b/tests/nightwatch.json
@@ -20,6 +20,8 @@
       "silent": true,
       "screenshots" : {
         "enabled" : true,
+        "on_failure": true,
+        "on_error": true,
         "path" : "screenshots"
       },
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -3,7 +3,7 @@
   "description": "Tests for the sandstorm platform",
   "version": "0.0.1",
   "devDependencies": {
-    "nightwatch": "0.6.11",
+    "nightwatch": "0.8.6",
     "phantomjs": "~1.9.10",
     "selenium-standalone": "4.2.2"
   },


### PR DESCRIPTION
@jparyani I would love it if we integrated screenshots with Jenkins, so when tests fail, we can see what the page looked like for the failed assertion.  Any thoughts on:

* if upgrading nightwatch is risky or not
* how might we organize/clean out the screenshots folder?
* how might we make Jenkins capture these things as build artifacts?
