### PR TITLE
Revert "run-bundle: bind /etc to /etc.host RO and symlink interesting…

### DIFF
--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -138,26 +138,11 @@ __EOF__
 gcc tmp/dnstest.c -o tmp/dnstest
 strace tmp/dnstest 2>&1 | grep -o '"/[^"]*"' | tr -d '"' | copyDeps
 
-# Add some whitelisted entries to etc.list that we always want to include,
-# even if the build machine doesn't necessarily use them.  This helps handle
-# systems that use resolvconf to manage /etc/resolv.conf.
-# We skip copyDeps because it only adds files that exist on this system; we
-# wish to make things work for systems configured differently from the build host.
-cat >> tmp/etc.list << '__EOF__'
-/etc/gai.conf
-/etc/host.conf
-/etc/hosts
-/etc/nsswitch.conf
-/etc/resolvconf
-/etc/resolv.conf
-/etc/services
-__EOF__
-
 # Dedup the etc.list and copy over.  Don't copy the ld.so.x files, though.
 cat tmp/etc.list | grep -v '/ld[.]so[.]' | sort | uniq > bundle/etc.list
 
 # Make mount points.
-mkdir -p bundle/{dev,proc,tmp,etc,etc.host,var}
+mkdir -p bundle/{dev,proc,tmp,etc,var}
 touch bundle/dev/{null,zero,random,urandom,fuse}
 
 # Mongo wants these localization files.


### PR DESCRIPTION
Reverts sandstorm-io/sandstorm#1030

This breaks some systems, e.g. ones where resolveconf is under /run. We need a more robust strategy here.