### PR TITLE
Typo in offer template data

### DIFF
--- a/shell/public/offer-template.html
+++ b/shell/public/offer-template.html
@@ -52,7 +52,7 @@ setInterval(function() {
   xhr.onreadystatechange = function () {
     if (xhr.readyState == 4) {
        if (xhr.status == 200) {
-          record.exires = Date.now() + selfDestructDuration;
+          record.expires = Date.now() + selfDestructDuration;
           sessionStorage.setItem(templateToken, JSON.stringify(record));
        } else {
           var errorText = "Error refreshing token. Reloading the page might help.";


### PR DESCRIPTION
If I'm understanding it correctly, it looks like `expires` has been sent as `exires` such that `data.expires < Date.now()` never matches and expired keys never get removed from sessionStorage.