### PR TITLE
Update the first-user-admin-promotion code to account for the new schema

### DIFF
--- a/shell/packages/sandstorm-db/user.js
+++ b/shell/packages/sandstorm-db/user.js
@@ -70,8 +70,8 @@ var ValidHandle = Match.Where(function (handle) {
 
 Accounts.onCreateUser(function (options, user) {
   // The first non-dev user to sign in should be automatically upgraded to admin.
-  // Dev users are identified by having the devName field.
-  if (Meteor.users.find({devName: {$exists: 0}}).count() === 0 && !user.devName) {
+  if (Meteor.users.find({"identities.service.dev": {$exists: 0}}).count() === 0 &&
+      !options.service.dev) {
     user.isAdmin = true;
     user.signupKey = "admin";
   }


### PR DESCRIPTION
The first dev user was erroneously becoming an admin.