### PR TITLE
Allow up to 60 seconds (not 20) for /getcertificate response

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1739,7 +1739,7 @@ sandcats_configure_https() {
   HTTP_STATUS=$(
     dotdotdot_curl \
       --silent \
-      --max-time 20 \
+      --max-time 60 \
       $SANDCATS_CURL_PARAMS \
       -A "$CURL_USER_AGENT" \
       -X POST \


### PR DESCRIPTION
This fixes what I believe is the one remaining flakiness of installer-tests.