### PR TITLE
App details cleanups

### DIFF
--- a/shell/packages/sandstorm-ui-app-details/app-details-client.js
+++ b/shell/packages/sandstorm-ui-app-details/app-details-client.js
@@ -189,6 +189,11 @@ Template.sandstormAppDetails.helpers({
     }
 
   },
+  onGrainClicked: function() {
+    return function (grainId) {
+      Router.go("grain", {grainId: grainId});
+    };
+  },
   website: function () {
     var ref = Template.instance().data;
     var pkg = latestPackageForAppId(ref._db, ref._appId);

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -144,7 +144,6 @@ Template.sandstormGrainListPage.events({
 
 Template.sandstormGrainTable.events({
   "click tbody tr.action": function(event) {
-    console.log("action clicked");
     this && this.onClick();
   },
   "click tbody tr.grain": function(event) {

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.html
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.html
@@ -28,7 +28,7 @@
           <p>A grain is an instance of a Sandstorm app. A grain might be a document, a chat room,
             a mail box, a notebook, a blog, or more.</p>
 
-          <p><a href="/grain/new">Install apps now to start creating.</a></p>
+          <p><a href="{{ pathFor route='apps' }}">Install apps now to start creating.</a></p>
         </div>
       {{/if}}
     {{/unless}}

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1339,6 +1339,15 @@ Router.map(function () {
       return new SandstormAppList(globalDb, globalQuotaEnforcer, this.params.query.highlight);
     },
   });
+  this.route("newGrainRedirect", {
+    // The path /grain/new used to be where you would go to create new grains.
+    // Its functionality has been superceded by the apps route, so redirect in
+    // case anyone has the old link saved somewhere.
+    path: "/grain/new",
+    onBeforeAction: function () {
+      Router.go("apps", {}, {replaceState: true});
+    },
+  });
   this.route("grains", {
     path: "/grain",
     waitOn: function () { return globalSubs; },


### PR DESCRIPTION
* Make rows in the app-details page clickable anywhere in the row, not just on the link
* Fix dangling link pointing to `/grain/new`
* Redirect `/grain/new` to `/apps`
* Remove a `console.log`