### PR TITLE
Don't highlight newly-installed apps in the Most Used row

### DIFF
--- a/shell/packages/sandstorm-ui-applist/applist.html
+++ b/shell/packages/sandstorm-ui-applist/applist.html
@@ -25,7 +25,7 @@
     <div class="popular-container">
       <h2 class="">Most used</h2>
       {{#each popularApps }}
-	  <a class="app-button {{#if dev}}dev-background {{/if}}{{#if shouldHighlight}}highlight{{/if}}" href="/apps/{{appId}}">
+      <a class="app-button {{#if dev}}dev-background {{/if}}" href="/apps/{{appId}}">
         <div class="app-icon" style="background-image: url('{{ iconSrc }}');"></div>
         <span class="app-title">{{appTitle}}</span>
         <span class="action-text">{{shortDescription}}</span>


### PR DESCRIPTION
They're most interesting in the main listing, and we're going to scroll to make sure that one's visible anyway, so calling attention to exactly one thing is preferable.

Fixes #1095.