### PR TITLE
Adjust links to capnp files to go to the right place

### DIFF
--- a/docs/developing/email-from-apps.md
+++ b/docs/developing/email-from-apps.md
@@ -66,11 +66,11 @@ box.
 
 Sending e-mails is a bit more tricky. For now, you have to use the
 Cap'n Proto
-[`HackSessionContext`](../blob/master/src/sandstorm/hack-session.capnp)
+[`HackSessionContext`](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/hack-session.capnp)
 interface that is re-exported by
 sandstorm-http-bridge. sandstorm-http-bridge creates a socket at
 `/tmp/sandstorm-api` and exports a bootstrap
-[`SandstormHttpBridge`](../blob/master/src/sandstorm/sandstorm-http-bridge.capnp)
+[`SandstormHttpBridge`](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/sandstorm-http-bridge.capnp)
 capability on it. You will need to call `getSessionContext()` with the
 ID that sandstorm-http-bridge places in the `X-Sandstorm-Session-Id`
 header. The result will be a `SessionContext` that can be cast to a
@@ -105,7 +105,7 @@ HackSessionContext](#sending-with-hacksessioncontext).
 ### Receiving through HackSession
 
 Your `UIView.newSession` method (refer to
-[grain.capnp](../blob/master/src/sandstorm/grain.capnp)) must return a
+[grain.capnp](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/grain.capnp)) must return a
 HackEmailSession. In your HackEmailSession capability, you must
 implement the `send` method, which will be called whenever an e-mail
 is sent to the grain.
@@ -114,7 +114,7 @@ is sent to the grain.
 
 A HackSessionContext is obtained upon call of `UIView.newSession`
 (refer to
-[grain.capnp](../blob/master/src/sandstorm/grain.capnp)). You will be
+[grain.capnp](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/grain.capnp)). You will be
 passed a HackSessionContext as the 2nd paramater, and it is up to your
 app to store/use it.
 

--- a/docs/developing/web-publishing.md
+++ b/docs/developing/web-publishing.md
@@ -135,7 +135,7 @@ the `SessionContext` capability you receive as a parameter to the
 `UiView.newSession()` method can be cast to `HackSessionContext`.  *
 If you are using `sandstorm-http-bridge`, you must open a Cap'n Proto
 connection to `unix:/tmp/sandstorm-api`, which will give you a
-[SandstormHttpBridge](../blob/master/src/sandstorm/sandstorm-http-bridge.capnp)
+[SandstormHttpBridge](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/sandstorm-http-bridge.capnp)
 capability. Call `getSessionContext()` on that capability, using the
 ID that sandstorm-http-bridge places in the `X-Sandstorm-Session-Id`
 header, and cast the result to a `HackSessionContext`.


### PR DESCRIPTION
These ../ links used to work when the docs were based on the
GitHub wiki for sandstorm-io/sandstorm, but seeing as they are
no longer there, we use absolute URLs.

Verified this was all of them by doing:

$ git grep '[.][.].*capnp'