### PR TITLE
Replace svg icons with an autogenerated webfont

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ tmp
 deps
 node_modules
 shell/client/changelog.html
-shell/client/_sandstorm-icons.scss
+shell/client/_icons.scss
 shell/sandstorm-shell.config
 shell/sandstorm-shell.creator
 shell/sandstorm-shell.creator.user

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ tmp
 deps
 node_modules
 shell/client/changelog.html
+shell/client/_sandstorm-icons.scss
 shell/sandstorm-shell.config
 shell/sandstorm-shell.creator
 shell/sandstorm-shell.creator.user
@@ -46,6 +47,7 @@ shell/public/google.svg
 shell/public/troubleshoot.svg
 shell/public/email-494949.svg
 shell/public/*-m.svg
+shell/public/sandstorm-icons
 shell-build
 sandstorm-*.tar.xz
 sandstorm-*.tar.xz.sig

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ IMAGES= \
 all: sandstorm-$(BUILD).tar.xz
 
 clean:
-	rm -rf bin tmp node_modules bundle shell-build sandstorm-*.tar.xz shell/.meteor/local $(IMAGES) shell/client/changelog.html shell/packages/*/.build* shell/packages/*/.npm/package/node_modules *.sig *.update-sig
+	rm -rf bin tmp node_modules bundle shell-build sandstorm-*.tar.xz shell/.meteor/local $(IMAGES) shell/client/changelog.html shell/packages/*/.build* shell/packages/*/.npm/package/node_modules *.sig *.update-sig icons/node_modules
 	@(if test -d deps && test ! -h deps; then printf "\033[0;33mTo update dependencies, use: make update-deps\033[0m\n"; fi)
 
 install: sandstorm-$(BUILD)-fast.tar.xz install.sh
@@ -220,11 +220,17 @@ shell-env: tmp/.shell-env
 
 # Note that we need Ekam to build node_modules before we can run Meteor, hence
 # the dependency on tmp/.ekam-run.
-tmp/.shell-env: tmp/.ekam-run $(IMAGES) shell/client/changelog.html
+tmp/.shell-env: tmp/.ekam-run $(IMAGES) shell/client/changelog.html shell/client/_sandstorm-icons.scss
 	@mkdir -p tmp
 	@touch tmp/.shell-env
 	@mkdir -p node_modules/capnp
 	@bash -O extglob -c 'cp src/capnp/!(*test*).capnp node_modules/capnp'
+
+icons/node_modules: icons/package.json
+	cd icons && npm install
+
+shell/client/_sandstorm-icons.scss: icons/node_modules icons/*svg icons/Gruntfile.js
+	cd icons && ./node_modules/.bin/grunt
 
 shell/client/changelog.html: CHANGELOG.md
 	@mkdir -p tmp

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ shell-env: tmp/.shell-env
 
 # Note that we need Ekam to build node_modules before we can run Meteor, hence
 # the dependency on tmp/.ekam-run.
-tmp/.shell-env: tmp/.ekam-run $(IMAGES) shell/client/changelog.html shell/client/_sandstorm-icons.scss
+tmp/.shell-env: tmp/.ekam-run $(IMAGES) shell/client/changelog.html shell/client/_icons.scss
 	@mkdir -p tmp
 	@touch tmp/.shell-env
 	@mkdir -p node_modules/capnp
@@ -229,7 +229,7 @@ tmp/.shell-env: tmp/.ekam-run $(IMAGES) shell/client/changelog.html shell/client
 icons/node_modules: icons/package.json
 	cd icons && npm install
 
-shell/client/_sandstorm-icons.scss: icons/node_modules icons/*svg icons/Gruntfile.js
+shell/client/_icons.scss: icons/node_modules icons/*svg icons/Gruntfile.js
 	cd icons && ./node_modules/.bin/grunt
 
 shell/client/changelog.html: CHANGELOG.md

--- a/icons/Gruntfile.js
+++ b/icons/Gruntfile.js
@@ -1,0 +1,24 @@
+module.exports = function(grunt) {
+  grunt.loadNpmTasks("grunt-webfont");
+
+
+  grunt.initConfig({
+    webfont: {
+      icons: {
+        src: "./*.svg",
+        dest: "../shell/public/icons",
+        destCss: "../shell/client",
+        options: {
+          font: "sandstorm-icons",
+          engine: "node",
+          autoHint: false,
+          htmlDemo: false,
+          relativeFontPath: "/icons/",
+          stylesheet: "scss",
+        },
+      },
+    },
+  });
+
+  grunt.registerTask("default", ["webfont"]);
+};

--- a/icons/Gruntfile.js
+++ b/icons/Gruntfile.js
@@ -9,12 +9,16 @@ module.exports = function(grunt) {
         dest: "../shell/public/icons",
         destCss: "../shell/client",
         options: {
-          font: "sandstorm-icons",
+          font: "icons",
           engine: "node",
           autoHint: false,
           htmlDemo: false,
           relativeFontPath: "/icons/",
           stylesheet: "scss",
+          templateOptions: {
+            classPrefix: "icon-",
+            mixinPrefix: "icon-",
+          },
         },
       },
     },

--- a/icons/package.json
+++ b/icons/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "sandstorm-fonts",
+  "description": "Fonts for sandstorm.",
+  "version": "0.1.0",
+  "devDependencies": {
+    "grunt": "0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-webfont": "0.4.8"
+  }
+}

--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -414,8 +414,8 @@ body>.topbar {
         >.count {
           display: block;
           position: absolute;
-          bottom: 0;
-          left: 0;
+          top: 16px;
+          left: 16px;
           width: 16px;
           height: 16px;
           background-color: red;
@@ -426,8 +426,8 @@ body>.topbar {
           font-size: 8pt;
 
           @media #{$mobile} {
-            left: 4px;
-            bottom: 8px;
+            top: 24px;
+            left: 24px;
           }
         }
       }

--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -952,19 +952,6 @@ body>.popup {
       background-color: #666;
     }
 
-    .notification-icon {
-      background-position: center 4px;
-      background-repeat: no-repeat;
-      background-size: contain;
-      width: 32px;
-      height: 32px;
-      border: none;
-      color: transparent;
-      background-color: black;
-      background-image: url("/notification.svg");
-      vertical-align: top;
-    }
-
     .notification-timestamp {
       text-align: left;
       color: #ccc;

--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -1,3 +1,18 @@
+@mixin webfont-icon ($color, $mobile-color) {
+  text-align: center;
+  @extend .icon;
+  &:before {
+    font-size: 24px;
+    color: $color;
+    font-family: "sandstorm-icons";
+
+    @media #{$mobile} {
+      font-size: 40px;
+      color: $mobile-color;
+    }
+  }
+}
+
 @media #{$mobile} {
   // Only show the menu button on mobile
   body>.menu-button {
@@ -393,7 +408,8 @@ body>.topbar {
         @extend %icon-button;
         @extend %mobile-icon-button;
 
-        background-image: url("/notification.svg");
+        @include webfont-icon(#CCCCCC, #CCCCCC);
+        @extend .icon_notification;
 
         >.count {
           display: block;

--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -4,7 +4,7 @@
   &:before {
     font-size: 24px;
     color: $color;
-    font-family: "sandstorm-icons";
+    font-family: "icons";
 
     @media #{$mobile} {
       font-size: 40px;
@@ -409,7 +409,7 @@ body>.topbar {
         @extend %mobile-icon-button;
 
         @include webfont-icon(#CCCCCC, #CCCCCC);
-        @extend .icon_notification;
+        @extend .icon-notification;
 
         >.count {
           display: block;

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -16,6 +16,7 @@
 
 // Include fonts (a somewhat verbose incantation) from _fonts.scss
 @import "_fonts.scss";
+@import "_sandstorm-icons.scss";
 
 @import "_geometry.scss";
 @import "_colors.scss";

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -16,7 +16,7 @@
 
 // Include fonts (a somewhat verbose incantation) from _fonts.scss
 @import "_fonts.scss";
-@import "_sandstorm-icons.scss";
+@import "_icons.scss";
 
 @import "_geometry.scss";
 @import "_colors.scss";


### PR DESCRIPTION
I've replaced the notification bell icon as an example of how this should be used.

There's some small stylistic things that I'm open to changing.

1. The icon classes are prefixed by default with `icon_` (eg. `icon_notification`). By convention, I think we have been using `-` instead of `_` in CSS.
2. I'm using a mixin for `webfont-icon`. This is a little inefficient, but I'm not sure how to cleanly do this with an extend instead.