### PR TITLE
Add missing cursor:pointer to some buttons on the app-details page.

### DIFF
--- a/shell/client/_app-details.scss
+++ b/shell/client/_app-details.scss
@@ -107,6 +107,7 @@
           }
           >button.show-authorship-button {
             @extend %unstyled-button;
+            cursor: pointer;
             padding-left: 8px;
             padding-right: 24px;
             background-repeat: no-repeat;

--- a/shell/client/_grainlist.scss
+++ b/shell/client/_grainlist.scss
@@ -174,6 +174,7 @@
       button {
         color: black;
         font-weight: bold;
+        cursor: pointer;
         @extend %unstyled-button;
       }
     }


### PR DESCRIPTION
This makes the "create new grain" and the "signed by" buttons more discoverably clickable.