### PR TITLE
Add symlink for crypto_generichash.h.

### DIFF
--- a/src/sodium/crypto_generichash.h
+++ b/src/sodium/crypto_generichash.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_generichash.h


### PR DESCRIPTION
This fixes the build failure seen in the Jenkins test for #1110.