### PR TITLE
Up the timeout for waiting for sessions to re-open

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -49,7 +49,7 @@ BASIC_AUTH_USER_AGENTS = [
 ];
 BASIC_AUTH_USER_AGENTS_REGEX = new RegExp("^(" + BASIC_AUTH_USER_AGENTS.join("|") + ")", '');
 
-var SESSION_PROXY_TIMEOUT = 15000;
+var SESSION_PROXY_TIMEOUT = 60000;
 
 var sandstormCoreFactory = makeSandstormCoreFactory();
 var backendAddress = "unix:" + (SANDSTORM_ALTHOME || "") + Backend.socketPath;


### PR DESCRIPTION
Partially fixes #1103. Currently, the client can wait up to 60s to send
a keepAlive. We probably want the Session to be properly reactive so
that the client never has to wait to re-open a session.