### PR TITLE
Update Web Publishing helper docs to install libtool dependency

### DIFF
--- a/docs/developing/web-publishing.md
+++ b/docs/developing/web-publishing.md
@@ -54,7 +54,7 @@ If you are using `vagrant-spk`, also add the following to the end of your
 # /usr/local/bin. This requires a C++ compiler. We opt for clang
 # because that's what Sandstorm is typically compiled with.
 if [ ! -e /usr/local/bin/capnp ] ; then
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q clang autoconf pkg-config
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q clang autoconf pkg-config libtool
     cd /tmp
     if [ ! -e capnproto ]; then git clone https://github.com/sandstorm-io/capnproto; fi
     cd capnproto


### PR DESCRIPTION
I was seeing the following error, when it failed and I reran manually:

```
vagrant@localhost:/tmp/capnproto/c++$ autoreconf -i
Makefile.am:189: error: Libtool library used but 'LIBTOOL' is undefined
Makefile.am:189:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
Makefile.am:189:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
Makefile.am:189:   If 'LT_INIT' is in 'configure.ac', make sure
Makefile.am:189:   its definition is in aclocal's search path.
Makefile.am:187: error: Libtool library used but 'LIBTOOL' is undefined
Makefile.am:187:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
Makefile.am:187:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
Makefile.am:187:   If 'LT_INIT' is in 'configure.ac', make sure
Makefile.am:187:   its definition is in aclocal's search path.
autoreconf: automake failed with exit status: 1
```