### PR TITLE
Allow apps to request that the "Share Access" menu be shown via postMessage

### DIFF
--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -357,6 +357,15 @@ SandstormTopbar.prototype.closePopup = function () {
   this._expanded.set(null);
 }
 
+SandstormTopbar.prototype.isPopupOpen = function () {
+  return !!this._expanded.get();
+}
+
+SandstormTopbar.prototype.openPopup = function(name) {
+  this._expanded.set(name);
+  this._menuExpanded.set(false);
+}
+
 SandstormTopbar.prototype.isUpdateBlocked = function () {
   return !!blockedReload.get();
 }

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1129,9 +1129,8 @@ if (Meteor.isClient) {
         // Only show this popup if no other popup is currently active.
         // TODO(security): defend against malicious apps spamming this call, blocking all other UI.
         var currentGrain = getActiveGrain(globalGrains.get());
-        if (senderGrain === currentGrain && !globalTopbar._expanded.get()) {
-          globalTopbar._expanded.set("share");
-          globalTopbar._menuExpanded.set(false);
+        if (senderGrain === currentGrain && !globalTopbar.isPopupOpen()) {
+          globalTopbar.openPopup("share");
         }
       } else if (event.data.setTitle) {
         senderGrain.setFrameTitle(event.data.setTitle);

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1124,6 +1124,15 @@ if (Meteor.isClient) {
         check(path.charAt(0), '/');
         // TODO(security): More sanitization of this path. E.g. reject "/../../".
         senderGrain.setPath(path);
+      } else if (event.data.startSharing) {
+        // Allow the current grain to request that the "Share Access" menu be shown.
+        // Only show this popup if no other popup is currently active.
+        // TODO(security): defend against malicious apps spamming this call, blocking all other UI.
+        var currentGrain = getActiveGrain(globalGrains.get());
+        if (senderGrain === currentGrain && !globalTopbar._expanded.get()) {
+          globalTopbar._expanded.set("share");
+          globalTopbar._menuExpanded.set(false);
+        }
       } else if (event.data.setTitle) {
         senderGrain.setFrameTitle(event.data.setTitle);
       } else if (event.data.renderTemplate) {


### PR DESCRIPTION
@jacksingleton noted at the recent meetup that it's nice to have a button in
the app to start the sharing flow, rather than showing a screenshot with
instructions for users that might become out-of-date.

This adds a postMessage handler the current grain can call that simply shows
the sharing popup.