### PR TITLE
Install flow shows app details

### DIFF
--- a/shell/.meteor/packages
+++ b/shell/.meteor/packages
@@ -29,6 +29,7 @@ sandstorm-permissions
 sandstorm-ui-topbar
 sandstorm-ui-applist
 sandstorm-ui-app-details
+sandstorm-ui-app-install
 sandstorm-ui-grainlist
 meteor-node-forge
 fourseven:scss

--- a/shell/.meteor/versions
+++ b/shell/.meteor/versions
@@ -73,6 +73,7 @@ sandstorm-email@0.1.0
 sandstorm-identicons@0.1.0
 sandstorm-permissions@0.1.0
 sandstorm-ui-app-details@0.1.0
+sandstorm-ui-app-install@0.1.0
 sandstorm-ui-applist@0.1.0
 sandstorm-ui-grainlist@0.1.0
 sandstorm-ui-topbar@0.1.0

--- a/shell/client/_app-details.scss
+++ b/shell/client/_app-details.scss
@@ -15,17 +15,48 @@
     background-color: #ccc;
   }
 
+  >.app-details-widget {
+    @extend %app-details-widget;
+  }
+  >.search-bar {
+    margin-top: 12px;
+    clear: both;
+    >label {
+      >span.search-icon {
+        @extend %pseudo-img-tag;
+        background-image: url("/search.svg");
+        background-size: 24px 24px;
+        background-position: center;
+        display: inline-block;
+        box-sizing: border-box;
+        width: 32px;
+        height: 32px;
+        vertical-align: top;
+      }
+      >input.search-bar {
+        font-size: 16pt;
+        height: 32px;
+        box-sizing: border-box;
+        background-color: $app-details-searchbar-background-color;
+        border: 1px solid $app-details-searchbar-outline-color;
+        &:focus {
+          border: 1px solid $app-details-searchbar-outline-color-focus;
+        }
+      }
+    }
+  }
+  >table.grain-list-table {
+    @extend %grain-table;
+  }
+}
+
+%app-details-widget {
+  margin: 0;
+  padding: 0;
+  position: relative;
   >.app-icon {
     position: absolute;
     @extend %pseudo-img-tag;
-    @media #{$desktop} {
-      left: 32px;
-      top: 24px;
-    }
-    @media #{$mobile} {
-      left: 8px;
-      top: 0px;
-    }
     width: 128px;
     height: 128px;
   }
@@ -179,42 +210,5 @@
         display:none;
       }
     }
-  }
-  >.actions {
-    margin-top: 12px;
-    >button {
-      @extend %button-base;
-      @extend %button-primary;
-    }
-  }
-  >.search-bar {
-    margin-top: 12px;
-    clear: both;
-    >label {
-      >span.search-icon {
-        @extend %pseudo-img-tag;
-        background-image: url("/search.svg");
-        background-size: 24px 24px;
-        background-position: center;
-        display: inline-block;
-        box-sizing: border-box;
-        width: 32px;
-        height: 32px;
-        vertical-align: top;
-      }
-      >input.search-bar {
-        font-size: 16pt;
-        height: 32px;
-        box-sizing: border-box;
-        background-color: $app-details-searchbar-background-color;
-        border: 1px solid $app-details-searchbar-outline-color;
-        &:focus {
-          border: 1px solid $app-details-searchbar-outline-color-focus;
-        }
-      }
-    }
-  }
-  >table.grain-list-table {
-    @extend %grain-table;
   }
 }

--- a/shell/client/_app-details.scss
+++ b/shell/client/_app-details.scss
@@ -18,6 +18,15 @@
   >.app-details-widget {
     @extend %app-details-widget;
   }
+  >.newer-version, >.older-version {
+    background-color: darken($app-details-background-color, 10%);
+    >p {
+      >button {
+        @extend %button-base;
+        @extend %button-primary;
+      }
+    }
+  }
   >.search-bar {
     margin-top: 12px;
     clear: both;

--- a/shell/client/_app-details.scss
+++ b/shell/client/_app-details.scss
@@ -174,14 +174,33 @@
       display: block;
       clear: both;
       background-color: #ffffff;
-      >p {
+      vertical-align: top;
+      >p.no-fingerprint {
+        padding: 8px;
+      }
+      >p.has-fingerprint {
+        vertical-align: top;
         padding-left: 8px;
-        display: inline-block;
-        max-width: 30%;
+        @media #{$desktop} {
+          display: inline-block;
+          max-width: 30%;
+        }
+        @media #{$mobile} {
+          display: block;
+          width: 100%;
+        }
       }
       >ul.publisher-proofs {
-        display: inline-block;
-        max-width: 65%;
+        @media #{$desktop} {
+          display: inline-block;
+          width: 65%;
+        }
+        @media #{$mobile} {
+          display: block;
+          width: 100%;
+        }
+        box-sizing: border-box;
+        padding: 8px;
         list-style: none;
         >li.publisher-proof {
           display: block;

--- a/shell/client/_applist.scss
+++ b/shell/client/_applist.scss
@@ -131,14 +131,6 @@
       background-size: 100% auto;
       background-color: #ccc;
     }
-    &.highlight {
-      background-color: #ccc;
-      border-radius: 6px;
-      .app-icon {
-        animation-duration: 2s;
-        animation-name: new-app;
-      }
-    }
     &.uninstall-action>.app-icon {
       &::before {
         position: absolute;
@@ -250,12 +242,4 @@
   border-radius: 4px;
   h1 { margin-top: 0; }
   p { margin-bottom: 0; }
-}
-
-@keyframes new-app {
-  from { transform: scale(0); }
-  80% { transform: scale(1); }
-  85% { transform: rotate(15deg); }
-  95% { transform: rotate(-15deg); }
-  to {  }
 }

--- a/shell/client/_install.scss
+++ b/shell/client/_install.scss
@@ -1,65 +1,54 @@
-#install {}
-
-#install button {
-  font-family: inherit;
-  background-color: $sandstorm-purple-color;
-  font-size: 150%;
-  font-weight: 600;
-
-  padding: 10px 16px;
-  line-height: 1.33;
-  border-radius: 6px;
-  border: none;
-  color: white;
-  cursor: pointer;
-  text-align: center;
+.install {
+  position: relative;
+  @media #{$desktop} {
+    padding: 24px 32px;
+  }
+  @media #{$mobile} {
+    padding: 0px 8px;
+  }
+  button {
+    @extend %button-base;
+    @extend %button-primary;
+    font-size: 150%;
+    font-weight: bold;
+    padding: 10px 16px;
+    line-height: 1.33;
+  }
+  pre {
+    font-family: inherit;
+    font-size: inherit;
+  }
+  
+  #step-wait {
+    display: block;
+  }
+  #step-download {
+    display: block;
+  }
+  #step-verify {
+    display: block;
+  }
+  #step-unpack {
+    display: block;
+  }
+  #step-analyze {
+    display: block;
+  }
+  #step-confirm {
+    display: block;
+    >.app-details-widget {
+      @extend %app-details-widget;
+    }
+    .confirm-form { display: block; }
+  }
+  #step-run {
+    display: block;
+    .done-notice { display: block; }
+  }
+  #step-delete {
+    display: block;
+  }
 }
-
-#install ol {
-  margin: 16px auto;
-  max-width: 600px;
-  padding: 0;
-
-  text-align: center;
-  list-style-type: none;
-  font-size: 200%;
-}
-#install ol p {
-  font-size: 50%;  /* revert above */
-  font-weight: normal;
-}
-
-#install pre {
-  font-family: inherit;
-  font-size: inherit;
-}
-
-#install li {
-  display: none;
-}
-
-#install li .progress {
-  display: none;
-}
-
-#install #step-confirm .confirm-form { display: none; }
-#install #step-run     .done-notice  { display: none; }
-
-#install.instep-wait     #step-wait     { display: block; font-weight: bold; }
-#install.instep-download #step-download { display: block; font-weight: bold; }
-#install.instep-verify   #step-verify   { display: block; font-weight: bold; }
-#install.instep-unpack   #step-unpack   { display: block; font-weight: bold; }
-#install.instep-analyze  #step-analyze  { display: block; font-weight: bold; }
-#install.instep-confirm  #step-confirm  { display: block; font-weight: bold; }
-#install.instep-run      #step-run      { display: block; font-weight: bold; }
-#install.instep-delete   #step-delete   { display: block; font-weight: bold; }
-
-#install.instep-download #step-download .progress { display: inline; }
-#install.instep-verify   #step-verify   .progress { display: inline; }
-#install.instep-unpack   #step-unpack   .progress { display: inline; }
-#install.instep-analyze  #step-analyze  .progress { display: inline; }
-#install.instep-confirm  #step-confirm  .confirm-form { display: block; }
-#install.instep-run      #step-run      .done-notice { display: block; }
 
 #my-files-arrow, #sign-in-arrow {
   position: absolute;

--- a/shell/client/_install.scss
+++ b/shell/client/_install.scss
@@ -18,12 +18,20 @@
     font-family: inherit;
     font-size: inherit;
   }
-  
+
   #step-wait {
     display: block;
   }
   #step-download {
     display: block;
+    >p {
+      width: 100%;
+      margin: 16px auto;
+      >.progress {
+        height: 32px;
+        width: 100%;
+      }
+    }
   }
   #step-verify {
     display: block;

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -565,15 +565,15 @@ limitations under the License.
 </template>
 
 <template name="apps">
-  {{> sandstormAppList }}
+  {{> sandstormAppListPage . }}
 </template>
 
 <template name="grains">
-  {{> sandstormGrainListPage}}
+  {{> sandstormGrainListPage . }}
 </template>
 
 <template name="appDetails">
-  {{> sandstormAppDetailsPage }}
+  {{> sandstormAppDetailsPage . }}
 </template>
 
 <template name="_grainSpinner">
@@ -597,7 +597,7 @@ limitations under the License.
 </template>
 
 <template name="install">
-  {{> sandstormAppInstall }}
+  {{> sandstormAppInstallPage . }}
 </template>
 
 <template name="account">

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -599,69 +599,7 @@ limitations under the License.
 <template name="install">
   {{> sandstormAppInstall }}
 </template>
-<!--
-<template name="install">
-  {{>title "Install app"}}
 
-  {{#if error}}
-    <div id="install" class="error">
-      <div class="centered-box">
-        <p>Failed to install app!
-          {{#if step}}<button id="retry">Try Again</button>{{/if}}</p>
-        <pre>{{error}}</pre>
-      </div>
-    </div>
-  {{else}}
-    <div id="install" class="instep-{{step}}">
-      {{! TODO(cleanup):  The use of a list here is vestigial.  We now display only the step
-            that is currently running. }}
-      <ol>
-        <li id="step-wait">Waiting for write access...</li>
-        <li id="step-download">Downloading... <span class="progress">{{progress}}
-            <button id="cancelDownload">Cancel</button></span></li>
-        <li id="step-verify">Verifying... <span class="progress">{{progress}}</span></li>
-        <li id="step-unpack">Unpacking... <span class="progress">{{progress}}</span></li>
-        <li id="step-analyze">Analyzing... <span class="progress">{{progress}}</span></li>
-        <li id="step-confirm">Install this app?
-          <div class="confirm-form">
-            {{! TODO(someday):  Support editing action names (i.e. make them petnames). }}
-            {{#if hasOlderVersion}}
-              <p>You have an older version of this app installed.  Do you want to upgrade?</p>
-              <p><button id="confirmInstall">Upgrade</button></p>
-            {{else}}
-            {{#if hasNewerVersion}}
-              <p>You already have a newer version of this app installed.  Are
-                you sure you want to revert to this older version?</p>
-              <p><button id="confirmInstall">Downgrade</button></p>
-            {{else}}
-              <p>Do you want to install this app?</p>
-              <p><button id="confirmInstall">Install</button></p>
-            {{/if}}
-            {{/if}}
-          </div></li>
-        <li id="step-run">App Installed
-          <div class="done-notice">
-            <p>Installation complete.  Click "Apps" to create a new file with this app.</p>
-
-            {{#if hasNewerVersion}}
-              <p>Some of your files were made with a
-                <a href="{{newVersionId}}">newer version</a> of this app.  They will keep
-                using the newer version, as going backwards could break them.</p>
-            {{else}}
-            {{#if hasOlderVersion}}
-              <p>Some of your files were made with an older version of this app.  Upgrade them?</p>
-              <p><button id="upgradeGrains">Upgrade Files</button></p>
-            {{else}}
-              <div id="my-files-arrow"></div>
-            {{/if}}
-            {{/if}}
-          </div></li>
-        <li id="step-delete">Server is currently deleting this app...</li>
-      </ol>
-    </div>
-  {{/if}}
-</template>
- -->
 <template name="account">
   <div class="account">
     {{#if .}}

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -573,7 +573,7 @@ limitations under the License.
 </template>
 
 <template name="appDetails">
-  {{> sandstormAppDetails }}
+  {{> sandstormAppDetailsPage }}
 </template>
 
 <template name="_grainSpinner">
@@ -596,6 +596,10 @@ limitations under the License.
   </div>
 </template>
 
+<template name="install">
+  {{> sandstormAppInstall }}
+</template>
+<!--
 <template name="install">
   {{>title "Install app"}}
 
@@ -657,7 +661,7 @@ limitations under the License.
     </div>
   {{/if}}
 </template>
-
+ -->
 <template name="account">
   <div class="account">
     {{#if .}}

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -153,6 +153,8 @@ button.revoke-token {
 @import "_grainlist.scss";
 // app details page
 @import "_app-details.scss";
+// app installation page
+@import "_install.scss";
 
 #storage-usage {
   margin: 16px 4px;
@@ -302,8 +304,6 @@ div.popup h2 {
   font-weight: bold;
   margin: 4px;
 }
-
-@import "_install.scss";
 
 #sign-in-arrow {
   left: auto;

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -863,6 +863,7 @@ _.extend(SandstormDb.prototype, {
   },
 
   addUserActions: function(packageId) {
+    //TODO(cleanup): implement this with meteor methods rather than client-side inserts/removes.
     var pack = Packages.findOne(packageId);
     if (pack) {
       // Remove old versions.

--- a/shell/packages/sandstorm-ui-app-details/app-details-client.js
+++ b/shell/packages/sandstorm-ui-app-details/app-details-client.js
@@ -32,7 +32,7 @@ var latestAppManifestForAppId = function (db, appId) {
 
 var getAppTitle = function (appDetailsHandle) {
   var pkg = latestPackageForAppId(appDetailsHandle._db, appDetailsHandle._appId);
-  return SandstormDb.appNameFromPackage(pkg);
+  return pkg && SandstormDb.appNameFromPackage(pkg) || "<unknown>";
 };
 
 var matchesGrainTitle = function (needle, grain) {
@@ -82,7 +82,7 @@ var pgpFingerprint = function (pkg) {
   return pkg && pkg.authorPgpKeyFingerprint;
 }
 
-Template.sandstormAppDetails.onCreated(function () {
+Template.sandstormAppDetailsPage.onCreated(function () {
   var ref = Template.instance().data;
   var templateThis = this;
   Tracker.autorun(function () {
@@ -98,7 +98,7 @@ Template.sandstormAppDetails.onCreated(function () {
   });
 });
 
-Template.sandstormAppDetails.onDestroyed(function () {
+Template.sandstormAppDetailsPage.onDestroyed(function () {
   if (this._keybaseSubscription) {
     this._keybaseSubscription.stop();
     this._keybaseSubscription = undefined;
@@ -115,27 +115,149 @@ var contactEmailForPackage = function (pkg) {
 };
 
 Template.sandstormAppDetails.helpers({
+  isPgpKey: function (arg) {
+    return arg === "pgpkey";
+  },
+  appIconSrc: function() {
+    var ref = Template.instance().data;
+    var pkg = ref.pkg;
+    return pkg && Identicon.iconSrcForPackage(pkg, 'appGrid', ref.staticHost);
+  },
+  debug: function () {
+    var ref = Template.instance().data;
+    console.log(ref);
+    console.log(ref.pkg);
+  },
+  appId: function() {
+    var pkg = Template.instance().data.pkg;
+    return pkg && pkg.appId;
+  },
+  appTitle: function() {
+    var pkg = Template.instance().data.pkg;
+    return pkg && SandstormDb.appNameFromPackage(pkg) || "<unknown>";
+  },
+  website: function () {
+    var pkg = Template.instance().data.pkg;
+    return pkg && pkg.manifest && pkg.manifest.metadata && pkg.manifest.metadata.website;
+  },
+  codeUrl: function () {
+    var pkg = Template.instance().data.pkg;
+    return codeUrlForPackage(pkg);
+  },
+  contactEmail: function () {
+    var pkg = Template.instance().data.pkg;
+    return contactEmailForPackage(pkg);
+  },
+  bugReportLink: function () {
+    var pkg = Template.instance().data.pkg;
+    // TODO(someday): allow app manifests to include an explicit bug report link.
+    // If the source code link is a github URL, then append /issues to it and use that.
+    var codeUrl = codeUrlForPackage(pkg);
+    if (codeUrl && codeUrl.lastIndexOf("https://github.com/", 0) === 0) {
+      return codeUrl + "/issues";
+    }
+    // Otherwise, provide a mailto: to the package's contact email if available.
+    var contactEmail = contactEmailForPackage(pkg);
+    if (contactEmail) {
+      return "mailto:" + contactEmail;
+    }
+    // Older app packages may have neither; return undefined.
+    return undefined;
+  },
+  authorPgpFingerprint: function () {
+    var pkg = Template.instance().data.pkg;
+    return pgpFingerprint(pkg);
+  },
+  marketingVersion: function () {
+    var pkg = Template.instance().data.pkg;
+    return pkg && pkg.manifest && pkg.manifest.appMarketingVersion &&
+           pkg.manifest.appMarketingVersion.defaultText || "<unknown>";
+  },
+  publisherDisplayName: function () {
+    var ref = Template.instance().data;
+    var fingerprint = pgpFingerprint(ref.pkg);
+    var profile = ref.keybaseProfile;
+    return (profile && profile.displayName) || fingerprint;
+  },
+  publisherProofs: function () {
+    var ref = Template.instance().data;
+    var pkg = ref.pkg;
+    var fingerprint = pgpFingerprint(pkg);
+    if (!fingerprint) return [];
+    var profile = ref.keybaseProfile;
+    if (!profile) return [];
+
+    var returnValue = [];
+
+    // Add the key fingerprint.
+    var keyFragments = [];
+    for (var i = 0 ; i <= ((fingerprint.length / 4) - 1); i++) {
+      keyFragments.push({ fragment: fingerprint.slice(4*i, 4*(i+1)) });
+    }
+    returnValue.push({
+      proofTypeClass: "pgpkey",
+      linkTarget: "",
+      linkText: fingerprint,
+      keyFragments: keyFragments,
+    });
+
+    // Add the keybase profile for that key
+    if (profile.handle) {
+      returnValue.push({
+        proofTypeClass: "keybase",
+        linkTarget: "https://keybase.io/" + profile.handle,
+        linkText: profile.handle,
+      });
+    }
+
+    var proofs = profile.proofs;
+    if (proofs) {
+      var externalProofs = _.chain(proofs)
+          // Filter down to twitter, github, and web
+          .filter(function(proof) {
+             return _.contains(["twitter", "github", "dns", "https"],
+             proof.proof_type);
+          })
+          // Then map fields into the things the template cares about
+          .map(function (proof) { return {
+            proofTypeClass: proof.proof_type,
+            linkTarget: proof.service_url,
+            linkText: proof.nametag,
+          }; })
+          .value();
+      externalProofs.forEach(function (proof) { returnValue.push(proof) });
+    }
+    return returnValue;
+  },
+});
+
+Template.sandstormAppDetailsPage.helpers({
   setDocumentTitle: function() {
     var ref = Template.instance().data;
     document.title = (getAppTitle(ref) + " details · Sandstorm");
+  },
+  pkg: function() {
+    var ref = Template.instance().data;
+    var pkg = latestPackageForAppId(ref._db, ref._appId);
+    return pkg;
+  },
+  staticHost: function () {
+    var ref = Template.instance().data;
+    return ref._staticHost;
   },
   isAppInDevMode: function() {
     var ref = Template.instance().data;
     var pkg = latestPackageForAppId(ref._db, ref._appId);
     return pkg && pkg.dev;
   },
+  isAppNotInDevMode: function() {
+    var ref = Template.instance().data;
+    var pkg = latestPackageForAppId(ref._db, ref._appId);
+    return !(pkg && pkg.dev);
+  },
   newGrainIsLoading: function () {
     var ref = Template.instance().data;
     return ref._newGrainIsLaunching.get();
-  },
-  appId: function() {
-    var ref = Template.instance().data;
-    return ref._appId
-  },
-  appIconSrc: function() {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
-    return pkg && Identicon.iconSrcForPackage(pkg, 'appGrid', ref._staticHost);
   },
   appTitle: function() {
     var ref = Template.instance().data;
@@ -194,41 +316,6 @@ Template.sandstormAppDetails.helpers({
       Router.go("grain", {grainId: grainId});
     };
   },
-  website: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
-    return pkg && pkg.manifest && pkg.manifest.metadata && pkg.manifest.metadata.website;
-  },
-  codeUrl: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
-    return codeUrlForPackage(pkg);
-  },
-  contactEmail: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
-    return contactEmailForPackage(pkg);
-  },
-  bugReportLink: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
-    // TODO(someday): allow app manifests to include an explicit bug report link.
-    // If the source code link is a github URL, then append /issues to it and use that.
-    var codeUrl = codeUrlForPackage(pkg);
-    if (codeUrl && codeUrl.lastIndexOf("https://github.com/", 0) === 0) {
-      return codeUrl + "/issues";
-    }
-    // Otherwise, provide a mailto: to the package's contact email if available.
-    var contactEmail = contactEmailForPackage(pkg);
-    if (contactEmail) {
-      return "mailto:" + contactEmail;
-    }
-    // Older app packages may have neither; return undefined.
-    return undefined;
-  },
-  isPgpKey: function (arg) {
-    return arg === "pgpkey";
-  },
   filteredSortedGrains: function () {
     var ref = Template.instance().data;
     return filteredSortedGrains(ref._db, ref._staticHost, ref._appId, getAppTitle(ref), ref._filter.get());
@@ -246,76 +333,15 @@ Template.sandstormAppDetails.helpers({
     var ref = Template.instance().data;
     return ref._showPublisherDetails.get();
   },
-  authorPgpFingerprint: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
-    return pgpFingerprint(pkg);
-  },
-  marketingVersion: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
-    return pkg && pkg.manifest && pkg.manifest.appMarketingVersion &&
-           pkg.manifest.appMarketingVersion.defaultText || "<unknown>";
-  },
-  publisherDisplayName: function () {
+  keybaseProfile: function () {
     var ref = Template.instance().data;
     var pkg = latestPackageForAppId(ref._db, ref._appId);
     var fingerprint = pgpFingerprint(pkg);
     var profile = fingerprint && ref._db.getKeybaseProfile(fingerprint);
-    return (profile && profile.displayName) || fingerprint;
-  },
-  publisherProofs: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
-    var fingerprint = pgpFingerprint(pkg);
-    if (!fingerprint) return [];
-    var profile = ref._db.getKeybaseProfile(fingerprint);
-    if (!profile) return [];
-
-    var returnValue = [];
-
-    // Add the key fingerprint.
-    var keyFragments = [];
-    for (var i = 0 ; i <= ((fingerprint.length / 4) - 1); i++) {
-      keyFragments.push({ fragment: fingerprint.slice(4*i, 4*(i+1)) });
-    }
-    returnValue.push({
-      proofTypeClass: "pgpkey",
-      linkTarget: "",
-      linkText: fingerprint,
-      keyFragments: keyFragments,
-    });
-
-    // Add the keybase profile for that key
-    if (profile.handle) {
-      returnValue.push({
-        proofTypeClass: "keybase",
-        linkTarget: "https://keybase.io/" + profile.handle,
-        linkText: profile.handle,
-      });
-    }
-
-    var proofs = profile.proofs;
-    if (proofs) {
-      var externalProofs = _.chain(proofs)
-          // Filter down to twitter, github, and web
-          .filter(function(proof) {
-             return _.contains(["twitter", "github", "dns", "https"],
-             proof.proof_type);
-          })
-          // Then map fields into the things the template cares about
-          .map(function (proof) { return {
-            proofTypeClass: proof.proof_type,
-            linkTarget: proof.service_url,
-            linkText: proof.nametag,
-          }; })
-          .value();
-      externalProofs.forEach(function (proof) { returnValue.push(proof) });
-    }
-    return returnValue;
+    return profile;
   },
 });
-Template.sandstormAppDetails.events({
+Template.sandstormAppDetailsPage.events({
   "input .search-bar": function(event) {
     Template.instance().data._filter.set(event.target.value);
   },

--- a/shell/packages/sandstorm-ui-app-details/app-details.html
+++ b/shell/packages/sandstorm-ui-app-details/app-details.html
@@ -15,6 +15,19 @@
        staticHost=staticHost
        keybaseProfile=keybaseProfile
     }}
+    {{#if hasNewerVersion}}
+    <div class="newer-version">
+      <p>Some of your files were made with a
+        newer version of this app.  They will keep
+        using the newer version, as going backwards could break them.</p>
+    </div>
+    {{/if}}
+    {{#if hasOlderVersion}}
+    <div class="older-version">
+      <p>Some of your files were made with an older version of this app.  Upgrade them?</p>
+      <p><button class="upgradeGrains">Upgrade Files</button></p>
+    </div>
+    {{/if}}
     <div class="search-bar">
       <label>
         <span class="search-icon" title="Search"></span>

--- a/shell/packages/sandstorm-ui-app-details/app-details.html
+++ b/shell/packages/sandstorm-ui-app-details/app-details.html
@@ -1,4 +1,4 @@
-<template name="sandstormAppDetails">
+<template name="sandstormAppDetailsPage">
   {{setDocumentTitle}}
   {{#sandstormTopbarItem name="title" priority=5 topbar=globalTopbar }}{{appTitle}}{{/sandstormTopbarItem}}
   {{#if newGrainIsLoading}}
@@ -6,20 +6,50 @@
           re-using the live HTML and not causing a flash for the user. --}}
     {{> _grainSpinner}}
   {{else}}
+
   <div class="app-details{{#if isAppInDevMode}} dev-background{{/if}}">
+    {{>sandstormAppDetails
+       showPublisherDetails=showPublisherDetails
+       showUninstall=isAppNotInDevMode
+       pkg=pkg
+       staticHost=staticHost
+       keybaseProfile=keybaseProfile
+    }}
+    <div class="search-bar">
+      <label>
+        <span class="search-icon" title="Search"></span>
+        <input class="search-bar" type="text" placeholder="search" value="{{ searchText }}" />
+      </label>
+    </div>
+
+    {{>sandstormGrainTable grains=filteredSortedGrains actions=actions onGrainClicked=onGrainClicked}}
+  </div>
+  {{/if}}
+</template>
+
+<template name="sandstormAppDetails">
+  {{!-- Arguments to this template are:
+       showPublisherDetails: Boolean.  Show Keybase/PGP infomation.
+       showUninstall: Boolean.  Show the uninstall button.
+       pkg: Object shaped like an element from the Packages collection.
+       staticHost: String.  The static wildcard host, needed for identicons.
+       keybaseProfile: Object shaped like an element from the KeybaseProfiles collection.
+  --}}
+  <div class="app-details-widget">
+    {{debug}}
     <div class="app-icon" style="background-image: url('{{appIconSrc}}');"></div>
     <div class="app-details-box">
       <h1 class="app-title">{{appTitle}}</h1>
       <ul class="app-links">
-        {{#if website}}<li role="presentation"><a class="website-link" href="{{website}}">Website</a></li>{{/if}}
-        <li role="presentation"><a class="app-market-link" href="https://apps.sandstorm.io/app/{{appId}}">App Market</a></li>
-        {{#if codeUrl}}<li role="presentation"><a class="source-code-link" href="{{codeUrl}}">Source</a></li>{{/if}}
-        {{#if bugReportLink}}<li role="presentation"><a class="bug-report-link" href="{{bugReportLink}}">Report Issue</a></li>{{/if}}
+        {{#if website}}<li role="presentation"><a class="website-link" target="_blank" href="{{website}}">Website</a></li>{{/if}}
+        <li role="presentation"><a class="app-market-link" target="_blank" href="https://apps.sandstorm.io/app/{{appId}}">App Market</a></li>
+        {{#if codeUrl}}<li role="presentation"><a class="source-code-link" target="_blank" href="{{codeUrl}}">Source</a></li>{{/if}}
+        {{#if bugReportLink}}<li role="presentation"><a class="bug-report-link" target="_blank" href="{{bugReportLink}}">Report Issue</a></li>{{/if}}
       </ul>
       <div class="info-row">
-        {{#unless isAppInDevMode}}
+        {{#if showUninstall}}
         <button class="uninstall-button">Uninstall</button>
-        {{/unless}}
+        {{/if}}
         <ul class="package-info">
           <li class="version">
             <span class="label">Version</span>
@@ -52,6 +82,7 @@
               </span>
             {{else}}
             <a class="{{proofTypeClass}}"
+               target="_blank"
                href="{{linkTarget}}">
                 {{linkText}}
             </a>
@@ -61,15 +92,5 @@
         </ul>
       </div>
     </div>
-
-    <div class="search-bar">
-      <label>
-        <span class="search-icon" title="Search"></span>
-        <input class="search-bar" type="text" placeholder="search" value="{{ searchText }}" />
-      </label>
-    </div>
-
-    {{>sandstormGrainTable grains=filteredSortedGrains actions=actions onGrainClicked=onGrainClicked}}
   </div>
-  {{/if}}
 </template>

--- a/shell/packages/sandstorm-ui-app-details/app-details.html
+++ b/shell/packages/sandstorm-ui-app-details/app-details.html
@@ -85,7 +85,8 @@
         </ul>
       </div>
       <div class="publisher-details {{#unless showPublisherDetails}}hide{{/unless}}">
-        <p>The app publisher has proven using PGP that they control these accounts.</p>
+        {{#if authorPgpFingerprint}}
+        <p class="has-fingerprint">The app publisher has proven using PGP that they control these accounts.</p>
         <ul class="publisher-proofs">
           {{#each publisherProofs}}
           <li class="publisher-proof">
@@ -103,6 +104,9 @@
           </li>
           {{/each}}
         </ul>
+        {{else}}
+        <p class="no-fingerprint">This app has no signature from its creator; its author cannot be verified.</p>
+        {{/if}}
       </div>
     </div>
   </div>

--- a/shell/packages/sandstorm-ui-app-install/install-client.js
+++ b/shell/packages/sandstorm-ui-app-install/install-client.js
@@ -3,11 +3,10 @@ var checkStep = function(step) {
   if (INSTALL_STEPS.indexOf(step) === -1) throw new Error("Invalid step " + step + ".");
 };
 
-SandstormAppInstall = function(packageId, packageUrl, db, quotaEnforcer) {
+SandstormAppInstall = function(packageId, packageUrl, db) {
   this._packageId = packageId;
   this._packageUrl = packageUrl;
   this._db = db;
-  this._quotaEnforcer = quotaEnforcer;
   this._error = new ReactiveVar("");
   this._recoverable = new ReactiveVar(true);
   this._keybaseSubscription = undefined;
@@ -55,10 +54,6 @@ SandstormAppInstall.prototype.step = function () {
   checkStep(pkg.status); // Expect no novel package statuses.
   if (pkg.status !== "ready") return pkg.status;
   return this.isInstalled() ? "run" : "confirm";
-};
-
-SandstormAppInstall.prototype.canRedirectAfterInstall = function () {
-  return this.isInstalled() && !this.hasOlderVersion() && !this.hasNewerVersion()
 };
 
 SandstormAppInstall.prototype.isInstalled = function () {
@@ -201,9 +196,5 @@ Template.sandstormAppInstallPage.events({
   "click #confirmInstall": function (event) {
     var ref = Template.instance().data;
     ref._db.addUserActions(ref.packageId());
-  },
-  "click #upgradeGrains": function (event) {
-    var ref = Template.instance().data;
-    Meteor.call("upgradeGrains", ref.appId(), ref.appVersion(), ref.packageId());
   },
 });

--- a/shell/packages/sandstorm-ui-app-install/install-client.js
+++ b/shell/packages/sandstorm-ui-app-install/install-client.js
@@ -90,7 +90,19 @@ SandstormAppInstall.prototype.hasNewerVersion = function () {
   return false;
 };
 
-SandstormAppInstall.prototype.progress = function () {
+SandstormAppInstall.prototype.hasFractionalProgress = function () {
+  var pkg = this.pkg();
+  var progress = pkg && pkg.progress;
+  return (progress > 0 && progress < 1);
+};
+
+SandstormAppInstall.prototype.progressFraction = function () {
+  var pkg = this.pkg();
+  var progress = pkg && pkg.progress;
+  return progress;
+}
+
+SandstormAppInstall.prototype.progressText = function () {
   var pkg = this.pkg();
   var progress = pkg && pkg.progress;
   if (!progress) return ""
@@ -153,9 +165,17 @@ Template.sandstormAppInstallPage.helpers({
     var ref = Template.instance().data;
     return ref.step() === step;
   },
-  progress: function () {
+  hasFractionalProgress: function () {
     var ref = Template.instance().data;
-    return ref.progress();
+    return ref.hasFractionalProgress();
+  },
+  progressFraction: function () {
+    var ref = Template.instance().data;
+    return ref.progressFraction();
+  },
+  progressText: function () {
+    var ref = Template.instance().data;
+    return ref.progressText();
   },
   pkg: function () {
     var ref = Template.instance().data;

--- a/shell/packages/sandstorm-ui-app-install/install-client.js
+++ b/shell/packages/sandstorm-ui-app-install/install-client.js
@@ -1,0 +1,209 @@
+var INSTALL_STEPS = ["download", "verify", "unpack", "analyze", "ready", "failed", "delete"];
+var checkStep = function(step) {
+  if (INSTALL_STEPS.indexOf(step) === -1) throw new Error("Invalid step " + step + ".");
+};
+
+SandstormAppInstall = function(packageId, packageUrl, db, quotaEnforcer) {
+  this._packageId = packageId;
+  this._packageUrl = packageUrl;
+  this._db = db;
+  this._quotaEnforcer = quotaEnforcer;
+  this._error = new ReactiveVar("");
+  this._recoverable = new ReactiveVar(true);
+  this._keybaseSubscription = undefined;
+};
+
+SandstormAppInstall.prototype.pkg = function () {
+  return this._packageId && this._db.collections.packages.findOne(this._packageId);
+};
+
+SandstormAppInstall.prototype.appId = function () {
+  var pkg = this.pkg();
+  return pkg && pkg.appId;
+};
+
+SandstormAppInstall.prototype.packageId = function () {
+  return this._packageId;
+};
+
+SandstormAppInstall.prototype.packageUrl = function () {
+  return this._packageUrl;
+};
+
+SandstormAppInstall.prototype.setUnrecoverableError = function (error) {
+  this._error.set(error);
+  this._recoverable.set(false);
+}
+
+SandstormAppInstall.prototype.setError = function (error) {
+  this._error.set(error);
+};
+
+SandstormAppInstall.prototype.error = function () {
+  return this._error.get();
+};
+
+SandstormAppInstall.prototype.appVersion = function () {
+  var pkg = this.pkg();
+  return pkg && pkg.manifest && pkg.manifest.appVersion;
+};
+
+SandstormAppInstall.prototype.step = function () {
+  if (this._error.get() !== "") return "error"; // Some error not associated with the package in the DB
+  var pkg = this.pkg();
+  if (!pkg) return "wait"; // Awaiting write access
+  checkStep(pkg.status); // Expect no novel package statuses.
+  if (pkg.status !== "ready") return pkg.status;
+  return this.isInstalled() ? "run" : "confirm";
+};
+
+SandstormAppInstall.prototype.canRedirectAfterInstall = function () {
+  return this.isInstalled() && !this.hasOlderVersion() && !this.hasNewerVersion()
+};
+
+SandstormAppInstall.prototype.isInstalled = function () {
+  return this._db.collections.userActions.findOne({userId: Meteor.userId(), packageId: this.packageId()});
+};
+
+SandstormAppInstall.prototype.hasOlderVersion = function () {
+  var existingGrains = this._db.collections.grains.find({userId: Meteor.userId(), appId: this.appId() }).fetch();
+  var thisVersion = this.appVersion();
+  for (var i in existingGrains) {
+    var grain = existingGrains[i];
+    if (grain.packageId !== this.packageId()) {
+      // Some other package version.
+      if (grain.appVersion <= thisVersion) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+SandstormAppInstall.prototype.hasNewerVersion = function () {
+  var existingGrains = this._db.collections.grains.find({userId: Meteor.userId(), appId: this.appId() }).fetch();
+  var thisVersion = this.appVersion();
+  for (var i in existingGrains) {
+    var grain = existingGrains[i];
+    if (grain.packageId !== this.packageId()) {
+      // Some other package version.
+      if (grain.appVersion > thisVersion) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+SandstormAppInstall.prototype.progress = function () {
+  var pkg = this.pkg();
+  var progress = pkg && pkg.progress;
+  if (!progress) return ""
+  if (progress < 0) return ""; // -1 means no progress to report
+  if (progress > 1) {
+    // Progress outside [0,1] indicates a byte count rather than a fraction.
+    // TODO(cleanup):  This is pretty ugly.  What if exactly 1 byte had been downloaded?
+    return Math.round(progress / 1024) + " KiB";
+  }
+  // Value between 0 and 1 indicates fractional progress.
+  return Math.round(progress * 100) + "%";
+};
+
+Template.sandstormAppInstall.onCreated(function () {
+  var ref = Template.instance().data;
+  Tracker.autorun(function () {
+    var pkg = ref.pkg();
+    if (ref._keybaseSubscription) {
+      ref._keybaseSubscription.stop();
+      ref._keybaseSubscription = undefined;
+    }
+    var fingerprint = pkg && pkg.authorPgpKeyFingerprint;
+    if (fingerprint) {
+      ref._keybaseSubscription = Meteor.subscribe("keybaseProfile", fingerprint);
+    }
+  });
+});
+
+Template.sandstormAppInstall.onDestroyed(function () {
+  if (this._keybaseSubscription) {
+    this._keybaseSubscription.stop();
+    this._keybaseSubscription = undefined;
+  }
+});
+
+Template.sandstormAppInstall.helpers({
+  setDocumentTitle: function() {
+    document.title = "Installing app · Sandstorm";
+  },
+  error: function() {
+    var ref = Template.instance().data;
+    return ref.error();
+  },
+  step: function() {
+    var ref = Template.instance().data;
+    return ref.step();
+  },
+  ready: function () {
+    return !!Template.instance().data;
+  },
+  packageId: function () {
+    var ref = Template.instance().data;
+    return ref.packageId();
+  },
+  packageUrl: function () {
+    var ref = Template.instance().data;
+    return ref.packageUrl();
+  },
+  isCurrentStep: function (step) {
+    var ref = Template.instance().data;
+    return ref.step() === step;
+  },
+  progress: function () {
+    var ref = Template.instance().data;
+    return ref.progress();
+  },
+  pkg: function () {
+    var ref = Template.instance().data;
+    return ref.pkg();
+  },
+  staticHost: function () {
+    var ref = Template.instance().data;
+    return ref._db.makeWildcardHost("static");
+  },
+  keybaseProfile: function () {
+    var ref = Template.instance().data;
+    var pkg = ref.pkg();
+    var fingerprint = pkg && pkg.authorPgpKeyFingerprint;
+    var profile = fingerprint && ref._db.getKeybaseProfile(fingerprint);
+    return profile;
+  },
+  appTitle: function () {
+    var ref = Template.instance().data;
+    var pkg = ref.pkg();
+    return pkg && SandstormDb.appNameFromPackage(pkg);
+  },
+  appId: function () {
+    var ref = Template.instance().data;
+    return ref.appId();
+  },
+});
+
+Template.sandstormAppInstall.events({
+  "click #retry": function(event) {
+    var ref = Template.instance().data;
+    Meteor.call("ensureInstalled", ref._packageId, ref._packageUrl, true);
+  },
+  "click #cancelDownload": function (event) {
+    var ref = Template.instance().data;
+    Meteor.call("cancelDownload", ref.packageId());
+    Router.go('apps');
+  },
+  "click #confirmInstall": function (event) {
+    var ref = Template.instance().data;
+    ref._db.addUserActions(ref.packageId());
+  },
+  "click #upgradeGrains": function (event) {
+    var ref = Template.instance().data;
+    Meteor.call("upgradeGrains", ref.appId(), ref.appVersion(), ref.packageId());
+  },
+});

--- a/shell/packages/sandstorm-ui-app-install/install-client.js
+++ b/shell/packages/sandstorm-ui-app-install/install-client.js
@@ -109,7 +109,7 @@ SandstormAppInstall.prototype.progress = function () {
   return Math.round(progress * 100) + "%";
 };
 
-Template.sandstormAppInstall.onCreated(function () {
+Template.sandstormAppInstallPage.onCreated(function () {
   var ref = Template.instance().data;
   Tracker.autorun(function () {
     var pkg = ref.pkg();
@@ -124,14 +124,14 @@ Template.sandstormAppInstall.onCreated(function () {
   });
 });
 
-Template.sandstormAppInstall.onDestroyed(function () {
+Template.sandstormAppInstallPage.onDestroyed(function () {
   if (this._keybaseSubscription) {
     this._keybaseSubscription.stop();
     this._keybaseSubscription = undefined;
   }
 });
 
-Template.sandstormAppInstall.helpers({
+Template.sandstormAppInstallPage.helpers({
   setDocumentTitle: function() {
     document.title = "Installing app · Sandstorm";
   },
@@ -188,7 +188,7 @@ Template.sandstormAppInstall.helpers({
   },
 });
 
-Template.sandstormAppInstall.events({
+Template.sandstormAppInstallPage.events({
   "click #retry": function(event) {
     var ref = Template.instance().data;
     Meteor.call("ensureInstalled", ref._packageId, ref._packageUrl, true);

--- a/shell/packages/sandstorm-ui-app-install/install-server.js
+++ b/shell/packages/sandstorm-ui-app-install/install-server.js
@@ -1,0 +1,15 @@
+Meteor.publish("packageInfo", function (packageId) {
+  check(packageId, String);
+  var db = this.connection.sandstormDb;
+  var pkgCursor = db.collections.packages.find(packageId);
+  var pkg = pkgCursor.fetch()[0];
+  if (pkg && this.userId) {
+    return [
+      pkgCursor,
+      db.collections.userActions.find({ userId: this.userId, appId: pkg.appId }),
+      db.collections.grains.find({ userId: this.userId, appId: pkg.appId}),
+    ];
+  } else {
+    return pkgCursor;
+  }
+});

--- a/shell/packages/sandstorm-ui-app-install/install.html
+++ b/shell/packages/sandstorm-ui-app-install/install.html
@@ -18,7 +18,13 @@
     {{#if isCurrentStep "download"}}
       <div id="step-download">
         <h1>Downloading...</h1>
-        <p><span class="progress">{{progress}}</span></p>
+        <p class="centered">
+          {{#if hasFractionalProgress}}
+          <progress class="progress" value="{{progressFraction}}">{{progressText}}</progress>
+          {{else}}
+          <span class="progress">{{progressText}}</span>
+          {{/if}}
+        </p>
         <p><button id="cancelDownload">Cancel</button></p>
       </div>
     {{/if}}

--- a/shell/packages/sandstorm-ui-app-install/install.html
+++ b/shell/packages/sandstorm-ui-app-install/install.html
@@ -1,0 +1,99 @@
+<template name="sandstormAppInstall">
+  {{setDocumentTitle}}
+  {{#sandstormTopbarItem name="title" priority=5 topbar=globalTopbar}}Install app{{/sandstormTopbarItem}}
+{{#if ready}}
+  {{#if error }}
+    <div class="install">
+      <h1>Failed to install app</h1>
+      <pre>{{error}}</pre>
+      <button id="retry">Try Again</button>
+    </div>
+  {{else}}
+    <div class="install">
+    {{#if isCurrentStep "wait"}}
+      <div id="step-wait">
+        <h1>Waiting for write access...</h1>
+      </div>
+    {{/if}}
+    {{#if isCurrentStep "download"}}
+      <div id="step-download">
+        <h1>Downloading...</h1>
+        <p><span class="progress">{{progress}}</span></p>
+        <p><button id="cancelDownload">Cancel</button></p>
+      </div>
+    {{/if}}
+    {{#if isCurrentStep "verify"}}
+      <div id="step-verify">
+        <h1>Verifying...</h1>
+      </div>
+    {{/if}}
+    {{#if isCurrentStep "unpack"}}
+      <div id="step-unpack">
+        <h1>Unpacking...</h1>
+      </div>
+    {{/if}}
+    {{#if isCurrentStep "analyze"}}
+      <div id="step-analyze">
+        <h1>Analyzing...</h1>
+      </div>
+    {{/if}}
+    {{#if isCurrentStep "confirm"}}
+      <div id="step-confirm">
+        <h1>Install {{ appTitle }}?</h1>
+        {{> sandstormAppDetails
+           showPublisherDetails=true
+           showUninstall=false
+           pkg=pkg
+           staticHost=staticHost
+           keybaseProfile=keybaseProfile
+        }}
+        <div class="confirm-form">
+          {{#if hasOlderVersion}}
+            <p>You have an older version of this app installed.  Do you want to upgrade?</p>
+            <p><button id="confirmInstall">Upgrade {{ appTitle }}</button></p>
+          {{else}}
+            {{#if hasNewerVersion}}
+              <p>You already have a newer version of this app installed.  Are
+                you sure you want to revert to this older version?</p>
+              <p><button id="confirmInstall">Downgrade {{ appTitle }}</button></p>
+            {{else}}
+              <p><button id="confirmInstall">Install {{ appTitle }}</button></p>
+            {{/if}}
+          {{/if}}
+        </div>
+      </div>
+    {{/if}}
+    {{#if isCurrentStep "run"}}
+      <div id="step-run">
+        <h1>{{ appTitle }} installed</h1>
+        <div class="done-notice">
+          <p>Installation complete.</p>
+          {{#if hasNewerVersion}}
+            <p>Some of your files were made with a
+              newer version of this app.  They will keep
+              using the newer version, as going backwards could break them.</p>
+            <p><a href="{{pathFor route='appDetails' appId=appId}}">Go to {{appTitle}}</a></p>
+          {{/if}}
+          {{#if hasOlderVersion}}
+            <p>Some of your files were made with an older version of this app.  Upgrade them?</p>
+            <p><button id="upgradeGrains">Upgrade Files</button></p>
+          {{/if}}
+        </div>
+      </div>
+    {{/if}}
+    {{#if isCurrentStep "delete"}}
+      <div id="step-delete">
+        <h1>Deleting...</h1>
+        <p>Server is currently deleting this app...</p>
+      </div>
+    {{/if}}
+    {{#if isCurrentStep "failed"}}
+      <div id="step-failed">
+        <h1>Failed</h1>
+        <p>Installation failed: {{error}}</p>
+      </div>
+    {{/if}}
+    </div>
+  {{/if}}
+{{/if}}
+</template>

--- a/shell/packages/sandstorm-ui-app-install/install.html
+++ b/shell/packages/sandstorm-ui-app-install/install.html
@@ -64,20 +64,13 @@
       </div>
     {{/if}}
     {{#if isCurrentStep "run"}}
+      {{!-- Note that this step should never really be shown -- you should be redirected to the app
+            page in this scenario automatically. --}}
       <div id="step-run">
         <h1>{{ appTitle }} installed</h1>
         <div class="done-notice">
           <p>Installation complete.</p>
-          {{#if hasNewerVersion}}
-            <p>Some of your files were made with a
-              newer version of this app.  They will keep
-              using the newer version, as going backwards could break them.</p>
-            <p><a href="{{pathFor route='appDetails' appId=appId}}">Go to {{appTitle}}</a></p>
-          {{/if}}
-          {{#if hasOlderVersion}}
-            <p>Some of your files were made with an older version of this app.  Upgrade them?</p>
-            <p><button id="upgradeGrains">Upgrade Files</button></p>
-          {{/if}}
+          <p><a href="{{pathFor 'appDetails' appId=appId}}">Go to {{appTitle}}</a></p>
         </div>
       </div>
     {{/if}}

--- a/shell/packages/sandstorm-ui-app-install/install.html
+++ b/shell/packages/sandstorm-ui-app-install/install.html
@@ -1,4 +1,4 @@
-<template name="sandstormAppInstall">
+<template name="sandstormAppInstallPage">
   {{setDocumentTitle}}
   {{#sandstormTopbarItem name="title" priority=5 topbar=globalTopbar}}Install app{{/sandstormTopbarItem}}
 {{#if ready}}

--- a/shell/packages/sandstorm-ui-app-install/package.js
+++ b/shell/packages/sandstorm-ui-app-install/package.js
@@ -1,0 +1,27 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Package.describe({
+  summary: "Sandstorm UI install page",
+  version: "0.1.0"
+});
+
+Package.onUse(function (api) {
+  api.use(["check", "reactive-var", "reload", "templating", "tracker", "underscore", "sandstorm-db", "sandstorm-ui-app-details"], "client");
+  api.addFiles(["install-server.js"], "server");
+  api.addFiles(["install.html", "install-client.js"], "client");
+  api.export("SandstormAppInstall");
+});

--- a/shell/packages/sandstorm-ui-applist/applist-client.js
+++ b/shell/packages/sandstorm-ui-applist/applist-client.js
@@ -1,10 +1,9 @@
-SandstormAppList = function(db, quotaEnforcer, highlight) {
+SandstormAppList = function(db, quotaEnforcer) {
   this._filter = new ReactiveVar("");
   this._sortOrder = new ReactiveVar([["appTitle", 1]]);
   this._staticHost = db.makeWildcardHost("static");
   this._db = db;
   this._quotaEnforcer = quotaEnforcer;
-  this._highlight = highlight;
   this._uninstalling = new ReactiveVar(false);
 }
 
@@ -141,9 +140,6 @@ Template.sandstormAppList.helpers({
   isSignedUpOrDemo: function() {
     return this._db.isSignedUpOrDemo();
   },
-  shouldHighlight: function () {
-    return this.appId === Template.instance().data._highlight;
-  },
   showMostPopular: function () {
     // Only show if not searching, not uninstalling, and you have apps installed
     var ref = Template.instance().data;
@@ -216,28 +212,13 @@ Template.sandstormAppList.events({
   }
 });
 Template.sandstormAppList.onRendered(function () {
-  // Scroll to highlighted app, if any.
-  if (this.data._highlight) {
-    var self = this;
-    this.autorun(function (computation) {
-      if (self.subscriptionsReady()) {
-        var item = self.findAll(".highlight")[0];
-        if (item) {
-          item.focus();
-          item.scrollIntoView();
-        }
-        computation.stop();
-      }
-    });
-  } else {
-    // Auto-focus search bar on desktop, but not mobile (on mobile it will open the software
-    // keyboard which is undesirable). window.orientation is generally defined on mobile browsers
-    // but not desktop browsers, but some mobile browsers don't support it, so we also check
-    // clientWidth. Note that it's better to err on the side of not auto-focusing.
-    if (window.orientation === undefined && window.innerWidth > 600) {
-      var searchbar = this.findAll(".search-bar")[0];
-      if (searchbar) searchbar.focus();
-    }
+  // Auto-focus search bar on desktop, but not mobile (on mobile it will open the software
+  // keyboard which is undesirable). window.orientation is generally defined on mobile browsers
+  // but not desktop browsers, but some mobile browsers don't support it, so we also check
+  // clientWidth. Note that it's better to err on the side of not auto-focusing.
+  if (window.orientation === undefined && window.innerWidth > 600) {
+    var searchbar = this.findAll(".search-bar")[0];
+    if (searchbar) searchbar.focus();
   }
 });
 Template.sandstormAppList.onCreated(function () {

--- a/shell/packages/sandstorm-ui-applist/applist-client.js
+++ b/shell/packages/sandstorm-ui-applist/applist-client.js
@@ -92,7 +92,7 @@ var matchApps = function (searchString) {
   return matchingApps;
 };
 
-Template.sandstormAppList.helpers({
+Template.sandstormAppListPage.helpers({
   setDocumentTitle: function() {
     document.title = "Apps · Sandstorm";
   },
@@ -154,7 +154,7 @@ Template.sandstormAppList.helpers({
     return Template.instance().appIsLoading.get();
   },
 });
-Template.sandstormAppList.events({
+Template.sandstormAppListPage.events({
   "click .install-button": function (event) {
     event.preventDefault();
     event.stopPropagation();
@@ -211,7 +211,7 @@ Template.sandstormAppList.events({
     }
   }
 });
-Template.sandstormAppList.onRendered(function () {
+Template.sandstormAppListPage.onRendered(function () {
   // Auto-focus search bar on desktop, but not mobile (on mobile it will open the software
   // keyboard which is undesirable). window.orientation is generally defined on mobile browsers
   // but not desktop browsers, but some mobile browsers don't support it, so we also check
@@ -221,6 +221,6 @@ Template.sandstormAppList.onRendered(function () {
     if (searchbar) searchbar.focus();
   }
 });
-Template.sandstormAppList.onCreated(function () {
+Template.sandstormAppListPage.onCreated(function () {
   this.appIsLoading = new ReactiveVar(false);
 });

--- a/shell/packages/sandstorm-ui-applist/applist.html
+++ b/shell/packages/sandstorm-ui-applist/applist.html
@@ -1,4 +1,4 @@
-<template name="sandstormAppList">
+<template name="sandstormAppListPage">
   {{setDocumentTitle}}
   {{#sandstormTopbarItem name="title" priority=5 topbar=globalTopbar }}Apps{{/sandstormTopbarItem}}
   {{#if appIsLoading}}

--- a/shell/packages/sandstorm-ui-applist/applist.html
+++ b/shell/packages/sandstorm-ui-applist/applist.html
@@ -57,14 +57,14 @@
     {{!-- data-app-id is only used for testing purposes --}}
     {{#each apps }}
     {{#if uninstalling}}
-    <button class="app-button uninstall-action {{#if shouldHighlight}}highlight{{/if}}"
+    <button class="app-button uninstall-action"
             data-app-id="{{appId}}">
       <div class="app-icon" style="background-image: url('{{ iconSrc }}');"></div>
       <span class="app-title">{{appTitle}}</span>
       <span class="action-text">Uninstall</span>
     </button>
     {{else}}
-    <a class="app-button {{#if dev}}dev-background {{/if}}{{#if shouldHighlight}}highlight{{/if}}" href="/apps/{{appId}}"
+    <a class="app-button {{#if dev}}dev-background {{/if}}" href="/apps/{{appId}}"
             data-app-id="{{appId}}">
       <div class="app-icon" style="background-image: url('{{ iconSrc }}');"></div>
       <span class="app-title">{{appTitle}}</span>

--- a/shell/server/installer.js
+++ b/shell/server/installer.js
@@ -99,8 +99,7 @@ var startInstallInternal = function (package) {
 }
 
 cancelDownload = function (packageId) {
-  Packages.update({_id: packageId, status: "download"},
-      {$set: {status: "failed"}, $unset: {url: ""}});
+  Packages.remove({_id: packageId, status: "download"});
 }
 
 var cancelDownloadInternal = function (package) {

--- a/shell/server/installer.js
+++ b/shell/server/installer.js
@@ -477,7 +477,7 @@ AppInstaller.prototype.doDownloadTo = function (out) {
           this.updateProgress("download", bytesReceived);
         }
       }
-    }), 1000);
+    }), 500);
 
     response.on("data", this.wrapCallback(function (chunk) {
       hasher.update(chunk);

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1336,7 +1336,7 @@ Router.map(function () {
         Router.go("root", {}, {replaceState: true});
       }
 
-      return new SandstormAppList(globalDb, globalQuotaEnforcer, this.params.query.highlight);
+      return new SandstormAppList(globalDb, globalQuotaEnforcer);
     },
   });
   this.route("newGrainRedirect", {

--- a/tests/commands/installApp.js
+++ b/tests/commands/installApp.js
@@ -17,7 +17,6 @@
 "use strict";
 
 var utils = require("../utils"),
-    appSelector = utils.appSelector,
     actionSelector = utils.actionSelector,
     short_wait = utils.short_wait,
     medium_wait = utils.medium_wait,
@@ -31,12 +30,11 @@ exports.command = function(url, packageId, appId, dontStartGrain, callback) {
     .waitForElementVisible("#step-confirm", very_long_wait)
     .click("#confirmInstall")
     .url(this.launch_url + "/apps")
-    .waitForElementVisible(".app-list", medium_wait)
+    .waitForElementVisible(".app-details", medium_wait)
     .resizeWindow(utils.default_width, utils.default_height);
 
   if (!dontStartGrain) {
     ret = ret
-      .click(appSelector(appId))
       .waitForElementVisible(actionSelector, short_wait)
       .click(actionSelector)
       .waitForElementVisible("#grainTitle", medium_wait);

--- a/tests/commands/installApp.js
+++ b/tests/commands/installApp.js
@@ -18,6 +18,7 @@
 
 var utils = require("../utils"),
     actionSelector = utils.actionSelector,
+    appSelector = utils.appSelector,
     short_wait = utils.short_wait,
     medium_wait = utils.medium_wait,
     long_wait = utils.long_wait,
@@ -30,11 +31,12 @@ exports.command = function(url, packageId, appId, dontStartGrain, callback) {
     .waitForElementVisible("#step-confirm", very_long_wait)
     .click("#confirmInstall")
     .url(this.launch_url + "/apps")
-    .waitForElementVisible(".app-details", medium_wait)
+    .waitForElementVisible(".app-list", medium_wait)
     .resizeWindow(utils.default_width, utils.default_height);
 
   if (!dontStartGrain) {
     ret = ret
+      .click(appSelector(appId))
       .waitForElementVisible(actionSelector, short_wait)
       .click(actionSelector)
       .waitForElementVisible("#grainTitle", medium_wait);

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -17,7 +17,7 @@
 'use strict';
 
 var utils = require('../utils'),
-    appSelector = utils.appSelector,
+    appDetailsTitleSelector = utils.appDetailsTitleSelector,
     actionSelector = utils.actionSelector,
     short_wait = utils.short_wait,
     medium_wait = utils.medium_wait,
@@ -119,13 +119,12 @@ module.exports = utils.testAllLogins({
       .url(browser.launch_url + "/install/ca690ad886bf920026f8b876c19539c1?url=http://sandstorm.io/apps/ssjekyll8.spk")
       .waitForElementVisible('#step-confirm', very_long_wait)
       .click('#confirmInstall')
-      .waitForElementVisible(appSelector('nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh'), short_wait)
-      .assert.containsText(appSelector('nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh')+'>.app-title', 'Hacker CMS');
+      .waitForElementVisible(appDetailsTitleSelector, short_wait)
+      .assert.containsText(appDetailsTitleSelector, 'Hacker CMS')
   },
 
   "Test new grain" : function (browser) {
     browser
-      .click(appSelector('nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh'))
       .waitForElementVisible(actionSelector, short_wait)
       .click(actionSelector)
       .waitForElementVisible('#grainTitle', medium_wait)
@@ -212,14 +211,9 @@ module.exports["Test roleless sharing"] = function (browser) {
     .url(browser.launch_url + "/install/ca690ad886bf920026f8b876c19539c1?url=http://sandstorm.io/apps/ssjekyll8.spk")
     .waitForElementVisible('#step-confirm', very_long_wait)
     .click('#confirmInstall')
-    .waitForElementVisible(
-      appSelector('nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh'),
-      short_wait)
-    .assert.containsText(
-      appSelector('nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh'),
-      'Hacker CMS')
+    .waitForElementVisible(appDetailsTitleSelector, short_wait)
+    .assert.containsText(appDetailsTitleSelector, 'Hacker CMS')
     // Create grain with that user
-    .click(appSelector('nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh'))
     .waitForElementVisible(actionSelector, short_wait)
     .click(actionSelector)
     .waitForElementVisible('#grainTitle', medium_wait)
@@ -294,14 +288,9 @@ module.exports["Test role sharing"] = function (browser) {
     .url(browser.launch_url + "/install/21f8dba75cf1bd9f51b97311ae64aaca?url=http://sandstorm.io/apps/etherpad9.spk")
     .waitForElementVisible('#step-confirm', very_long_wait)
     .click('#confirmInstall')
-    .waitForElementVisible(
-      appSelector('h37dm17aa89yrd8zuqpdn36p6zntumtv08fjpu8a8zrte7q1cn60'),
-      short_wait)
-    .assert.containsText(
-      appSelector('h37dm17aa89yrd8zuqpdn36p6zntumtv08fjpu8a8zrte7q1cn60'),
-      'Etherpad')
+    .waitForElementVisible(appDetailsTitleSelector, short_wait)
+    .assert.containsText(appDetailsTitleSelector, 'Etherpad')
     // Create grain with that user
-    .click(appSelector('h37dm17aa89yrd8zuqpdn36p6zntumtv08fjpu8a8zrte7q1cn60'))
     .waitForElementVisible(actionSelector, short_wait)
     .click(actionSelector)
 
@@ -363,14 +352,9 @@ module.exports["Test grain incognito interstitial"] = function (browser) {
     .url(browser.launch_url + "/install/ca690ad886bf920026f8b876c19539c1?url=http://sandstorm.io/apps/ssjekyll8.spk")
     .waitForElementVisible('#step-confirm', very_long_wait)
     .click('#confirmInstall')
-    .waitForElementVisible(
-      appSelector('nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh'),
-      short_wait)
-    .assert.containsText(
-      appSelector('nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh'),
-      'Hacker CMS')
+    .waitForElementVisible(appDetailsTitleSelector, short_wait)
+    .assert.containsText(appDetailsTitleSelector, 'Hacker CMS')
     // Create grain with that user
-    .click(appSelector('nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh'))
     .waitForElementVisible(actionSelector, short_wait)
     .click(actionSelector)
     .waitForElementVisible('#grainTitle', medium_wait)

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -53,5 +53,6 @@ module.exports = {
   appSelector: function (appId) {
     return '.app-list>.app-button[data-app-id="' + appId + '"]';
   },
+  appDetailsTitleSelector: '.app-details .app-details-widget .app-title',
   actionSelector: '.grain-list-table tr.action button.action'
 };


### PR DESCRIPTION
Adapted the app details components to allow for reuse in the install flow.

If "safe", installing an app proceeds directly to the app page after successful
download and installation.  If not known safe, users are prompted with the details
of the app before confirming installation.

Fixes #15 (as of this writing, the oldest open bug!)
Fixes #1043
Fixes #1135 as part of the refactor
Closes #873