### PR TITLE
Whitelist the owncloud mobile client apps for HTTP Basic auth.

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -45,6 +45,8 @@ BASIC_AUTH_USER_AGENTS = [
   "GitHub-Hookshot\\/",
   "mirall\\/",
   "Mozilla\\/5\\.0 \\([^\\\\]*\\) mirall\\/",
+  "Mozilla\\/5\\.0 \\(iOS\\) ownCloud-iOS\\/",
+  "Mozilla\\/5\\.0 \\(Android\\) ownCloud-android\\/",
   "litmus\\/",
 ];
 BASIC_AUTH_USER_AGENTS_REGEX = new RegExp("^(" + BASIC_AUTH_USER_AGENTS.join("|") + ")", '');


### PR DESCRIPTION
This will result in us sending a 401 to the apps when they try to connect
without providing credentials.

@mnutt do you think this change will allow the owncloud mobile apps to work with Davros on Sandstorm, or will additional changes be needed?