### PR TITLE
Add note to run `vagrant-spk dev` before packaging

### DIFF
--- a/docs/vagrant-spk/packaging-tutorial-meteor.md
+++ b/docs/vagrant-spk/packaging-tutorial-meteor.md
@@ -361,6 +361,10 @@ vagrant-spk pack ~/projects/package.spk
 This will take a few moments, and once it is done, there will be a
 file in `~/projects/package.spk` that contains the full app.
 
+Note
+
+Packaging your data requires running the `vagrant-spk dev` command first. `vagrant-spk pack` only copies the output from the dev command into the package. This might be an oversight when applying minor changes without testing on your local sandstorm instance.
+
 You can see how large it is by running the following command:
 
 ```bash


### PR DESCRIPTION
This was a bit of a stumbling block for me this morning, which zarvox (on IRC, not sure what their GitHub handle is) helped me fix through troubleshooting that I hadn't actually built the app before packaging it. This note might prevent future people from having the same problem.

Edit: I also stole the note syntax from [the readthedocs documentation](https://read-the-docs.readthedocs.org/en/latest/versions.html). Hopefully it works!
