### PR TITLE
Protect against missing Overwrite header in WebDAV MOVE or COPY

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1634,7 +1634,7 @@ Proxy.prototype.handleRequest = function (request, data, response, retryCount) {
     }
 
     function noOverwrite() {
-      return request.headers["overwrite"].toLowerCase() === "f";
+      return (request.headers["overwrite"] || "").toLowerCase() === "f";
     }
 
     function destination() {


### PR DESCRIPTION
The "overwrite" header seems to be somewhat optional, defaulting to "t", so we should make sure the proxy doesn't break if it doesn't get sent on a `MOVE` or `COPY` action.