### PR TITLE
Adjust `make update-deps` to pull from the remote branch that has the...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ update-deps:
 	@$(foreach DEP,capnproto ekam libseccomp libsodium node-capnp, \
 	    cd deps/$(DEP) && \
 	    echo "pulling $(DEP)..." && \
-	    git pull $(REMOTE_$(DEP)) && \
+	    git pull $(REMOTE_$(DEP)) `git symbolic-ref --short HEAD` && \
 	    cd ../..;)
 
 # ====================================================================


### PR DESCRIPTION
...same name as the current branch. Usually this is 'master', but in the case of libsodium, it is 'stable'.

https://github.com/sandstorm-io/sandstorm/commit/0c4b4d106cf64ebb60ab73dd95137d54f9629bb5 is broken. `git pull` by default tries to merge the master branch of the remote into the current branch. For libsodium, we need to specify that we want to merge the stable branch if that's what we are currently on.