### PR TITLE
Docs: Add example for using PNGs as app icons.

### DIFF
--- a/docs/developing/publishing-apps.md
+++ b/docs/developing/publishing-apps.md
@@ -129,7 +129,7 @@ Your app's manifest, or package definition file, (`sandstorm-pkgdef.capnp`) cont
 
 #### icons
 
-You can embed both SVGs or PNGs, and Sandstorm will use the best version provided for the use in question.
+You can embed both SVGs or PNGs, and Sandstorm will use the best version provided for the use in question. Using PNGs requires a slightly different structure, which you can find an example of [here](https://github.com/dwrensha/sharelatex/blob/sandstorm-app/sandstorm-pkgdef.capnp#L26).
 
 * The `appGrid` icon represents your app on the "New" screen on Sandstorm. It should be 128 x 128 pixels, and no larger than 64 KB.
 * The `grain` icon represents individual grains on both the navbar and the grain list. It should be 24 x 24 pixels, and no larger than 4 KB. If you omit this, the appGrid icon will be used.


### PR DESCRIPTION
This is probably not the best way to explain it, but it's short, and it works. Most people are using SVGs, so I don't want to devote a large amount of page space to it, so long as this is a single-page document.