### PR TITLE
Change the app-index to produce index-unpublished.json

### DIFF
--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -84,6 +84,7 @@ function wwwHandlerForGrain(grainId) {
     };
 
     if (path === "apps/index.json" ||
+        path === "apps/index-unpublished.json" ||
         path.match(/apps\/[a-z0-9]{52}[.]json/)) {
       // TODO(cleanup): Extra special terrible hack: The app index needs to serve these JSON files
       //   cross-origin. We could almost just make all web sites allow cross-origin since generally

--- a/src/sandstorm/app-index/app-index.c++
+++ b/src/sandstorm/app-index/app-index.c++
@@ -137,7 +137,7 @@ public:
           indexer.getSubmissionStatus(packageId, response);
 
           auto status = response.getRoot<SubmissionStatus>();
-          if (status.isApproved() && changed) {
+          if (changed) {
             // Force update now!
             indexer.updateIndex();
           }

--- a/src/sandstorm/app-index/indexer.c++
+++ b/src/sandstorm/app-index/indexer.c++
@@ -226,7 +226,7 @@ public:
 
 }  // namespace
 
-void Indexer::updateIndex() {
+void Indexer::updateIndexInternal(kj::StringPtr outputFilename, bool unapprovedApps) {
   capnp::MallocMessageBuilder scratch;
   auto orphanage = scratch.getOrphanage();
 
@@ -248,7 +248,10 @@ void Indexer::updateIndex() {
 
       capnp::StreamFdMessageReader statusMessage(raiiOpen(statusFile, O_RDONLY));
       auto status = statusMessage.getRoot<SubmissionStatus>();
-      if (status.getRequestState() == SubmissionState::PUBLISH && status.isApproved()) {
+      if ((!unapprovedApps && status.getRequestState() == SubmissionState::PUBLISH &&
+            status.isApproved()) ||
+          (unapprovedApps && status.getRequestState() != SubmissionState::IGNORE &&
+            !status.isApproved())) {
         capnp::StreamFdMessageReader metadataMessage(raiiOpen(metadataFile, O_RDONLY));
         auto info = metadataMessage.getRoot<spk::VerifiedInfo>();
         auto metadata = info.getMetadata();
@@ -414,7 +417,12 @@ void Indexer::updateIndex() {
   auto text = json.encode(indexData);
   StagingFile file("/var/www/apps");
   kj::FdOutputStream(file.getFd()).write(text.begin(), text.size());
-  file.finalize(kj::str("/var/www/apps/index.json"));
+  file.finalize(kj::str("/var/www/apps/", outputFilename));
+}
+
+void Indexer::updateIndex() {
+  updateIndexInternal("index.json", false);
+  updateIndexInternal("index-unpublished.json", true);
 }
 
 kj::String Indexer::writeIcon(spk::Metadata::Icon::Reader icon) {

--- a/src/sandstorm/app-index/indexer.h
+++ b/src/sandstorm/app-index/indexer.h
@@ -63,7 +63,7 @@ private:
   kj::String writeImage(kj::ArrayPtr<const byte> data, kj::StringPtr extension);
   capnp::Text::Reader categoryName(spk::Category category);
 
-  void updateIndexInternal(kj::StringPtr outputFilename, bool unapprovedApps);
+  void updateIndexInternal(kj::StringPtr outputFilename, bool approvedApps);
 };
 
 } // namespace appindex

--- a/src/sandstorm/app-index/indexer.h
+++ b/src/sandstorm/app-index/indexer.h
@@ -62,6 +62,8 @@ private:
   kj::String writeScreenshot(spk::Metadata::Screenshot::Reader screenshot);
   kj::String writeImage(kj::ArrayPtr<const byte> data, kj::StringPtr extension);
   capnp::Text::Reader categoryName(spk::Category category);
+
+  void updateIndexInternal(kj::StringPtr outputFilename, bool unapprovedApps);
 };
 
 } // namespace appindex


### PR DESCRIPTION
This includes all non-published, non-embargoed packages. We will soon setup a mirror of the Sandstorm App Market that points to this.