### PR TITLE
Turn topbar into a flexbox

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -203,6 +203,7 @@ body>.topbar {
     overflow: hidden;
     @media #{$desktop} {
       height: $topbar-height-desktop;
+      display: flex;
     }
 
     >.home-button {
@@ -366,7 +367,8 @@ body>.topbar {
 
     >.notifications {
       @media #{$desktop} {
-        float: right;
+        // The notification bell and everything after it are right-aligned.
+        margin-left: auto;
       }
 
       @media #{$mobile} {
@@ -416,9 +418,6 @@ body>.topbar {
       }
 
       @media #{$desktop} {
-        float: right;
-        display: block;
-
         >button.show-popup {
           >a {
             padding: 0 8px;

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -58,16 +58,15 @@ limitations under the License.
     <a href="/">Sandstorm</a>
   {{/sandstormTopbarItem}}
   {{#if showAccountButtons}}
-    {{>sandstormTopbarItem name="account" topbar=globalTopbar data=accountButtonsData
+    {{>sandstormTopbarItem name="account" topbar=globalTopbar data=accountButtonsData priority=61
                            template="accountButtons" popupTemplate="accountButtonsPopup"}}
   {{else}}
     {{>sandstormTopbarItem name="login" topbar=globalTopbar data=globalAccountsUi
                            template="loginButtons" popupTemplate="loginButtonsPopup"}}
   {{/if}}
   {{#if currentUser}}
-    {{>sandstormTopbarItem name="notifications" topbar=globalTopbar
-                           template="notifications" popupTemplate="notificationsPopup"
-                           priority=-1}}
+    {{>sandstormTopbarItem name="notifications" topbar=globalTopbar priority=60
+                           template="notifications" popupTemplate="notificationsPopup"}}
   {{/if}}
   {{!-- admin alerts --}}
   {{#with adminAlert}}
@@ -207,7 +206,7 @@ limitations under the License.
 </template>
 
 <template name="title">
-  {{#sandstormTopbarItem name="title" priority=5 topbar=globalTopbar}}{{.}}{{/sandstormTopbarItem}}
+  {{#sandstormTopbarItem name="title" priority=10 topbar=globalTopbar}}{{.}}{{/sandstormTopbarItem}}
 </template>
 
 <template name="loading">
@@ -530,7 +529,7 @@ limitations under the License.
 
 <template name="grain">
   {{>sandstormTopbarItem name="title" priority=5 topbar=globalTopbar template="grainTitle"}}
-  {{#sandstormTopbarItem name="grain-size" priority=5 topbar=globalTopbar}}
+  {{#sandstormTopbarItem name="grain-size" priority=11 topbar=globalTopbar}}
     {{grainSize}}
   {{/sandstormTopbarItem}}
 
@@ -540,25 +539,25 @@ limitations under the License.
 
   {{#if currentUser}}
     {{>sandstormTopbarItem name="share" topbar=globalTopbar
-          template="grainShareButton" popupTemplate="grainSharePopup"}}
-    {{>sandstormTopbarItem name="delete" topbar=globalTopbar template="grainDeleteButton"}}
+          template="grainShareButton" popupTemplate="grainSharePopup" priority=12}}
+    {{>sandstormTopbarItem name="delete" topbar=globalTopbar template="grainDeleteButton" priority=30}}
   {{/if}}
   {{#if isOwner}}
-    {{>sandstormTopbarItem name="debug-log" topbar=globalTopbar template="grainDebugLogButton" data=globalTopbar}}
-    {{>sandstormTopbarItem name="backup" topbar=globalTopbar template="grainBackupButton" data=globalTopbar}}
-    {{>sandstormTopbarItem name="restart" topbar=globalTopbar template="grainRestartButton" data=globalTopbar}}
+    {{>sandstormTopbarItem name="debug-log" topbar=globalTopbar template="grainDebugLogButton" data=globalTopbar priority=31}}
+    {{>sandstormTopbarItem name="backup" topbar=globalTopbar template="grainBackupButton" data=globalTopbar priority=32}}
+    {{>sandstormTopbarItem name="restart" topbar=globalTopbar template="grainRestartButton" data=globalTopbar priority=33}}
   {{/if}}
   {{#if displayWebkeyButton}}
     {{>sandstormTopbarItem name="webkey" topbar=globalTopbar
-        template="grainApiTokenButton" popupTemplate="grainApiTokenPopup"}}
+        template="grainApiTokenButton" popupTemplate="grainApiTokenPopup" priority=34}}
   {{/if}}
   {{#if showPowerboxRequest}}
     {{>sandstormTopbarItem name="request" topbar=globalTopbar template="grainPowerboxRequest"
-        startOpen=true popupTemplate="grainPowerboxRequestPopup"}}
+        startOpen=true popupTemplate="grainPowerboxRequestPopup" priority=35}}
   {{/if}}
   {{#if showPowerboxOffer}}
     {{>sandstormTopbarItem name="offer" topbar=globalTopbar template="grainPowerboxOffer"
-        startOpen=true popupTemplate="grainPowerboxOfferPopup"}}
+        startOpen=true popupTemplate="grainPowerboxOfferPopup" priority=36}}
   {{/if}}
 </template>
 

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -28,7 +28,7 @@ limitations under the License.
     <ul class="menubar">
       {{#each items}}
         {{#unless onlyPopup}}
-          <li class="{{name}}">
+          <li style="{{inlineStyle}}" class="{{name}}">
             {{#if ./popupTemplate}}
               <button class="show-popup">
                 {{> template data.get}}

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -459,6 +459,13 @@ SandstormTopbar.prototype.addItem = function (item) {
     throw new Error("duplicate top bar item name:", item.name);
   }
 
+  // We need inline style to convert the topbar "priority" into an "order" for the flexbox.
+  item.inlineStyle = "";
+  if (item.priority) {
+    item.inlineStyle = 'order: ' + item.priority + ';'
+  }
+
+
   this._items[item.name] = item;
   this._itemsTracker.changed();
 


### PR DESCRIPTION
This works around the Chrome bug that has been driving me crazy for the past six months.

Notes:

- I need to manually test on IE11 I suppose.

- This elegantly uses `priority=n` to set the order of topbar elements.

@kentonv Thanks for mentioning that a flexbox is a good workaround for this Chrome bug.