### PR TITLE
add pseudocollection for tracking other accounts that an identity is linked to

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -748,7 +748,7 @@ div.identity-editor {
     color: #777777;
   }
 
-  .picture {
+  .editor .picture {
     width: 128px;
     position: absolute;
     label {
@@ -1298,6 +1298,38 @@ body>.popup.billing-prompt>.frame {
       @extend %button-primary;
     }
   }
+}
+
+.login-identities-of-linked-accounts {
+  border: 1px solid gray;
+  border-radius: 2px;
+  padding: 10px;
+  ul.unlinkable-identities {
+    list-style-type: none;
+    padding: 0;
+    li{
+      position: relative;
+      padding-bottom: 10px;
+      .identity-card {
+        border: 1px solid black;
+      }
+      button.unlink {
+        @extend %button-base;
+        @extend %button-secondary;
+        position: absolute;
+        left: 240px;
+        top: 15px;
+      }
+    }
+  }
+  button.hide-other-accounts {
+    @extend %button-base;
+    @extend %button-secondary;
+  }
+}
+button.show-other-accounts {
+  @extend %button-base;
+  @extend %button-secondary;
 }
 
 ul.identity-card-list {

--- a/shell/packages/accounts-identity/accounts-identity-client.js
+++ b/shell/packages/accounts-identity/accounts-identity-client.js
@@ -14,16 +14,70 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+var LoginIdentitiesOfLinkedAccounts = new Mongo.Collection("loginIdentitiesOfLinkedAccounts");
+// Pseudocollection populated by the `accountsOfIdentity(sourceIdentityId)` subscription. Contains
+// information about all login identities for all accounts that have the "source identity" linked.
+//   _id: Identity ID of the login identity;
+//   profile: Profile object for the login identity, as in the Users collection. Profile defaults
+//            and the intrinsic name have already been filled in.
+//   loginAccountId: ID of the account that the login identity can log in to.
+//   sourceIdentityId: Identity ID of the source identity.
+
+Template.identityLoginInterstitial.onCreated(function () {
+  this._state = new ReactiveVar({justLoggingIn: true});
+  var token = sessionStorage.getItem("linkingIdentityLoginToken");
+  if (token) {
+    this._state.set({linkingIdentity: true});
+    sessionStorage.removeItem("linkingIdentityLoginToken");
+    Meteor.call("linkIdentityToAccount", token, function (err, result) {
+      if (err) {
+        // TODO(soon): display this error somewhere that the user will see.
+        console.log("Error", err);
+      }
+      Meteor.loginWithToken(token);
+    });
+  } else {
+    var self = this;
+    var sub = this.subscribe("accountsOfIdentity", Meteor.userId());
+    Tracker.autorun(function() {
+      if (sub.ready()) {
+        var loginAccount =
+            LoginIdentitiesOfLinkedAccounts.findOne({sourceIdentityId: Meteor.userId(),
+                                                     _id: Meteor.userId()});
+        if (loginAccount) {
+          Meteor.loginWithIdentity(loginAccount.loginAccountId);
+        } else if (!LoginIdentitiesOfLinkedAccounts.findOne({sourceIdentityId: Meteor.userId()})) {
+          Meteor.call("createAccountForIdentity", function(err, result) {
+            if (err) {
+              console.log("error", err);
+            } else {
+              Meteor.loginWithIdentity(result);
+            }
+          });
+        } else if ("justLoggingIn" in self._state.get()) {
+          self._state.set({needInput: true});
+        }
+      }
+    });
+  }
+});
+
 Template.identityLoginInterstitial.helpers({
+  needInput: function () {
+    return "needInput" in Template.instance()._state.get();
+  },
+  linkingIdentity: function () {
+    return "linkingIdentity" in Template.instance()._state.get();
+  },
   currentIdentity: function () {
     var identities = SandstormDb.getUserIdentities(Meteor.user());
     return identities && identities.length > 0 && identities[0];
   },
-  foundNonloginAccounts: function () {
-    return !!Session.get("nonloginAccounts");
-  },
   nonloginAccounts: function () {
-    return Session.get("nonloginAccounts");
+    return LoginIdentitiesOfLinkedAccounts.find().fetch().map(function (identity) {
+      SandstormDb.fillInPictureUrl(identity);
+      return identity;
+    });
   },
 });
 
@@ -39,11 +93,45 @@ Template.identityLoginInterstitial.events({
     Meteor.call("unlinkIdentity", userId, identityId, function (err, result) {
       if (err) {
         console.log("error: ", err);
-      } else {
-        // Remove the account from our display list.
-        var list = Session.get("nonloginAccounts");
-        Session.set("nonloginAccounts",
-                    list.filter(function (account) {return account.accountId !== userId; }));
+      }
+    });
+  },
+});
+
+Template.loginIdentitiesOfLinkedAccounts.onCreated(function() {
+  this.subscribe("accountsOfIdentity", this.data._id);
+  this._showOtherAccounts = new ReactiveVar(false);
+});
+
+Template.loginIdentitiesOfLinkedAccounts.helpers({
+  showOtherAccounts: function () {
+    return Template.instance()._showOtherAccounts.get();
+  },
+  getOtherAccounts: function() {
+    var id = Template.instance().data._id;
+    return LoginIdentitiesOfLinkedAccounts.find({sourceIdentityId: id,
+                                                 loginAccountId: {$ne: Meteor.userId()}})
+        .fetch().map(function (identity) {
+      SandstormDb.fillInPictureUrl(identity);
+      return identity;
+    });
+  }
+});
+
+Template.loginIdentitiesOfLinkedAccounts.events({
+  "click button.show-other-accounts": function(event, instance) {
+    instance._showOtherAccounts.set(true);
+  },
+  "click button.hide-other-accounts": function(event, instance) {
+    instance._showOtherAccounts.set(false);
+  },
+  "click button.unlink": function (event, instance) {
+    var userId = event.target.getAttribute("data-user-id")
+    var identityId = instance.data._id;
+
+    Meteor.call("unlinkIdentity", userId, identityId, function (err, result) {
+      if (err) {
+        console.log("error: ", err);
       }
     });
   },
@@ -88,39 +176,3 @@ Meteor.loginWithIdentity = function (accountId, callback) {
     }
   });
 };
-
-Accounts.onLogin(function () {
-  Session.set("nonloginAccounts", undefined);
-  var user = Meteor.user();
-  var token = sessionStorage.getItem("linkingIdentityLoginToken");
-  if (user.loginIdentities || token === Accounts._storedLoginToken()) { return; }
-  sessionStorage.removeItem("linkingIdentityLoginToken");
-
-  if (token) {
-    Meteor.call("linkIdentityToAccount", token, function (err, result) {
-      if (err) {
-        // TODO(soon): display this error somewhere that the user will see.
-        console.log("Error", err);
-      }
-      Meteor.loginWithToken(token);
-    });
-  } else {
-    Meteor.call("getLoginAccountOfIdentity", function(err, result) {
-      if (err) {
-        console.log("Error", err);
-        Meteor.logout();
-      } else if (result) {
-        if (result.loginAccountId) {
-          Meteor.loginWithIdentity(result.loginAccountId);
-        } else if (result.nonloginAccounts) {
-          var loginIdentities = result.nonloginAccounts.map(function (account) {
-            SandstormDb.fillInPictureUrl(account.loginIdentityUser);
-            return {accountId: account.accountId,
-                    identity: account.loginIdentityUser};
-          });
-          Session.set("nonloginAccounts", loginIdentities);
-        }
-      }
-    });
-  }
-});

--- a/shell/packages/accounts-identity/accounts-identity-client.js
+++ b/shell/packages/accounts-identity/accounts-identity-client.js
@@ -114,7 +114,7 @@ Accounts.onLogin(function () {
           Meteor.loginWithIdentity(result.loginAccountId);
         } else if (result.nonloginAccounts) {
           var loginIdentities = result.nonloginAccounts.map(function (account) {
-            SandstormDb.fillInIdenticon(account.loginIdentityUser);
+            SandstormDb.fillInPictureUrl(account.loginIdentityUser);
             return {accountId: account.accountId,
                     identity: account.loginIdentityUser};
           });

--- a/shell/packages/accounts-identity/accounts-identity-server.js
+++ b/shell/packages/accounts-identity/accounts-identity-server.js
@@ -45,70 +45,38 @@ Meteor.methods({
                                  "identity", function () { return { userId: accountUserId }; });
   },
 
-  getLoginAccountOfIdentity: function() {
-    // Attempts to find an account that has the current user as a login identity. If the identity
-    // is not linked to any account, creates a new account for it. Returns a value of type
-    // `OneOf({alreadyAccount: null},
-    //        {loginAccountId: String},
-    //        {nonloginAccounts: [{accountId: String, loginIdentityUser: User}]})`
-    // where the nonloginAccounts variant indicates that this identity cannot log in to any existing
-    // account, and the corresponding list has information about the accounts that this identity is
-    // linked to. The alreadyAccount variant is not an error because the client is allowed to call
-    // this method before its accountIdentities subscription is ready, and therefore it might
-    // not yet know whether the user is an identity or an account.
+  createAccountForIdentity: function() {
+    // Creates a new account for the currently-logged-in identity.
 
     var user = Meteor.user();
-    if (!user) {
-      throw new Meteor.Error(403, "Must be logged in to look up accounts.")
-    }
-    if (user.loginIdentities) return {alreadyAccount: null};
-
-    var loginAccount = Meteor.users.findOne({"loginIdentities.id": user._id},
-                                            {fields: {_id: 1, "loginIdentities.$": 1}});
-
-    if (loginAccount) {
-      return {loginAccountId: loginAccount._id};
+    if (!(user && user.profile)) {
+      throw new Meteor.Error(403, "Must be logged in as an identity in order to create an account.");
     }
 
-    var nonloginAccounts = Meteor.users.find({"nonloginIdentities.id": user._id}).fetch();
+    if (Meteor.users.findOne({"loginIdentities.id": user._id})) {
+      throw new Meteor.Error(403,
+                             "Cannot create an account for an identity that can already a login");
+    }
 
-    var accountUserId;
-    if (nonloginAccounts.length == 0) {
-      // Make a new account for this user.
-      var newUser = {loginIdentities: [{id: user._id}],
-                     nonloginIdentities: []};
-      if (user.services.dev) {
-        newUser.signupKey = "devAccounts";
-        if (user.services.dev.isAdmin) {
-          newUser.isAdmin = true;
-        }
-        if (user.services.dev.hasCompletedSignup) {
-          newUser.hasCompletedSignup = true;
-        }
-      } else if (user.expires) {
-        // Demo user.
-        newUser.expires = user.expires;
+    var newUser = {loginIdentities: [{id: user._id}],
+                   nonloginIdentities: []};
+    if (user.services.dev) {
+      newUser.signupKey = "devAccounts";
+      if (user.services.dev.isAdmin) {
+        newUser.isAdmin = true;
       }
-      var options = {};
-      accountUserId = Accounts.insertUserDoc(options, newUser);
-      return {loginAccountId: accountUserId};
-    } else {
-      var resultData = [];
-      nonloginAccounts.forEach(function(account) {
-        if (account.loginIdentities.length > 0) {
-          for (var jj = 0; jj < account.loginIdentities.length; ++jj) {
-            var loginIdentityUser =
-                Meteor.users.findOne({_id: account.loginIdentities[jj].id});
-            if (loginIdentityUser) {
-              var userWithDefaults = SandstormDb.getUserIdentities(loginIdentityUser)[0];
-              resultData.push({accountId: account._id,
-                               loginIdentityUser: _.pick(userWithDefaults, "_id", "profile")});
-            }
-          }
-        }
-      });
-      return {nonloginAccounts: resultData};
+      if (user.services.dev.hasCompletedSignup) {
+        newUser.hasCompletedSignup = true;
+      }
+    } else if (user.expires) {
+      // Demo user.
+      newUser.expires = user.expires;
     }
+    var options = {};
+
+    // This will throw an error if the identity has been added as a login identity to some
+    // other account while we were executing the body of this method.
+    return Accounts.insertUserDoc(options, newUser);
   },
 
   linkIdentityToAccount: function(token) {
@@ -172,18 +140,14 @@ Meteor.methods({
     if (!this.userId) {
       throw new Meteor.Error(403, "Not logged in.");
     }
-    if (!this.connection.sandstormDb.userHasIdentity(accountUserId, identityId)) {
+    if (!this.connection.sandstormDb.userHasIdentity(this.userId, identityId)) {
       throw new Meteor.Error(403, "Current user does not own identity " + identityId);
     }
 
     var identityUser = Meteor.users.findOne({_id: identityId});
-    if (this.userId === accountUserId || this.userId === identityUser._id) {
-      Meteor.users.update({_id: accountUserId},
-                          {$pull: {nonloginIdentities: {id: identityId},
-                                   loginIdentities: {id: identityId}}});
-    } else {
-      throw new Meteor.Error(403, "Not authorized to unlink identity " + identityId);
-    }
+    Meteor.users.update({_id: accountUserId},
+                        {$pull: {nonloginIdentities: {id: identityId},
+                                 loginIdentities: {id: identityId}}});
   },
 
   setIdentityAllowsLogin: function(identityId, allowLogin) {
@@ -238,3 +202,62 @@ Accounts.linkIdentityToAccount = function (identityId, accountId) {
                       {$push: {"nonloginIdentities": {id: identityId}}});
 
 }
+
+Meteor.publish("accountsOfIdentity", function (identityId) {
+  check(identityId, String);
+  var hasIdentityCursor =
+      Meteor.users.find({$or: [{_id: identityId},
+                               {_id: this.userId, "loginIdentities.id": identityId},
+                               {_id: this.userId, "nonloginIdentities.id": identityId}]});
+  if (hasIdentityCursor.count() == 0) return;
+  var self = this;
+  hasIdentityCursor.observe({removed: function () { self.stop(); }});
+
+  // We maintain a map from identity IDs to live query handles that track profile changes.
+  var loginIdentities = {};
+
+  function addIdentitiesOfAccount(account) {
+    account.loginIdentities.forEach(function(identity) {
+      if (!(identity.id in loginIdentities)) {
+        var user = Meteor.users.findOne({_id: identity.id});
+        if (user) {
+          SandstormDb.fillInProfileDefaults(user);
+          SandstormDb.fillInIntrinsicName(user);
+          var filteredUser = _.pick(user, "_id", "profile");
+          filteredUser.loginAccountId = account._id;
+          filteredUser.sourceIdentityId = identityId;
+          self.added("loginIdentitiesOfLinkedAccounts", user._id, filteredUser);
+        }
+        loginIdentities[identity.id] =
+          Meteor.users.find({_id: identity.id}, {fields: {profile: 1}}).observeChanges({
+            changed: function (id, fields) {
+              self.changed("loginIdentitiesOfLinkedAccounts", id, fields);
+            }
+          });
+      }
+    });
+  }
+  var cursor = Meteor.users.find({$or: [{"loginIdentities.id": identityId},
+                                        {"nonloginIdentities.id": identityId}]});
+  cursor.forEach(addIdentitiesOfAccount);
+  this.ready();
+
+  var handle = cursor.observe({
+    added: function (account) {
+      addIdentitiesOfAccount(account);
+    },
+    changed: function (newAccount, oldAccount) {
+      addIdentitiesOfAccount(newAccount);
+    },
+    removed: function (account) {
+      account.loginIdentities.forEach(function(identity) {
+        if (identity.id in loginIdentities) {
+          self.removed("loginIdentitiesOfLinkedAccounts", identity.id);
+          loginIdentities[identity.id].stop();
+          delete loginIdentities[identity.id];
+        }
+      });
+    },
+  });
+  this.onStop(function() { handle.stop(); });
+});

--- a/shell/packages/accounts-identity/accounts-identity-server.js
+++ b/shell/packages/accounts-identity/accounts-identity-server.js
@@ -267,5 +267,9 @@ Meteor.publish("accountsOfIdentity", function (identityId) {
   this.onStop(function() {
     hasIdentityHandle.stop();
     handle.stop();
+    Object.keys(loginIdentities).forEach(function(identityId) {
+      loginIdentities[identityId].stop();
+      delete loginIdentities[identityId];
+    });
   });
 });

--- a/shell/packages/accounts-identity/accounts-identity.html
+++ b/shell/packages/accounts-identity/accounts-identity.html
@@ -17,13 +17,16 @@ limitations under the License.
 -->
 
 <template name="identityLoginInterstitial">
+  {{!--
+    Interstitial to display when the user is logged in as an identity, rather than as an account.
+  --}}
   <div class="identity-login-interstitial">
     {{#sandstormTopbarItem name="title" priority=5 topbar=globalTopbar}}
       Logging in...
     {{/sandstormTopbarItem}}
 
     <div class="centered-content">
-      {{#if foundNonloginAccounts}}
+      {{#if needInput}}
       <br><br>
       <p>
         You have authenticated as this identity
@@ -38,18 +41,48 @@ limitations under the License.
       <ul>
         {{#each nonloginAccounts}}
         <li>
-          {{> identityCard identity}}
-          <button class="unlink" data-user-id="{{accountId}}">unlink</button>
+          {{> identityCard .}}
+          <button class="unlink" data-user-id="{{loginAccountId}}">unlink</button>
         </li>
         {{/each}}
       </ul>
       <button class="logout">Go back</button>
       {{else}}
+      {{#if linkingIdentity}}
+      <h1>linking identity to account...</h1>
+      {{else}}
       <h1>logging in to account...</h1>
+      {{/if}}
       <button class="logout">Cancel</button>
       {{/if}}
     </div>
   </div>
+</template>
+
+<template name="loginIdentitiesOfLinkedAccounts">
+  {{#if showOtherAccounts}}
+  <div class="login-identities-of-linked-accounts">
+    <p>This identity is shared with other accounts.
+       Those accounts have the following login identities:
+    </p>
+    <ul class="unlinkable-identities">
+      {{#each getOtherAccounts}}
+      <li>
+        {{> identityCard .}}
+        <button class="unlink" data-user-id="{{loginAccountId}}">unlink</button>
+      </li>
+      {{/each}}
+    </ul>
+    <button class="hide-other-accounts">hide other accounts</button>
+  </div>
+  {{else}}
+  {{#if getOtherAccounts}}
+  <div class="login-identities-of-linked-accounts">
+    This identity is shared with at least one other account.
+    <button class="show-other-accounts">show other accounts</button>
+  </div>
+  {{/if}}
+  {{/if}}
 </template>
 
 <template name="identityPicker">

--- a/shell/packages/accounts-identity/package.js
+++ b/shell/packages/accounts-identity/package.js
@@ -20,7 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use(["underscore", "random", "sandstorm-db"]);
+  api.use(["underscore", "random", "sandstorm-db", "mongo"]);
   api.use("accounts-base", ["client", "server"]);
   api.use(["templating"], ["client"]);
   api.imply("accounts-base", ["client", "server"]);

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -205,6 +205,7 @@ limitations under the License.
       <button class="make-login" data-identity-id="{{_id}}">Login disabled</button>
       {{/if}}
     </div>
+    {{>loginIdentitiesOfLinkedAccounts _id=_id}}
     {{/if}}
   </div>
 </template>

--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -136,7 +136,7 @@ function emailToHandle(email) {
   return filterHandle(base);
 }
 
-function fillInProfileDefaults(user) {
+SandstormDb.fillInProfileDefaults = function(user) {
   var profile = user.profile;
   if (profile.service === "github") {
     profile.name = profile.name || user.services.github.username || "Name Unknown";
@@ -244,7 +244,7 @@ SandstormDb.getUserIdentities = function (user) {
 
   return rawIdentities.map(function(identity) {
     SandstormDb.fillInPictureUrl(identity);
-    fillInProfileDefaults(identity);
+    SandstormDb.fillInProfileDefaults(identity);
     SandstormDb.fillInIntrinsicName(identity);
     return identity;
   });


### PR DESCRIPTION
This big change here is the addition of the fully reactive `LoginIdentitiesOfLinkedAccounts` pseudocollection. This allows for some simplifications in the login interstitial. The new pseudocollection also gets used for a new widget on the profile editor page; now if an identity is linked to other accounts, you can click a button to expand a list of login identities for those accounts, which looks like this (and needs some design work):
<img width="439" alt="hidden" src="https://cloud.githubusercontent.com/assets/495768/11376532/367b6b50-92af-11e5-924d-53bc8a2f00ee.png">

<img width="435" alt="expanded" src="https://cloud.githubusercontent.com/assets/495768/11376541/48138bea-92af-11e5-8664-f7193e8f4599.png">

