### PR TITLE
For review/feedback, not ready for merge: Response Header Whitelist

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1509,6 +1509,18 @@ class Proxy {
     context.eTagPrecondition = parsePreconditionHeader(request);
 
     context.additionalHeaders = [];
+
+    // If the whitelist entry is prefixed with the app header prefix, add it.
+    Object.keys(request.headers).forEach(function(requestHeaderName) {
+      if (requestHeaderName.startsWith(WebSession.appHeaderPrefix)) {
+        context.additionalHeaders.push({
+          name: requestHeaderName,
+          value: request.headers[requestHeaderName]
+        });
+      }
+    });
+
+    // Add any headers that appear in the whitelist.
     WebSession.Context.headerWhitelist.forEach((headerName) => {
       if (headerName.endsWith("*")) {
         const prefix = headerName.substr(0, headerName.length - 1);

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1510,31 +1510,29 @@ class Proxy {
 
     context.additionalHeaders = [];
 
-    // If the whitelist entry is prefixed with the app header prefix, add it.
-    Object.keys(request.headers).forEach(function(requestHeaderName) {
+    // If the whitelist entry is prefixed with the app header prefix,
+    // or if it is prefixed with a whitelisted prefix, add it.
+    Object.keys(request.headers).forEach((requestHeaderName) => {
       if (requestHeaderName.startsWith(WebSession.appHeaderPrefix)) {
         context.additionalHeaders.push({
           name: requestHeaderName,
           value: request.headers[requestHeaderName]
+        });
+      } else {
+        WebSession.Context.headerPrefixWhitelist.forEach((prefix) => {
+          if (requestHeaderName.startsWith(prefix)) {
+            context.additionalHeaders.push({
+              name: requestHeaderName,
+              value: request.headers[requestHeaderName]
+            });
+          }
         });
       }
     });
 
     // Add any headers that appear in the whitelist.
     WebSession.Context.headerWhitelist.forEach((headerName) => {
-      if (headerName.endsWith("*")) {
-        const prefix = headerName.substr(0, headerName.length - 1);
-        for (const h in request.headers) {
-          if (!h.startsWith(prefix)) {
-            continue;
-          }
-
-          context.additionalHeaders.push({
-            name: h,
-            value: request.headers[h],
-          });
-        }
-      } else if (request.headers[headerName]) {
+      if (request.headers[headerName]) {
         context.additionalHeaders.push({
           name: headerName,
           value: request.headers[headerName],

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1587,6 +1587,26 @@ class Proxy {
       response.setHeader("Content-Security-Policy", "default-src 'none'; sandbox");
     }
 
+    if (rpcResponse.additionalHeaders && rpcResponse.additionalHeaders.length > 0) {
+      // Build object for whitelisted header lookup
+      var whitelisted = {};
+      WebSession.Response.headerWhitelist.forEach(function(header) {
+        whitelisted[header] = 1;
+      });
+
+      // Add any additional prefixed/whitelisted headers to the response.
+      // We cannot trust that the headers in the RPC response are actually
+      // allowed, so we check if they are prefixed or whitelisted.
+      rpcResponse.additionalHeaders.forEach(function(header) {
+        if (header.name.startsWith(WebSession.appHeaderPrefix) ||
+            whitelisted[header.name]) {
+          // If header is prefixed with appHeaderPrefix,
+          // or if the header name is in whitelist, set it.
+          response.setHeader(header.name,  header.value);
+        }
+      });
+    }
+
     // On first response, update the session to have hasLoaded=true
     this.setHasLoaded();
 

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -1561,6 +1561,14 @@ private:
             checkIsHttpToken(headerName),
             ": ",
             checkIsHeaderValue(headerValue)));
+        } else {
+          for (auto const &prefix : *WebSession::Context::HEADER_PREFIX_WHITELIST)
+            if (headerName.startsWith(prefix.cStr())) {
+              lines.add(kj::str(
+                checkIsHttpToken(headerName),
+                ": ",
+                checkIsHeaderValue(headerValue)));
+          }
         }
       }
     }

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -31,6 +31,7 @@
 #include <capnp/serialize.h>
 #include <arpa/inet.h>
 #include <unistd.h>
+#include <regex>
 #include <map>
 #include <unordered_map>
 #include <set>
@@ -1543,8 +1544,24 @@ private:
     }
     auto additionalHeaderList = context.getAdditionalHeaders();
     if (additionalHeaderList.size() > 0) {
+
+      // Create a set from the headerWhitelist
+      auto headerWhitelist = std::set<std::string>(
+          WebSession::Context::HEADER_WHITELIST->begin(),
+          WebSession::Context::HEADER_WHITELIST->end());
+
       for (auto header : additionalHeaderList) {
-        lines.add(kj::str(header.getName(), ": ", header.getValue()));
+        auto headerName = header.getName();
+        auto headerValue = header.getValue();
+        if (headerWhitelist.find(headerName) != headerWhitelist.end() ||
+            headerName.startsWith(WebSession::APP_HEADER_PREFIX)) {
+          // Check header is present in whitelist.
+          // Check header name and value to prevent header injection.
+          lines.add(kj::str(
+            checkIsHttpToken(headerName),
+            ": ",
+            checkIsHeaderValue(headerValue)));
+        }
       }
     }
     auto eTagPrecondition = context.getETagPrecondition();
@@ -1581,6 +1598,36 @@ private:
 
     lines.add(kj::str(""));
     lines.add(kj::str(""));
+  }
+
+  static kj::StringPtr checkIsHttpToken(kj::StringPtr val) {
+    // Allowable values for HTTP tokens per RFC 7230 ("token").
+    // Same as valid header field names ("field-name").
+    // Notably, this excludes CR and LF, thus preventing header injection.
+    // TODO(cleanup): Use kj::parse rather than std::regex.
+    static const std::regex tokenRe = std::regex("^[a-zA-Z0-9_!#$%&'*+.^`|~-]+$");
+    if (!std::regex_match(val.cStr(), tokenRe)) {
+      KJ_FAIL_ASSERT("Invalid HTTP token.", val.cStr());
+    } else {
+      return val;
+    }
+  }
+
+  static kj::StringPtr  checkIsHeaderValue(kj::StringPtr val) {
+    static const std::regex headerValRe = std::regex(
+      "^[\x21-\x7E,\x80-\xFF]+([\x20,\x09]+[\x21-\x7E,\x80-\xFF]+)*?$");
+    // Allowable values for header field values per RFC 7230 ("field-content").
+    // Does not check for obsolete line-folding ("obs-fold").
+    // Notably, this excludes CR and LF, thus preventing header injection.
+    // Character ranges explained:
+    // \x21-\x7E: visible (printing) characters ("VCHAR").
+    // \x80-\xFF: characters outside of US ASCII, treated as opaque data ("obs-text").
+    // \x20,x09: space and horizontal tab ("SP / HTAB")
+    if (!std::regex_match(val.cStr(), headerValRe)) {
+      KJ_FAIL_ASSERT("Invalid HTTP token.", val.cStr());
+    } else {
+      return val;
+    }
   }
 
   template <typename Context>

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -38,6 +38,11 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   # application's storage was written and may automatically implement etags based on hashing the
   # content.
 
+  const appHeaderPrefix :Text = "x-sandstorm-app-";
+  # Headers with this prefix will always be allowed in both the request and response.
+  # They represent custom HTTP headers that an app is intentionally exposing through
+  # Sandstorm.
+
   struct Params {
     # Startup params for web sessions.  See `UiView.newSession()`.
 

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -391,6 +391,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       # purposes. This whitelist exists to help avoid the need to modify code originally written
       # without Sandstorm in mind -- especially to avoid modifying client apps.
       # Feel free to send us pull requests adding additional headers.
+      "x-oc-mtime",            # Owncloud protocol
     ];
 
   }

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -376,6 +376,23 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       # TODO(someday):  Return blob directly from storage, so data doesn't have to stream through
       #   the app?
     }
+
+    additionalHeaders @19 :List(Header);
+    # Additional headers present in the reponse. Only whitelisted headers are
+    # permitted.
+
+    struct Header {
+      name @0 :Text;  # lower-cased name
+      value @1 :Text;
+    }
+
+    const headerWhitelist :List(Text) = [
+      # Non-standard response headers which are whitelisted for backwards-compatibility
+      # purposes. This whitelist exists to help avoid the need to modify code originally written
+      # without Sandstorm in mind -- especially to avoid modifying client apps.
+      # Feel free to send us pull requests adding additional headers.
+    ];
+
   }
 
   interface RequestStream extends(Util.ByteStream) {

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -154,14 +154,18 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       # purposes. This whitelist exists to help avoid the need to modify code originally written
       # without Sandstorm in mind -- especially to avoid modifying client apps. Feel free
       # to send us pull requests adding additional headers.
-      # Values in this list that end with '*' whitelist a prefix.
 
       "oc-total-length",       # Owncloud client
       "oc-chunk-size",         # Owncloud client
       "x-oc-mtime",            # Owncloud client
       "oc-fileid",             # Owncloud client
       "oc-chunked",            # Owncloud client
-      "x-hgarg-*",             # Mercurial client
+    ];
+
+    const headerPrefixWhitelist :List(Text) = [
+      # Any headers matching any prefix here will be whitelisted.
+
+      "x-hgarg-",             # Mercurial client
     ];
   }
 


### PR DESCRIPTION
The idea is to allow through a header, X-Session-Id, that identifies an anonymous browser session in the context of exported HTTP APIs. Like a session cookie, a session id is generated server-side by the app, signed, and sent to the client. Client-side JavaScript receives the header, and stores it in sessionStorage. In future requests, the client sends back the X-Session-Id header, and the backend validates the signature, then uses the id to authorize the request.

Perhaps a more general solution is to use a JWT as a store for arbitrary session data, and name the header X-Session.

This patch is not yet working: the client never sees any X-Session-Id originating from the app. I also was not clear on when external-ui-view.js plays a role.