### PR TITLE
Add a C.UTF-8 locale descriptor, and generate a locale in make-bundle.sh

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -76,6 +76,15 @@ base64 handling in src/sandstorm/sandstorm-http-bridge.c++
     License: Public Domain
     License text: http://creativecommons.org/licenses/publicdomain/
 
+localedata-C
+    What: A C locale supporting UTF-8, based on Debian and Fedora's C.UTF-8 locales
+    Source URLs:
+      http://sources.debian.net/data/main/g/glibc/2.19-22/localedata/locales/C
+      https://lists.stg.fedoraproject.org/archives/list/glibc%40lists.fedoraproject.org/message/RAIVZBJH55SKKLPSR6AX7RJOIUG3BF57/attachment/2/0001-Add-a-C.UTF-8-locale.patch
+    Copyright: Aurelien Jarno (Debian), Mike Fabian (Fedora)
+    License: LGPL Version 2.1 or later
+    License text: http://opensource.org/licenses/LGPL-2.1
+
 Trademarks
 ==========
 

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ shell-build: shell/lib/* shell/client/* shell/server/* shell/shared/* shell/publ
 # ====================================================================
 # Bundle
 
-bundle: tmp/.ekam-run shell-build make-bundle.sh meteor-bundle-main.js
+bundle: tmp/.ekam-run shell-build make-bundle.sh localedata-C meteor-bundle-main.js
 	@$(call color,bundle)
 	@./make-bundle.sh
 

--- a/localedata-C
+++ b/localedata-C
@@ -1,0 +1,227 @@
+escape_char /
+comment_char %
+% Locale for C locale in UTF-8
+
+LC_IDENTIFICATION
+title      "C locale"
+source     ""
+address    ""
+contact    ""
+email      "drew@sandstorm.io"
+tel        ""
+fax        ""
+language   "C"
+territory  ""
+revision   "1.0"
+date       "2015-11-30"
+%
+category  "C:2015";LC_IDENTIFICATION
+category  "C:2015";LC_CTYPE
+category  "C:2015";LC_COLLATE
+category  "C:2015";LC_TIME
+category  "C:2015";LC_NUMERIC
+category  "C:2015";LC_MONETARY
+category  "C:2015";LC_MESSAGES
+category  "C:2015";LC_PAPER
+category  "C:2015";LC_NAME
+category  "C:2015";LC_ADDRESS
+category  "C:2015";LC_TELEPHONE
+category  "C:2015";LC_MEASUREMENT
+END LC_IDENTIFICATION
+
+LC_CTYPE
+copy "i18n"
+
+translit_start
+include "translit_combining";""
+translit_end
+
+END LC_CTYPE
+
+LC_COLLATE
+% Using Fedora's technique for reducing this from 1114111 literals to a tiny handful.
+order_start forward
+<U0000>
+..
+<UFFFF>
+<U10000>
+..
+<UFFFFF>
+<U100000>
+..
+<U10FFFF>
+UNDEFINED
+order_end
+END LC_COLLATE
+
+LC_MONETARY
+% This is the 14652 i18n fdcc-set definition for
+% the LC_MONETARY category
+% (except for the int_curr_symbol and currency_symbol, they are empty in
+% the 14652 i18n fdcc-set definition and also empty in
+% glibc/locale/C-monetary.c. But localedef complains in that case).
+%
+% Using "USD" for int_curr_symbol. But maybe "XXX" would be better?
+% XXX is "No currency" (https://en.wikipedia.org/wiki/ISO_4217)
+int_curr_symbol     "<U0055><U0053><U0044><U0020>"
+% Using "$" for currency_symbol. But maybe <U00A4> would be better?
+% U+00A4 is the "generic currency symbol"
+% (https://en.wikipedia.org/wiki/Currency_sign_%28typography%29)
+currency_symbol     "<U0024>"
+mon_decimal_point   "<U002E>"
+mon_thousands_sep   ""
+mon_grouping        -1
+positive_sign       ""
+negative_sign       "<U002D>"
+int_frac_digits     -1
+frac_digits         -1
+p_cs_precedes       -1
+int_p_sep_by_space  -1
+p_sep_by_space      -1
+n_cs_precedes       -1
+int_n_sep_by_space  -1
+n_sep_by_space      -1
+p_sign_posn         -1
+n_sign_posn         -1
+%
+END LC_MONETARY
+
+LC_NUMERIC
+% This is the POSIX Locale definition for
+% the LC_NUMERIC category.
+%
+decimal_point   "<U002E>"
+thousands_sep   ""
+grouping        -1
+END LC_NUMERIC
+
+LC_TIME
+% This is the POSIX Locale definition for
+% the LC_TIME category.
+%
+% Abbreviated weekday names (%a)
+abday       "<U0053><U0075><U006E>";"<U004D><U006F><U006E>";/
+            "<U0054><U0075><U0065>";"<U0057><U0065><U0064>";/
+            "<U0054><U0068><U0075>";"<U0046><U0072><U0069>";/
+            "<U0053><U0061><U0074>"
+
+% Full weekday names (%A)
+day         "<U0053><U0075><U006E><U0064><U0061><U0079>";/
+            "<U004D><U006F><U006E><U0064><U0061><U0079>";/
+            "<U0054><U0075><U0065><U0073><U0064><U0061><U0079>";/
+            "<U0057><U0065><U0064><U006E><U0065><U0073><U0064><U0061><U0079>";/
+            "<U0054><U0068><U0075><U0072><U0073><U0064><U0061><U0079>";/
+            "<U0046><U0072><U0069><U0064><U0061><U0079>";/
+            "<U0053><U0061><U0074><U0075><U0072><U0064><U0061><U0079>"
+
+% Abbreviated month names (%b)
+abmon       "<U004A><U0061><U006E>";"<U0046><U0065><U0062>";/
+            "<U004D><U0061><U0072>";"<U0041><U0070><U0072>";/
+            "<U004D><U0061><U0079>";"<U004A><U0075><U006E>";/
+            "<U004A><U0075><U006C>";"<U0041><U0075><U0067>";/
+            "<U0053><U0065><U0070>";"<U004F><U0063><U0074>";/
+            "<U004E><U006F><U0076>";"<U0044><U0065><U0063>"
+
+% Full month names (%B)
+mon         "<U004A><U0061><U006E><U0075><U0061><U0072><U0079>";/
+            "<U0046><U0065><U0062><U0072><U0075><U0061><U0072><U0079>";/
+            "<U004D><U0061><U0072><U0063><U0068>";/
+            "<U0041><U0070><U0072><U0069><U006C>";/
+            "<U004D><U0061><U0079>";/
+            "<U004A><U0075><U006E><U0065>";/
+            "<U004A><U0075><U006C><U0079>";/
+            "<U0041><U0075><U0067><U0075><U0073><U0074>";/
+            "<U0053><U0065><U0070><U0074><U0065><U006D><U0062><U0065><U0072>";/
+            "<U004F><U0063><U0074><U006F><U0062><U0065><U0072>";/
+            "<U004E><U006F><U0076><U0065><U006D><U0062><U0065><U0072>";/
+            "<U0044><U0065><U0063><U0065><U006D><U0062><U0065><U0072>"
+
+% Week description, consists of three fields:
+% 1. Number of days in a week.
+% 2. Gregorian date that is a first weekday (19971130 for Sunday, 19971201 for Monday).
+% 3. The weekday number to be contained in the first week of the year.
+%
+% ISO 8601 conforming applications should use the values 7, 19971201 (a
+% Monday), and 4 (Thursday), respectively.
+% We mimic Debian here, with the US-centric Sunday-through-Saturday week
+week    7;19971130;7
+first_weekday	1
+first_workday	2
+
+% Appropriate date and time representation (%c)
+%	"%a %b %e %H:%M:%S %Y"
+d_t_fmt "<U0025><U0061><U0020><U0025><U0062><U0020><U0025><U0065><U0020><U0025><U0048><U003A><U0025><U004D><U003A><U0025><U0053><U0020><U0025><U0059>"
+
+% Appropriate date representation (%x)
+%	"%m/%d/%y"
+d_fmt   "<U0025><U006D><U002F><U0025><U0064><U002F><U0025><U0079>"
+
+% Appropriate time representation (%X)
+%	"%H:%M:%S"
+t_fmt   "<U0025><U0048><U003A><U0025><U004D><U003A><U0025><U0053>"
+
+% Appropriate AM/PM time representation (%r)
+%	"%I:%M:%S %p"
+t_fmt_ampm "<U0025><U0049><U003A><U0025><U004D><U003A><U0025><U0053><U0020><U0025><U0070>"
+
+% Equivalent of AM/PM (%p)      "AM"/"PM"
+am_pm	"<U0041><U004D>";"<U0050><U004D>"
+
+% Appropriate date representation (date(1))   "%a %b %e %H:%M:%S %Z %Y"
+date_fmt	"<U0025><U0061><U0020><U0025><U0062><U0020><U0025><U0065><U0020><U0025><U0048><U003A><U0025><U004D><U003A><U0025><U0053><U0020><U0025><U005A><U0020><U0025><U0059>"
+END LC_TIME
+
+LC_MESSAGES
+% This is the POSIX Locale definition for
+% the LC_NUMERIC category.
+%
+yesexpr "<U005E><U005B><U0079><U0059><U005D>"
+noexpr  "<U005E><U005B><U006E><U004E><U005D>"
+yesstr  "<U0059><U0065><U0073>"
+nostr   "<U004E><U006F>"
+END LC_MESSAGES
+
+LC_PAPER
+% This is the ISO/IEC 14652 "i18n" definition for
+% the LC_PAPER category.
+% (A4 paper, this is also used in the built in C/POSIX
+% locale in glibc/locale/C-paper.c)
+height   297
+width    210
+END LC_PAPER
+
+LC_NAME
+% This is the ISO/IEC 14652 "i18n" definition for
+% the LC_NAME category.
+% "%p%t%g%t%m%t%f"
+% (this value matches the built in C/POSIX locale in glibc/locale/C-name.c)
+name_fmt    "<U0025><U0070><U0025><U0074><U0025><U0067><U0025><U0074>/
+<U0025><U006D><U0025><U0074><U0025><U0066>"
+END LC_NAME
+
+LC_ADDRESS
+% This is the ISO/IEC 14652 "i18n" definition for the LC_ADDRESS category.
+% "%a%N%f%N%d%N%b%N%s %h %e %r%N%C-%z %T%N%c%N"
+% (this value matches the built in C/POSIX locale in glibc/locale/C-address.c)
+postal_fmt    "<U0025><U0061><U0025><U004E><U0025><U0066><U0025><U004E>/
+<U0025><U0064><U0025><U004E><U0025><U0062><U0025><U004E><U0025><U0073>/
+<U0020><U0025><U0068><U0020><U0025><U0065><U0020><U0025><U0072><U0025>/
+<U004E><U0025><U0043><U002D><U0025><U007A><U0020><U0025><U0054><U0025>/
+<U004E><U0025><U0063><U0025><U004E>"
+END LC_ADDRESS
+
+LC_TELEPHONE
+% This is the ISO/IEC 14652 "i18n" definition for the LC_TELEPHONE category.
+% "+%c %a %l"
+tel_int_fmt    "<U002B><U0025><U0063><U0020><U0025><U0061><U0020><U0025>/
+<U006C>"
+% (this value matches the built in C/POSIX locale in glibc/locale/C-telephone.c)
+END LC_TELEPHONE
+
+LC_MEASUREMENT
+% This is the ISO/IEC 14652 "i18n" definition for the LC_MEASUREMENT category.
+% (this value matches the built in C/POSIX locale in glibc/locale/C-measurement.c)
+%metric
+measurement    1
+END LC_MEASUREMENT
+

--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -162,11 +162,9 @@ cat tmp/host.list | grep -v '/ld[.]so[.]' | sort | uniq > bundle/host.list
 mkdir -p bundle/{dev,proc,tmp,etc,etc.host,run,run.host,var}
 touch bundle/dev/{null,zero,random,urandom,fuse}
 
-# Mongo wants these localization files.
-mkdir -p bundle/usr/lib
-cp -r /usr/lib/locale bundle/usr/lib
-mkdir -p bundle/usr/share/locale
-cp /usr/share/locale/locale.alias bundle/usr/share/locale
+# Generate a suitable C.UTF-8 locale that we and Mongo can rely on
+mkdir -p bundle/usr/lib/locale
+localedef --no-archive --inputfile=./localedata-C --charmap=UTF-8 bundle/usr/lib/locale/C.UTF-8
 
 # Make bundle smaller by stripping stuff.
 strip bundle/sandstorm bundle/bin/*


### PR DESCRIPTION
Before this patch, to obtain a sane locale, we would copy in locales from the
host system, then set `LANG=C.UTF-8` in `run-bundle.c++`.  This had two issues:

* Build hosts that aren't running Debian don't have a C.UTF-8 locale, so the
  generated bundle wouldn't run unless you'd manually defined one on the host
* This included *all locales* from the host system, including the whole
  locale-archive, which (if you have additional locales installed) could add
  ~100MB to the package.

With this patch, we move to standardize what locale data we ship:
`make-bundle.sh` will generate a locale similar to Debian's C.UTF-8 locale for
inclusion in the bundle.  This locale, like Debian's, is non-conforming to the
SUS, but is significantly more useful in a variety of ways that are more
important for real applications, such as:

* having actual correct character classes for the whole Unicode character set
* having a guaranteed sort order for characters beyond U+007F

To minimize duplicated effort delta from glibc upstream, this implementation
still relies on the system's UTF-8 character map and some other glibc-provided
i18n files that were available as part of the minimal install on all systems I
tested.

Closes #169.