### PR TITLE
move identity switcher into account buttons dropdown

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -1,4 +1,4 @@
-body>.popup.account>.frame {
+body>.popup.login>.frame {
   width: 200px;
   border: none;
   min-width: 200px;
@@ -15,6 +15,63 @@ body>.popup.account>.frame {
   }
 }
 
+body>.popup.account>.frame {
+  width: 250px;
+  border: none;
+
+  >p.demo-note {
+    border-bottom: 1px solid #c1c1c1;
+    font-size: 80%;
+    color: #444;
+    padding: 4px 16px;
+  }
+
+  >* {
+    margin: 0;
+  }
+}
+
+.account-buttons-list {
+  width: 250px;
+  margin: 0;
+  text-align: left;
+
+  >button.logout, >button.switch-identity, >form, >a {
+    display: block;
+    width: 250px;
+    height: 32px;
+    box-sizing: border-box;
+    text-decoration: none;
+    color: black;
+    font-weight: normal;
+
+    cursor: pointer;
+    padding: 4px 8px;
+
+    font-size: 80%;
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    line-height: 1.5;
+
+    text-align: left;
+    text-indent: 40px;
+    color: black;
+
+    background: white;
+
+    border: none;
+    border-bottom: 1px solid #c1c1c1;
+
+    &:hover {
+      background-color: #f5f5f5;
+    }
+  }
+  .inline-identity-switcher {
+    padding-left: 16px;
+    padding-bottom: 5px;
+    border-bottom: 1px solid #c1c1c1;
+  }
+}
+
 .login-buttons-list {
   width: 200px;
   margin: 0;
@@ -22,7 +79,7 @@ body>.popup.account>.frame {
 
   /* TODO(cleanup): Much of the below was brought it from Meteor's accounts-ui and needs cleanup. */
 
-  >button.login, >button.logout, >form, >a {
+  >button.login, >form, >a {
     display: block;
     width: 200px;
     height: 32px;
@@ -95,29 +152,6 @@ body>.popup.account>.frame {
     }
   }
 
-  .login-image {
-    display: inline-block;
-    position: absolute;
-    left: 6px;
-    top: 6px;
-    width: 16px;
-    height: 16px;
-  }
-
-  .login-buttons-with-only-one-button {
-    display: inline-block;
-    .login-button { display: inline-block; }
-    .login-text-and-button {
-      display: inline-block;
-    }
-  }
-
-  .login-display-name {
-    display: inline-block;
-    padding-right: 2px;
-    line-height: 1.5;
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  }
   .loading {
     line-height: 1;
     background-image: url("data:image/gif;base64,R0lGODlhEAALAPQAAP///wAAANra2tDQ0Orq6gYGBgAAAC4uLoKCgmBgYLq6uiIiIkpKSoqKimRkZL6+viYmJgQEBE5OTubm5tjY2PT09Dg4ONzc3PLy8ra2tqCgoMrKyu7u7gAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCwAAACwAAAAAEAALAAAFLSAgjmRpnqSgCuLKAq5AEIM4zDVw03ve27ifDgfkEYe04kDIDC5zrtYKRa2WQgAh+QQJCwAAACwAAAAAEAALAAAFJGBhGAVgnqhpHIeRvsDawqns0qeN5+y967tYLyicBYE7EYkYAgAh+QQJCwAAACwAAAAAEAALAAAFNiAgjothLOOIJAkiGgxjpGKiKMkbz7SN6zIawJcDwIK9W/HISxGBzdHTuBNOmcJVCyoUlk7CEAAh+QQJCwAAACwAAAAAEAALAAAFNSAgjqQIRRFUAo3jNGIkSdHqPI8Tz3V55zuaDacDyIQ+YrBH+hWPzJFzOQQaeavWi7oqnVIhACH5BAkLAAAALAAAAAAQAAsAAAUyICCOZGme1rJY5kRRk7hI0mJSVUXJtF3iOl7tltsBZsNfUegjAY3I5sgFY55KqdX1GgIAIfkECQsAAAAsAAAAABAACwAABTcgII5kaZ4kcV2EqLJipmnZhWGXaOOitm2aXQ4g7P2Ct2ER4AMul00kj5g0Al8tADY2y6C+4FIIACH5BAkLAAAALAAAAAAQAAsAAAUvICCOZGme5ERRk6iy7qpyHCVStA3gNa/7txxwlwv2isSacYUc+l4tADQGQ1mvpBAAIfkECQsAAAAsAAAAABAACwAABS8gII5kaZ7kRFGTqLLuqnIcJVK0DeA1r/u3HHCXC/aKxJpxhRz6Xi0ANAZDWa+kEAA7AAAAAAAAAAAA");
@@ -391,6 +425,7 @@ body>.main-content>.account {
         cursor: pointer;
         background-color: white;
         width: 218px;
+        margin-bottom: 10px;
 
         &[aria-selected=true] {
           z-index: 1;
@@ -1333,6 +1368,7 @@ button.show-other-accounts {
 }
 
 ul.identity-card-list {
+  padding-left: 0;
   li {
     list-style-type: none;
     button {
@@ -1350,7 +1386,7 @@ ul.identity-card-list {
   height: 52px;
   width: 218px;
   text-align: left;
-  margin-bottom: 10px;
+  margin-bottom: 0;
   background-color: white;
   background-repeat: no-repeat;
   background-position: 50px 30px;

--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -430,7 +430,7 @@ body>.topbar {
       }
     }
 
-    >.account {
+    >.account, >.login {
       >button.show-popup {
         @extend %hamburger-menu-item;
         >a.expiring-soon {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -66,8 +66,13 @@ limitations under the License.
       <div class="toggle-navbar-button">Sandstorm</div>
       {{/sandstormTopbarItem}}
   {{/if}}
-  {{>sandstormTopbarItem name="account" topbar=globalTopbar data=globalAccountsUi
-                         template="loginButtons" popupTemplate="loginButtonsPopup"}}
+  {{#if showAccountButtons}}
+    {{>sandstormTopbarItem name="account" topbar=globalTopbar template="loginButtons"
+                           popupTemplate="accountButtonsPopup"}}
+  {{else}}
+    {{>sandstormTopbarItem name="login" topbar=globalTopbar data=globalAccountsUi
+                           template="loginButtons" popupTemplate="loginButtonsPopup"}}
+  {{/if}}
   {{#if currentUser}}
     {{>sandstormTopbarItem name="notifications" topbar=globalTopbar
                            template="notifications" popupTemplate="notificationsPopup"}}
@@ -531,14 +536,6 @@ limitations under the License.
   </div>
 </template>
 
-<template name="grainIdentityPopup">
-  {{> identityPicker identityPickerData}}
-</template>
-
-<template name="grainIdentity">
-  <div>Switch Identity</div>
-</template>
-
 <template name="grain">
   {{>sandstormTopbarItem name="title" priority=5 topbar=globalTopbar template="grainTitle"}}
   {{#sandstormTopbarItem name="grain-size" priority=5 topbar=globalTopbar}}
@@ -571,10 +568,6 @@ limitations under the License.
     {{>sandstormTopbarItem name="offer" topbar=globalTopbar template="grainPowerboxOffer"
         startOpen=true popupTemplate="grainPowerboxOfferPopup"}}
   {{/if}}
-
-  {{>sandstormTopbarItem name="identity" topbar=globalTopbar
-                         template="grainIdentity" popupTemplate="grainIdentityPopup"}}
-
 </template>
 
 <template name="apps">

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -67,8 +67,8 @@ limitations under the License.
       {{/sandstormTopbarItem}}
   {{/if}}
   {{#if showAccountButtons}}
-    {{>sandstormTopbarItem name="account" topbar=globalTopbar template="loginButtons"
-                           popupTemplate="accountButtonsPopup"}}
+    {{>sandstormTopbarItem name="account" topbar=globalTopbar data=accountButtonsData
+                           template="accountButtons" popupTemplate="accountButtonsPopup"}}
   {{else}}
     {{>sandstormTopbarItem name="login" topbar=globalTopbar data=globalAccountsUi
                            template="loginButtons" popupTemplate="loginButtonsPopup"}}

--- a/shell/packages/accounts-identity/package.js
+++ b/shell/packages/accounts-identity/package.js
@@ -22,7 +22,7 @@ Package.describe({
 Package.onUse(function (api) {
   api.use(["underscore", "random", "sandstorm-db", "mongo"]);
   api.use("accounts-base", ["client", "server"]);
-  api.use(["templating"], ["client"]);
+  api.use(["session", "templating"], ["client"]);
   api.imply("accounts-base", ["client", "server"]);
   api.use("check");
 

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -199,7 +199,7 @@ limitations under the License.
       <button class="unlink-identity" data-identity-id="{{_id}}">Unlink this identity</button>
     </div>
     <div>
-      {{#if login}}
+      {{#if isLogin _id}}
       <button class="make-no-login" data-identity-id="{{_id}}">Login enabled</button>
       {{else}}
       <button class="make-login" data-identity-id="{{_id}}">Login disabled</button>

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -43,13 +43,15 @@
 
   <div class="account-buttons-list" role="menu">
     <a href="/account" role="menuitem">Account settings</a>
-    <button class="switch-identity">
-      Switch identity {{#if showIdentitySwitcher}}▴{{else}}▾{{/if}}
-    </button>
     {{#if showIdentitySwitcher}}
+    <button class="switch-identity">
+      Switch identity {{#if identitySwitcherExpanded}}▴{{else}}▾{{/if}}
+    </button>
+    {{#if identitySwitcherExpanded}}
     <div class="inline-identity-switcher">
       {{> identityPicker identitySwitcherData}}
     </div>
+    {{/if}}
     {{/if}}
     {{#if isAdmin}}
     <a href="/admin" role="menuitem">Admin settings</a>

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -22,24 +22,11 @@
 
 <template name="loginButtonsPopup">
   {{!-- Data context is an instance of AccountsUi. --}}
+  {{> _loginButtonsLoggedOutDropdown}}
+</template>
 
-  {{#if currentUser}}
-    {{#if loggingIn}}
-      {{! We aren't actually logged in yet; we're just setting Meteor.userId
-          optimistically during an at-startup login-with-token. We expose this
-          state so other UIs can treat it specially, but we'll just treat it
-          as logged out. }}
-      {{> _loginButtonsLoggedOutDropdown}}
-    {{else}}
-      {{#if isDemoUser}}
-        {{> _loginButtonsLoggedOutDropdown}}
-      {{else}}
-        {{> _loginButtonsLoggedInDropdown}}
-      {{/if}}
-    {{/if}}
-  {{else}}
-    {{> _loginButtonsLoggedOutDropdown}}
-  {{/if}}
+<template name="accountButtonsPopup">
+  {{> _loginButtonsLoggedInDropdown}}
 </template>
 
 <template name="_loginButtonsMessages">
@@ -54,9 +41,16 @@
 <template name="_loginButtonsLoggedInDropdown">
   <h4>Account</h4>
 
-  {{!-- TODO(cleanup): Don't wrap this in login-buttons-list? --}}
-  <div class="login-buttons-list" role="menu">
+  <div class="account-buttons-list" role="menu">
     <a href="/account" role="menuitem">Account settings</a>
+    <button class="switch-identity">
+      Switch identity {{#if showIdentitySwitcher}}▴{{else}}▾{{/if}}
+    </button>
+    {{#if showIdentitySwitcher}}
+    <div class="inline-identity-switcher">
+      {{> identityPicker identitySwitcherData}}
+    </div>
+    {{/if}}
     {{#if isAdmin}}
     <a href="/admin" role="menuitem">Admin settings</a>
     {{/if}}

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -1,23 +1,14 @@
 <template name="loginButtons">
   {{!-- Data context is an instance of AccountsUi. --}}
-
-  {{#if currentUser}}
-    {{#if loggingIn}}
-      {{! We aren't actually logged in yet; we're just setting Meteor.userId
-          optimistically during an at-startup login-with-token. We expose this
-          state so other UIs can treat it specially, but we'll just treat it
-          as logged out. }}
-      <a>Sign in ▾</a>
-    {{else}}
-      {{#if isDemoUser}}
-        <a class="{{#if expiringSoon}}expiring-soon{{/if}}">Demo {{demoTimeLeft}} ▾</a>
-      {{else}}
-        <a>{{displayName}} ▾</a>
-      {{/if}}
-    {{/if}}
+  {{#if isDemoUser}}
+    <a class="{{#if expiringSoon}}expiring-soon{{/if}}">Demo {{demoTimeLeft}} ▾</a>
   {{else}}
     <a>Sign in ▾</a>
   {{/if}}
+</template>
+
+<template name="accountButtons">
+  <a>{{displayName}} ▾</a>
 </template>
 
 <template name="loginButtonsPopup">

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -42,7 +42,7 @@ Template.loginButtonsPopup.onRendered(function() {
   this.find("[role=menuitem]").focus();
 });
 
-Template.loginButtonsPopup.events({
+Template.accountButtonsPopup.events({
   'click button.logout': function() {
     var topbar = Template.parentData(3);
     Meteor.logout(function () {
@@ -60,10 +60,12 @@ Template.loginButtonsPopup.events({
 });
 
 var displayName = function () {
-  var user = Meteor.user();
-  if (!user) return '';
-  var mainIdentity = SandstormDb.getUserIdentities(user)[0];
-  return mainIdentity && mainIdentity.profile.name;
+  var currentIdentityId = Accounts.getCurrentIdentityId();
+  var user = Meteor.users.findOne({_id: currentIdentityId});
+  if (!user) return "(incognito)";
+
+  SandstormDb.fillInProfileDefaults(user);
+  return user.profile.name;
 };
 
 Template.loginButtons.helpers({
@@ -148,8 +150,39 @@ var capitalize = function(str){
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
 
+Template._loginButtonsLoggedInDropdown.onCreated(function() {
+  this._identitySwitcherExpanded = new ReactiveVar(false);
+});
+
 Template._loginButtonsLoggedInDropdown.helpers({
   displayName: displayName,
+  showIdentitySwitcher: function () {
+    return Template.instance()._identitySwitcherExpanded.get();
+  },
+  identitySwitcherData: function () {
+    var identities = SandstormDb.getUserIdentityIds(Meteor.user()).map(function (id) {
+      var identity = Meteor.users.findOne({_id: id});
+      if (identity) {
+        SandstormDb.fillInProfileDefaults(identity);
+        SandstormDb.fillInIntrinsicName(identity);
+        SandstormDb.fillInPictureUrl(identity);
+        return identity;
+      }
+    });
+    function onPicked(identityId) {
+      Accounts.setCurrentIdentityId(identityId);
+    }
+    return { identities: identities, onPicked: onPicked,
+             currentIdentityId: Accounts.getCurrentIdentityId() };
+  },
+
+
+});
+
+Template._loginButtonsLoggedInDropdown.events({
+  "click button.switch-identity" : function (event, instance) {
+    instance._identitySwitcherExpanded.set(!instance._identitySwitcherExpanded.get());
+  }
 });
 
 var sendEmail = function (email, linkingNewIdentity) {

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -156,7 +156,10 @@ Template._loginButtonsLoggedInDropdown.onCreated(function() {
 
 Template._loginButtonsLoggedInDropdown.helpers({
   displayName: displayName,
-  showIdentitySwitcher: function () {
+  showIdentitySwitcher: function() {
+    return SandstormDb.getUserIdentityIds(Meteor.user()).length > 1;
+  },
+  identitySwitcherExpanded: function () {
     return Template.instance()._identitySwitcherExpanded.get();
   },
   identitySwitcherData: function () {

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -8,9 +8,6 @@ var helpers = {
   isDemoUser: function () {
     return this._db.isDemoUser();
   },
-  isAdmin: function () {
-    return this._db.isAdmin();
-  },
   demoTimeLeft: function () {
     var ms = Meteor.user().expires.getTime() - Date.now();
     var sec = Math.floor(ms / 1000) % 60;
@@ -68,7 +65,7 @@ var displayName = function () {
   return user.profile.name;
 };
 
-Template.loginButtons.helpers({
+Template.accountButtons.helpers({
   displayName: displayName
 });
 

--- a/shell/packages/sandstorm-accounts-ui/package.js
+++ b/shell/packages/sandstorm-accounts-ui/package.js
@@ -6,7 +6,7 @@ Package.describe({
 Package.onUse(function (api) {
   api.use(['check', 'tracker', 'service-configuration', 'accounts-base',
            'underscore', 'templating', 'session', 'http', 'sandstorm-db'], 'client');
-  api.use(['check', 'accounts-base'], 'server');
+  api.use(['check', 'accounts-base', "accounts-identity"], 'server');
 
   // Export Accounts (etc) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);

--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -18,49 +18,59 @@ var makeIdenticon;
 var httpProtocol;
 
 if (Meteor.isServer) {
+  Meteor.publish("identityProfile", function (identityId) {
+    check(identityId, String);
+
+    // Dummy query handle for the case where this.userId === identityId
+    var hasIdentityHandle = {stop: function () {} };
+
+    if (this.userId !== identityId) {
+      var hasIdentityCursor =
+          Meteor.users.find({$or: [{_id: this.userId, "loginIdentities.id": identityId},
+                                   {_id: this.userId, "nonloginIdentities.id": identityId}]});
+      if (hasIdentityCursor.count() == 0) return;
+      hasIdentityHandle = hasIdentityCursor.observe({removed: function () { self.stop(); }});
+    }
+
+    this.onStop(function () { hasIdentityHandle.stop(); });
+    return Meteor.users.find({_id: identityId},
+      {fields: {
+        "profile":1,
+        "unverifiedEmail":1,
+        "expires": 1,
+
+        "services.dev.name":1,
+
+        "services.google.id":1,
+        "services.google.email":1,
+        "services.google.verified_email":1,
+        "services.google.name":1,
+        "services.google.picture":1,
+        "services.google.gender":1,
+
+        "services.github.id":1,
+        "services.github.email":1,
+        "services.github.username":1,
+
+        "services.email.email":1,
+      }});
+  }),
+
   Meteor.publish("accountIdentities", function () {
+    // Maybe this should be folded into the "credentials" subscription?
+
     if (!this.userId) return [];
 
-    // The bad news is that we need to do a join here. The good news is that linking a new
-    // identity is a relatively uncommon action, and the client initiating the action gets
-    // automatically resubscribed during the authentication handshake. Unlinking an identity
-    // is less of a problem, as it just means that subscribers will have more information than
-    // they need.
-    //
-    // TODO(someday): Implement a fully reactive join for this.
-    var user = Meteor.users.findOne(this.userId);
-    var linkedIdentities = user.loginIdentities &&
-        user.loginIdentities.concat(user.nonloginIdentities);
-    var linkedIdentityIds =
-      linkedIdentities ? _.pluck(linkedIdentities, "id") : [];
-
-    return [
-      Meteor.users.find({$or: [{_id: this.userId}, {_id: {$in: linkedIdentityIds}}]},
-        {fields: {
-          "profile":1,
-          "verifiedEmail":1,
-          "unverifiedEmail":1,
-          "loginIdentities": 1,
-          "nonloginIdentities": 1,
-          "expires": 1,
-          "primaryEmail": 1,
-
-          "services.dev.name":1,
-
-          "services.google.id":1,
-          "services.google.email":1,
-          "services.google.verified_email":1,
-          "services.google.name":1,
-          "services.google.picture":1,
-          "services.google.gender":1,
-
-          "services.github.id":1,
-          "services.github.email":1,
-          "services.github.username":1,
-
-          "services.email.email":1,
-        }})
-    ];
+    return Meteor.users.find(
+      {_id: this.userId},
+      {fields: {
+        "profile": 1,
+        "verifiedEmail": 1,
+        "loginIdentities": 1,
+        "nonloginIdentities": 1,
+        "expires": 1,
+        "primaryEmail": 1,
+      }});
   });
 
   makeIdenticon = function (id) {
@@ -206,49 +216,13 @@ SandstormDb.fillInPictureUrl = function(user) {
     makeIdenticon(user._id);
 }
 
-SandstormDb.getUserIdentities = function (user) {
-  // Given a user object, return an array containing all of the user's identities. Always returns
-  // the user's most recently added login identity first.
-  //
-  // On the client, must be subscribed "accountIdentities" for the user.
-  //
-  // TODO(cleanup): This actually does need to query the database to fetch profile information
-  //   for linked identities, so it probably makes more sense for it to be a non-static method
-  //   on SandstormDb.
-  if (!user) return [];
-
-  var rawIdentities = [];
-  if (user.profile) {
-    rawIdentities.push(user);
-  } else if (user.loginIdentities) {
-    // We call reverse() because we want the most recently added identities to appear first.
-    var loginIdentities =
-        user.loginIdentities.map(function (i) { return _.extend(i, {login: true}); }).reverse();
-    var nonloginIdentities =
-        user.nonloginIdentities.map(function (i) { return _.extend(i, {login: false}); }).reverse();
-    var linkedIdentities = loginIdentities.concat(nonloginIdentities);
-    var linkedIdentityIds = linkedIdentities.map(function (i) { return i.id; });
-    var linkedUsersMap = {};
-    Meteor.users.find({_id: {$in: linkedIdentityIds}}).forEach(function (user) {
-      linkedUsersMap[user._id] = user;
-    });
-    linkedIdentities.forEach(function (linkedIdentity) {
-      if (linkedUsersMap[linkedIdentity.id]) {
-        rawIdentities.push(_.extend({login: linkedIdentity.login},
-                                    linkedUsersMap[linkedIdentity.id]));
-      }
-    });
+SandstormDb.getUserIdentityIds = function (user) {
+  if (user && user.loginIdentities) {
+    return _.pluck(user.nonloginIdentities.concat(user.loginIdentities), "id").reverse();
   } else {
     return [];
   }
-
-  return rawIdentities.map(function(identity) {
-    SandstormDb.fillInPictureUrl(identity);
-    SandstormDb.fillInProfileDefaults(identity);
-    SandstormDb.fillInIntrinsicName(identity);
-    return identity;
-  });
-}
+};
 
 SandstormDb.getUserEmails = function (user) {
   // Given a user object, returns an array containing all email addresses associated with that user.
@@ -261,18 +235,19 @@ SandstormDb.getUserEmails = function (user) {
   //   for linked identities, so it probably makes more sense for it to be a non-static method
   //   on SandstormDb.
 
-  var identities = SandstormDb.getUserIdentities(user);
+  var identityIds = SandstormDb.getUserIdentityIds(user);
   verifiedEmails = {};
   unverifiedEmails = {};
 
-  identities.forEach(function (identity) {
-    if (identity.services) {
+  identityIds.forEach(function (id) {
+    var identity = Meteor.users.findOne({_id: id});
+    if (identity && identity.services) {
       var verifiedEmail = getVerifiedEmail(identity);
       if (verifiedEmail) {
         verifiedEmails[verifiedEmail] = true;
       }
     }
-    if (identity.unverifiedEmail) {
+    if (identity && identity.unverifiedEmail) {
       unverifiedEmails[identity.unverifiedEmail] = true;
     }
   });

--- a/shell/packages/sandstorm-db/user.js
+++ b/shell/packages/sandstorm-db/user.js
@@ -130,6 +130,9 @@ Accounts.onCreateUser(function (options, user) {
   } else if (user.services && "github" in user.services) {
     serviceUserId = user.services.github.id;
     user.profile.service = "github";
+  } else {
+    throw new Meteor.Error(400, "user does not have a recognized identity provider: " +
+                           JSON.stringify(user));
   }
   user._id = Crypto.createHash("sha256")
     .update(user.profile.service + ":" + serviceUserId).digest("hex");

--- a/shell/packages/sandstorm-permissions/permissions-tests.js
+++ b/shell/packages/sandstorm-permissions/permissions-tests.js
@@ -24,32 +24,32 @@ function initializeDb() {
   globalDb.collections.grains.remove({});
   globalDb.collections.apiTokens.remove({});
 
-  var aliceUserId = Accounts.insertUserDoc(
+  var aliceIdentityId = Accounts.insertUserDoc(
     {profile: {name: "Alice"}},
-    {services: {dev : {name: "alice" + Crypto.randomBytes(10).toString("hex"),
-                       isAdmin: false, hasCompletedSignup: true}}});
-  var aliceIdentityId = SandstormDb.getUserIdentities(globalDb.getUser(aliceUserId))[0]._id;
-  var bobUserId = Accounts.insertUserDoc(
+    {services: {dev: {name: "alice" + Crypto.randomBytes(10).toString("hex"),
+                      isAdmin: false, hasCompletedSignup: true}}});
+  var aliceAccountId = Accounts.insertUserDoc({},
+    {loginIdentities: [{id: aliceIdentityId}], nonloginIdentities: []});
+  var bobIdentityId = Accounts.insertUserDoc(
     {profile: {name: "Bob"}},
     {services: {dev: {name: "Bob" + Crypto.randomBytes(10).toString("hex"),
                       isAdmin: false, hasCompletedSignup: true}}});
-  var bobIdentityId = SandstormDb.getUserIdentities(globalDb.getUser(bobUserId))[0]._id;
-  var carolUserId = Accounts.insertUserDoc(
+  var carolIdentityId = Accounts.insertUserDoc(
     {profile: {name: "Carol"}},
     {services: {dev:{name: "Carol" + Crypto.randomBytes(10).toString("hex"),
                      isAdmin: false, hasCompletedSignup: true}}});
-  var carolIdentityId = SandstormDb.getUserIdentities(globalDb.getUser(carolUserId))[0]._id;
 
   var grain = { _id: "mock-grain-id", packageId: "mock-package-id", appId: "mock-app-id",
-                appVersion: 0, userId: aliceUserId,
+                appVersion: 0, userId: aliceAccountId,
                 identityId: carolIdentityId, // Shouldn't affect permissions computations.
                 title: "mock-grain-title", private: true };
 
   globalDb.collections.grains.insert(grain);
   return {grainId: grain._id,
-          aliceUserId: aliceUserId,
+          aliceUserId: aliceAccountId,
           aliceIdentityId: aliceIdentityId,
-          bobIdentityId: bobIdentityId, carolIdentityId: carolIdentityId};
+          bobIdentityId: bobIdentityId,
+          carolIdentityId: carolIdentityId};
 }
 
 var viewInfo = {

--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -197,8 +197,8 @@ function collectEdges(db, vertex) {
 
   var owningUser = Meteor.users.findOne({_id: grain.userId});
   if (owningUser) {
-    SandstormDb.getUserIdentities(owningUser).forEach(function(identity) {
-      result.edgesByRecipient[identity._id] = [{sharer: "OwningAccount", roleAssignments: []}];
+    SandstormDb.getUserIdentityIds(owningUser).forEach(function(identityId) {
+      result.edgesByRecipient[identityId] = [{sharer: "OwningAccount", roleAssignments: []}];
     });
   }
 
@@ -542,8 +542,7 @@ Meteor.methods({
       throw new Meteor.Error(404, "No such token found.");
     }
 
-    if (_.findWhere(SandstormDb.getUserIdentities(db.getUser(this.userId)),
-                    {id: apiToken.identityId})) {
+    if (db.userHasIdentity(this.userId, apiToken.identityId)) {
       var modifier = {$set: newFields};
       db.collections.apiTokens.update(token, modifier);
     } else {

--- a/shell/server/backup.js
+++ b/shell/server/backup.js
@@ -67,8 +67,9 @@ Meteor.methods({
     return token._id;
   },
 
-  restoreGrain: function (tokenId) {
+  restoreGrain: function (tokenId, identityId) {
     check(tokenId, String);
+    check(identityId, String);
     var token = FileTokens.findOne(tokenId);
     if (!token || !isSignedUpOrDemo()) {
       throw new Meteor.Error(403, "Unauthorized",
@@ -126,17 +127,13 @@ Meteor.methods({
                                ", Old version: " + appVersion);
       }
 
-      var identity = SandstormDb.getUserIdentities(Meteor.user())[0];
-      // TODO(soon): Backed-up grains should remember the identity that owned them.
-      // Until that is the case, we restore using the user's main identity.
-
       Grains.insert({
         _id: grainId,
         packageId: packageId,
         appId: grainInfo.appId,
         appVersion: appVersion,
         userId: this.userId,
-        identityId: identity._id,
+        identityId: identityId,
         title: grainInfo.title,
         private: true
       });

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -343,7 +343,13 @@ if (Meteor.isClient) {
       return Meteor.users.find({loginIdentities: {$exists: 1}}, {sort: {createdAt: 1}});
     },
     userIdentity: function () {
-      return SandstormDb.getUserIdentities(this)[0];
+      var identityId = SandstormDb.getUserIdentityIds(this)[0];
+      var identity = Meteor.users.findOne({_id: identityId});
+      if (identity) {
+        SandstormDb.fillInProfileDefaults(identity);
+        SandstormDb.fillInIntrinsicName(identity);
+        return identity;
+      }
     },
     userSignupNote: function () {
       if (this.signupEmail) {

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -497,6 +497,9 @@ if (Meteor.isClient) {
     showAccountButtons: function () {
       return Meteor.user() && !Meteor.loggingIn() && !isDemoUser();
     },
+    accountButtonsData: function () {
+      return {isAdmin: globalDb.isAdmin()};
+    },
     firstLogin: function () {
       return credentialsSubscription.ready() && !isDemoUser() && !Meteor.loggingIn()
           && Meteor.user() && !Meteor.user().hasCompletedSignup;

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -35,6 +35,25 @@ if (Meteor.isClient) {
     Meteor.subscribe("credentials"),
     Meteor.subscribe("accountIdentities"),
   ];
+
+  Tracker.autorun(function () {
+    var me = Meteor.user();
+    if (me) {
+      if (me.profile) {
+        Meteor.subscribe("identityProfile", me._id);
+      }
+      if (me.loginIdentities) {
+        me.loginIdentities.forEach(function (identity) {
+          Meteor.subscribe("identityProfile", identity.id);
+        })
+      }
+      if (me.nonloginIdentities) {
+        me.nonloginIdentities.forEach(function (identity) {
+          Meteor.subscribe("identityProfile", identity.id);
+        })
+      }
+    }
+  });
 }
 
 if (Meteor.isServer) {
@@ -87,8 +106,7 @@ if (Meteor.isServer) {
           }
         });
       }
-      var identityIds = SandstormDb.getUserIdentities(globalDb.getUser(this.userId))
-          .map(function (x) { return x._id; });
+      var identityIds = SandstormDb.getUserIdentityIds(globalDb.getUser(this.userId));
       return [
         UserActions.find({userId: this.userId}),
         Grains.find({userId: this.userId}),
@@ -476,6 +494,9 @@ if (Meteor.isClient) {
       var user = Meteor.user();
       return user && user.profile;
     },
+    showAccountButtons: function () {
+      return Meteor.user() && !Meteor.loggingIn() && !isDemoUser();
+    },
     firstLogin: function () {
       return credentialsSubscription.ready() && !isDemoUser() && !Meteor.loggingIn()
           && Meteor.user() && !Meteor.user().hasCompletedSignup;
@@ -606,10 +627,10 @@ if (Meteor.isClient) {
 
     var title = "Untitled " + appTitle + " " + nounPhrase;
 
-    var identity = SandstormDb.getUserIdentities(Meteor.user())[0];
+    var identityId = Accounts.getCurrentIdentityId();
 
     // We need to ask the server to start a new grain, then browse to it.
-    Meteor.call("newGrain", packageId, command, title, identity._id, function (error, grainId) {
+    Meteor.call("newGrain", packageId, command, title, identityId, function (error, grainId) {
       if (error) {
         console.error(error);
         alert(error.message);
@@ -809,7 +830,8 @@ promptRestoreBackup = function(input) {
   promptForFile(input, function (file) {
     startUpload(file, "/uploadBackup", function (response) {
       Session.set("uploadStatus", "Unpacking");
-      Meteor.call("restoreGrain", response, function (err, grainId) {
+      var identityId = Accounts.getCurrentIdentityId();
+      Meteor.call("restoreGrain", response, identityId, function (err, grainId) {
         if (err) {
           console.log(err);
           Session.set("uploadStatus", undefined);

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -205,7 +205,7 @@ module.exports["Test roleless sharing"] = function (browser) {
   browser
   // Upload app as 1st user
     .loginDevAccount()
-    .execute(function () { return SandstormDb.getUserIdentities(Meteor.user())[0].profile.intrinsicName; }, [], function(result) {
+    .execute(function () { return globalDb.getIdentity(Meteor.user().loginIdentities[0].id).profile.intrinsicName; }, [], function(result) {
       firstUserName = result.value;
     })
     .url(browser.launch_url + "/install/ca690ad886bf920026f8b876c19539c1?url=http://sandstorm.io/apps/ssjekyll8.spk")
@@ -228,7 +228,7 @@ module.exports["Test roleless sharing"] = function (browser) {
     .getText('#share-token-text', function(response) {
       browser
         .loginDevAccount()
-        .execute(function () { return SandstormDb.getUserIdentities(Meteor.user())[0].profile.intrinsicName; }, [], function(result) {
+        .execute(function () { return globalDb.getIdentity(Meteor.user().loginIdentities[0].id).profile.intrinsicName; }, [], function(result) {
           secondUserName = result.value;
         })
         .url(response.value)


### PR DESCRIPTION
This rebases and adds one commit (https://github.com/sandstorm-io/sandstorm/commit/7ef09579d34335d239f48473072a54ae0e623f62) to #1199, moving the identity switcher into the account buttons dropdown menu. I'll rebase away the duplicated commits if #1199 ends up getting merged first.

The new commit also gets rid of the `SandstormDb.getUserIdentities()` function, replacing it with `SandstormDb.getUserIdentityIds()`, which doesn't need to make a database query.