### PR TITLE
Ensure that expectSize() request gets sent.

### DIFF
--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -2009,7 +2009,7 @@ public:
         req.setSize(stats.st_size);
         auto expectSizeTask = req.send();
         auto inStream = kj::heap<kj::FdInputStream>(kj::mv(*fd));
-        return pump(*inStream, kj::mv(stream)).attach(kj::mv(inStream));
+        return pump(*inStream, kj::mv(stream)).attach(kj::mv(inStream), kj::mv(expectSizeTask));
       } else if (S_ISDIR(stats.st_mode)) {
         context.getResults(capnp::MessageSize {4, 0})
             .setStatus(Supervisor::WwwFileStatus::DIRECTORY);


### PR DESCRIPTION
On IRC, mortehu noted that `expectSizeTask` is unused. When it gets dropped, the `expectSize()` request could (and probably does) get cancelled.

This patch ensures that the request goes through and ignores any errors, as recommended by the documentation in [util.capnp](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/util.capnp).

Note: that documentation may have been written before `Exception.Type.Unimplemented` existed. A more complete solution might be to only ignore errors if they are of type `Unimplemented`. Indeed, there is some code to that effect in blackrock.