### PR TITLE
Lots of cleanup for the account profile UI

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -411,6 +411,24 @@ body>.main-content>.account {
     border: none;
   }
 
+  div.action-completed {
+    margin-top: 10px;
+    width: 660px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+
+    &.success {
+      color: #3c763d;
+      background-color: #dff0d8;
+      border-color: #d6e9c6;
+    }
+    &.error {
+      color: #a94442;
+      background-color: #f2dede;
+      border-color: #ebccd1;
+    }
+  }
+
   .identities-tabs {
     display: inline-block;
     white-space: normal;
@@ -478,21 +496,39 @@ body>.main-content>.account {
     position: relative;
     width: 680px;
     .already-verified {
-      width: 320px;
+      width: 340px;
       left: 0px;
       ul {
+        margin-top: 5px;
         padding-left: 15px;
         background-color: white;
         li {
           height: 30px;
           list-style-type: none;
-          overflow: hidden;
-          text-overflow: ellipsis;
           white-space: nowrap;
           padding-top: 10px;
 
           &:last-child hr {
             display: none;
+          }
+          span.email {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            display: inline-block;
+            width: 63%;
+          }
+          button.make-primary {
+            @extend %button-base;
+            @extend %button-secondary;
+            width: 32%;
+            display: inline-block;
+          }
+          span.primary-badge {
+            background-color: $sandstorm-purple-color;
+            color: white;
+            width: 32%;
+            text-align: center;
+            display: inline-block;
           }
         }
       }
@@ -500,7 +536,7 @@ body>.main-content>.account {
     .add-new {
       position: absolute;
       top: 0px;
-      left: 340px;
+      left: 360px;
       .info, .hidden {
         display: none;
       }
@@ -885,16 +921,6 @@ div.identity-editor {
         }
       }
     }
-  }
-
-  button.unlink-identity {
-    @extend %button-base;
-    @extend %button-secondary;
-    width: 200px;
-    height: 30px;
-    background-image: url("unlink-m.svg");
-    background-repeat: no-repeat;
-    background-position: 10px;
   }
 }
 
@@ -1335,36 +1361,50 @@ body>.popup.billing-prompt>.frame {
   }
 }
 
-.login-identities-of-linked-accounts {
-  border: 1px solid gray;
-  border-radius: 2px;
-  padding: 10px;
-  ul.unlinkable-identities {
-    list-style-type: none;
-    padding: 0;
-    li{
-      position: relative;
-      padding-bottom: 10px;
-      .identity-card {
-        border: 1px solid black;
-      }
-      button.unlink {
-        @extend %button-base;
-        @extend %button-secondary;
-        position: absolute;
-        left: 240px;
-        top: 15px;
+.identity-management-controls {
+  >div {
+    margin-top: 10px;
+  }
+  .login-identities-of-linked-accounts {
+    border: 1px solid gray;
+    border-radius: 2px;
+    padding: 10px;
+    ul.unlinkable-identities {
+      list-style-type: none;
+      padding: 0;
+      li{
+        position: relative;
+        padding-bottom: 10px;
+        .identity-card {
+          border: 1px solid black;
+        }
+        button.unlink {
+          @extend %button-base;
+          @extend %button-secondary;
+          position: absolute;
+          left: 240px;
+          top: 15px;
+        }
       }
     }
+    button.hide-other-accounts {
+      @extend %button-base;
+      @extend %button-secondary;
+    }
   }
-  button.hide-other-accounts {
+  button.show-other-accounts {
     @extend %button-base;
     @extend %button-secondary;
   }
-}
-button.show-other-accounts {
-  @extend %button-base;
-  @extend %button-secondary;
+  button.unlink-identity {
+    @extend %button-base;
+    @extend %button-secondary;
+    width: 200px;
+    height: 30px;
+    background-image: url("unlink-m.svg");
+    background-repeat: no-repeat;
+    background-position: 10px;
+  }
 }
 
 ul.identity-card-list {

--- a/shell/packages/accounts-email-token/package.js
+++ b/shell/packages/accounts-email-token/package.js
@@ -11,6 +11,7 @@ Package.onUse(function (api) {
   api.use("check");
   api.use("sha", ["client", "server"]);
   api.use("email", ["server"]);
+  api.use("reactive-var", ["client"]);
 
   api.addFiles("token_common.js", ["client", "server"]);
   api.addFiles(["token_client.js", "token_templates.html"], ["client"]);

--- a/shell/packages/accounts-email-token/token_common.js
+++ b/shell/packages/accounts-email-token/token_common.js
@@ -9,10 +9,15 @@ Accounts.emailToken._hashToken = function (token) {
 
 var enabled = false;
 
+if (Meteor.isClient) {
+  var enabledReactive = new ReactiveVar(false);
+}
+
 Accounts.emailToken.enable = function (accountsUi) {
   enabled = true;
   if (Meteor.isClient) {
     accountsUi.registerService("emailToken", "an Email + Token");
+    enabledReactive.set(true);
   }
 };
 
@@ -20,11 +25,16 @@ Accounts.emailToken.disable = function (accountsUi) {
   enabled = false;
   if (Meteor.isClient) {
     accountsUi.deregisterService("emailToken");
+    enabledReactive.set(false);
   }
 };
 
 Accounts.emailToken.isEnabled = function () {
-  return enabled;
+  if (Meteor.isClient) {
+    return enabledReactive.get();
+  } else {
+    return enabled;
+  }
 };
 
 Router.route("/_emailLogin/:_email/:_token", function () {

--- a/shell/packages/accounts-identity/accounts-identity.html
+++ b/shell/packages/accounts-identity/accounts-identity.html
@@ -59,6 +59,24 @@ limitations under the License.
   </div>
 </template>
 
+<template name="identityManagementButtons">
+  <div class="identity-management-controls">
+    <div class="toggle-login">
+      <label title={{disableToggleLogin.why}}>
+        <input class="toggle-login" type=checkbox checked={{isLogin}} disabled={{disableToggleLogin}}
+               data-identity-id="{{_id}}">
+        Allow this identity to log in to your account.
+      </label>
+    </div>
+    {{>loginIdentitiesOfLinkedAccounts _id=_id}}
+    <div>
+      <button class="unlink-identity" data-identity-id="{{_id}}">
+        Unlink this identity
+      </button>
+    </div>
+  </div>
+</template>
+
 <template name="loginIdentitiesOfLinkedAccounts">
   {{#if showOtherAccounts}}
   <div class="login-identities-of-linked-accounts">

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -55,11 +55,25 @@ limitations under the License.
     {{#each identities}}
     <div id="profile-tab-{{_id}}" aria-labelled-by="profile-tab-header-{{_id}}"
          role="tabpanel" aria-hidden="{{isIdentityHidden _id}}">
-       {{>_accountProfileEditor}}
+      {{>_accountProfileEditor identity=. setActionCompleted=setActionCompleted
+                               staticHost=../_staticHost}}
      </div>
     {{/each}}
   </section>
   </div>
+
+  {{#with actionCompleted}}
+  {{#with success}}
+  <div class="action-completed success">
+    Success: {{.}}
+  </div>
+  {{/with}}
+  {{#with error}}
+  <div class="action-completed error">
+    Error: {{.}}
+  </div>
+  {{/with}}
+  {{/with}}
 
   <h3 class="title-bar">Primary e-mail address for service-related notifications</h3>
   <div class="verified-emails-editor">
@@ -68,10 +82,14 @@ limitations under the License.
       <ul>
         {{#each verifiedEmails}}
         <li>
-          <label><input type="radio" name="verifiedEmail" class="primary-email"
-                        data-email="{{email}}" checked={{primary}}>
-            {{email}}
-          </label>
+          <span class="email" title="{{email}}">{{email}}</span>
+          {{#if primary}}
+          <span class="primary-badge">Primary</span>
+          {{else}}
+          <button class="make-primary" data-email="{{email}}" checked={{primary}}>
+            make primary
+          </button>
+          {{/if}}
           <hr>
         </li>
         {{/each}}
@@ -98,20 +116,19 @@ limitations under the License.
 <template name="sandstormAccountsFirstSignIn">
   <h1>Confirm your profile</h1>
   <div class="single-identity-editor">
-  {{#with identityToConfirm}}
-      {{>_accountProfileEditor}}
-  {{/with}}
+    {{>_accountProfileEditor identity=identityToConfirm termsAndPrivacy=termsAndPrivacy
+                             staticHost=_staticHost}}
   </div>
 </template>
 
 <template name="_accountProfileEditor">
   <div class="identity-editor">
-    <form class="account-profile-editor" data-identity-id="{{_id}}">
+    <form class="account-profile-editor" data-identity-id="{{identity._id}}">
       <div class="editor">
         <div class="picture">
           <label>Avatar:
             <button type="button">
-              <img src="{{profile.pictureUrl}}" alt="Upload picture">
+              <img src="{{identity.profile.pictureUrl}}" alt="Upload picture">
             </button>
           </label>
           <input type="file" name="picture" style="display:none">
@@ -124,7 +141,7 @@ limitations under the License.
           <li class="name">
             <label><img class="inline-icon" src="/people-m.svg" role="presentation">
               Full name:
-              <input type="text" name="nameInput" value="{{profile.name}}"
+              <input type="text" name="nameInput" value="{{identity.profile.name}}"
                      placeholder="full name" required>
             </label>
             <span class="details">Your regular first and last name, as you would like it
@@ -134,8 +151,8 @@ limitations under the License.
           <li class="handle">
             <label>@ Handle:
               <div class="input-container">
-                <input type="text" name="handle" value="{{profile.handle}}" placeholder="handle"
-                       pattern="^[a-z_][a-z0-9_]*$" required>
+                <input type="text" name="handle" value="{{identity.profile.handle}}"
+                       placeholder="handle" pattern="^[a-z_][a-z0-9_]*$" required>
               </div>
             </label>
             <span class="details">
@@ -144,17 +161,17 @@ limitations under the License.
               already taken this name within the specific grain.
             </span>
           </li>
-          {{#if verifiedEmail}}
+          {{#if identity.verifiedEmail}}
           <li class="email">
             <label><img class="inline-icon" src="/email-m.svg" role="presentation">
               E-mail:
-              <span class="email-address">{{verifiedEmail}}</span>
+              <span class="email-address">{{identity.verifiedEmail}}</span>
             </label>
             <span class="details">E-mail address attached to this identity.</span>
           </li>
           {{/if}}
           <li class="pronoun">
-            {{#with profile}}
+            {{#with identity.profile}}
             <label><img class="inline-icon" src="/pronoun-m.svg" role="presentation">
               Preferred pronoun:
               <select name="pronoun">
@@ -195,17 +212,7 @@ limitations under the License.
       </div>
     </form>
     {{#if hasCompletedSignup}}
-    <div>
-      <button class="unlink-identity" data-identity-id="{{_id}}">Unlink this identity</button>
-    </div>
-    <div>
-      {{#if isLogin _id}}
-      <button class="make-no-login" data-identity-id="{{_id}}">Login enabled</button>
-      {{else}}
-      <button class="make-login" data-identity-id="{{_id}}">Login disabled</button>
-      {{/if}}
-    </div>
-    {{>loginIdentitiesOfLinkedAccounts _id=_id}}
+      {{> identityManagementButtons identityManagementButtonsData}}
     {{/if}}
   </div>
 </template>

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -53,8 +53,6 @@
     <button class="logout" role="menuitem">
       Sign out
     </button>
-
-    {{> _loginButtonsMessages}}
   </div>
 </template>
 
@@ -122,7 +120,7 @@
 
     <label class="email {{#if awaitingToken}}hidden{{/if}}">{{prompt}}
       <span title="Passwordless E-mail Login allows you to log in using an e-mail address. No password is required; instead, every time you log in, we send you a new email confirmation code. You will only need to log in once per device." class="info">i</span>
-      <input name="email" type="email">
+      <input name="email" type="email" disabled={{disabled}}>
     </label>
 
     {{#with awaitingToken}}
@@ -138,9 +136,13 @@
     </div>
     {{else}}
     <div class="button-box">
-      <button class="login email">{{sendButtonText}}</button>
+      <button class="login email" disabled={{disabled}}>{{sendButtonText}}</button>
     </div>
     {{/with}}
+
+    {{#if disabled}}
+    <p>A server admin must enable email authentication before you can confirm your email.</p>
+    {{/if}}
   </form>
 </template>
 

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -39,6 +39,10 @@ Template.loginButtonsPopup.onRendered(function() {
   this.find("[role=menuitem]").focus();
 });
 
+Template.accountButtonsPopup.onRendered(function() {
+  this.find("[role=menuitem]").focus();
+});
+
 Template.accountButtonsPopup.events({
   'click button.logout': function() {
     var topbar = Template.parentData(3);
@@ -323,6 +327,9 @@ Template.emailLoginForm.events({
 });
 
 Template.emailLoginForm.helpers({
+  disabled: function () {
+    return !hasEmailTokenService();
+  },
   awaitingToken: function () {
     return loginButtonsSession.get('inSignupFlow');
   },


### PR DESCRIPTION
1. Add warning messages for 'unlink identity' buttons.
2. Switch to using a checkbox for toggling login.
3. Disable various actions that could get the user into trouble.
4. Display a message on success or failure.
5. Use 'make primary' buttons for selecting a verified email.