### PR TITLE
Split /account route into /account/profile and /account/billing.

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -387,6 +387,29 @@ body>.main-content>.account {
     padding: 0;
   }
 
+  ul.account-tabs {
+    position: absolute;
+    top: 5px;
+    left: 300px;
+    font-size: 18px;
+    >li {
+      float: left;
+      display: block;
+      >a {
+        padding: 10px;
+        border-radius: 4px;
+        &:hover {
+          background-color: lighten($sandstorm-purple-color, 40%);
+        }
+      }
+      &.active >a {
+        color: white;
+        background-color: $sandstorm-purple-color;
+      }
+
+    }
+  }
+
   .identities-editor {
     position: relative;
     white-space: nowrap;

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -608,15 +608,32 @@ limitations under the License.
 
 <template name="account">
   <div class="account">
-    {{#if .}}
-      {{>sandstormAccountSettings .}}
+    <h2>My Account</h2>
+    {{#if isPaymentsEnabled}}
+    <ul class="account-tabs">
+      <li class="{{#if profileActive}}active{{/if}}">
+        {{#linkTo route="accountProfile"}}Profile{{/linkTo}}
+      </li>
+      <li class="{{#if billingActive}}active{{/if}}">
+        {{#linkTo route="accountBilling"}}Billing{{/linkTo}}
+      </li>
+    </ul>
     {{/if}}
+    {{> Template.dynamic template=accountTab}}
   </div>
 </template>
 
-<template name="accountUsage">
-  {{> billingUsage db=globalDb}}
-  {{> billingSettings db=globalDb}}
+<template name="accountProfile">
+  {{#if .}}
+    {{>sandstormAccountSettings .}}
+  {{/if}}
+</template>
+
+<template name="accountBilling">
+  <div class="billing">
+    {{> billingUsage db=db topbar=_topbar}}
+    {{> billingSettings db=db}}
+  </div>
 </template>
 
 <template name="signup">

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -23,7 +23,6 @@ limitations under the License.
     Account Settings
   {{/sandstormTopbarItem}}
 
-  <h2>My Account</h2>
   <div class="identities-editor">
   <h3 class="title-bar"> Linked Identities </h3>
   <div class="identities-tabs">
@@ -104,13 +103,6 @@ limitations under the License.
       {{> _loginButtonsMessages}}
     </div>
   </div>
-
-  {{#if isPaymentsEnabled}}
-  <div class="billing">
-  {{> billingUsage db=db topbar=_topbar}}
-  {{> billingSettings db=db}}
-  </div>
-  {{/if}}
 </template>
 
 <template name="sandstormAccountsFirstSignIn">

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -64,15 +64,6 @@ var helpers = {
   isMale: function () { return this.pronoun === "male"; },
   isFemale: function () { return this.pronoun === "female"; },
   isRobot: function () { return this.pronoun === "robot"; },
-  isPaymentsEnabled: function () {
-    try {
-      BlackrockPayments; // This checks that BlackrockPayments is defined.
-      return true;
-    } catch (e) {
-      return false;
-    }
-  },
-
   isAccountUser: function() {
     return Meteor.user() && !!Meteor.user().loginIdentities;
   },

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -757,6 +757,26 @@ if (Meteor.isClient) {
       );
     });
   });
+
+  Template.account.helpers({
+    accountTab: function () {
+      return Router.current().route.getName();
+    },
+    profileActive: function () {
+      return Router.current().route.getName() === "accountProfile";
+    },
+    billingActive: function () {
+      return Router.current().route.getName() === "accountBilling";
+    },
+    isPaymentsEnabled: function () {
+      try {
+        BlackrockPayments; // This checks that BlackrockPayments is defined.
+        return true;
+      } catch (e) {
+        return false;
+      }
+    },
+  });
 }
 Router.configure({
   layoutTemplate: 'layout',
@@ -866,6 +886,10 @@ promptUploadApp = function (input) {
   });
 }
 
+var accountRoute = RouteController.extend({
+  template: "account",
+});
+
 Router.map(function () {
   this.route("root", {
     path: "/",
@@ -962,6 +986,14 @@ Router.map(function () {
 
   this.route("account", {
     path: "/account",
+    action: function () {
+      this.redirect("accountProfile");
+    },
+  });
+
+  this.route("accountProfile", {
+    path: "/account/profile",
+    controller: accountRoute,
 
     data: function () {
       // Don't allow logged-out or demo users to visit the accounts page. There should be no way
@@ -976,7 +1008,9 @@ Router.map(function () {
     }
   });
 
-  this.route("accountUsage", {
-    path: "/account/usage",
+  this.route("accountBilling", {
+    path: "/account/billing",
+    controller: accountRoute,
+    data: {db: globalDb},
   });
 });


### PR DESCRIPTION
This adds a "Profile" and a "Billing" tab to the /account page when payments are enabled. The design follows the pattern of the tabs in our /admin page.