### PR TITLE
Make demo timer much more obvious.

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -606,6 +606,53 @@ body>.topbar {
         }
       }
     }
+
+    .demo-notice {
+      p {
+        color: $topbar-foreground-color;
+        margin: 8px;
+        line-height: normal;
+        font-size: 14px;
+
+        a {
+          color: white;
+          padding: 0;
+          white-space: normal;
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
+
+      .countdown {
+        display: block;
+        font-size: 30px;
+        font-weight: bold;
+        color: #bb0;
+        text-align: center;
+        border: 1px solid $topbar-foreground-color;
+        border-radius: 4px;
+        margin-top: 8px;
+
+        &.urgent {
+          color: #f00;
+        }
+      }
+
+      button {
+        @extend %unstyled-button;
+        display: block;
+        border: 1px solid $topbar-foreground-color;
+        border-radius: 4px;
+        width: 100%;
+        box-sizing: border-box;
+        text-align: center;
+        padding: 4px;
+        background-color: $topbar-background-color-active;
+        color: $topbar-foreground-color-active;
+        margin-top: 8px;
+      }
+    }
   }
 }
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -75,12 +75,13 @@ limitations under the License.
   {{/if}}
   {{#if currentUser}}
     {{>sandstormTopbarItem name="notifications" topbar=globalTopbar
-                           template="notifications" popupTemplate="notificationsPopup"}}
+                           template="notifications" popupTemplate="notificationsPopup"
+                           priority=-1}}
   {{/if}}
   {{!-- admin alerts --}}
   {{#with adminAlert}}
     {{#if adminAlertIsTooLarge}}
-      {{#sandstormTopbarItem name="admin-alert" topbar=globalTopbar}}
+      {{#sandstormTopbarItem name="admin-alert" topbar=globalTopbar priority=-2}}
         {{!-- TODO(cleaup): Awkwardly, the event handlers on Template.layout actually work
             on this topbar item solely because the whole topbar itself is embedded inside the
             "layout" template. But, we shouldn't be relying on that! Move this to its own

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -1,7 +1,7 @@
 <template name="loginButtons">
   {{!-- Data context is an instance of AccountsUi. --}}
   {{#if isDemoUser}}
-    <a class="{{#if expiringSoon}}expiring-soon{{/if}}">Demo {{demoTimeLeft}} ▾</a>
+    <a>Create Account ▾</a>
   {{else}}
     <a>Sign in ▾</a>
   {{/if}}
@@ -57,11 +57,11 @@
 </template>
 
 <template name="_loginButtonsLoggedOutDropdown">
-  <h4>Sign in</h4>
-
   {{#if isDemoUser}}
-    <p class="demo-note">Sign in to make your demo data permanent.</p>
+    <h4>Create Account</h4>
+    <p class="demo-note">Your demo data will be transferred to your new account.</p>
   {{else}}
+    <h4>Sign in</h4>
     {{#if isCurrentRoute 'shared'}}
       <p class="demo-note">Sign in to save this link.</p>
     {{/if}}

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -7,26 +7,6 @@ var helpers = {
   },
   isDemoUser: function () {
     return this._db.isDemoUser();
-  },
-  demoTimeLeft: function () {
-    var ms = Meteor.user().expires.getTime() - Date.now();
-    var sec = Math.floor(ms / 1000) % 60;
-    if (sec < 10) sec = "0" + sec;
-    var min = Math.floor(ms / 60000);
-    var comp = Tracker.currentComputation;
-    if (comp) {
-      Meteor.setTimeout(comp.invalidate.bind(comp), 1000);
-    }
-    return min + ":" + sec;
-  },
-  expiringSoon: function () {
-    var timeToExpiring = Meteor.user().expires.getTime() - Date.now() - 600000;
-    if (timeToExpiring <= 0) return true;
-    var comp = Tracker.currentComputation;
-    if (comp) {
-      Meteor.setTimeout(comp.invalidate.bind(comp), timeToExpiring);
-    }
-    return false;
   }
 };
 

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -51,6 +51,17 @@ limitations under the License.
           <button class="close-button" title="Close {{title}}"></button>
         </li>
         {{/each}}
+
+        {{#with accountExpires}}
+          <li><div class="demo-notice">
+            <p>This demo expires in: <span class="countdown {{#if urgent}}urgent{{/if}}">{{countdown}}</span></p>
+
+            <p>To make your data permanent, create an account:
+              <button class="sign-in">Create account »</button></p>
+
+            <p class="self-host"><a href="https://sandstorm.io/install" target="_blank">Or, get Sandstorm on your own server (it's open source) »</a></p>
+          </div></li>
+        {{/with}}
       </ul>
     </ul>
   </ul>

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -59,7 +59,7 @@ limitations under the License.
             <p>To make your data permanent, create an account:
               <button class="sign-in">Create Account »</button></p>
 
-            <p class="self-host"><a href="https://sandstorm.io/install" target="_blank">Or, get Sandstorm on your own server (it's open source) »</a></p>
+            <p class="self-host"><a href="https://sandstorm.io/install/" target="_blank">Or, get Sandstorm on your own server (it's open source) »</a></p>
           </div></li>
         {{/with}}
       </ul>

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -57,7 +57,7 @@ limitations under the License.
             <p>This demo expires in: <span class="countdown {{#if urgent}}urgent{{/if}}">{{countdown}}</span></p>
 
             <p>To make your data permanent, create an account:
-              <button class="sign-in">Create account »</button></p>
+              <button class="sign-in">Create Account »</button></p>
 
             <p class="self-host"><a href="https://sandstorm.io/install" target="_blank">Or, get Sandstorm on your own server (it's open source) »</a></p>
           </div></li>

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -165,6 +165,23 @@ Template.sandstormTopbar.helpers({
       return { align: "left", px: -10000 };
     }
   },
+
+  accountExpires: function () {
+    if (!Meteor.user().expires) return null;
+
+    var ms = Meteor.user().expires.getTime() - Date.now();
+    var sec = Math.floor(ms / 1000) % 60;
+    if (sec < 10) sec = "0" + sec;
+    var min = Math.floor(ms / 60000);
+    var comp = Tracker.currentComputation;
+    if (comp) {
+      Meteor.setTimeout(comp.invalidate.bind(comp), 1000);
+    }
+    return {
+      countdown: min + ":" + sec,
+      urgent: ms < 600000
+    };
+  },
 });
 
 var windowWidth = new ReactiveVar(window.innerWidth);
@@ -260,7 +277,12 @@ Template.sandstormTopbar.events({
       grains.splice(closeIndex, 1);
       topbar._grains.set(grains);
     }
-  }
+  },
+
+  "click .demo-notice .sign-in": function (event) {
+    var topbar = Template.instance().data;
+    topbar.openPopup("login");
+  },
 });
 
 Template.sandstormTopbarItem.onCreated(function () {


### PR DESCRIPTION
We were already planning to do this, but also a Twitter conversation with @hintjens today made it really clear to me that we have a problem here: people don't realize that the demo is time-bound, and don't see the countdown timer in the upper-right. This change makes it much bigger and eye-catching on the sidebar, with a "create account" button that opens the login menu.

@hintjens also gave feedback that:
* If we had asked him to register upfront before doing anything, he probably would have refused.
* Once he created some data he wanted it to be permanent, and to that end he would have registered if prompted.
* The demo / non-demo dichotomy is confusing and unexpected.

So far I haven't thought of a way to satisfy all three constraints: We can't let people create permanent data without registering, since we wouldn't know how to authenticate them later. So it seems like demo mode is necessary and we have to live with it being confusing, but maybe it will be less confusing after this change?

The styling in this change is my own. I assume @neynah will come up with something better when she has a chance but IMO this seems good enough to ship for now.

![screenshot from 2015-12-02 16-39-56](https://cloud.githubusercontent.com/assets/4001805/11548915/2842bcba-9916-11e5-908d-57226fa70af4.png)

(TODO: make visible in mobile view)