### PR TITLE
Tighter constraints on which identities may be linked or set to login.

### DIFF
--- a/shell/packages/accounts-email-token/token_common.js
+++ b/shell/packages/accounts-email-token/token_common.js
@@ -57,17 +57,21 @@ Router.route("/_emailLogin/:_email/:_token", function () {
 
 Router.route("/_emailLinkIdentity/:_email/:_token/:_accountId", function () {
   this.render("Loading");
-  var self = this;
-  if (Meteor.userId() === this.params._accountId) {
-    Meteor.call("linkEmailIdentityToAccount",
-                this.params._email, this.params._token, function (err, result) {
-      if (err) {
-        self.render("_emailLinkIdentityError", {data: function () {return {error: err};}});
-      } else {
-        Router.go("/account");
-      }
-    });
+  if (this.state.get("error")) {
+    this.render("_emailLinkIdentityError", {data: {error: this.state.get("error")}});
   } else {
-    this.render("_emailLinkIdentityError");
+    var self = this;
+    if (Meteor.userId() === this.params._accountId) {
+      Meteor.call("linkEmailIdentityToAccount",
+                  this.params._email, this.params._token, function (err, result) {
+        if (err) {
+          self.state.set("error", err.toString());
+        } else {
+          Router.go("/account");
+        }
+      });
+    } else {
+      this.render("_emailLinkIdentityError");
+    }
   }
 });

--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -198,12 +198,11 @@ Meteor.methods({
     var identity = Meteor.users.findOne({"services.email.email": email},
                                         {fields: {"services.email": 1}});
     if (!identity) {
-      throw new Meteor.Error(403, "Invalid authorization token.");
+      throw new Meteor.Error(403, "Invalid authentication code.");
     }
     if (!consumeToken(identity, token)) {
-      throw new Meteor.Error(403, "Invalid authorization token.");
+      throw new Meteor.Error(403, "Invalid authentication code.");
     }
-
     Accounts.linkIdentityToAccount(identity._id, account._id);
   }
 });

--- a/shell/packages/accounts-identity/accounts-identity-client.js
+++ b/shell/packages/accounts-identity/accounts-identity-client.js
@@ -31,8 +31,10 @@ Template.identityLoginInterstitial.onCreated(function () {
     sessionStorage.removeItem("linkingIdentityLoginToken");
     Meteor.call("linkIdentityToAccount", token, function (err, result) {
       if (err) {
-        // TODO(soon): display this error somewhere that the user will see.
-        console.log("Error", err);
+        // TODO(cleanup): Figure out a better way to get this data to the /account page.
+        Session.set("linkingIdentityError", err.toString());
+      } else {
+        Session.set("linkingIdentityError");
       }
       Meteor.loginWithToken(token);
     });
@@ -142,6 +144,9 @@ Template.identityManagementButtons.helpers({
       if (LoginIdentitiesOfLinkedAccounts.findOne({sourceIdentityId: this._id,
                                                    loginAccountId: {$ne: Meteor.userId()}})) {
         return {why: "A shared identity is not allowed to be promoted to a login identity."}
+      }
+      if (this.isDemo) {
+        return {why: "Demo identities cannot be used to log in."}
       }
     }
   },

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -70,7 +70,7 @@ limitations under the License.
   {{/with}}
   {{#with error}}
   <div class="action-completed error">
-    Error: {{.}}
+    {{.}}
   </div>
   {{/with}}
   {{/with}}

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -26,6 +26,14 @@ Template.sandstormAccountSettings.onCreated(function () {
   this._actionCompleted = new ReactiveVar();
   var self = this;
 
+  // TODO(cleanup): Figure out a better way to pass in this data. Perhaps it should be part of
+  //   the URL?
+  if (Session.get("linkingIdentityError")) {
+    this._actionCompleted.set(
+      {error: "Error linking identity: " + Session.get("linkingIdentityError")});
+    Session.set("linkingIdentityError");
+  }
+
   this.autorun(function () {
     // Reset the selected identity ID when appropriate.
     var user = Meteor.user();
@@ -129,6 +137,7 @@ Template._accountProfileEditor.helpers({
       return {
         _id: identityId,
         isLogin: user.loginIdentities && !!_.findWhere(user.loginIdentities, {id: identityId}),
+        isDemo: this.identity.profile.service === "demo",
         setActionCompleted: Template.instance()._setActionCompleted,
       };
     }


### PR DESCRIPTION
This patch prevents an account from linking an identity that is already a login identity for another account.  When the account attempts (and fails) to perform such a link, an explanatory error message will be shown in the usual place on the /account page.

This patch also makes sure that demo identities are nonlogin and cannot be upgraded to login.