### PR TITLE
Fix setPath/identity switcher interaction

### DIFF
--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -52,6 +52,8 @@ GrainView.prototype.reset = function (identityId) {
 
   this._dep.changed();
   this.destroy();
+  this._hasLoaded = undefined;
+  this._hostId = undefined;
   this._sessionId = null;
   this._sessionSalt = null;
   if (this._sessionObserver) {
@@ -66,6 +68,8 @@ GrainView.prototype.reset = function (identityId) {
   this._status = "closed";
   this._userIdentityId = new ReactiveVar(undefined);
   this.revealIdentity(identityId);
+  // We want the iframe to receive the most recently-set path whenever we rerender.
+  this._originalPath = this._path;
   this._blazeView = Blaze.renderWithData(Template.grainView, this, this._parentElement);
 }
 


### PR DESCRIPTION
GrainView's `reset()` did not clear all the fields it needed to clear,
so other derived data were incorrect.  This includes having bad values
for the iframe's src in transitional states.