### PR TITLE
Make identity provider icons darker and a bit larger, for readability.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ shell/public/google-color.svg
 shell/public/google.svg
 shell/public/troubleshoot.svg
 shell/public/email-494949.svg
+shell/public/debug-9E9E9E.svg
+shell/public/email-9E9E9E.svg
+shell/public/github-9E9E9E.svg
+shell/public/google-9E9E9E.svg
 shell/public/*-m.svg
 shell/public/sandstorm-icons
 shell-build

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,11 @@ IMAGES= \
     shell/public/email-494949.svg \
     shell/public/close-FFFFFF.svg \
                                   \
+    shell/public/debug-9E9E9E.svg \
+    shell/public/email-9E9E9E.svg \
+    shell/public/github-9E9E9E.svg \
+    shell/public/google-9E9E9E.svg \
+                                  \
     shell/public/install-6A237C.svg \
     shell/public/install-9E40B5.svg \
     shell/public/plus-6A237C.svg \
@@ -288,6 +293,10 @@ shell/public/google-color.svg: icons/google.svg
 shell/public/github-color.svg: icons/github.svg
 	@$(call color,custom color $<)
 	@sed -e 's/#111111/#191919/g' < $< > $@
+
+shell/public/%-9E9E9E.svg: icons/%.svg
+	@$(call color,custom color $<)
+	@sed -e 's/#111111/#9E9E9E/g' < $< > $@
 
 shell/public/email-494949.svg: icons/email.svg
 	@$(call color,custom color $<)

--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -1430,22 +1430,22 @@ ul.identity-card-list {
   background-color: white;
   background-repeat: no-repeat;
   background-position: 50px 30px;
-  background-size: 15px 15px;
+  background-size: 16px 16px;
 
   &[data-service-name=github] {
-    background-image: url("/github.svg");
+    background-image: url("/github-9E9E9E.svg");
   }
 
   &[data-service-name=google] {
-    background-image: url("/google.svg");
+    background-image: url("/google-9E9E9E.svg");
   }
 
   &[data-service-name=dev] {
-    background-image: url("/debug.svg");
+    background-image: url("/debug-9E9E9E.svg");
   }
 
   &[data-service-name=email] {
-    background-image: url("/email.svg");
+    background-image: url("/email-9E9E9E.svg");
   }
 
   .picture {


### PR DESCRIPTION
This makes the icons the same shade of gray that they are in @neynah's mock-ups.

before:
<img width="227" alt="before" src="https://cloud.githubusercontent.com/assets/495768/11595749/ffa55ae6-9a7e-11e5-87fe-a2fac2a7cd6a.png">


after:
<img width="229" alt="after" src="https://cloud.githubusercontent.com/assets/495768/11595755/05b9815a-9a7f-11e5-8eec-220532e499e3.png">
