### PR TITLE
sandcats https: Do date arithmetic on the right operands

### DIFF
--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -285,7 +285,7 @@ function monkeypatchHttpAndHttps() {
 
       if (useThisCertificate.keyFilename != referenceCertificate.keyFilename) {
         var twentyMinutesInMilliseconds = 1000 * 60 * 20;
-        var twentyMinutesFromNow = now + twentyMinutesFromNow;
+        var twentyMinutesFromNow = now + twentyMinutesInMilliseconds;
         var notAfterMinusTwentyMinutes = result.notAfter - twentyMinutesInMilliseconds;
 
         // But never attempt to re-key in the past...

--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -286,7 +286,7 @@ function monkeypatchHttpAndHttps() {
       if (useThisCertificate.keyFilename != referenceCertificate.keyFilename) {
         var twentyMinutesInMilliseconds = 1000 * 60 * 20;
         var twentyMinutesFromNow = now + twentyMinutesFromNow;
-        var notAfterMinusTwentyMinutes = result.notAfter - twentyMinutesFromNow;
+        var notAfterMinusTwentyMinutes = result.notAfter - twentyMinutesInMilliseconds;
 
         // But never attempt to re-key in the past...
         if (notAfterMinusTwentyMinutes < now) {


### PR DESCRIPTION
This fixes a bug that logs this message:

```
Will switch certs, probably to /var/sandcats/https/{{hostname}}/{{filename}}, at time Invalid Date via real-time SNI re-keying system.
```

which has the side-effect that real-time SNI re-keying didn't work.

Details:

- I was adding `undefined` to an integer and getting `NaN`, then
- Adding `NaN` to another number and getting `NaN`.
- As a result, I had an unused helper value, `twentyMinutesInMilliseconds`.
- Eventually I converted some of these things to `new Date()`s and got an `Invalid Date`.

Testing done:

- Added this patch to `rose.sandcats.io` (my self-install), then
- Manually fiddled with time on my self-install to Sat Dec 5, then
- Caused it to log this message: `Will switch certs, probably to /var/sandcats/https/rose.sandcats.io/1449306826631 , at time Sat Dec 05 2015 04:33:57 GMT+0000 (UTC) via real-time SNI re-keying system.` then
- manually fiddled with time to be Sun Dec 6, then
- made a HTTPS request, and got this log message `Re-keying resulting in a new certificate. Good.`, then
- tested in a browser that it using the new certificate, and indeed it is.