### PR TITLE
Use linkEmailIdentityToAccount() Meteor method in all cases when linking an email identity.

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -103,10 +103,17 @@ limitations under the License.
     {{>billingPrompt}}
   {{/with}}
 
-  <div class="main-content {{#if hideNavbar}}hide-navbar{{else}}{{#if shrinkNavbar}}shrink-navbar{{/if}}{{/if}}">
-    {{> yield}}
-  </div>
   {{/if}} {{!-- firstLogin --}}
+
+  {{!-- If the main-content div were inside the {{#if firstLogin}} block, then grain views could be
+        blanked out when a demo user upgrades to a real account by linking an email identity.
+   --}}
+  <div class="main-content {{#if hideNavbar}}hide-navbar{{else}}{{#if shrinkNavbar}}shrink-navbar{{/if}}{{/if}}">
+    {{#unless firstLogin}}
+      {{> yield}}
+    {{/unless}}
+  </div>
+
   {{/if}} {{!-- identityUser --}}
   {{/with}}
 </template>

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -40,7 +40,7 @@ limitations under the License.
   {{#if isAccountUser}}
     {{#if isLinkingNewIdentity}}
       <h4>Link new identity:</h4>
-      {{#with linkingNewIdentity=true}}
+      {{#with linkingNewIdentity=linkingNewIdentityData}}
         {{> loginButtonsList globalAccountsUi}}
       {{/with}}
     <p><button class="account-button cancel-link-new-identity">Cancel</button></p>
@@ -99,7 +99,7 @@ limitations under the License.
     </div>
     <div class="add-new">
       Add new e-mail address
-      {{> emailLoginForm linkingNewIdentity=true sendButtonText="Confirm"}}
+      {{> emailLoginForm emailLoginFormData}}
       {{> _loginButtonsMessages}}
     </div>
   </div>

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -122,6 +122,30 @@ Template.sandstormAccountSettings.helpers({
   setActionCompleted: function () {
     var actionCompleted = Template.instance()._actionCompleted;
     return function (x) { actionCompleted.set(x); };
+  },
+  linkingNewIdentityData: function () {
+    var instance = Template.instance();
+    return {
+      doneCallback: function () {
+        instance._isLinkingNewIdentity.set(false);
+        instance._actionCompleted.set({success: "identity added"});
+      }
+    };
+  },
+  emailLoginFormData: function () {
+    var instance = Template.instance();
+    return {
+      linkingNewIdentity: {
+        doneCallback: function() {
+          var input = instance.find("input[name='email']");
+          if (input) {
+            input.value = "";
+          };
+          instance._actionCompleted.set({success: "identity added"});
+        }
+      },
+      sendButtonText: "Confirm",
+    }
   }
 });
 


### PR DESCRIPTION
This fixes a bug that sometimes created blank grain views when a user linked an email identity.
