### PR TITLE
Suggest sign-in when opening a sharing link anonymously.

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -72,6 +72,19 @@ body>.popup.account>.frame {
   }
 }
 
+.login-suggestion {
+  >button {
+    @extend %button-base;
+    @extend %button-primary;
+    width: calc(100% - 20px);
+    display: block;
+    margin: 10px;
+  }
+  >button.dismiss {
+    @extend %button-secondary;
+  }
+}
+
 .login-buttons-list {
   width: 200px;
   margin: 0;

--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -33,6 +33,9 @@ GrainView = function GrainView(grainId, path, token, parentElement) {
   if (token) {
     if (!Meteor.userId()) {
       this.doNotRevealIdentity();
+
+      // Suggest to the user that they log in by opening the login menu.
+      globalTopbar.openPopup("login");
     }
   } else {
     this.revealIdentity();

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -63,14 +63,27 @@
   {{#if isDemoUser}}
     <h4>Create Account</h4>
     <p class="demo-note">Your demo data will be transferred to your new account.</p>
+    {{> loginButtonsList}}
   {{else}}
     <h4>Sign in</h4>
     {{#if isCurrentRoute 'shared'}}
-      <p class="demo-note">Sign in to save this link.</p>
+      <p class="demo-note">Sign in so that collaborators know who you are.</p>
+      {{#if choseLogin}}
+        {{> loginButtonsList}}
+      {{else}}
+        <div class="login-suggestion" role="menu">
+          <button class="login" role="menuitem">
+            Sign in
+          </button>
+          <button class="dismiss" role="menuitem">
+            Stay anonymous
+          </button>
+        </div>
+      {{/if}}
+    {{else}}
+      {{> loginButtonsList}}
     {{/if}}
   {{/if}}
-
-  {{> loginButtonsList}}
 </template>
 
 <template name="loginButtonsDialog">

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -121,6 +121,27 @@ var capitalize = function(str){
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
 
+Template._loginButtonsLoggedOutDropdown.onCreated(function() {
+  this._topbar = Template.parentData(3);
+  this._choseLogin = new ReactiveVar(false);
+});
+
+Template._loginButtonsLoggedOutDropdown.helpers({
+  choseLogin: function () {
+    return Template.instance()._choseLogin.get();
+  }
+});
+
+Template._loginButtonsLoggedOutDropdown.events({
+  "click .login-suggestion>button.login": function (event, instance) {
+    instance._choseLogin.set(true);
+  },
+
+  "click .login-suggestion>button.dismiss": function (event, instance) {
+    instance._topbar.closePopup();
+  }
+});
+
 Template._loginButtonsLoggedInDropdown.onCreated(function() {
   this._identitySwitcherExpanded = new ReactiveVar(false);
 });
@@ -156,7 +177,7 @@ Template._loginButtonsLoggedInDropdown.helpers({
 Template._loginButtonsLoggedInDropdown.events({
   "click button.switch-identity" : function (event, instance) {
     instance._identitySwitcherExpanded.set(!instance._identitySwitcherExpanded.get());
-  }
+  },
 });
 
 var sendEmail = function (email, linkingNewIdentity) {


### PR DESCRIPTION
We auto-open the login popup with options for "sign in" (goes to the normal login button list) and "stay anonymous" (closes the popup).

Currently looks like screenshot below. I suspect @neynah can come up with something better, but I think this is good enough to push now.

![screenshot from 2015-12-07 21-01-20](https://cloud.githubusercontent.com/assets/4001805/11648153/b0b2bbbe-9d25-11e5-9742-ac713d6fc0e5.png)
