### PR TITLE
Clean up more data from demo users when they expire. 

### DIFF
--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -55,6 +55,7 @@ if (Meteor.isServer) {
       Grains.find({userId: user._id}, {fields: {_id: 1, lastUsed: 1, appId: 1}})
             .forEach(function (grain) {
         console.log("delete grain: " + grain._id);
+        ApiTokens.remove({grainId: grain._id});
         Grains.remove(grain._id);
         if (grain.lastUsed) {
           DeleteStats.insert({type: "demoGrain", lastActive: grain.lastUsed, appId: grain.appId});
@@ -62,6 +63,11 @@ if (Meteor.isServer) {
         globalBackend.deleteGrain(grain._id, user._id);
       });
       console.log("delete user: " + user._id);
+      // We intentionally do not do `ApiTokens.remove({accountId: user._id})`, because some such
+      // tokens might still play an active role in the sharing graph.
+      Contacts.remove({ownerId: user._id});
+      UserActions.remove({userId: user._id});
+      Notifications.remove({userId: user._id});
       Meteor.users.remove(user._id);
       waitPromise(globalBackend.cap().deleteUser(user._id));
       if (user.lastActive) {

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -94,19 +94,24 @@ if (Meteor.isServer) {
     } else {
       var grainId = apiToken.grainId;
       var grain = Grains.findOne({_id: grainId}, {fields: {packageId: 1, appId: 1}});
-      var pkg = Packages.findOne({_id: grain.packageId}, {fields: {manifest: 1}});
-      var appTitle = (pkg && pkg.manifest && pkg.manifest.appTitle) || { defaultText: ""};
-      var appIcon = undefined;
-      if (pkg && pkg.manifest && pkg.manifest.metadata && pkg.manifest.metadata.icons) {
-        var icons = pkg.manifest.metadata.icons;
-        appIcon = icons.grain || icons.appGrid;
+      if (!grain) {
+        this.added("tokenInfo", token, {invalidToken: true});
+      } else {
+        var pkg = Packages.findOne({_id: grain.packageId}, {fields: {manifest: 1}});
+        var appTitle = (pkg && pkg.manifest && pkg.manifest.appTitle) || { defaultText: ""};
+        var appIcon = undefined;
+        if (pkg && pkg.manifest && pkg.manifest.metadata && pkg.manifest.metadata.icons) {
+          var icons = pkg.manifest.metadata.icons;
+          appIcon = icons.grain || icons.appGrid;
+        }
+        var denormalizedGrainMetadata = {
+          appTitle: appTitle,
+          icon: appIcon,
+          appId: appIcon ? undefined : grain.appId,
+        };
+        this.added("tokenInfo", token,
+                   {apiToken: apiToken, grainMetadata: denormalizedGrainMetadata});
       }
-      var denormalizedGrainMetadata = {
-        appTitle: appTitle,
-        icon: appIcon,
-        appId: appIcon ? undefined : grain.appId,
-      };
-      this.added("tokenInfo", token, {apiToken: apiToken, grainMetadata: denormalizedGrainMetadata});
     }
     this.ready();
     return;


### PR DESCRIPTION
Also, don't show a blank screen if a token's grain has been deleted.

Currently, it's possible for the shared links of demo users to lead to blank pages.  For example: https://twitter.com/hintjens/status/672118319961513984

This patch doubly fixes the problem:
  1. Shared links whose grains have been deleted now display "invalid token" rather than a blank screen.
  2. Shared links to demo grains are now actually cleaned up when the demo user is deleted.
