### PR TITLE
Fix bug where an expired demo user could see a grain just by refreshing the page.

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -30,7 +30,7 @@ limitations under the License.
   {{#with demoExpired}}
     {{>title "Demo Expired"}}
 
-    <div id="demo-expired" class="main-content {{#if hideNavbar}}hide-navbar{{else}}{{#if shrinkNavbar}}shrink-navbar{{/if}}{{/if}}">
+    <div id="demo-expired" class="demo-expired-main-content {{#if hideNavbar}}hide-navbar{{else}}{{#if shrinkNavbar}}shrink-navbar{{/if}}{{/if}}">
       <h1>Demo Expired</h1>
       {{#if canUpgradeDemo}}
         <p>Thanks for trying the Sandstorm Demo! Your demo account has expired. If
@@ -115,7 +115,7 @@ limitations under the License.
   </div>
 
   {{/if}} {{!-- identityUser --}}
-  {{/with}}
+  {{/with}} {{!-- demoExpired --}}
 </template>
 
 <template name="grainView">

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -103,7 +103,7 @@ button.revoke-token {
   background-image: url("/close.svg");
 }
 
-.main-content, .first-sign-in-main-content {
+.main-content, .first-sign-in-main-content, .demo-expired-main-content {
   margin: 0;
   padding: 0;
   position: fixed;


### PR DESCRIPTION
Problem: [this selector](https://github.com/sandstorm-io/sandstorm/blob/09c03628b27e86957b41a7dfc483a0e891da9d96/shell/shared/grain.js#L1419) matches the `main-content` element.

Solution: use a different class, as we did with `first-sign-in-main-content`.