### PR TITLE
Don't clear the admin token after setting just one setting.

### DIFF
--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -855,10 +855,6 @@ if (Meteor.isServer) {
 
       ServiceConfiguration.configurations.upsert({service: options.service}, options);
     },
-    clearAdminToken: function(token) {
-      check(token, String);
-      clearAdminToken(token);
-    },
     clearResumeTokensForService: function (token, serviceName) {
       checkAuth(token);
       check(serviceName, String);

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -200,7 +200,6 @@ if (Meteor.isClient) {
     }
   };
 
-  var successTracker;
   Template.adminSettings.events({
     "click .oauth-checkbox": function (event) {
       var state = Iron.controller().state;
@@ -242,21 +241,6 @@ if (Meteor.isClient) {
       resetResult(state);
       state.set("numSettings", 4);
 
-      if (successTracker) {
-        successTracker.stop();
-        successTracker = null;
-      }
-      if (token) {
-        successTracker = Tracker.autorun(function () {
-          if (state.get("successes") == state.get("numSettings")) {
-            Meteor.call("clearAdminToken", token, function (err) {
-              if (err) {
-                console.error("Failed to clear admin token: ", err);
-              }
-            });
-          }
-        });
-      }
       var handleErrorBound = handleError.bind(state);
       if (event.target.emailTokenLogin.checked && !event.target.smtpUrl.value) {
         handleErrorBound(new Meteor.Error(400,
@@ -687,21 +671,6 @@ if (Meteor.isClient) {
       resetResult(state);
       state.set("numSettings", 10);
 
-      if (successTracker) {
-        successTracker.stop();
-        successTracker = null;
-      }
-      if (token) {
-        successTracker = Tracker.autorun(function () {
-          if (state.get("successes") == state.get("numSettings")) {
-            Meteor.call("clearAdminToken", token, function (err) {
-              if (err) {
-                console.error("Failed to clear admin token: ", err);
-              }
-            });
-          }
-        });
-      }
       var handleErrorBound = handleError.bind(state);
       Meteor.call("setSetting", token, "splashDialog", event.target.splashDialog.value, handleErrorBound);
       Meteor.call("setSetting", token, "signupDialog", event.target.signupDialog.value, handleErrorBound);


### PR DESCRIPTION
The behavior in which the first setting change succeeds but subsequent changes fail is not intuitive to users. The intent of the admin token is to give the user time-limited access to the admin interface -- but not to limit it to only one change.

In the past, the problem was masked by the fact that the first setting change was usually to enable a login service. The user would then log in and, by virtue of being first user, get promoted to admin, so never use an admin token again.

However, the "first user becomes admin" thing has changed. Now, the user must exchange the admin token to receive permanent admin rights. With the token being good for only one change, this means that two admin tokens are required while setting up a server: one to enable login, and another to actually become admin. This is poor UX.

This commit simply removes the logic that clears the admin token after a successful change.