### PR TITLE
Work around libsodium's force-push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,11 +193,18 @@ deps/node-capnp:
 
 update-deps:
 	@$(call color,updating all dependencies)
-	@$(foreach DEP,capnproto ekam libseccomp libsodium node-capnp, \
+	@$(foreach DEP,capnproto ekam libseccomp node-capnp, \
 	    cd deps/$(DEP) && \
 	    echo "pulling $(DEP)..." && \
 	    git pull $(REMOTE_$(DEP)) `git symbolic-ref --short HEAD` && \
 	    cd ../..;)
+	# Argh, libsodium did a force push of their stable branch,
+	# necessitating an explicit checkout.
+	@cd deps/libsodium && \
+	    echo "pulling deps/libsodium..." && \
+	    git fetch $(REMOTE_libsodium) stable && \
+	    git checkout FETCH_HEAD && \
+	    cd ../../
 
 # ====================================================================
 # Ekam bootstrap and C++ binaries


### PR DESCRIPTION
libsodium's "stable" branch received a force-push recently, which breaks our current approach to `make update-deps`.

This change fetches the stable branch from the remote and checks out the FETCH_HEAD, rather than attempting to pull and fast-forward.

It does cause git to make a kinda scary warning about having a detached head, which is a little sad.  If we don't mind clobbering any data in deps/libsodium we could instead `git reset --hard FETCH_HEAD` but that might be a user's dev folder if they do the ekam symlink trick for deps, so I figured this was preferable.