### PR TITLE
On initial signup, if billing is enabled, show a billing plan selector.

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -1272,7 +1272,6 @@ body>.popup.billing-prompt>.frame, .first-time-billing-prompt {
   >.faq {
     margin: 0;
     padding: 16px 0 32px;
-    background-color: #efefef;
     color: #494949;
     text-align: left;
 

--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -971,7 +971,8 @@ div.identity-editor {
 }
 
 body>.main-content>.account,
-body>.popup {
+body>.popup,
+.first-time-billing-prompt {
   .mobile-iframe-hack {
     border: 0px;
     opacity: .01;
@@ -983,7 +984,6 @@ body>.popup {
 }
 
 body>.popup.billing-prompt>.frame {
-  text-align: center;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 
@@ -998,6 +998,17 @@ body>.popup.billing-prompt>.frame {
   @media #{$mobile} {
     max-width: 500px;
   }
+}
+
+.first-time-billing-prompt {
+  max-width: 932px;
+  margin: 32px auto 0;
+  background-color: white;
+  overflow: hidden;
+}
+
+body>.popup.billing-prompt>.frame, .first-time-billing-prompt {
+  text-align: center;
 
   >h2 {
     text-align: center;

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -52,6 +52,11 @@ limitations under the License.
       {{> sandstormAccountsFirstSignIn accountSettingsUi}}
     </div>
   {{else}}
+  {{#with firstTimeBillingPromptState}}
+    <div class="first-sign-in-main-content {{#if hideNavbar}}hide-navbar{{else}}{{#if shrinkNavbar}}shrink-navbar{{/if}}{{/if}}">
+      {{> billingPromptFirstTime}}
+    </div>
+  {{else}}
 
   {{!-- standard topbar items --}}
   {{#sandstormTopbarItem name="home-button" topbar=globalTopbar}}
@@ -103,6 +108,7 @@ limitations under the License.
     {{>billingPrompt}}
   {{/with}}
 
+  {{/with}} {{!-- firstTimeBillingPromptState --}}
   {{/if}} {{!-- firstLogin --}}
 
   {{!-- If the main-content div were inside the {{#if firstLogin}} block, then grain views could be

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -87,6 +87,19 @@ if (Meteor.isServer && process.env.LOG_MONGO_QUERIES) {
 //   referredCompleteDate: The Date at which the completed referral occurred.
 //   referredIdentityIds: List of Identity IDs that this Account has referred. This is used for
 //                        reliably determining which Identity's names are safe to display.
+//   experiments: Object where each field is an experiment that the user is in, and each value
+//           is the parameters for that experiment. Typically, the value simply names which
+//           experiment group which the user is in, where "control" is one group. If an experiment
+//           is not listed, then the user should not be considered at all for the purpose of that
+//           experiment. Each experiment may define a point in time where users not already in the
+//           experiment may be added to it and assigned to a group (for example, at user creation
+//           time). Current experiments:
+//       firstTimeBillingPrompt: Value is "control" or "test". Users are assigned to groups at
+//               account creation on servers where billing is enabled (i.e. Oasis). Users in the
+//               test group will see a plan selection dialog and asked to make an explitic choice
+//               (possibly "free") before they can create grains (but not when opening someone
+//               else's shared grain). The goal of the experiment is to determine whether this
+//               prompt scares users away -- and also whether it increases paid signups.
 //   stashedOldUser: A complete copy of this user from before the accounts/identities migration.
 //                   TODO(cleanup): Delete this field once we're sure it's safe to do so.
 
@@ -516,7 +529,7 @@ if (Meteor.isServer) {
       return [
         Meteor.users.find({_id: this.userId},
             {fields: {signupKey: 1, isAdmin: 1, expires: 1, storageUsage: 1,
-                      plan: 1, hasCompletedSignup: 1}}),
+                      plan: 1, hasCompletedSignup: 1, experiments: 1}}),
         Plans.find()
       ];
     } else {

--- a/shell/packages/sandstorm-db/user.js
+++ b/shell/packages/sandstorm-db/user.js
@@ -81,6 +81,14 @@ Accounts.onCreateUser(function (options, user) {
                  expires: Match.Optional(Date),
                  loginIdentities: [{id: String}],
                  nonloginIdentities: [{id: String}]});
+
+    if (Meteor.settings.public.quotaEnabled) {
+      user.experiments = user.experiments || {};
+      user.experiments = {
+        firstTimeBillingPrompt: Math.random() < 0.5 ? "control" : "test"
+      };
+    }
+
     return user;
   }
 

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -701,6 +701,9 @@ if (Meteor.isClient) {
       // Don't show if not logged in.
       if (!user) return;
 
+      // Don't show if not in the experiment.
+      if (!user.experiments || user.experiments.firstTimeBillingPrompt !== "test") return;
+
       // Don't show if the user has selected a plan already.
       if (user.plan && !Session.get("firstTimeBillingPromptOpen")) return;
 

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -689,6 +689,51 @@ if (Meteor.isClient) {
     },
     accountSettingsUi: function () {
       return makeAccountSettingsUi();
+    },
+    firstTimeBillingPromptState: function () {
+      // Should we show the first-time billing plan selector?
+
+      // Don't show if billing is not enabled.
+      if (!window.BlackrockPayments) return;
+
+      var user = Meteor.user();
+
+      // Don't show if not logged in.
+      if (!user) return;
+
+      // Don't show if the user has selected a plan already.
+      if (user.plan && !Session.get("firstTimeBillingPromptOpen")) return;
+
+      // Only show to account users (not identities).
+      if (!user.loginIdentities) return;
+
+      // Don't show to demo users.
+      if (user.expires) return;
+
+      // Don't show when viewing another user's grain. We don't want to scare people away from
+      // logging in to collaborate.
+      var route = Router.current().route.getName();
+      if (route === "shared") return;
+      if (route === "grain") {
+        if (_.some(globalGrains.get(), function (grain) {
+          return grain.isActive() && !grain.isOwner();
+        })) {
+          return;
+        }
+      }
+
+      // Don't let the plan chooser disappear instantly once user.plan is set.
+      Session.set("firstTimeBillingPromptOpen", true);
+
+      // OK, show it.
+      return {
+        db: globalDb,
+        topbar: globalTopbar,
+        accountsUi: globalAccountsUi,
+        onComplete: function () {
+          Session.set("firstTimeBillingPromptOpen", false);
+        }
+      };
     }
   });
 


### PR DESCRIPTION
This lets the user know that billing is a thing. The user can of course choose "free", but perhaps some will want to choose a plan immediately, and others will want to keep in mind that they have options.

The strategy is similar to the profile confirmation page, in that the plan selector overrides other routes. However, there is an exception: if the user is trying to view a shared grain (not one they own), then we do not interrupt them, since this would be weird for people who are only here to interact with their friend's grains.

There is a risk that this change will scare some users away too early. We should consider running a controlled experiment.

![screenshot from 2015-12-08 22-01-20](https://cloud.githubusercontent.com/assets/4001805/11677865/4ec2d61e-9df7-11e5-979e-cc49480f4a8c.png)

Note how the prompt does not show any plan as "current", even though the free plan is technically current.

This PR is the Sandstorm side of the change. Most of the meat is in Blackrock.