### PR TITLE
Use normal syntax for template helper

### DIFF
--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -481,7 +481,9 @@ if (Meteor.isClient) {
   });
 
   Template.referrals.helpers({
-    isPaid: (Meteor.user() && Meteor.user().plan !== "free"),
+    isPaid: function() {
+      return (Meteor.user() && Meteor.user().plan && Meteor.user().plan !== "free");
+    },
     notYetCompleteReferralNames: function() {
       return ReferralInfo.find({completed: false});
     },


### PR DESCRIPTION
@jadeqwang reported a bug with the following steps to reproduce:

- Have a paid plan, and

- Go to /referrals on Oasis, and

- See text about how you could earn up to 2GB of storage, when that text really should be telling you that you can earn up to 30GB of storage

I took a shortcut here in the template helper, which was not to wrap it in `function()`, but perhaps that was wrong. So this commit fixes that. I say "perhaps that was wrong" because it seems to work fine both ways for me on localhost. But maybe if I don't make it a function, it doesn't get reactively re-run, but I can't trigger the reactivity on localhost because latency is too low.

@jparyani I had emailed you about this before; everything I know is here, so maybe if we discuss, let's discuss here.

Note that I _can_ reproduce the problem Jade reports using `testrock.sandstorm.io` so that's (approximately) good. It means I should be able to use testrock to confirm if this fixes the bug.

@kentonv I don't suppose there's a way for me to personally push to testrock...?