### PR TITLE
Don't set the current identityId for demo users.

### DIFF
--- a/shell/packages/accounts-identity/accounts-identity-client.js
+++ b/shell/packages/accounts-identity/accounts-identity-client.js
@@ -52,8 +52,6 @@ Template.identityLoginInterstitial.onCreated(function () {
           Meteor.call("createAccountForIdentity", function(err, result) {
             if (err) {
               console.log("error", err);
-            } else {
-              Meteor.loginWithIdentity(result);
             }
           });
         } else if ("justLoggingIn" in self._state.get()) {
@@ -223,7 +221,7 @@ Meteor.loginWithIdentity = function (accountId, callback) {
   // Attempts to log into the account with ID `accountId`.
 
   check(accountId, String);
-  var identityId = Meteor.userId();
+  var identity = Meteor.user();
 
   Accounts.callLoginMethod({
     methodName: "loginWithIdentity",
@@ -232,7 +230,9 @@ Meteor.loginWithIdentity = function (accountId, callback) {
       if (error) {
         callback && callback(error);
       } else {
-        Accounts.setCurrentIdentityId(identityId);
+        if (identity.profile.service !== "demo") {
+          Accounts.setCurrentIdentityId(identity._id);
+        }
         callback && callback();
       }
     }


### PR DESCRIPTION
Addresses #1263 by avoiding ever explicitly setting the current identity ID for demo users. When such users link a non-demo identity, that identity will become the current identity as a result of the default identity precedence order in `Accounts.getCurrentIdentityId()`.

Also, removes a call to `Meteor.loginWithIdentity(result)` that's unneeded, due to reactivity.