### PR TITLE
Automatically delete unused accounts when doing so would free up an identity that a user wants to link.

### DIFF
--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -203,7 +203,7 @@ Meteor.methods({
     if (!consumeToken(identity, token)) {
       throw new Meteor.Error(403, "Invalid authentication code.");
     }
-    Accounts.linkIdentityToAccount(identity._id, account._id);
+    Accounts.linkIdentityToAccount(this.connection.sandstormDb, identity._id, account._id);
   }
 });
 

--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -203,7 +203,8 @@ Meteor.methods({
     if (!consumeToken(identity, token)) {
       throw new Meteor.Error(403, "Invalid authentication code.");
     }
-    Accounts.linkIdentityToAccount(this.connection.sandstormDb, identity._id, account._id);
+    Accounts.linkIdentityToAccount(this.connection.sandstormDb, this.connection.sandstormBackend,
+                                   identity._id, account._id);
   }
 });
 

--- a/shell/packages/accounts-identity/accounts-identity-server.js
+++ b/shell/packages/accounts-identity/accounts-identity-server.js
@@ -14,10 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-function linkIdentityToAccountInternal(identityId, accountId) {
+function linkIdentityToAccountInternal(db, identityId, accountId) {
   // Links the identity to the account. If the account is a demo account, makes the account durable
   // and gives the identity login access to it.
 
+  check(db, SandstormDb);
   check(identityId, String);
   check(accountId, String);
 
@@ -30,6 +31,11 @@ function linkIdentityToAccountInternal(identityId, accountId) {
     throw new Meteor.Error(400, "Cannot link an identity to another identity.");
   }
 
+  if (!!_.findWhere(accountUser.loginIdentities, {id: identityId}) ||
+      !!_.findWhere(accountUser.nonloginIdentities, {id: identityId})) {
+    throw new Meteor.Error(400, "Cannot link an identity that's alread linked to this account.");
+  }
+
   var identityUser = Meteor.users.findOne({_id: identityId});
 
   if (!identityUser) {
@@ -40,6 +46,7 @@ function linkIdentityToAccountInternal(identityId, accountId) {
     throw new Meteor.Error(400, "Cannot link an account to another account");
   }
 
+  db.deleteUnusedAccount(identityUser._id);
   if (Meteor.users.findOne({"loginIdentities.id": identityUser._id})) {
     throw new Meteor.Error(403,
                            "Cannot link an identity that can already log into another account");
@@ -160,7 +167,7 @@ Meteor.methods({
     var hashed = Accounts._hashLoginToken(token);
     var accountUser = Meteor.users.findOne({"services.resume.loginTokens.hashedToken": hashed});
 
-    linkIdentityToAccountInternal(this.userId, accountUser._id);
+    linkIdentityToAccountInternal(this.connection.sandstormDb, this.userId, accountUser._id);
   },
 
   unlinkIdentity: function (accountUserId, identityId) {
@@ -220,12 +227,13 @@ Meteor.methods({
   }
 });
 
-Accounts.linkIdentityToAccount = function (identityId, accountId) {
+Accounts.linkIdentityToAccount = function (db, identityId, accountId) {
   // Links the identity to the account. If the account is a demo account, makes it durable and
   // gives the identity login access to it.
+  check(db, SandstormDb);
   check(identityId, String);
   check(accountId, String);
-  linkIdentityToAccountInternal(identityId, accountId);
+  linkIdentityToAccountInternal(db, identityId, accountId);
 }
 
 Meteor.publish("accountsOfIdentity", function (identityId) {

--- a/shell/packages/accounts-identity/accounts-identity-server.js
+++ b/shell/packages/accounts-identity/accounts-identity-server.js
@@ -14,11 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-function linkIdentityToAccountInternal(db, identityId, accountId) {
+function linkIdentityToAccountInternal(db, backend, identityId, accountId) {
   // Links the identity to the account. If the account is a demo account, makes the account durable
   // and gives the identity login access to it.
 
   check(db, SandstormDb);
+  check(backend, SandstormBackend);
   check(identityId, String);
   check(accountId, String);
 
@@ -46,7 +47,7 @@ function linkIdentityToAccountInternal(db, identityId, accountId) {
     throw new Meteor.Error(400, "Cannot link an account to another account");
   }
 
-  db.deleteUnusedAccount(identityUser._id);
+  db.deleteUnusedAccount(backend, identityUser._id);
   if (Meteor.users.findOne({"loginIdentities.id": identityUser._id})) {
     throw new Meteor.Error(403,
                            "Cannot link an identity that can already log into another account");
@@ -167,7 +168,8 @@ Meteor.methods({
     var hashed = Accounts._hashLoginToken(token);
     var accountUser = Meteor.users.findOne({"services.resume.loginTokens.hashedToken": hashed});
 
-    linkIdentityToAccountInternal(this.connection.sandstormDb, this.userId, accountUser._id);
+    linkIdentityToAccountInternal(this.connection.sandstormDb, this.connection.sandstormBackend,
+                                  this.userId, accountUser._id);
   },
 
   unlinkIdentity: function (accountUserId, identityId) {
@@ -227,13 +229,14 @@ Meteor.methods({
   }
 });
 
-Accounts.linkIdentityToAccount = function (db, identityId, accountId) {
+Accounts.linkIdentityToAccount = function (db, backend, identityId, accountId) {
   // Links the identity to the account. If the account is a demo account, makes it durable and
   // gives the identity login access to it.
   check(db, SandstormDb);
+  check(backend, SandstormBackend);
   check(identityId, String);
   check(accountId, String);
-  linkIdentityToAccountInternal(db, identityId, accountId);
+  linkIdentityToAccountInternal(db, backend, identityId, accountId);
 }
 
 Meteor.publish("accountsOfIdentity", function (identityId) {

--- a/shell/packages/accounts-identity/package.js
+++ b/shell/packages/accounts-identity/package.js
@@ -20,7 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use(["underscore", "random", "sandstorm-db", "mongo"]);
+  api.use(["underscore", "random", "sandstorm-db", "sandstorm-backend", "mongo"]);
   api.use("accounts-base", ["client", "server"]);
   api.use(["session", "templating"], ["client"]);
   api.imply("accounts-base", ["client", "server"]);

--- a/shell/packages/sandstorm-backend/sandstorm-backend.js
+++ b/shell/packages/sandstorm-backend/sandstorm-backend.js
@@ -59,6 +59,10 @@ SandstormBackend.prototype.cap = function() {
   return this._backendCap;
 }
 
+SandstormBackend.prototype.deleteUser = function (userId) {
+  return waitPromise(this._backendCap.deleteUser());
+}
+
 SandstormBackend.prototype.shutdownGrain = function (grainId, ownerId, keepSessions) {
   if (!keepSessions) {
     Sessions.remove({grainId: grainId});

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1454,7 +1454,7 @@ if (Meteor.isServer) {
     });
   };
 
-  SandstormDb.prototype.deleteUnusedAccount = function(identityId) {
+  SandstormDb.prototype.deleteUnusedAccount = function(backend, identityId) {
     // If there is an *unused* account that has `identityId` as a login identity, deletes it.
 
     check(identityId, String);
@@ -1465,9 +1465,11 @@ if (Meteor.isServer) {
         !Grains.findOne({userId: account._id}) &&
         !ApiTokens.findOne({accountId: account._id}) &&
         (!account.plan || account.plan === "free") &&
+        !account.payments &&
         !Notifications.findOne({userId: account._id}) &&
         !Contacts.findOne({ownerId: account._id})) {
       Meteor.users.remove({_id: account._id});
+      backend.deleteUser(account._id);
     }
   }
 

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1454,6 +1454,23 @@ if (Meteor.isServer) {
     });
   };
 
+  SandstormDb.prototype.deleteUnusedAccount = function(identityId) {
+    // If there is an *unused* account that has `identityId` as a login identity, deletes it.
+
+    check(identityId, String);
+    var account = Meteor.users.findOne({"loginIdentities.id": identityId});
+    if (account &&
+        account.loginIdentities.length == 1 &&
+        account.nonloginIdentities.length == 0 &&
+        !Grains.findOne({userId: account._id}) &&
+        !ApiTokens.findOne({accountId: account._id}) &&
+        (!account.plan || account.plan === "free") &&
+        !Notifications.findOne({userId: account._id}) &&
+        !Contacts.findOne({ownerId: account._id})) {
+      Meteor.users.remove({_id: account._id});
+    }
+  }
+
   Meteor.publish("keybaseProfile", function (keyFingerprint) {
     check(keyFingerprint, ValidKeyFingerprint);
     var db = this.connection.sandstormDb;


### PR DESCRIPTION
This prevents the error seen in #1255.

Note that we now need to explicitly check that we aren't linking an identity that's already linked to the current account --- otherwise, a fresh account that tries to re-link its only identity gets pushed back to the login interstitial with no helpful error reported.