### PR TITLE
Make the share-via-email message more recipient-friendly

### DIFF
--- a/shell/packages/sandstorm-email/email.js
+++ b/shell/packages/sandstorm-email/email.js
@@ -148,6 +148,7 @@ SandstormEmail.send = function (options) {
     to: options.to,
     cc: options.cc,
     bcc: options.bcc,
+    envelope: options.envelope,
     replyTo: options.replyTo,
     subject: options.subject,
     text: options.text,


### PR DESCRIPTION
* Include the grain title at the start of the subject line
* Include the grain title in the button
  * Adjust padding and min-width on button.  The button should grow in width to
    accommodate longer grain titles.
* Change the button to be Sandstorm purple.
* Set the From: header to include the sharing user's display name and
  if available, the first verified email for that identity.
* Avoid jargon like "Shared Grain" in favor of "collaborate" and using
  the sharer's title for the grain.