### PR TITLE
App index improvements

### DIFF
--- a/src/sandstorm/app-index/app-index.c++
+++ b/src/sandstorm/app-index/app-index.c++
@@ -136,7 +136,6 @@ public:
 
           indexer.getSubmissionStatus(packageId, response);
 
-          auto status = response.getRoot<SubmissionStatus>();
           if (changed) {
             // Force update now!
             indexer.updateIndex();

--- a/src/sandstorm/app-index/app-index.c++
+++ b/src/sandstorm/app-index/app-index.c++
@@ -421,6 +421,7 @@ public:
     KJ_SYSCALL(mkdir("/var/keybase", 0777));
     KJ_SYSCALL(mkdir("/var/www", 0777));
     KJ_SYSCALL(mkdir("/var/www/apps", 0777));
+    KJ_SYSCALL(mkdir("/var/www/experimental", 0777));
     KJ_SYSCALL(mkdir("/var/www/images", 0777));
     KJ_SYSCALL(mkdir("/var/www/packages", 0777));
     KJ_SYSCALL(mkdir("/var/tmp", 0777));
@@ -428,6 +429,8 @@ public:
   }
 
   kj::MainBuilder::Validity run() {
+    mkdir("/var/www/experimental", 0777);  // back-compat; ignore already exists error
+
     Indexer indexer;
 
     // Set up RPC on file descriptor 3.

--- a/src/sandstorm/app-index/app-index.c++
+++ b/src/sandstorm/app-index/app-index.c++
@@ -417,6 +417,7 @@ public:
 
   kj::MainBuilder::Validity init() {
     KJ_SYSCALL(mkdir("/var/packages", 0777));
+    KJ_SYSCALL(mkdir("/var/apps", 0777));
     KJ_SYSCALL(mkdir("/var/keybase", 0777));
     KJ_SYSCALL(mkdir("/var/www", 0777));
     KJ_SYSCALL(mkdir("/var/www/apps", 0777));
@@ -429,6 +430,7 @@ public:
 
   kj::MainBuilder::Validity run() {
     mkdir("/var/www/experimental", 0777);  // back-compat; ignore already exists error
+    mkdir("/var/apps", 0777);  // back-compat; ignore already exists error
 
     Indexer indexer;
 

--- a/src/sandstorm/app-index/app-index.capnp
+++ b/src/sandstorm/app-index/app-index.capnp
@@ -24,6 +24,8 @@
 #       spk          Raw SPK file (immutable).
 #       metadata     Serialized Package.VerifiedInfo (immutable).
 #       status       Serialized SubmissionStatus (mutable).
+#   apps/
+#     <appId>        Symlink to latest approved package version.
 #   keybase/
 #     <keyId>        Serialized KeybaseIdentity for a person.
 #   descriptions     Serialized ShortDescriptionOverrides
@@ -163,7 +165,7 @@ const pkgdef :Package.PackageDefinition = (
 
   manifest = (
     appTitle = (defaultText = "Sandstorm App Index"),
-    appVersion = 1,
+    appVersion = 2,
     appMarketingVersion = (defaultText = "2015-12-11"),
 
     actions = [
@@ -171,7 +173,14 @@ const pkgdef :Package.PackageDefinition = (
         command = (argv = ["/app-index", "--init"])
       )
     ],
-    continueCommand = (argv = ["/app-index"])
+    continueCommand = (argv = ["/app-index"]),
+
+    metadata = (
+      author = (contactEmail = "support@sandstorm.io"),
+      categories = [developerTools],
+      license = (openSource = apache2),
+      shortDescription = (defaultText = "App Market")
+    )
   ),
 
   fileList = "app-index-sandstorm-files.list",

--- a/src/sandstorm/app-index/indexer.c++
+++ b/src/sandstorm/app-index/indexer.c++
@@ -226,7 +226,8 @@ public:
 
 }  // namespace
 
-void Indexer::updateIndexInternal(kj::StringPtr outputFilename, bool approvedApps) {
+void Indexer::updateIndexInternal(kj::StringPtr outputFilename, kj::StringPtr outputDir,
+                                  bool approvedApps) {
   capnp::MallocMessageBuilder scratch;
   auto orphanage = scratch.getOrphanage();
 
@@ -406,9 +407,9 @@ void Indexer::updateIndexInternal(kj::StringPtr outputFilename, bool approvedApp
     apps.setWithCaveats(i++, appEntry.second.summary.getReader());
 
     auto text = json.encode(appEntry.second.details.getReader());
-    StagingFile file("/var/www/apps");
+    StagingFile file(outputDir);
     kj::FdOutputStream(file.getFd()).write(text.begin(), text.size());
-    file.finalize(kj::str("/var/www/apps/", appEntry.first, ".json"));
+    file.finalize(kj::str(outputDir, "/", appEntry.first, ".json"));
   }
   KJ_ASSERT(i == apps.size());
 
@@ -419,8 +420,8 @@ void Indexer::updateIndexInternal(kj::StringPtr outputFilename, bool approvedApp
 }
 
 void Indexer::updateIndex() {
-  updateIndexInternal("index.json", true);
-  updateIndexInternal("index-experimental.json", false);
+  updateIndexInternal("index.json", "/var/www/apps", true);
+  updateIndexInternal("index-experimental.json", "/var/www/experimental", false);
 }
 
 kj::String Indexer::writeIcon(spk::Metadata::Icon::Reader icon) {

--- a/src/sandstorm/app-index/indexer.h
+++ b/src/sandstorm/app-index/indexer.h
@@ -63,7 +63,8 @@ private:
   kj::String writeImage(kj::ArrayPtr<const byte> data, kj::StringPtr extension);
   capnp::Text::Reader categoryName(spk::Category category);
 
-  void updateIndexInternal(kj::StringPtr outputFilename, bool approvedApps);
+  void updateIndexInternal(kj::StringPtr outputFilename, kj::StringPtr outputDir,
+                           bool approvedApps);
 };
 
 } // namespace appindex


### PR DESCRIPTION
1. Fix a bug introduced by the "experimental" index change: Detailed metadata from non-approved version of packages was taking precedence over approved packages of the same app. Details for experimental packages are now placed under `/experimental` rather than `/apps`.
2. Reject app updates that fail to bump `appVersion`.

I've actually already updated the master index with these changes because we were displaying bogus metadata on app details pages.