### PR TITLE
DenormalizedGrainMetadata has an 'icon' field, not an 'appIcon' field.

### DIFF
--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -470,9 +470,10 @@ SandstormPermissions.createNewApiToken = function (db, provider, grainId, petnam
 
     if (pkg && pkg.manifest && pkg.manifest.metadata && pkg.manifest.metadata.icons) {
       var icons = pkg.manifest.metadata.icons;
-      grainInfo.appIcon = icons.grain || icons.appGrid;
+      grainInfo.icon = icons.grain || icons.appGrid;
     }
-    if (!grainInfo.appIcon && pkg) {
+    // Only provide an app ID if we have no icon asset to provide and need to offer an identicon.
+    if (!grainInfo.icon && pkg) {
       grainInfo.appId = pkg.appId;
     }
     apiToken.owner = {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -316,16 +316,6 @@ Meteor.methods({
       referralProgramLogSharingTokenUse(globalDb, apiToken.accountId);
     }
 
-    var pkg = Packages.findOne({_id: grain.packageId});
-    var appTitle = (pkg && pkg.manifest && pkg.manifest.appTitle) || { defaultText: ""};
-    var appIcon = undefined;
-    if (pkg && pkg.manifest && pkg.manifest.metadata && pkg.manifest.metadata.icons) {
-      var icons = pkg.manifest.metadata.icons;
-      appIcon = icons.grain || icons.appGrid;
-    }
-    // Only provide an app ID if we have no icon asset to provide and need to offer an identicon.
-    var appId = appIcon ? undefined : grain.appId;
-
     var title;
     if (grain.userId === apiToken.accountId) {
       title = grain.title;


### PR DESCRIPTION
Grains that have been shared since #1161 have broken app icons. This patch fixes the problem and deletes some now-unused code.

It would not be too difficult to also write a migration that fixes up any tokens that have been created in the mean time.

Related question: I seem to remember that we had some discussions at one point where we decided that the recipients of shares should not get to see the appId of grains that are shared with them. Do we still think that would be desirable? 