### PR TITLE
Test code cleanup

### DIFF
--- a/shell/shared/devAccounts.js
+++ b/shell/shared/devAccounts.js
@@ -78,23 +78,26 @@ if (allowDevAccounts) {
     };
 
     loginDevAccountFast = function(displayName, isAdmin) {
-      // This skips the firstSignUp page. Mostly used for testing purposes.
-      var profile = {
-        name: displayName,
-        pronoun: "robot",
-        handle: "_" + displayName.toLowerCase()
-      };
+      return new Promise(function (resolve, reject) {
+        // This skips the firstSignUp page. Mostly used for testing purposes.
+        var profile = {
+          name: displayName,
+          pronoun: "robot",
+          handle: "_" + displayName.toLowerCase()
+        };
 
-      Accounts.callLoginMethod({
-        methodName: "createDevAccount",
-        methodArguments: [displayName, isAdmin, profile, displayName + "@example.com"],
-        userCallback: function (err) {
-          if (err) {
-            window.alert(err);
-          } else {
-            Router.go("apps");
+        Accounts.callLoginMethod({
+          methodName: "createDevAccount",
+          methodArguments: [displayName, isAdmin, profile, displayName + "@example.com"],
+          userCallback: function (err) {
+            if (err) {
+              reject(new Error(err));
+            } else {
+              Router.go("apps");
+              resolve();
+            }
           }
-        }
+        });
       });
     };
 

--- a/tests/tests/backup-restore.js
+++ b/tests/tests/backup-restore.js
@@ -78,10 +78,6 @@ module.exports = {
     makeCleanDownloadsDirSync();
     configureAutoDownload(browser, done);
   },
-  after: function(browser, done) {
-    browser.end();
-    done();
-  }
 };
 
 module.exports["Test backup and restore"] = function(browser) {

--- a/tests/tests/basic.js
+++ b/tests/tests/basic.js
@@ -40,6 +40,5 @@ if (!disable_demo) {
       .loginDemo()
       .waitForElementVisible('.topbar .account>.show-popup>a', short_wait)
       .assert.containsText(".topbar .account>.show-popup>a", "Demo")
-      .end();
   };
 }


### PR DESCRIPTION
Attempt to remove the need for arbitrary `pause()` invocations.  Ideally, we
should wait for things to reach a desired state, with a timeout for that
happening, so we don't sit idly for the rest of the timeout period.

This change makes login cleanly async, which should save a couple seconds on
each test that performs login.