### PR TITLE
Stop intrinsic name from overflowing in identity cards

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -1523,7 +1523,6 @@ ul.identity-card-list {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
-    height:30px;
     font-size: 10pt;
     color: #777777;
   }


### PR DESCRIPTION
Fixes #1277