### PR TITLE
Add a migration to clean up some ill-formed entries in ApiTokens.

### DIFF
--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -446,8 +446,6 @@ SandstormPermissions.createNewApiToken = function (db, provider, grainId, petnam
       parentForSharing = true;
     }
 
-    // TODO(soon): For a while this field was failing to get set due to a typo. We should migrate
-    //   old entries in ApiTokens to populate this field where appropriate.
     apiToken.identityId = parentApiToken.identityId;
     apiToken.accountId = parentApiToken.accountId;
 

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -671,18 +671,15 @@ getProxyForApiToken = function (token) {
         }
 
         var proxy;
-        if (tokenInfo.identityId) {
-          var identityId = null;
-          if (!tokenInfo.forSharing) {
-            identityId = tokenInfo.identityId;
-          }
-
-          proxy = new Proxy(tokenInfo.grainId, grain.userId, null, null, identityId, true);
-          proxy.apiToken = tokenInfo;
-        } else if (tokenInfo.userInfo) {
+        if (tokenInfo.userInfo) {
           throw new Error("API tokens created with arbitrary userInfo no longer supported");
         } else {
-          proxy = new Proxy(tokenInfo.grainId, grain.userId, null, null, null, true);
+          var identityId = null;
+          if (tokenInfo.identityId && !tokenInfo.forSharing) {
+            identityId = tokenInfo.identityId;
+          }
+          proxy = new Proxy(tokenInfo.grainId, grain.userId, null, null, identityId, true);
+          proxy.apiToken = tokenInfo;
         }
 
         if (!SandstormPermissions.mayOpenGrain(globalDb, {token: tokenInfo})) {


### PR DESCRIPTION
This deletes the ill-formed tokens discussed in https://github.com/sandstorm-io/sandstorm/pull/1179#issuecomment-162548946, fixes the tokens described in #1285, and adds the `identityId` field in some tokens where it had been accidentally omitted previously. It also simplifies some conditional login in proxy.js; the deleted branch should have had `proxy.apiToken = tokenInfo`.