### PR TITLE
twiddle with some symlinks to get libsodium to build

### DIFF
--- a/src/sodium/crypto_core
+++ b/src/sodium/crypto_core
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/crypto_core/

--- a/src/sodium/crypto_core_hsalsa20.h
+++ b/src/sodium/crypto_core_hsalsa20.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_core_hsalsa20.h

--- a/src/sodium/crypto_core_salsa20.h
+++ b/src/sodium/crypto_core_salsa20.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_core_salsa20.h

--- a/src/sodium/crypto_core_salsa2012.h
+++ b/src/sodium/crypto_core_salsa2012.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_core_salsa2012.h

--- a/src/sodium/crypto_core_salsa208.h
+++ b/src/sodium/crypto_core_salsa208.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_core_salsa208.h

--- a/src/sodium/crypto_sign
+++ b/src/sodium/crypto_sign
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/crypto_sign/

--- a/src/sodium/crypto_sign.c
+++ b/src/sodium/crypto_sign.c
@@ -1,1 +1,0 @@
-../../deps/libsodium/src/libsodium/crypto_sign/crypto_sign.c

--- a/src/sodium/crypto_sign_ed25519
+++ b/src/sodium/crypto_sign_ed25519
@@ -1,1 +1,0 @@
-../../deps/libsodium/src/libsodium/crypto_sign/ed25519


### PR DESCRIPTION
This makes the directory structure more faithful to the original repository, so that [this include](https://github.com/jedisct1/libsodium/blob/f9d982480ba68895dd90f29cf072bc3e533f09de/src/libsodium/crypto_sign/ed25519/ref10/open.c#L10) has a chance of working.