### PR TITLE
Add tooltip with grain title to links in navbar

### DIFF
--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -54,8 +54,8 @@ limitations under the License.
       {{!-- TODO(cleanup): ul's can only contain li's, so this ul is not really valid --}}
       <ul class="navbar-grains">
         {{#each grains}}
-        <li data-grainid="{{grainId}}" class="navitem-grain {{#if active}}current{{/if}}">
-          <div class="app-icon" style="background-image: url('{{iconSrc}}');" title="{{appTitle}}" alt="{{appTitle}}"></div>
+        <li data-grainid="{{grainId}}" class="navitem-grain {{#if active}}current{{/if}}" title={{title}}>
+          <div class="app-icon" style="background-image: url('{{iconSrc}}');" alt="{{appTitle}}"></div>
           <a href="{{grainLink}}">{{title}}</a>
           <button class="close-button" title="Close {{title}}"></button>
         </li>


### PR DESCRIPTION
Removed the title attribute on the app icon, since you can't actually trigger a
hover on the app icon because the link stacks above it.

Fixes #1325.