### PR TITLE
Modularize login buttons registration and rendering.

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -158,10 +158,26 @@ body>.popup.account>.frame {
       background-image: url("/troubleshoot-m.svg");
     }
   }
-  >button.login.devAccounts {
+  >form.login.dev {
     background-image: url("/debug.svg");
+    background-position-y: 0px;
+    height: auto;
     &:hover {
       background-image: url("/debug-m.svg");
+    }
+    ul.dev-identities {
+      text-indent: 0;
+      list-style-type: none;
+      padding-left: 0;
+      li {
+        margin: 0;
+        width: auto;
+        button {
+          @extend %button-base;
+          @extend %button-secondary;
+          width: 100%;
+        }
+      }
     }
   }
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -1130,32 +1130,6 @@ limitations under the License.
   </div>
 </template>
 
-<template name="devAccounts">
-  {{>title pageTitle}}
-
-  <div class="dev-accounts centered-box">
-    <h2>Developer Accounts</h2>
-    {{#if shouldShowStartDevAccounts}}
-      {{#if loggingIn}}
-        <p>Logging in...</p>
-      {{else}}
-        <button id="loginAliceDevAccount" class="devLogin">Log in as Alice (admin) »</button>
-        <button id="loginBobDevAccount" class="devLogin">Log in as Bob »</button>
-        <button id="loginCarolDevAccount" class="devLogin">Log in as Carol »</button>
-        <button id="loginDaveDevAccount" class="devLogin">Log in as Dave »</button>
-        <button id="loginEveDevAccount" class="devLogin">Log in as Eve »</button>
-      {{/if}}
-    {{else}}
-        <p>You are already logged in.</p>
-        <p><button onclick="browseHome()">See your apps »</button></p>
-    {{/if}}
-
-    <h3>What is this?</h3>
-    <p>This page is only for developer Sandstorm instances (ie. the ALLOW_DEV_ACCOUNTS setting
-    is enabled in your sandstorm.conf).</p>
-  </div>
-</template>
-
 <template name="referrals">
   {{#if quotaEnabled}}
   {{>title "Referral Program"}}

--- a/shell/packages/accounts-email-token/token_common.js
+++ b/shell/packages/accounts-email-token/token_common.js
@@ -7,36 +7,6 @@ Accounts.emailToken._hashToken = function (token) {
   };
 };
 
-var enabled = false;
-
-if (Meteor.isClient) {
-  var enabledReactive = new ReactiveVar(false);
-}
-
-Accounts.emailToken.enable = function (accountsUi) {
-  enabled = true;
-  if (Meteor.isClient) {
-    accountsUi.registerService("emailToken", "an Email + Token");
-    enabledReactive.set(true);
-  }
-};
-
-Accounts.emailToken.disable = function (accountsUi) {
-  enabled = false;
-  if (Meteor.isClient) {
-    accountsUi.deregisterService("emailToken");
-    enabledReactive.set(false);
-  }
-};
-
-Accounts.emailToken.isEnabled = function () {
-  if (Meteor.isClient) {
-    return enabledReactive.get();
-  } else {
-    return enabled;
-  }
-};
-
 Router.route("/_emailLogin/:_email/:_token", function () {
   this.render("Loading");
   var that = this;

--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -180,7 +180,7 @@ Meteor.methods({
     check(email, String);
     check(linkingIdentity, Boolean);
 
-    if (!Accounts.emailToken.isEnabled()) {
+    if (!Accounts.identityServices.email.isEnabled()) {
       throw new Meteor.Error(403, "Email identity service is disabled.");
     }
     // Create user. result contains id and token.

--- a/shell/packages/sandstorm-accounts-oauth/oauth_common.js
+++ b/shell/packages/sandstorm-accounts-oauth/oauth_common.js
@@ -1,7 +1,6 @@
 Accounts.oauth = {};
 
 var services = {};
-var servicesDep = new Tracker.Dependency;
 
 // Helper for registering OAuth based accounts packages.
 // On the server, adds an index to the user collection.
@@ -9,7 +8,6 @@ Accounts.oauth.registerService = function (name) {
   if (_.has(services, name))
     throw new Error("Duplicate service: " + name);
   services[name] = true;
-  servicesDep.changed();
 
   if (Meteor.server) {
     // Accounts.updateOrCreateUserFromExternalService does a lookup by this id,
@@ -30,10 +28,8 @@ Accounts.oauth.deregisterService = function (name) {
   if (!_.has(services, name))
     throw new Error("Service not found: " + name);
   delete services[name];
-  servicesDep.changed();
 };
 
 Accounts.oauth.serviceNames = function () {
-  servicesDep.depend();
   return _.keys(services);
 };

--- a/shell/packages/sandstorm-accounts-packages/accounts.js
+++ b/shell/packages/sandstorm-accounts-packages/accounts.js
@@ -21,40 +21,23 @@ if (Meteor.isClient) {
   };
 }
 
-var services = [];
-
-Accounts.registerService = function (serviceName, accountsUi) {
-  if (_.contains(services, serviceName)) {
-    return;
-  }
-  services.push(serviceName);
-  if (serviceName === "emailToken") {
-    Accounts.emailToken.enable(accountsUi);
-  }
-  else if (Meteor.isClient && (serviceName === "demo" || serviceName === "devAccounts")) {
-    var serviceUserDisplay;
-    if (serviceName === "demo") {
-      serviceUserDisplay = "a Demo User";
-    } else {
-      serviceUserDisplay = "a Dev Account";
-    }
-    accountsUi.registerService(serviceName, serviceUserDisplay);
-  } else {
-    Accounts.oauth.registerService(serviceName);
-  }
-};
-
-Accounts.deregisterService = function (serviceName, accountsUi) {
-  if (!_.contains(services, serviceName)) {
-    return;
-  }
-  services = _.without(services, serviceName);
-  if (serviceName === "emailToken") {
-    Accounts.emailToken.disable(accountsUi);
-  }
-  else if (Meteor.isClient && (serviceName === "demo" || serviceName === "devAccounts")) {
-    accountsUi.deregisterService(serviceName);
-  } else {
-    Accounts.oauth.deregisterService(serviceName);
-  }
-};
+Accounts.identityServices = {};
+// A dictionary of identity services. At the moment, this is mainly used for rendering login UI
+// components. Each key in the dictionary is the name of the service, e.g. "github", exactly as it
+// would appear in the `Users.profile.service` field in the Sandstorm database. Each value in the
+// dictionary is an object with the following fields:
+//
+//   isEnabled: A function of no arguments. Returns a boolean indicating whether this service is
+//              currently configured to be active.
+//   loginTemplate: An object indicating how to render this service's login UI. Contains the
+//                  following fields:
+//       name: The name of the template to render.
+//       priority: Number representing this template's sort order when it appears within a list
+//                 with other login templates. Lower priority means higher in the list.
+//       data: An object to pass along to the template when it is rendered. The value of this
+//             field will be placed in the `data` field. In addition, there will be a
+//             boolean `linkingNewIdentity` field, which is true if the component is currently being
+//             used to link an new identity, rather than just to log in.
+//
+// TODO(someday): It probably makes sense also to collect in these objects the service-specific
+// user initialization logic currently found in sandstorm-db/user.js and sandstorm-db/profile.js.

--- a/shell/packages/sandstorm-accounts-packages/package.js
+++ b/shell/packages/sandstorm-accounts-packages/package.js
@@ -9,7 +9,6 @@ Package.onUse(function (api) {
   // Export Accounts (etc) to packages using this one.
   api.imply("accounts-base", ["client", "server"]);
   api.use("sandstorm-accounts-oauth", ["client", "server"]);
-  api.use("sandstorm-accounts-ui", {weak: true});
   api.use("google", ["client", "server"]);
   api.use("github", ["client", "server"]);
 

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -99,7 +99,7 @@ limitations under the License.
     </div>
     <div class="add-new">
       Add new e-mail address
-      {{> emailLoginForm emailLoginFormData}}
+      {{> emailAuthenticationForm emailLoginFormData}}
       {{> _loginButtonsMessages}}
     </div>
   </div>

--- a/shell/packages/sandstorm-accounts-ui/accounts_ui.js
+++ b/shell/packages/sandstorm-accounts-ui/accounts_ui.js
@@ -2,22 +2,6 @@ AccountsUi = function (db) {
   // Object implementing the accounts UI. Must be passed as the data context for the `loginButtons`
   // and `loginButtonsPopup` templates.
 
-  this._services = new ReactiveDict();
   this._db = db;
 }
 
-AccountsUi.prototype.registerService = function (serviceName, displayName) {
-  // Still register it as an oauth service
-  // TODO(someday): don't do this?
-  Accounts.oauth.registerService(serviceName);
-
-  this._services.set(serviceName, displayName);
-};
-
-AccountsUi.prototype.deregisterService = function (serviceName) {
-  // Still register it as an oauth service
-  // TODO(someday): don't do this?
-  Accounts.oauth.deregisterService(serviceName);
-
-  this._services.set(serviceName, undefined);
-};

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -100,17 +100,9 @@
 <template name="loginButtonsList">
   <div class="login-buttons-list" role="menu">
   {{#each services}}
-    {{#if isEmailTokenService}}
-      {{#if hasOtherServices}} {{! the email token service will always come last }}
-        {{> _loginButtonsSeparator}}
-      {{/if}}
-      {{> emailLoginForm linkingNewIdentity=linkingNewIdentity description="with e-mail"
-                         prompt="email" sendButtonText="send Login Email"}}
-    {{else}}
-      <button class="login oneclick {{name}}" role="menuitem">
-        with {{capitalizedName}}
-      </button>
-    {{/if}}
+    {{#with data=loginTemplate.data linkingNewIdentity=linkingNewIdentity}}
+      {{> Template.dynamic template=../loginTemplate.name }}
+    {{/with}}
   {{else}}
     <a class="troubleshooting" href="/admin" role="menuitem">configure login</a>
   {{/each}}
@@ -126,7 +118,44 @@
   </div>
 </template>
 
+<template name="oauthLoginButton">
+  <button class="login oneclick {{data.name}}" role="menuitem">
+    with {{data.displayName}}
+  </button>
+</template>
+
+<template name="devLoginForm">
+  <form class="dev login expand">
+    with a Dev account {{#if expanded}}▴{{else}}▾{{/if}}
+    {{#if expanded}}
+    <ul class="dev-identities">
+      <li><button type="button" class="login-dev-account" data-name="Alice Dev Admin"
+                  data-is-admin="true">
+          Alice (admin)
+      </button></li>
+      <li><button type="button" class="login-dev-account" data-name="Bob Dev User">
+          Bob
+      </button></li>
+      <li><button type="button" class="login-dev-account" data-name="Carol Dev User">
+          Carol
+      </button></li>
+      <li><button type="button" class="login-dev-account" data-name="Dave Dev User">
+          Dave
+      </button></li>
+      <li><button type="button" class="login-dev-account" data-name="Eve Dev User">
+          Eve
+      </button></li>
+    </ul>
+    {{/if}}
+  </form>
+</template>
+
 <template name="emailLoginForm">
+  {{> emailAuthenticationForm linkingNewIdentity=linkingNewIdentity description="with e-mail"
+                              prompt="email" sendButtonText="send Login Email"}}
+</template>
+
+<template name="emailAuthenticationForm">
   <form class="email">
     {{description}}
 

--- a/shell/packages/sandstorm-accounts-ui/package.js
+++ b/shell/packages/sandstorm-accounts-ui/package.js
@@ -11,9 +11,7 @@ Package.onUse(function (api) {
   // Export Accounts (etc) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);
 
-  // Allow us to call Accounts.oauth.serviceNames, if there are any OAuth
-  // services.
-  api.use('sandstorm-accounts-oauth', {weak: true});
+  api.use('sandstorm-accounts-packages', {weak: true});
 
   // Allow us to check if payments are enabled
   api.use('blackrock-payments', {weak: true});

--- a/shell/shared/devAccounts.js
+++ b/shell/shared/devAccounts.js
@@ -17,6 +17,16 @@
 var allowDevAccounts = Meteor.settings && Meteor.settings.public &&
                  Meteor.settings.public.allowDevAccounts;
 
+Accounts.identityServices.dev = {
+  isEnabled: function () {
+    return allowDevAccounts;
+  },
+  loginTemplate: {
+    name: "devLoginForm",
+    priority: -10, // Put it at the top.
+  }
+}
+
 if (allowDevAccounts) {
   if (Meteor.isServer) {
     var Crypto = Npm.require("crypto");
@@ -57,12 +67,6 @@ if (allowDevAccounts) {
   }
 
   if (Meteor.isClient) {
-    Meteor.loginWithDevAccounts = function (options, callback) {
-      Router.go("devAccounts");
-      callback();
-    };
-    globalAccountsUi.registerService("devAccounts", "a Dev Account");
-
     loginDevAccount = function(displayName, isAdmin) {
       Accounts.callLoginMethod({
         methodName: "createDevAccount",
@@ -70,8 +74,6 @@ if (allowDevAccounts) {
         userCallback: function (err) {
           if (err) {
             window.alert(err);
-          } else {
-            Router.go("root");
           }
         }
       });
@@ -100,48 +102,6 @@ if (allowDevAccounts) {
         });
       });
     };
-
-    Template.devAccounts.events({
-      "click #loginAliceDevAccount": function (event) {
-        var displayName = "Alice Dev Admin";
-        loginDevAccount(displayName, true);
-      },
-      "click #loginBobDevAccount": function (event) {
-        var displayName = "Bob Dev User";
-        loginDevAccount(displayName);
-      },
-      "click #loginCarolDevAccount": function (event) {
-        var displayName = "Carol Dev User";
-        loginDevAccount(displayName);
-      },
-      "click #loginDaveDevAccount": function (event) {
-        var displayName = "Dave Dev User";
-        loginDevAccount(displayName);
-      },
-      "click #loginEveDevAccount": function (event) {
-        var displayName = "Eve Dev User";
-        loginDevAccount(displayName);
-      },
-    });
   }
-
-  Router.map(function () {
-    this.route("devAccounts", {
-      path: "/devAccounts",
-      waitOn: function () {
-        return Meteor.subscribe("credentials");
-      },
-      data: function () {
-        return {
-          allowDevAccounts: allowDevAccounts,
-          // We show the Start the Demo button if you are not logged in.
-          shouldShowStartDevAccounts: ! isSignedUpOrDemo(),
-          createLocalUserLabel: "Start the devAccounts",
-          pageTitle: "Developer Accounts",
-          isDemoUser: isDemoUser()
-        };
-      }
-    });
-  });
 }
 


### PR DESCRIPTION
Notes:

We were previously calling `Accounts.oauth.registerService()` on every service. The only thing that got us was the ability use `Accounts.oauth.serviceNames()` as a convenient way to enumerate the enabled services. `Accounts.identityServices` now gives us a better way to enumerate them.

`Meteor.loginWithDevAccounts` was only needed previously so that clicking on the devAccounts login button would redirect to the devAccounts page.

I deleted some code that existed to close the topbar popup on login. It's no longer needed because the login menu is now different from the account menu; logging in destroys the former, triggering an `onDestroyed()` callback that clears the topbar-expanded state.