### PR TITLE
Only attempt to sign up as admin if there actually is a token.

### DIFF
--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -51,7 +51,7 @@ var adminRoute = RouteController.extend({
     });
     var user = Meteor.user();
     if (user && user.loginIdentities) {
-      if (!user.signupKey || !user.isAdmin) {
+      if (this.params._token && (!user.signupKey || !user.isAdmin)) {
         Meteor.call("signUpAsAdmin", this.params._token);
       }
     }


### PR DESCRIPTION
Currently if any non-admin visits /admin/settings they will see an error like "Error invoking Method 'signUpAsAdmin': Match failed [400]".