### PR TITLE
Fix sessions sometimes not refreshing within 60s

### DIFF
--- a/shell/packages/sandstorm-ui-app-details/app-details-client.js
+++ b/shell/packages/sandstorm-ui-app-details/app-details-client.js
@@ -127,11 +127,6 @@ Template.sandstormAppDetails.helpers({
     var pkg = ref.pkg;
     return pkg && Identicon.iconSrcForPackage(pkg, 'appGrid', ref.staticHost);
   },
-  debug: function () {
-    var ref = Template.instance().data;
-    console.log(ref);
-    console.log(ref.pkg);
-  },
   appId: function() {
     var pkg = Template.instance().data.pkg;
     return pkg && pkg.appId;

--- a/shell/packages/sandstorm-ui-app-details/app-details.html
+++ b/shell/packages/sandstorm-ui-app-details/app-details.html
@@ -51,7 +51,6 @@
        lastUpdated: Date.  The date of publication of the package.
   --}}
   <div class="app-details-widget">
-    {{debug}}
     <div class="app-icon" style="background-image: url('{{appIconSrc}}');"></div>
     <div class="app-details-box">
       <h1 class="app-title">{{appTitle}}</h1>

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1207,7 +1207,7 @@ if (Meteor.isClient) {
     // Meteor has an exponential backoff of up to 5 minutes for reconnect. This is unnacceptable
     // for us, since we rely on Sessions being re-established in under 60s.
     if (Meteor.status().status === "waiting") {
-      console.log("Sandstorm is trying to reconnect meteor.");
+      console.log("Sandstorm is trying to reconnect...");
       Meteor.reconnect();
     }
 

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1203,6 +1203,14 @@ if (Meteor.isClient) {
   Meteor.setInterval(function () {
     var grains = globalGrains.get();
     if (!grains) return;
+
+    // Meteor has an exponential backoff of up to 5 minutes for reconnect. This is unnacceptable
+    // for us, since we rely on Sessions being re-established in under 60s.
+    if (Meteor.status().status === "waiting") {
+      console.log("Sandstorm is trying to reconnect meteor.");
+      Meteor.reconnect();
+    }
+
     grains.forEach(function (grain) {
       if (grain.sessionId()) {
         // TODO(soon):  Investigate what happens in background tabs.  Maybe arrange to re-open the


### PR DESCRIPTION
This is almost certainly due to the fact that meteor's reconnect timer can exceed 60s (it caps at 5 minutes). Add a check in the keepAlive interval and manually call Meteor.reconnect if needed.