### PR TITLE
Fix mobile double completing contacts on click

### DIFF
--- a/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
+++ b/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
@@ -224,7 +224,7 @@ Template.contactInputBox.events({
   "blur input": function(event, template) {
     template.inputActive.set(false);
   },
-  "mousedown .autocomplete, click .autocomplete": function(event, template) {
+  "mousedown .autocomplete": function(event, template) {
     selectContact(template, this, template.find("input"));
     template.find("input").focus();
 


### PR DESCRIPTION
It turns out we only need to monitor `mousedown` events. `click` events
don't trigger correctly for these elements on desktop anyways.