### PR TITLE
offerTemplate $GRAIN_SLUG replacement

### DIFF
--- a/docs/developing/http-apis.md
+++ b/docs/developing/http-apis.md
@@ -158,8 +158,8 @@ automatically refreshes the IFRAME every 5 minutes.
 * `rpcId`: **String** of a message ID that will be passed back to your
   code.
 
-* `template`: **String** to display to the user, where `$API_HOST`
-  and `$API_TOKEN` will be replaced.
+* `template`: **String** to display to the user, where `$API_HOST`,
+  `$API_TOKEN`, and `$GRAIN_TITLE_SLUG` will be replaced.
 
 * `petname`: **String (optional)** of a name that this API token will
   have, when the user lists the API tokens and sharing links they have

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1814,8 +1814,18 @@ if (Meteor.isClient) {
           // template namespace under key id2.
           const key = "offerTemplate" + id2;
           const host = globalDb.makeApiHost(tokenId);
+          var grain = getActiveGrain(globalGrains.get());
+          var grainTitle = grain.title();
+          // grainTitleSlug is the grain title with url-unsafe characters replaced
+          var grainTitleSlug = grainTitle.toLowerCase().trim();
+          grainTitleSlug = grainTitleSlug.replace(/\s+/g, '-')
+                                         .replace(/[^\w\-]+/g, '')
+                                         .replace(/\-\-+/g, '-')
+                                         .replace(/^-+/, '')
+                                         .replace(/-+$/, '');
           const renderedTemplate = template.replace(/\$API_TOKEN/g, tokenId)
-                                           .replace(/\$API_HOST/g, host);
+                                           .replace(/\$API_HOST/g, host)
+                                           .replace(/\$GRAIN_TITLE_SLUG/g, grainTitleSlug);
           sessionStorage.setItem(key, JSON.stringify({
               token: tokenId,
               renderedTemplate: renderedTemplate,

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1814,15 +1814,15 @@ if (Meteor.isClient) {
           // template namespace under key id2.
           const key = "offerTemplate" + id2;
           const host = globalDb.makeApiHost(tokenId);
-          var grain = getActiveGrain(globalGrains.get());
-          var grainTitle = grain.title();
+          const grain = getActiveGrain(globalGrains.get());
+          const grainTitle = grain.title();
           // grainTitleSlug is the grain title with url-unsafe characters replaced
-          var grainTitleSlug = grainTitle.toLowerCase().trim();
-          grainTitleSlug = grainTitleSlug.replace(/\s+/g, '-')
-                                         .replace(/[^\w\-]+/g, '')
-                                         .replace(/\-\-+/g, '-')
-                                         .replace(/^-+/, '')
-                                         .replace(/-+$/, '');
+          let grainTitleSlug = grainTitle.toLowerCase().trim();
+          grainTitleSlug = grainTitleSlug.replace(/\s+/g, "-")
+                                         .replace(/[^\w\-]+/g, "")
+                                         .replace(/\-\-+/g, "-")
+                                         .replace(/^-+/, "")
+                                         .replace(/-+$/, "");
           const renderedTemplate = template.replace(/\$API_TOKEN/g, tokenId)
                                            .replace(/\$API_HOST/g, host)
                                            .replace(/\$GRAIN_TITLE_SLUG/g, grainTitleSlug);


### PR DESCRIPTION
This adds the ability to use `$GRAIN_SLUG` in an offer template to generate a useful representation of the name of the grain.

My use case for this is Owncloud Client authentication. While Sandstorm ignores the username field of basic auth, Owncloud Client displays it when listing remote servers, so setting it to the name of the grain is the only real way to distinguish remote servers in Owncloud Client.

![image](https://cloud.githubusercontent.com/assets/3705/12256154/377473e0-b8c9-11e5-8a95-a132b633c5a1.png)

Unfortunately not anything can go in the `username` part of a URL, so it sanitizes things like `Michael's Grain` down to `michaels-grain`.