### PR TITLE
Add configurable server title and return address for notification emails

### DIFF
--- a/shell/client/_admin.scss
+++ b/shell/client/_admin.scss
@@ -73,8 +73,10 @@
   @extend %button-secondary;
 }
 
-#admin-settings-form input[type="text"] {
-  width: 100%;
+#admin-settings-form {
+  input[type="text"], input[type="email"] {
+    width: 100%;
+  }
 }
 
 #settings-content {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -1063,6 +1063,10 @@ limitations under the License.
 <template name="adminAdvanced">
   {{setDocumentTitle}}
   <form id="admin-settings-form">
+    <p>Server Title: <input type="text" name="serverTitle" value="{{serverTitle}}"><br>
+      <span class="details">The name of this server, for use when communicating with users. Example: "Bob's Sandstorm Server"</span></p>
+    <p>Return Address: <input type="email" name="returnAddress" value="{{returnAddress}}"><br>
+      <span class="details">E-mail address to place in the "From" header of email notifications from this server. You can specify a "no-reply" address, but we suggest using an address that users can mail if they need help.</span></p>
     <p>Splash URL: <input type="text" name="splashUrl" value="{{splashUrl}}" placeholder="https://example.com"><br>
       <span class="details">This web page will be displayed in the background behind the login dialog (the home page when logged out). For security reasons, the page must be hosted within this Sandstorm server's wildcard host (otherwise it will be blocked by <code>Content-Security-Policy</code>). We suggest using a static web publishing app like <a href="https://apps.sandstorm.io/app/nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh?host={{origin}}" target="_blank">Hacker CMS</a> to host the content. <strong>WARNING: This feature is experimental; in particular the style and positioning of the login box is subject to change without notice.</strong> Please <a href="https://github.com/sandstorm-io/sandstorm/issues" target="_blank">let us know</a> if you'd like to see it stabilize.</span></p>
     <p>Signup Dialog: <input type="text" name="signupDialog" value="{{signupDialog}}"><br>

--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -101,7 +101,7 @@ var makeTokenUrl = function (email, token, linkingIdentity) {
 ///
 /// EMAIL VERIFICATION
 ///
-var sendTokenEmail = function (email, token, linkingIdentity) {
+var sendTokenEmail = function (db, email, token, linkingIdentity) {
   var subject;
   var text;
   if (!linkingIdentity) {
@@ -118,7 +118,7 @@ var sendTokenEmail = function (email, token, linkingIdentity) {
 
   var options = {
     to:  email,
-    from: HOSTNAME + " <no-reply@" + HOSTNAME + ">",
+    from: db.getServerTitle() + " <" + db.getReturnAddress() + ">",
     subject: subject,
     text: text,
   };
@@ -130,7 +130,7 @@ var sendTokenEmail = function (email, token, linkingIdentity) {
 /// CREATING USERS
 ///
 // returns the user id
-var createAndEmailTokenForUser = function (email, linkingIdentity) {
+var createAndEmailTokenForUser = function (db, email, linkingIdentity) {
   check(email, String);
   check(linkingIdentity, Boolean);
   var atIndex = email.indexOf("@");
@@ -166,7 +166,7 @@ var createAndEmailTokenForUser = function (email, linkingIdentity) {
     userId = Accounts.insertUserDoc(options, user);
   }
 
-  sendTokenEmail(email, token, linkingIdentity);
+  sendTokenEmail(db, email, token, linkingIdentity);
 
   return userId;
 };
@@ -184,7 +184,7 @@ Meteor.methods({
       throw new Meteor.Error(403, "Email identity service is disabled.");
     }
     // Create user. result contains id and token.
-    var user = createAndEmailTokenForUser(email, linkingIdentity);
+    var user = createAndEmailTokenForUser(this.connection.sandstormDb, email, linkingIdentity);
   },
 
   linkEmailIdentityToAccount: function (email, token) {

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1037,6 +1037,14 @@ _.extend(SandstormDb.prototype, {
   getKeybaseProfile: function (keyFingerprint) {
     return this.collections.keybaseProfiles.findOne(keyFingerprint) || {};
   },
+
+  getServerTitle: function () {
+    return Settings.findOne({_id: "serverTitle"}).value;
+  },
+
+  getReturnAddress: function () {
+    return Settings.findOne({_id: "returnAddress"}).value;
+  }
 });
 
 var appNameFromPackage = function(packageObj) {

--- a/shell/packages/sandstorm-db/migrations.js
+++ b/shell/packages/sandstorm-db/migrations.js
@@ -5,6 +5,7 @@
 // idempotent and safe to accidentally run multiple times.
 
 var Future = Npm.require("fibers/future");
+var Url = Npm.require("url");
 
 var updateLoginStyleToRedirect = function() {
   var configurations = Package["service-configuration"].ServiceConfiguration.configurations;
@@ -404,6 +405,12 @@ function cleanUpApiTokens() {
                   parentToken: {$exists: false}}).forEach(repairChain);
 }
 
+function initServerTitleAndReturnAddress() {
+  var hostname = Url.parse(process.env.ROOT_URL).hostname;
+  Settings.insert({_id: "serverTitle", value: hostname});
+  Settings.insert({_id: "returnAddress", value: "no-reply@" + hostname});
+}
+
 // This must come after all the functions named within are defined.
 // Only append to this list!  Do not modify or remove list entries;
 // doing so is likely change the meaning and semantics of user databases.
@@ -425,6 +432,7 @@ var MIGRATIONS = [
   splitAccountUsersAndIdentityUsers,
   populateContactsFromApiTokens,
   cleanUpApiTokens,
+  initServerTitleAndReturnAddress
 ];
 
 function migrateToLatest() {

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -17,7 +17,8 @@
 var ADMIN_TOKEN_EXPIRATION_TIME = 15 * 60 * 1000;
 var publicAdminSettings = ["google", "github", "emailToken", "splashUrl", "signupDialog",
                            "adminAlert", "adminAlertTime", "adminAlertUrl", "termsUrl",
-                           "privacyUrl", "appMarketUrl", "appIndexUrl", "appUpdatesEnabled"];
+                           "privacyUrl", "appMarketUrl", "appIndexUrl", "appUpdatesEnabled",
+                           "serverTitle", "returnAddress"];
 
 DEFAULT_SIGNUP_DIALOG = "You've been invited to join this Sandstorm server!";
 
@@ -654,9 +655,13 @@ if (Meteor.isClient) {
       var state = Iron.controller().state;
       var token = this.token;
       resetResult(state);
-      state.set("numSettings", 10);
+      state.set("numSettings", 12);
 
       var handleErrorBound = handleError.bind(state);
+      Meteor.call("setSetting", token, "serverTitle",
+                  event.target.serverTitle.value, handleErrorBound);
+      Meteor.call("setSetting", token, "returnAddress",
+                  event.target.returnAddress.value, handleErrorBound);
       Meteor.call("setSetting", token, "splashUrl", event.target.splashUrl.value, handleErrorBound);
       Meteor.call("setSetting", token, "signupDialog", event.target.signupDialog.value, handleErrorBound);
       Meteor.call("setSetting", token, "termsUrl", event.target.termsUrl.value, handleErrorBound);
@@ -689,6 +694,14 @@ if (Meteor.isClient) {
   Template.adminAdvanced.helpers({
     setDocumentTitle: function () {
       document.title = "Advanced · Admin · Sandstorm";
+    },
+    serverTitle: function() {
+      var setting = Settings.findOne({_id: "serverTitle"});
+      return (setting && setting.value) || "";
+    },
+    returnAddress: function() {
+      var setting = Settings.findOne({_id: "returnAddress"});
+      return (setting && setting.value) || "";
     },
     splashUrl: function() {
       var setting = Settings.findOne({_id: "splashUrl"});
@@ -860,7 +873,7 @@ if (Meteor.isServer) {
 
       SandstormEmail.send({
         to: to,
-        from: "Sandstorm Test <no-reply@" + HOSTNAME + ">",
+        from: globalDb.getServerTitle() + " <" + globalDb.getReturnAddress() + ">",
         subject: "Testing your Sandstorm's SMTP setting",
         text: "Success! Your outgoing SMTP is working.",
         smtpUrl: smtpUrl


### PR DESCRIPTION
For now this is only used on login emails, but I also plan to use it for invoice emails in Blackrock.

Note that I intentionally did NOT apply this to sharing emails because we plan to make those be "from" the sharing user soon.