### PR TITLE
Fix references to WebSocketReceiver.queue.

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -2108,8 +2108,8 @@ WebSocketReceiver = class WebSocketReceiver {
   }
 
   go() {
-    for (let i in queue) {
-      this.socket.write(queue[i]);
+    for (let i in this.queue) {
+      this.socket.write(this.queue[i]);
     }
 
     this.queue = null;


### PR DESCRIPTION
Looks like this broke in one of the big ES6 changes: https://github.com/sandstorm-io/sandstorm/commit/eed6e5a2dab392f59d610a9ec8f3669e38a4be72 (which GitHub apparently can't render in-browser)