### PR TITLE
Give demo users an intrinsicName of the form 'demo on 2016-01-14'.

### DIFF
--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -49,6 +49,7 @@ if (Meteor.isServer) {
         "profile":1,
         "unverifiedEmail":1,
         "expires": 1,
+        "createdAt": 1,
 
         "services.dev.name":1,
 
@@ -202,7 +203,7 @@ SandstormDb.fillInIntrinsicName = function(user) {
   } else if (profile.service === "dev") {
     profile.intrinsicName = user.services.dev.name;
   } else if (profile.service === "demo") {
-    // No intrinsic name.
+    profile.intrinsicName = "demo on " + user.createdAt.toISOString().substring(0,10);
   } else {
     throw new Error("unrecognized identity service: ", profile.service);
   }


### PR DESCRIPTION
Some of our code assumes that `intrinsicName` exists for all identities:
https://github.com/sandstorm-io/sandstorm/blob/097ee0da80dcd1ec76823b38396a03365a04a079/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js#L55
https://github.com/sandstorm-io/sandstorm/blob/097ee0da80dcd1ec76823b38396a03365a04a079/shell/shared/grain.js#L275

Currently we don't fill in `intrinsicName` for demo identities, mostly I couldn't think of what it would make sense to put there.

With this patch, we fill in `intrinsicName` with the date that the demo started.

An account profile that has a linked demo identity will look like this now:
<img width="451" alt="demo intrinsic name" src="https://cloud.githubusercontent.com/assets/495768/12333699/cba4d586-bac3-11e5-9cc9-7c060456ab75.png">
