### PR TITLE
Makes contact input sized more flexibly

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -904,6 +904,7 @@ body>.popup {
         border: 0px;
         outline: 0px;
         width: 100%;
+        box-sizing: border-box;
       }
       &.active {
         outline: $focus-outline-color solid 1px;

--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -903,7 +903,7 @@ body>.popup {
       input.emails {
         border: 0px;
         outline: 0px;
-        width: 200px;
+        width: 100%;
       }
       &.active {
         outline: $focus-outline-color solid 1px;


### PR DESCRIPTION
Fixes #1299 

I'm not sure this is actually any clearer than  using a table, since I'd never heard of "block formatting contexts" before doing this. I'm also not sure if there's some easier way to do this with display: flex. Feel free to suggest alternatives.