### PR TITLE
use /shared/ links in share-by-identity emails

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -110,18 +110,27 @@ limitations under the License.
 
   {{/with}} {{!-- firstTimeBillingPromptState --}}
   {{/if}} {{!-- firstLogin --}}
-
-  {{!-- If the main-content div were inside the {{#if firstLogin}} block, then grain views could be
-        blanked out when a demo user upgrades to a real account by linking an email identity.
-   --}}
-  <div class="main-content {{#if hideNavbar}}hide-navbar{{else}}{{#if shrinkNavbar}}shrink-navbar{{/if}}{{/if}}">
-    {{#unless firstLogin}}
-      {{> yield}}
-    {{/unless}}
-  </div>
-
   {{/if}} {{!-- identityUser --}}
   {{/with}} {{!-- demoExpired --}}
+
+  {{!-- Make sure to always render the main-content div, but only yield if there is no interstitial
+        to render on top. The main-content div needs to be stable so that any GrainView that gets
+        attached does not get orphaned. For example, if the main-content div were inside the
+        {{#if firstLogin}} block, then grain views could appear to become blanked out when a demo
+        user upgrades to a real account by linking an email identity.
+   --}}
+  <div class="main-content {{#if hideNavbar}}hide-navbar{{else}}{{#if shrinkNavbar}}shrink-navbar{{/if}}{{/if}}">
+  {{#unless demoExpired}}
+    {{#unless identityUser}}
+      {{#unless firstLogin}}
+        {{#unless firstTimeBillingPromptState}}
+          {{> yield}}
+        {{/unless}}
+      {{/unless}}
+    {{/unless}}
+  {{/unless}}
+  </div>
+
 </template>
 
 <template name="grainView">
@@ -142,14 +151,31 @@ limitations under the License.
         {{> _grainSpinner}}
       {{/if}}
     {{else}}
-    {{#if interstitial}}
+    {{#if interstitial.chooseIdentity}}
       <div class="interstitial-button-box">
         <p>With which of your identities would you like to open this grain?</p>
         {{> identityPicker identityPickerData}}
         <button class="incognito-button" data-token="{{token}}">Open in Incognito Mode</button>
       </div>
     {{else}}
-      {{> _grainSpinner}}
+      {{#if interstitial.directShare}}
+        <div class="direct-share-denied">
+          <p>Access Denied.</p>
+          {{#if currentUser}}
+            <p>
+              This grain was shared to the following identity,
+              which is not linked to the current account.
+            </p>
+          {{else}}
+            <p>
+              This grain was shared to the following identity. Please sign in to gain access.
+            </p>
+          {{/if}}
+          {{> identityCard interstitial.directShare.recipient }}
+        </div>
+      {{else}}
+        {{> _grainSpinner}}
+      {{/if}}
     {{/if}}
     {{/if}}
     {{/if}}

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -172,6 +172,13 @@ limitations under the License.
             </p>
           {{/if}}
           {{> identityCard interstitial.directShare.recipient }}
+          {{#if currentUser}}
+            <p>
+              To gain access,
+              try <a href="/account">linking the above identity to your account</a>
+              or signing in with a different account.
+            </p>
+          {{/if}}
         </div>
       {{else}}
         {{> _grainSpinner}}

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -160,23 +160,19 @@ limitations under the License.
     {{else}}
       {{#if interstitial.directShare}}
         <div class="direct-share-denied">
-          <p>Access Denied.</p>
-          {{#if currentUser}}
-            <p>
-              This grain was shared to the following identity,
-              which is not linked to the current account.
-            </p>
-          {{else}}
-            <p>
-              This grain was shared to the following identity. Please sign in to gain access.
-            </p>
-          {{/if}}
+          <p>
+            Access through this URL is restricted to this identity:
+          </p>
           {{> identityCard interstitial.directShare.recipient }}
           {{#if currentUser}}
             <p>
               To gain access,
-              try <a href="/account">linking the above identity to your account</a>
-              or signing in with a different account.
+              <a href="/account">link the above identity to your account</a>
+              or sign in with the appropriate account.
+            </p>
+          {{else}}
+            <p>
+              Please sign in to gain access.
             </p>
           {{/if}}
         </div>

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -175,9 +175,12 @@ button.revoke-token {
   color: red;
 }
 
-.main-content .interstitial-button-box {
+.main-content .interstitial-button-box,.direct-share-denied {
   text-align: center;
   background-color: $default-content-background-color;
+  .identity-card {
+    display: inline-block;
+  }
   & button.incognito-button {
     font-family: inherit;
     font-size: inherit;


### PR DESCRIPTION
This allows us to display a helpful error message if the intended recipient is not logged in when they click the link:

<img width="1230" alt="access denied" src="https://cloud.githubusercontent.com/assets/495768/12363279/ec986c1c-bb95-11e5-81da-13090170c629.png">
