### PR TITLE
Implement the plan described in #1374

### DIFF
--- a/shell/client/_admin.scss
+++ b/shell/client/_admin.scss
@@ -49,6 +49,9 @@
   .fade-out {
     opacity: .5;
   }
+  .reset-reason {
+    margin: 10px;
+  }
 }
 
 .settings-tabs {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -839,14 +839,30 @@ limitations under the License.
   <form id="admin-settings-form">
     <p>
       <label><input type="checkbox" class="oauth-checkbox" name="googleLogin"
-             value="value" checked={{googleEnabled}} data-servicename="google"> Enable Google Login
-       (<a class="configure-oauth" data-servicename="google" href="">configure</a>)
-       (<a class="reset-login-tokens" data-servicename="google" href="">log out all users</a>)</label><br>
-       <label><input type="checkbox" class="oauth-checkbox" name="githubLogin"
-              value="value" checked={{githubEnabled}} data-servicename="github"> Enable Github Login
-       (<a class="configure-oauth" data-servicename="github" href="">configure</a>)
-       (<a class="reset-login-tokens" data-servicename="github" href="">log out all users</a>)</label><br>
-       <label><input type="checkbox" name="emailTokenLogin" value="value" checked={{emailTokenEnabled}}> Enable Passwordless Email Login</label><br>
+                    value="value" checked={{googleSetting.value}} data-servicename="google">
+        Enable Google Login
+        (<a class="configure-oauth" data-servicename="google" href="">configure</a>)
+        (<a class="reset-login-tokens" data-servicename="google" href="">log out all users</a>)
+      </label><br>
+      {{#with googleSetting.resetReason}}
+        <p class="alert-danger reset-reason">
+          Google login has been automatically disabled because: {{.}}.
+          Please make sure the configuration is correct before re-enabling.
+        </p>
+      {{/with}}
+      <label><input type="checkbox" class="oauth-checkbox" name="githubLogin"
+                    value="value" checked={{githubSetting.value}} data-servicename="github">
+        Enable Github Login
+        (<a class="configure-oauth" data-servicename="github" href="">configure</a>)
+        (<a class="reset-login-tokens" data-servicename="github" href="">log out all users</a>)
+      </label><br>
+      {{#with githubSetting.resetReason}}
+        <p class="alert-danger reset-reason">
+          GitHub login had been automatically disabled because: {{.}}.
+          Please make sure the configuration is correct before re-enabling.
+        </p>
+      {{/with}}
+      <label><input type="checkbox" name="emailTokenLogin" value="value" checked={{emailTokenEnabled}}> Enable Passwordless Email Login</label><br>
       <span class="details">Choose which services users may use to identify themselves. Anyone can log in, but only users you {{#linkTo route="adminInvites" data=getToken}}invite{{/linkTo}} will be able to install apps or create files.</span></p>
     <p>SMTP Url: <button id="admin-settings-send-toggle">Test</button><input id="smptUrl" type="text" name="smtpUrl" value="{{smtpUrl}}"><br>
       <span class="details">Address of an SMTP relay server, like <code>smtp://user:pass@host:port</code>, which will be used by email apps and to send {{#linkTo route="adminInvites" data=getToken}}email invites{{/linkTo}}. The SMTP server should be configured to allow sending email from your Sandstorm domain and from email addresses that will be used to send invites. Read the <a href="https://docs.sandstorm.io/en/latest/administering/email/#outgoing-smtp">docs</a> for more details.</span>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -844,10 +844,16 @@ limitations under the License.
         (<a class="configure-oauth" data-servicename="google" href="">configure</a>)
         (<a class="reset-login-tokens" data-servicename="google" href="">log out all users</a>)
       </label><br>
-      {{#with googleSetting.resetReason}}
+      {{#with googleSetting.automaticallyReset}}
         <p class="alert-danger reset-reason">
-          Google login has been automatically disabled because: {{.}}.
+          Google login was automatically disabled
+          {{#with baseUrlChangedFrom}}
+            because this server's BASE_URL has been updated. Its old value was {{.}}.
+          {{else}}
+            for an unknown reason.
+          {{/with}}
           Please make sure the configuration is correct before re-enabling.
+          You will likely need to update the OAuth redirect URL in the Google Developer Console.
         </p>
       {{/with}}
       <label><input type="checkbox" class="oauth-checkbox" name="githubLogin"
@@ -856,10 +862,16 @@ limitations under the License.
         (<a class="configure-oauth" data-servicename="github" href="">configure</a>)
         (<a class="reset-login-tokens" data-servicename="github" href="">log out all users</a>)
       </label><br>
-      {{#with githubSetting.resetReason}}
+      {{#with githubSetting.automaticallyReset}}
         <p class="alert-danger reset-reason">
-          GitHub login had been automatically disabled because: {{.}}.
+          GitHub login was automatically disabled
+          {{#with baseUrlChangedFrom}}
+            because this server's BASE_URL has been updated. Its old value was {{.}}.
+          {{else}}
+            for an unknown reason.
+          {{/with}}
           Please make sure the configuration is correct before re-enabling.
+          You will likely need to update the OAuth redirect URL in GitHub application settings.
         </p>
       {{/with}}
       <label><input type="checkbox" name="emailTokenLogin" value="value" checked={{emailTokenEnabled}}> Enable Passwordless Email Login</label><br>

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -448,11 +448,18 @@ Misc = new Mongo.Collection("misc");
 
 Settings = new Mongo.Collection("settings");
 // Settings for this Sandstorm instance go here. They are configured through the adminSettings
-// route. This collection differs from misc in that this collection is completely user controlled.
+// route. This collection differs from misc in that any admin user can update it through the admin
+// interface.
 //
 // Each contains:
 //   _id:       The name of the setting. eg. "MAIL_URL"
 //   value:     The value of the setting.
+//   automaticallyReset: Sometimes the server needs to automatically reset a setting. When it does
+//                       so, it will also write an object to this field indicating why the reset was
+//                       needed. That object can have the following variants:
+//       baseUrlChangedFrom: The reset was due to BASE_URL changing. This field contains a string
+//                           with the old BASE_URL.
+//
 //   potentially other fields that are unique to the setting
 
 Migrations = new Mongo.Collection("migrations");

--- a/shell/server/startup.js
+++ b/shell/server/startup.js
@@ -27,7 +27,13 @@ Meteor.startup(() => {
     Misc.insert(baseUrlRow);
   } else if (baseUrlRow.value !== ROOT_URL) {
     console.log('resetting oauth');
-    Accounts.loginServiceConfiguration.remove({});
+    Settings.find({_id: {$in: ["google", "github"]}}).forEach((setting) => {
+      if (!!setting.value) {
+        Settings.update({_id: setting._id},
+                        {$set: {value: false,
+                                resetReason: "BASE_URL changed"}});
+      }
+    });
     baseUrlRow = {_id: 'BASE_URL', value: ROOT_URL};
     Misc.update({_id: 'BASE_URL'}, {$set: {value: ROOT_URL}});
   }

--- a/shell/server/startup.js
+++ b/shell/server/startup.js
@@ -31,7 +31,7 @@ Meteor.startup(() => {
       if (!!setting.value) {
         Settings.update({_id: setting._id},
                         {$set: {value: false,
-                                resetReason: "BASE_URL changed"}});
+                                automaticallyReset: {baseUrlChangedFrom: baseUrlRow.value}}});
       }
     });
     baseUrlRow = {_id: 'BASE_URL', value: ROOT_URL};

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -197,7 +197,8 @@ if (Meteor.isClient) {
       var serviceName = event.target.getAttribute("data-servicename");
       var config = Package["service-configuration"].ServiceConfiguration.configurations.findOne({service: serviceName});
 
-      if (!config && event.target.checked) {
+      var setting = Settings.findOne({_id: serviceName});
+      if (event.target.checked && (!config || (setting && setting.automaticallyReset))) {
         state.set("configurationServiceName", serviceName);
       }
     },
@@ -815,7 +816,7 @@ if (Meteor.isServer) {
       }
       Settings.upsert({_id: serviceName}, {$set: {value: value}});
       if (value) {
-        Settings.update({_id: serviceName}, {$unset: {resetReason: 1}});
+        Settings.update({_id: serviceName}, {$unset: {automaticallyReset: 1}});
       }
     },
     setSetting: function (token, name, value) {

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -250,21 +250,11 @@ if (Meteor.isClient) {
     setDocumentTitle: function () {
       document.title = "Settings · Admin · Sandstorm";
     },
-    googleEnabled: function () {
-      var setting = Settings.findOne({_id: "google"});
-      if (setting) {
-        return setting.value;
-      } else {
-        return false;
-      }
+    googleSetting: function () {
+      return Settings.findOne({_id: "google"});
     },
-    githubEnabled: function () {
-      var setting = Settings.findOne({_id: "github"});
-      if (setting) {
-        return setting.value;
-      } else {
-        return false;
-      }
+    githubSetting: function () {
+      return Settings.findOne({_id: "github"});
     },
     emailTokenEnabled: function () {
       var setting = Settings.findOne({_id: "emailToken"});
@@ -818,8 +808,15 @@ if (Meteor.isServer) {
           throw new Meteor.Error(403, "You must configure the " + serviceName +
             " service before you can enable it. Click the \"configure\" link.");
         }
+        if (!config.clientId || !config.secret) {
+          throw new Meteor.Error(403, "You must provide a non-empty clientId and secret for the " +
+            serviceName + " service before you can enable it. Click the \"configure\" link.");
+        }
       }
       Settings.upsert({_id: serviceName}, {$set: {value: value}});
+      if (value) {
+        Settings.update({_id: serviceName}, {$unset: {resetReason: 1}});
+      }
     },
     setSetting: function (token, name, value) {
       checkAuth(token);


### PR DESCRIPTION
Disables oauth services on BASE_URL change, but does not delete the config. Displays red boxes in the admin area, explaining why the services were disabled.

Looks like this:
<img width="1147" alt="admin" src="https://cloud.githubusercontent.com/assets/495768/12367340/2bb13f96-bbaf-11e5-84c6-47f3e37720d0.png">

