### PR TITLE
get the backgrounding test to work on selenium 2.49

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -385,6 +385,10 @@ body>.topbar {
         @include webfont-icon(#CCCCCC, #CCCCCC);
         @extend .icon-notification;
 
+        span.button-helper-text {
+           position: absolute;
+           width: 0px;
+        }
         >.count {
           display: block;
           position: absolute;

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -171,7 +171,9 @@ limitations under the License.
   {{#if notificationCount}}
     <span class="count">{{notificationCount}}</span>
   {{/if}}
-  Notifications
+  <span class="button-helper-text">
+    Notifications
+  </span>
 </template>
 
 <template name="notificationsPopup">


### PR DESCRIPTION
After this change, all tests pass for me using Selenium version 2.49. Before this change, the notifications button on the topbar extends to more than twice its visible height down behind the main-content element. When we ask Selenium to click on this element, as in our backgrounding test, Selenium chooses a pixel near the center of the element. The newer versions of Selenium then block the click because at that pixel the element isn't actually clickable (see [this thread](https://github.com/SeleniumHQ/selenium/issues/1202)).

The solution is to eliminate the useless hidden overlapped part of the notifications button.

Note that the "Notifications" inner text of the button, although not visible, is important for screen readers. We have similar inner texts for the other topbar buttons. As an alternative to the approach in this pull request, I attempted to just remove those inner texts and replace them with "title" attributes. The snag I hit there was that VoiceOver seems to ignore the title attribute if there is any inner text at all. So for the notifications button it picked up only the inner number of notifications, not the title "Notifications".

