### PR TITLE
install.sh: Create error codes for install.sh failures

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2005,13 +2005,13 @@ sandcats_generate_keys() {
 
 # Now that the steps exist as functions, run them in an order that
 # would result in a working install.
-assert_on_terminal
 assert_linux_x86_64
 assert_usable_kernel
 detect_current_uid
 detect_userns_clone
 assert_userns_clone_works_or_can_be_made_to_work
 handle_args "$@"
+assert_on_terminal
 assert_dependencies
 assert_valid_bundle_file
 detect_init_system

--- a/installer-tests/fail-on-32-bit-system.t
+++ b/installer-tests/fail-on-32-bit-system.t
@@ -2,7 +2,7 @@ Title: Can't install Sandstorm on old kernels
 Vagrant-Box: debian-7.8-32-nocm
 
 $[run]CURL_USER_AGENT=testing /vagrant/install.sh
-$[slow]Sorry, the Sandstorm server currently only runs on x86_64 machines.
-*** INSTALLATION FAILED ***
-Report bugs at: http://github.com/sandstorm-io/sandstorm
+$[slow]*** INSTALLATION FAILED ***
+Sorry, the Sandstorm server currently only runs on x86_64 machines.
+bugs at: http://github.com/sandstorm-io/sandstorm
 $[exitcode]1


### PR DESCRIPTION
NOTE that this changes the "fail" function to have two arguments.

Also:

- installer-tests: Adjust failure string to be more lenient.

- Capitalize the first word in a sentence.

- Include half-written code for sending errors to an Oasis grain, if
  users opt in. This is disabled by default at the moment.

- Avoid race condition in permissions for sandcats logs by creating
  the file with touch and then setting its permissions.