### PR TITLE
Make dev login element a button when not expanded.

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -158,7 +158,7 @@ body>.popup.account>.frame {
       background-image: url("/troubleshoot-m.svg");
     }
   }
-  >form.login.dev {
+  >form.login.dev,>button.login.dev {
     background-image: url("/debug.svg");
     background-position-y: 0px;
     height: auto;

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -125,9 +125,9 @@
 </template>
 
 <template name="devLoginForm">
-  <form class="dev login expand">
-    with a Dev account {{#if expanded}}▴{{else}}▾{{/if}}
-    {{#if expanded}}
+  {{#if expanded}}
+  <form class="dev login expanded">
+    with a Dev account ▴
     <ul class="dev-identities">
       <li><button type="button" class="login-dev-account" data-name="Alice Dev Admin"
                   data-is-admin="true">
@@ -146,8 +146,12 @@
           Eve
       </button></li>
     </ul>
-    {{/if}}
   </form>
+  {{else}}
+  <button class="dev login expand">
+    with a Dev account ▾
+  </button>
+  {{/if}}
 </template>
 
 <template name="emailLoginForm">

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -284,9 +284,13 @@ Template.devLoginForm.helpers({
 });
 
 Template.devLoginForm.events({
-  "click form.expand": function (event, instance) {
+  "click button.expand": function (event, instance) {
     event.preventDefault();
-    instance._expanded.set(!instance._expanded.get());
+    instance._expanded.set(true);
+  },
+  "click form.expanded": function (event, instance) {
+    event.preventDefault();
+    instance._expanded.set(false);
   },
   "click button.login-dev-account": function (event, instance) {
     var displayName = event.currentTarget.getAttribute("data-name");


### PR DESCRIPTION
I noticed that it was difficult to navigate to dev login using just the keyboard, probably because the dev login element in the login buttons list is a form, not a button. This makes it easier.