### PR TITLE
Fix autofocus in login dropdown and account dropdown.

### DIFF
--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -16,11 +16,11 @@ Template._loginButtonsLoggedOutDropdown.helpers(helpers);
 Template._loginButtonsLoggedInDropdown.helpers(helpers);
 
 Template.loginButtonsPopup.onRendered(function() {
-  this.find("[role=menuitem]").focus();
+  this.find(".login-buttons-list :first-child").focus();
 });
 
 Template.accountButtonsPopup.onRendered(function() {
-  this.find("[role=menuitem]").focus();
+  this.find(".account-buttons-list :first-child").focus();
 });
 
 Template.accountButtonsPopup.events({


### PR DESCRIPTION
Fixes some fallout from https://github.com/sandstorm-io/sandstorm/commit/1887ba24dcf79d9e07dd75143d97b1c1748c9b65.

Currently, I see errors like `TypeError: Cannot read property 'focus' of null` when I expand the login menu.