### PR TITLE
Ignore notifications in SandstormDb.deleteUnusedAccount().

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1521,7 +1521,6 @@ if (Meteor.isServer) {
         !ApiTokens.findOne({accountId: account._id}) &&
         (!account.plan || account.plan === "free") &&
         !account.payments &&
-        !Notifications.findOne({userId: account._id}) &&
         !Contacts.findOne({ownerId: account._id})) {
       Meteor.users.remove({_id: account._id});
       backend.deleteUser(account._id);


### PR DESCRIPTION
@phildini reported being unable to link an identity from a unused account on Oasis. The problem was that the account had received the referrals announcement notification, so Sandstorm did not consider it to be unused.

This patch changes the logic so that Sandstorm would still have considered that account to be unused. Deleting an account that has some notifications but nothing else should not be dangerous.