### PR TITLE
Fix invisible identity-login-interstitial and demo-expired-interstitial.

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -1381,6 +1381,7 @@ body>.popup.billing-prompt>.frame, .first-time-billing-prompt {
 }
 
 .identity-login-interstitial {
+  z-index: 1;
   background-color: #efefef;
   height: 100%;
   div.centered-content{

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -103,7 +103,8 @@ button.revoke-token {
   background-image: url("/close.svg");
 }
 
-.main-content, .first-sign-in-main-content, .demo-expired-main-content {
+.main-content, .first-sign-in-main-content, .demo-expired-main-content,
+.identity-login-interstitial {
   margin: 0;
   padding: 0;
   position: fixed;
@@ -414,6 +415,7 @@ div.popup h2 {
 }
 
 #demo-expired {
+  z-index: 1;
   >p, >h1, >h2, >h3, >h4 {
     margin-left: auto;
     margin-right: auto;

--- a/shell/packages/accounts-identity/accounts-identity.html
+++ b/shell/packages/accounts-identity/accounts-identity.html
@@ -27,7 +27,7 @@ limitations under the License.
 
     <div class="centered-content">
       {{#if needInput}}
-      <br><br>
+      <br>
       <p>
         You have authenticated as this identity
       </p>


### PR DESCRIPTION
https://github.com/sandstorm-io/sandstorm/commit/c62deea2485d5012bc98f965b6ba784bb34186e5 included some changes to make the `.main-content` div more stable. Unfortunately, those changes imply that now the `.main-content` div gets rendered on top of the identity login interstitial and the demo expired interstitial. This means that attempts to log in with non-login identities get stuck at what looks like a blank screen, and demos seem to continue past their 60 minutes.

Here we fix the problem by ensuring that the interstitials get rendered on top.