### PR TITLE
Add support for using a HTTP proxy for outbound connections (just for app install for now)

### DIFF
--- a/docs/administering/faq.md
+++ b/docs/administering/faq.md
@@ -213,3 +213,49 @@ you'd like to see it stabilize.
 When creating your own page like this, we suggest using the Oasis splash URL as a starting point.
 Use your browser's DOM inspector to find the `IFRAME` that is on the background of Oasis. Use its
 CSS rules to guide your own.
+
+## Can Sandstorm use a HTTP proxy for outgoing connections?
+
+Yes. Set the `http_proxy` and `https_proxy` environment variables in your systemd service or init
+script. Right now, this can be used to install apps, but other uses of the proxy are untested. If
+you discover problems with the HTTP proxy support, please [file a
+bug](https://github.com/sandstorm-io/sandstorm/issues).
+
+As background, a Sandstorm server uses Internet access to achieve tasks like:
+
+- Downloading apps to install.
+
+- Automatically updating itself.
+
+- Automatically downloading app updates.
+
+- Updating your IP address on file with the sandcats service.
+
+If your environment requires configuring a HTTP proxy for outbound Internet connectivity, and you
+are using systemd, then you can edit `/etc/systemd/system/sandstorm.service` to look like the
+following. You will then need to run `sudo systemctl daemon-reload` then `sudo systemctl restart
+sandstorm`.
+
+```
+[Unit]
+Description=Sandstorm server
+After=local-fs.target remote-fs.target network.target
+Requires=local-fs.target remote-fs.target network.target
+
+[Service]
+Type=forking
+ExecStart=/opt/sandstorm/sandstorm start
+ExecStop=/opt/sandstorm/sandstorm stop
+Environment=http_proxy=http://127.0.0.1:3128/
+Environment=https_proxy=http://127.0.0.1:3128/
+
+[Install]
+WantedBy=multi-user.target
+```
+
+If you use `sysvinit` or a different init system, then make whatever similar change results in
+the `http_proxy` and `https_proxy` environment variables being set.
+
+**Note** that the sandcats.io dynamic DNS protocol requires the ability to send UDP packets to the
+Internet, so if the system cannot do that, then its IP address will not auto-update. If your IP
+address does not change frequently, this should be OK.

--- a/shell/.meteor/packages
+++ b/shell/.meteor/packages
@@ -49,3 +49,4 @@ sandstorm-ui-autocomplete-input
 meteor-node-forge
 fourseven:scss
 introjs
+npm-request

--- a/shell/.meteor/versions
+++ b/shell/.meteor/versions
@@ -66,6 +66,7 @@ minimongo@1.0.10
 mongo@1.1.3
 mongo-id@1.0.1
 npm-mongo@1.4.39_1
+npm-request@2.67.0
 oauth@1.1.6
 oauth2@1.1.5
 observe-sequence@1.0.7

--- a/shell/packages/npm-request/.npm/package/.gitignore
+++ b/shell/packages/npm-request/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/shell/packages/npm-request/.npm/package/README
+++ b/shell/packages/npm-request/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/shell/packages/npm-request/.npm/package/npm-shrinkwrap.json
+++ b/shell/packages/npm-request/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,235 @@
+{
+  "dependencies": {
+    "request": {
+      "version": "2.67.0",
+      "dependencies": {
+        "bl": {
+          "version": "1.0.1",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.5",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2"
+                },
+                "inherits": {
+                  "version": "2.0.1"
+                },
+                "isarray": {
+                  "version": "0.0.1"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6"
+                },
+                "string_decoder": {
+                  "version": "0.10.31"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2"
+                }
+              }
+            }
+          }
+        },
+        "caseless": {
+          "version": "0.11.0"
+        },
+        "extend": {
+          "version": "3.0.0"
+        },
+        "forever-agent": {
+          "version": "0.6.1"
+        },
+        "form-data": {
+          "version": "1.0.0-rc3",
+          "dependencies": {
+            "async": {
+              "version": "1.5.2"
+            }
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1"
+        },
+        "mime-types": {
+          "version": "2.1.9",
+          "dependencies": {
+            "mime-db": {
+              "version": "1.21.0"
+            }
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.7"
+        },
+        "qs": {
+          "version": "5.2.0"
+        },
+        "tunnel-agent": {
+          "version": "0.4.2"
+        },
+        "tough-cookie": {
+          "version": "2.2.1"
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.2.0"
+            },
+            "jsprim": {
+              "version": "1.2.2",
+              "dependencies": {
+                "extsprintf": {
+                  "version": "1.0.2"
+                },
+                "json-schema": {
+                  "version": "0.2.2"
+                },
+                "verror": {
+                  "version": "1.3.6"
+                }
+              }
+            },
+            "sshpk": {
+              "version": "1.7.3",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.2.3"
+                },
+                "dashdash": {
+                  "version": "1.12.2"
+                },
+                "jsbn": {
+                  "version": "0.1.0"
+                },
+                "tweetnacl": {
+                  "version": "0.13.3"
+                },
+                "jodid25519": {
+                  "version": "1.0.2"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1"
+                }
+              }
+            }
+          }
+        },
+        "oauth-sign": {
+          "version": "0.8.0"
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "dependencies": {
+            "hoek": {
+              "version": "2.16.3"
+            },
+            "boom": {
+              "version": "2.10.1"
+            },
+            "cryptiles": {
+              "version": "2.0.5"
+            },
+            "sntp": {
+              "version": "1.0.9"
+            }
+          }
+        },
+        "aws-sign2": {
+          "version": "0.6.0"
+        },
+        "stringstream": {
+          "version": "0.0.5"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "dependencies": {
+            "delayed-stream": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "isstream": {
+          "version": "0.1.2"
+        },
+        "is-typedarray": {
+          "version": "1.0.0"
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.1",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.4"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "commander": {
+              "version": "2.9.0",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1"
+                }
+              }
+            },
+            "is-my-json-valid": {
+              "version": "2.12.4",
+              "dependencies": {
+                "generate-function": {
+                  "version": "2.0.0"
+                },
+                "generate-object-property": {
+                  "version": "1.2.0",
+                  "dependencies": {
+                    "is-property": {
+                      "version": "1.0.2"
+                    }
+                  }
+                },
+                "jsonpointer": {
+                  "version": "2.0.0"
+                },
+                "xtend": {
+                  "version": "4.0.1"
+                }
+              }
+            },
+            "pinkie-promise": {
+              "version": "2.0.0",
+              "dependencies": {
+                "pinkie": {
+                  "version": "2.0.1"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/shell/packages/npm-request/package.js
+++ b/shell/packages/npm-request/package.js
@@ -1,0 +1,14 @@
+Package.describe({
+  summary: "Export the 'request' package from npm",
+  version: "2.67.0",
+  name: "npm-request"
+});
+
+Package.onUse(function(api) {
+  api.export("Request", "server");
+  api.addFiles("server.js", "server");
+});
+
+Npm.depends({
+  'request': '2.67.0'
+});

--- a/shell/packages/npm-request/server.js
+++ b/shell/packages/npm-request/server.js
@@ -1,0 +1,1 @@
+Request = Npm.require('request');

--- a/shell/server/installer.js
+++ b/shell/server/installer.js
@@ -310,92 +310,74 @@ AppInstaller = class AppInstaller {
     };
 
     let protocol;
-    if (url.protocol === 'http:') {
-      protocol = Http;
-    } else if (url.protocol === 'https:') {
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      protocol = Request.defaults({
+        maxRedirects: 1,
       // Since we will verify the download against a hash anyway, we don't need to verify the server's
       // certificate. In fact, the only reason we support HTTPS at all here is because some servers
       // refuse to serve over HTTP (which is, in general, a good thing). Skipping the certificate check
       // here is helpful in that it means we don't have to worry about having a reasonable list of trusted
       // CAs available to Sandstorm.
-      options.rejectUnauthorized = false;
-      protocol = Https;
+        strictSSL: false
+      });
     } else {
       throw new Error('Protocol not supported: ' + url.protocol);
     }
 
     // TODO(security):  It could arguably be a security problem that it's possible to probe the
     //   server's local network (behind any firewalls) by presenting URLs here.
-    const request = protocol.get(options, this.wrapCallback((response) => {
-      if (response.statusCode === 301 ||
-          response.statusCode === 302 ||
-          response.statusCode === 303 ||
-          response.statusCode === 307 ||
-          response.statusCode === 308) {
-        // jscs:disable requireDotNotation
-        // Got redirect. Follow it.
-        this.url = Url.resolve(this.url, response.headers['location']);
-        this.doDownloadTo(out);
-        return;
+    let bytesExpected = undefined;
+    let bytesReceived = 0;
+    const hasher = Crypto.createHash('sha256');
+    let done = false;
+    const updateDownloadProgress = _.throttle(this.wrapCallback(() => {
+      if (!done) {
+        if (bytesExpected) {
+          this.updateProgress('download', bytesReceived / bytesExpected);
+        } else {
+          this.updateProgress('download', bytesReceived);
+        }
       }
+    }), 500);
 
-      if (response.statusCode !== 200) {
-        throw new Error('Download failed with HTTP status code: ' + response.statusCode);
-      }
+    const request = protocol.get(this.url);
 
-      let bytesExpected = undefined;
-      let bytesReceived = 0;
-
+    request.on('response', this.wrapCallback((response) => {
       if ('content-length' in response.headers) {
         bytesExpected = parseInt(response.headers['content-length']);
       }
-
-      let done = false;
-      const hasher = Crypto.createHash('sha256');
-
-      const updateDownloadProgress = _.throttle(this.wrapCallback(() => {
-        if (!done) {
-          if (bytesExpected) {
-            this.updateProgress('download', bytesReceived / bytesExpected);
-          } else {
-            this.updateProgress('download', bytesReceived);
-          }
-        }
-      }), 500);
-
-      response.on('data', this.wrapCallback((chunk) => {
-        hasher.update(chunk);
-        out.write(chunk);
-        bytesReceived += chunk.length;
-        updateDownloadProgress();
-      }));
-
-      response.on('end', this.wrapCallback(() => {
-        out.done();
-
-        if (hasher.digest('hex').slice(0, 32) !== this.packageId) {
-          throw new Error('Package hash did not match.');
-        }
-
-        done = true;
-        delete this.downloadRequest;
-
-        this.updateProgress('unpack');
-        out.saveAs(this.packageId).then(this.wrapCallback((info) => {
-          this.appId = info.appId;
-          this.authorPgpKeyFingerprint = info.authorPgpKeyFingerprint;
-          this.done(info.manifest);
-        }), this.wrapCallback((err) => {
-          throw err;
-        }));
-      }));
-
-      response.on('error', this.wrapCallback((err) => { throw err; }));
     }));
 
-    this.downloadRequest = request;
+    request.on('data', this.wrapCallback((chunk) => {
+      hasher.update(chunk);
+      out.write(chunk);
+      bytesReceived += chunk.length;
+      updateDownloadProgress();
+    }));
+
+    request.on('end', this.wrapCallback(() => {
+      out.done();
+
+      if (hasher.digest('hex').slice(0, 32) !== this.packageId) {
+        throw new Error('Package hash did not match.');
+      }
+
+      done = true;
+      delete this.downloadRequest;
+
+      this.updateProgress('unpack');
+      out.saveAs(this.packageId).then(this.wrapCallback((info) => {
+        this.appId = info.appId;
+        this.authorPgpKeyFingerprint = info.authorPgpKeyFingerprint;
+        this.done(info.manifest);
+      }), this.wrapCallback((err) => {
+        throw err;
+      }));
+    }));
 
     request.on('error', this.wrapCallback((err) => { throw err; }));
+
+    this.downloadRequest = request;
   }
 
   done(manifest) {

--- a/shell/server/installer.js
+++ b/shell/server/installer.js
@@ -312,12 +312,12 @@ AppInstaller = class AppInstaller {
     let protocol;
     if (url.protocol === 'http:' || url.protocol === 'https:') {
       protocol = Request.defaults({
-        maxRedirects: 1,
-      // Since we will verify the download against a hash anyway, we don't need to verify the server's
-      // certificate. In fact, the only reason we support HTTPS at all here is because some servers
-      // refuse to serve over HTTP (which is, in general, a good thing). Skipping the certificate check
-      // here is helpful in that it means we don't have to worry about having a reasonable list of trusted
-      // CAs available to Sandstorm.
+        maxRedirects: 20,
+        // Since we will verify the download against a hash anyway, we don't need to verify the
+        // server's certificate. In fact, the only reason we support HTTPS at all here is because
+        // some servers refuse to serve over HTTP (which is, in general, a good thing). Skipping the
+        // certificate check here is helpful in that it means we don't have to worry about having a
+        // reasonable list of trusted CAs available to Sandstorm.
         strictSSL: false
       });
     } else {

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1162,12 +1162,23 @@ private:
 
     // The environment inherited from the host is probably no good for us. E.g. an oddball
     // locale setting can crash Mongo because we don't have the appropriate locale files available.
+    //
+    // That said, there are a few environment variables that we do re-export.
+    char * http_proxy, * https_proxy;
+    KJ_SYSCALL(http_proxy = getenv("https_proxy"));
+    KJ_SYSCALL(https_proxy = getenv("https_proxy"));
     KJ_SYSCALL(clearenv());
 
     // Set up an environment appropriate for us.
     KJ_SYSCALL(setenv("LANG", "C.UTF-8", true));
     KJ_SYSCALL(setenv("PATH", "/usr/bin:/bin", true));
     KJ_SYSCALL(setenv("LD_LIBRARY_PATH", "/usr/local/lib:/usr/lib:/lib", true));
+    if (http_proxy) {
+      KJ_SYSCALL(setenv("http_proxy", http_proxy, true));
+    }
+    if (https_proxy) {
+      KJ_SYSCALL(setenv("https_proxy", https_proxy, true));
+    }
 
     // See if /etc/resolv.conf exists, and if not, try replacing it with the backup made earlier.
     restoreResolvConfIfNeeded();

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1166,11 +1166,10 @@ private:
     // That said, there are a few environment variables that we do re-export.
     std::map<const char *, kj::String> envVars;
     const char * keepTheseVars[] = {"http_proxy", "https_proxy"};
-    auto numberOfVarsToKeep = 2; // FIXME: How am I supposed to express this & the previous line?
-    for (int i = 0; i < numberOfVarsToKeep; i++) {
-      const char * envValue = getenv(keepTheseVars[i]);
+    for (char * varName: keepTheseVars) {
+      const char * envValue = getenv(varName);
       if (envValue) {
-        envVars.insert(std::make_pair(keepTheseVars[i], kj::str(envValue)));
+        envVars.insert(std::make_pair(varName, kj::str(envValue)));
       }
     }
     KJ_SYSCALL(clearenv());

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1164,11 +1164,11 @@ private:
     // locale setting can crash Mongo because we don't have the appropriate locale files available.
     //
     // That said, there are a few environment variables that we do re-export.
-    std::map<const char *, kj::String> envVars;
-    const char * keepTheseVars[] = {"http_proxy", "https_proxy"};
-    for (const char * varName: keepTheseVars) {
-      const char * envValue = getenv(varName);
-      if (envValue) {
+    std::map<const char*, kj::String> envVars;
+    static const char* const KEEP_VARS[] = {"http_proxy", "https_proxy"};
+    for (const char* varName: KEEP_VARS) {
+      const char* envValue = getenv(varName);
+      if (envValue != nullptr) {
         envVars.insert(std::make_pair(varName, kj::str(envValue)));
       }
     }
@@ -1180,8 +1180,8 @@ private:
     KJ_SYSCALL(setenv("LD_LIBRARY_PATH", "/usr/local/lib:/usr/lib:/lib", true));
 
     // Copy any remaining environment variables in that we captured.
-    for (auto iterator = envVars.begin(); iterator != envVars.end(); iterator++) {
-      KJ_SYSCALL(setenv(iterator->first, iterator->second.cStr(), true));
+    for (auto& entry: envVars) {
+      KJ_SYSCALL(setenv(entry.first, entry.second.cStr(), true));
     }
 
     // See if /etc/resolv.conf exists, and if not, try replacing it with the backup made earlier.

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1166,7 +1166,7 @@ private:
     // That said, there are a few environment variables that we do re-export.
     std::map<const char *, kj::String> envVars;
     const char * keepTheseVars[] = {"http_proxy", "https_proxy"};
-    for (char * varName: keepTheseVars) {
+    for (const char * varName: keepTheseVars) {
       const char * envValue = getenv(varName);
       if (envValue) {
         envVars.insert(std::make_pair(varName, kj::str(envValue)));


### PR DESCRIPTION
This adjusts `installer.js` to use the `request` API, rather than the node
HTTP/HTTPS API. It also adjusts `run-bundle.c++` to pass this variable through,
and adjusts the docs to explain how to use this feature.

Refs #693

Does not fully close #693 yet because a few other places need a similar update.