### PR TITLE
Add a pause to roundcube test to increase reliability

### DIFF
--- a/tests/apps/roundcube.js
+++ b/tests/apps/roundcube.js
@@ -35,6 +35,8 @@ module.exports["Incoming Mail"] = function (browser) {
   browser
     .waitForElementVisible('.grain-frame', short_wait)
     .frame("grain-frame")
+    .waitForElementVisible(".button-settings", short_wait)
+    .pause(short_wait) // Roundcube seems to swallow the click if you click while it's doing the initial mailbox load AJAX, sadly.
     .click(".button-settings")
     .waitForElementVisible("#settings-tabs .identities > a", short_wait)
     .click("#settings-tabs .identities > a")


### PR DESCRIPTION
Roundcube appears to discard an early click on the settings button.  The click
changes the button's appearance, but does not actually lead to the settings
pane being shown, which makes the rest of the test fail.

Adding a short pause to allow the initial pageload to complete seems to make this
better.