### PR TITLE
Sort dev apps at the top of the app list

### DIFF
--- a/shell/packages/sandstorm-ui-applist/applist-client.js
+++ b/shell/packages/sandstorm-ui-applist/applist-client.js
@@ -110,6 +110,7 @@ Template.sandstormAppListPage.helpers({
     return _.chain(apps)
             .map(appToTemplateObject)
             .sortBy(function (appTemplateObj) { return appTemplateObj.appTitle.toLowerCase(); })
+            .sortBy(function (appTemplateObj) { return appTemplateObj.dev ? 0 : 1; })
             .value();
   },
   popularApps: function() {


### PR DESCRIPTION
They are the most likely app for a developer to be interested in launching, so sort dev apps before non-dev apps.