### PR TITLE
Add / extend Cap'n Proto interfaces for key drivers.

### DIFF
--- a/src/sandstorm/api-session.capnp
+++ b/src/sandstorm/api-session.capnp
@@ -30,7 +30,103 @@ interface ApiSession @0xc879e379c625cdc7 extends(WebSession.WebSession) {
     # it.  However, for those that benefit from it (like analytics), clients can opt into passing
     # their IP on to the backend by adding an "X-Sandstorm-Passthrough: address" header to their
     # request.  This would be a privacy leak for WebSession, since the grain can give the client
-    # scripts which would send the header, but ApiSession requires a user action, so it's safe here.
+    # scripts which would send the header, but ApiSession requires a user action, so it's safe
+    # here.
     remoteAddress @0 :IpAddress;
+  }
+
+  struct PowerboxTag {
+    # A tag used for PowerboxDescriptors describing HTTP APIs. Such descriptors should typically
+    # indicate `ApiSession` as the requested interface and use HttpApiTag to specify what API is
+    # expected.
+    #
+    # Usually, this tag is used to request APIs implemented by internet services external to
+    # Sandstorm. However, a Sandstorm grain may advertise itself as supporting a compatible API
+    # to the Powerbox, and if so the Powerbox will allow the user to select that grain for such
+    # requests. Note that publishing an `ApiSession` has nothing to do with `UiView` or Sandstorm's
+    # normal HTTP API support.
+    #
+    # Requests of this type trigger the HTTP driver, such that the powerbox UI will display a
+    # special flow for connecting to external web services. The Powerbox will also surface other
+    # grains that advertise their ability to handle these requests under the usual matching rules.
+    # This struct is carefully designed such that the usual Powerbox query rules make sense for
+    # performing such queries.
+    #
+    # If you make a Powerbox request containing multiple PowerboxDescriptors describing HTTP APIs,
+    # the HTTP driver will offer the user a choice among the options. This can make sense for, say,
+    # allowing the user to choose from multiple popular servers implementing the same protocol, or
+    # to choose whether or not to grant the app optional permissions (OAuth scopes). The HTTP
+    # driver will return a capability with a descriptor matching one of the requested descriptors
+    # which best-describes the user's choice.
+
+    canonicalUrl @0 :Text;
+    # The standard URL at which this service is found. Use this especially for traditional SaaS
+    # services. For example, you might request "https://api.github.com" to request access to the
+    # GitHub API.
+    #
+    # If you include a path in the URL, requests will automatically be prefixed with that path. You
+    # should usually include enough path components to identity a specific product and version, but
+    # usually not specific collection types within that product. For example, you would request the
+    # Google Calendar API version 2 as "https://apidata.googleusercontent.com/caldav/v2". However,
+    # you would not normally request "https://api.github.com/users" because "GitHub users" is not
+    # considered a separate API but rather one part of the overall GitHub API. Note that
+    # `canonicalUrl` should never end with a '/', because request paths to `ApiSession` are
+    # requried to start with a '/', so this would result in two consecutive '/'s which is usually
+    # wrong.
+    #
+    # The HTTP driver will present `canonicalUrl` as a strong suggestion to the user. However, the
+    # user is always allowed to substitute a different URL instead, causing requests to be
+    # redirected to some other service. This is the user's choice. In cases where the app does not
+    # trust the user, the app will need to defend itself against the possibility that the user
+    # connects it to a malicious server.
+    #
+    # The Powerbox will also offer matches published by other grains using the usual query matching
+    # rules. That is, a grain may advertise that it can handle queries for HTTP APIs with a
+    # particular `canonicalUrl`, indicating that the grain offers ApiSession capabilities
+    # implementing a compatible protocol.
+
+    struct OAuthScope {
+      name @0 :Text;
+    }
+
+    oauthScopes @1 :List(OAuthScope);
+    # List of OAuth scopes required by the requesting app. OAuth APIs usually publish a list
+    # of "scope" names representing permissions that can be requested. For example, see:
+    #
+    #     https://developer.github.com/v3/oauth/#scopes
+    #
+    # When this list is present (even if empty), it indicates that the requested API requires
+    # OAuth-based authentication. The HTTP driver will guide the user through connecting their
+    # Sandstorm account to the remote service and requesting the appropriate permissions.
+    #
+    # The Sandstorm project maintains an ad hoc mapping of hostnames to OAuth endpoints allowing
+    # the HTTP driver to automatically determine what kind of OAuth request to make for a given
+    # `canonicalUrl`. For example, if `canonicalUrl` is `https://api.github.com`, the HTTP driver
+    # will initiate a Github OAuth handshake. For any URL under apidata.googleusercontent.com, the
+    # driver will initiate a Google OAuth handshake. Etc. Unfortunately, it is not possible to
+    # make OAuth requests to endpoints not on the list. However, we welcome pull requests to add
+    # new endpoints, large or small.
+    #
+    # Sandstorm grains offering compatible APIs may wish to list the OAuth scopes they support.
+    # Powerbox matching rules state that when a Powerbox query and potential matching descriptor
+    # both contain a field of list-of-struct type, then they are treated as sets, and the match
+    # must advertise a superset of the request. Therefore, if you list OAuth scopes when
+    # publishing, then only requests for a subset of these will lead to your offer being listed in
+    # the Powerbox. Often, offers will want to leave `oauthScopes` null, which will cause the scope
+    # list to be ignored for matching purposes (always match).
+
+    authentication @2 :Text;
+    # If not null, indicates that this endpoint is expected to need old-fashion authentication.
+    # The field contains a text string naming the type of authentication. Currently there is only
+    # one type recognized: "basic", meaning HTTP Basic Auth. Specifying this instructs the HTTP
+    # driver to prompt the user for a username and password.
+    #
+    # Note that even if this isn't specified, the HTTP driver will probe the target server to see
+    # if it demands authentication and, if so, will prompt the user for a password anyway. Thus
+    # this is only needed in cases where the target server supports both authenticated and
+    # unauthenticated use and thus the probe will not notice the need for authentication.
+    #
+    # When publishing support of HTTP APIs to the Powerbox, you should usually leave this field
+    # null, so that it is not considered for matching.
   }
 }

--- a/src/sandstorm/api-session.capnp
+++ b/src/sandstorm/api-session.capnp
@@ -37,8 +37,8 @@ interface ApiSession @0xc879e379c625cdc7 extends(WebSession.WebSession) {
 
   struct PowerboxTag {
     # A tag used for PowerboxDescriptors describing HTTP APIs. Such descriptors should typically
-    # indicate `ApiSession` as the requested interface and use HttpApiTag to specify what API is
-    # expected.
+    # indicate `ApiSession` as the requested interface and use PowerboxTag to specify what API is
+    # expected (so, the tag ID is ApiSession's ID, but the tag value is an ApiSession.PowerboxTag).
     #
     # Usually, this tag is used to request APIs implemented by internet services external to
     # Sandstorm. However, a Sandstorm grain may advertise itself as supporting a compatible API
@@ -65,7 +65,7 @@ interface ApiSession @0xc879e379c625cdc7 extends(WebSession.WebSession) {
     # GitHub API.
     #
     # If you include a path in the URL, requests will automatically be prefixed with that path. You
-    # should usually include enough path components to identity a specific product and version, but
+    # should usually include enough path components to identify a specific product and version, but
     # usually not specific collection types within that product. For example, you would request the
     # Google Calendar API version 2 as "https://apidata.googleusercontent.com/caldav/v2". However,
     # you would not normally request "https://api.github.com/users" because "GitHub users" is not

--- a/src/sandstorm/email.capnp
+++ b/src/sandstorm/email.capnp
@@ -31,7 +31,7 @@ struct EmailAddress {
   address @0 :Text;
   name @1 :Text;
 
-  # TODO(someday): We could add a field `token` which is a capability representing "email captial",
+  # TODO(someday): We could add a field `token` which is a capability representing "email capital",
   #   which you can think of like "political capital", but specifically representing some social
   #   permission to send email to this address. A token can be used some small number of times to
   #   send email to a particular address. Tokens can be requested using the inline powerbox: if a

--- a/src/sandstorm/email.capnp
+++ b/src/sandstorm/email.capnp
@@ -27,8 +27,17 @@ using Util = import "util.capnp";
 struct EmailAddress {
   # Email addresses are (usually) of the form "Full Name <example@example.org>".
   # This struct separates the display name and address into distinct fields.
+
   address @0 :Text;
   name @1 :Text;
+
+  # TODO(someday): We could add a field `token` which is a capability representing "email captial",
+  #   which you can think of like "political capital", but specifically representing some social
+  #   permission to send email to this address. A token can be used some small number of times to
+  #   send email to a particular address. Tokens can be requested using the inline powerbox: if a
+  #   human user types (or selects from autocomplete) an address, this is good enough to allow the
+  #   app to send a few messages to that address. Tokens would also be received as part of incoming
+  #   messages, representing permission to reply (and reply-all).
 }
 
 struct EmailAttachment {
@@ -53,6 +62,8 @@ struct EmailMessage {
   references @7 :List(Text);
   inReplyTo @8 :List(Text); # header is actually in-reply-to
 
+  # TODO(someday): Add list-id.
+
   subject @9 :Text;
 
   # Separate body into text and html fields.
@@ -65,10 +76,62 @@ struct EmailMessage {
 interface EmailSendPort @0xec831dbf4cc9bcca {
   # Represents a destination for e-mail.
   #
-  # Usually, a port you get from the user through the powerbox will
-  # represent a particular address owned by the user.  All messages
-  # sent through the port will have the `from` field overwritten with the
-  # user's address.
+  # Make a Powerbox request for `EmailSendPort` when you want to request permission to send email
+  # to the current user. For example, a mailing list app would request this when a user indicates
+  # they wish to subscribe to the list.
+  #
+  # Make a Powerbox offer of an `EmailSendPort` when you want to receive email on that port.
+  # The user will be prompted to assign your port to an address. For example, a mailing list app
+  # would offer an `EmailSendPort` to the owner during initial setup.
 
   send @0 (email :EmailMessage);
+  # Send a message through this port.
+
+  hintAddress @1 (address :EmailAddress);
+  # Hint to the port that it is now receiving email sent to the given address. The email driver
+  # will call this after the port has been bound to an address after being offered through the
+  # Powerbox. The purpose is to allow the app to display back to the user what address it is
+  # bound to. Implementing this is optional.
+
+  struct PowerboxTag {
+    # Tag which can be set on `PowerboxDescriptor`s when requesting an `EmailSendPort`.
+
+    fromHint @0 :EmailAddress;
+    # The user will be offered the ability to override the "from" address on emails sent through
+    # this port. The application requesting the port may provide `fromHint` to suggest an override
+    # address to the user. Do not provide a `fromHint` if you do not want `from` addresses to be
+    # overridden, but note that the user may choose to do so anyway.
+    #
+    # It does not make sense to fill in this field when making a Powerbox offer.
+
+    listIdHint @1 :Text;
+    # The user will be offered the ability to set the "list-id" on emails sent through this port.
+    # The application requesting the port may provide 'listIdHint' to suggest a list ID to use.
+    # Do not provide a `listIdHint` if you do not want the list ID to be set, but note that the
+    # user may choose to set it anyway.
+    #
+    # It does not make sense to fill in this field when making a Powerbox offer.
+  }
 }
+
+interface EmailAgent @0x8b6f158d70cbc773 {
+  # Represents the ability to send and receive email as some user.
+  #
+  # Make a Powerbox request for `EmailAgent` when you want to request the ability to send and
+  # receive email under some address. For example, an email client app would request this.
+
+  send @0 (email :EmailMessage);
+  # Send a message from this user to all the addresses listed in the message's `to`, `cc`, and
+  # `bcc` fields. `email.from` is ignored; it will be replaced with the address associated with
+  # this capability. `email.bcc` will not be revealed to recipients.
+
+  addReceiver @1 (port :EmailSendPort) -> (handle :Util.Handle);
+  # Arrange for future mail sent to this user to be delivered to `port`.
+  #
+  # Drop the returned handle to unsubscribe. This handle is persistent (can be saved as a
+  # SturdyRef).
+  #
+  # Multiple `port`s can be added; each will receive a copy.
+}
+
+# TODO(someday): Support remote mailboxes, e.g. IMAP. Look at Nylas API for design hints!

--- a/src/sandstorm/util.capnp
+++ b/src/sandstorm/util.capnp
@@ -116,6 +116,27 @@ interface ByteStream {
   # is not necessary for the callee to actually implement it.
 }
 
+interface Blob @0xe53527a75d90198f {
+  # Represents a large byte blob.
+
+  getSize @0 () -> (size :UInt64);
+  # Get the total size of the blob. May block if the blob is still being uploaded and the size is
+  # not yet known.
+
+  writeTo @1 (stream :ByteStream, startAtOffset :UInt64 = 0) -> (handle :Handle);
+  # Write the contents of the blob to `stream`.
+
+  getSlice @2 (offset :UInt64, size :UInt32) -> (data :Data);
+  # Read a slice of the blob starting at the given offset. `size` cannot be greater than Cap'n
+  # Proto's limit of 2^29-1, and reasonable servers will likely impose far lower limits. If the
+  # slice would cross past the end of the blob, it is truncated. Otherwise, `data` is always
+  # exactly `size` bytes (though the caller should check for security purposes).
+  #
+  # One technique that makes a lot of sense is to start off by calling e.g. `getSlice(0, 65536)`.
+  # If the returned data is less than 65536 bytes then you know you got the whole blob, otherwise
+  # you may want to switch to `writeTo`.
+}
+
 interface Assignable(T) {
   # An "assignable" -- a mutable memory cell. Supports subscribing to updates.
 

--- a/src/sandstorm/web-publishing.capnp
+++ b/src/sandstorm/web-publishing.capnp
@@ -21,7 +21,7 @@ $import "/capnp/c++.capnp".namespace("sandstorm");
 using Util = import "util.capnp";
 using Handle = Util.Handle;
 
-interface WebSite {
+interface WebSite @0xdddcca47803e2377 {
   # Represents an HTTP URL to which a web site can be published.
   #
   # Make a powerbox request for `WebSite` when you wish to publish a web site accessible over HTTP
@@ -45,17 +45,34 @@ interface WebSite {
       blob @4 :Util.Blob;
       # Use when content is larger than 1MB. Currently, the blob must be created via uploadBlob().
     }
+
+    redirectTo @5 :Text;
+    # If non-null, this entity is a 301 redirect to the URL `redirectTo`, which may be relative or
+    # absolute.
+    #
+    # The redirect is always a 301 redirect. Other redirect types do not make much sense in the
+    # context of a static web site. Note that the web publishing driver will set cache control
+    # headers on these responses just like any other, so a 301 redirect isn't really "permanent".
   }
 
   getEntities @1 (path :Text) -> (entities :Util.Assignable(List(Entity)));
   # Get the list of static HTTP entities that make up the resource at the given path. Often there
   # is only one entity, but if you provide multiple entities, one will be chosen based on "Accept"
   # headers provided by the client. Setting the entity list empty effectively deletes the resource;
-  # the client will receive a 404 error, which can be customizedb using `getNotFoundEntities()`.
+  # the client will receive a 404 error, which can be customized using `getNotFoundEntities()`.
   #
   # The path normally should not contain the character '?' nor '#'; if it does, then requests for
   # this resource will have to URL-escape those characters since otherwise they have special
   # meanings.
+  #
+  # The path normally should not include a leading '/'; getUrl() normally returns a string with
+  # a trailing '/', and `path` should only contain text intended to be appended to that.
+
+  listResources @5 (shallow :Bool) -> (names :List(Text));
+  # Enumerate the names of all resources which have non-empty entity lists. If `shallow` is true,
+  # then names will be truncated after the first '/' and de-duped to simulate a directory structure
+  # (even though web sites aren't necessarily stored this way). Note that if a resource is mapped
+  # at the site root (which usually there is!) then the returned list will include an empty string.
 
   getNotFoundEntities @2 () -> (entities :Util.Assignable(List(Entity)));
   # Get the entity set used to respond when a path is not found. Such responses also have HTTP
@@ -70,12 +87,12 @@ interface WebSite {
   # without calling `done()`, the blob will be left in a broken state in which some methods will
   # throw exceptions.
 
-  getSubsite @4 (suffix :Text) -> (site :WebSite);
-  # Append `suffix` to the URL and return a `WebSite` capability that can only modify resources
+  getSubsite @4 (prefix :Text) -> (site :WebSite);
+  # Append `prefix` to the URL and return a `WebSite` capability that can only modify resources
   # under that URL. Note that the web driver assigns *no* special meaning to the character '/', so
   # you should use a suffix ending in '/' if you want a site that represents a subdirectory.
 
-  # TODO(someday): Allow registering dynamaic handlers.
+  # TODO(someday): Allow registering dynamic handlers.
 
   # TODO(someday): Allow transactionally changing a bunch of things at once.
 }

--- a/src/sandstorm/web-publishing.capnp
+++ b/src/sandstorm/web-publishing.capnp
@@ -1,0 +1,110 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xd5d3e63bd0a552b6;
+
+$import "/capnp/c++.capnp".namespace("sandstorm");
+
+using Util = import "util.capnp";
+using Handle = Util.Handle;
+
+interface WebSite {
+  # Represents an HTTP URL to which a web site can be published.
+  #
+  # Make a powerbox request for `WebSite` when you wish to publish a web site accessible over HTTP
+  # without going through the Sandstorm UI.
+
+  getUrl @0 () -> (path :Text);
+  # Get the URL of this resource.
+
+  struct Entity {
+    # An HTTP entity (using the term "entity" as defined in the HTTP spec). Think of this as the
+    # "payload" of an HTTP response.
+
+    mimeType @0 :Text;  # Content-Type header.
+    language @1 :Text;  # Content-Language header (optional).
+    encoding @2 :Text;  # Content-Encoding header (optional).
+
+    body :union {
+      bytes @3 :Data;
+      # Use when content is smaller than 1MB.
+
+      blob @4 :Util.Blob;
+      # Use when content is larger than 1MB. Currently, the blob must be created via uploadBlob().
+    }
+  }
+
+  getEntities @1 (path :Text) -> (entities :Util.Assignable(List(Entity)));
+  # Get the list of static HTTP entities that make up the resource at the given path. Often there
+  # is only one entity, but if you provide multiple entities, one will be chosen based on "Accept"
+  # headers provided by the client. Setting the entity list empty effectively deletes the resource;
+  # the client will receive a 404 error, which can be customizedb using `getNotFoundEntities()`.
+  #
+  # The path normally should not contain the character '?' nor '#'; if it does, then requests for
+  # this resource will have to URL-escape those characters since otherwise they have special
+  # meanings.
+
+  getNotFoundEntities @2 () -> (entities :Util.Assignable(List(Entity)));
+  # Get the entity set used to respond when a path is not found. Such responses also have HTTP
+  # error code 404.
+
+  uploadBlob @3 () -> (blob :Util.Blob, stream :Util.ByteStream);
+  # Upload a data blob to be stored by the driver and possibly used as an entity-body.
+  #
+  # The content of the blob must be written to the returned stream. Once `done()` is called on the
+  # stream, the blob is ready. Before that point, calling methods on the blob may block waiting
+  # until enough data has actually been uploaded for them to respond. If the stream is dropped
+  # without calling `done()`, the blob will be left in a broken state in which some methods will
+  # throw exceptions.
+
+  getSubsite @4 (suffix :Text) -> (site :WebSite);
+  # Append `suffix` to the URL and return a `WebSite` capability that can only modify resources
+  # under that URL. Note that the web driver assigns *no* special meaning to the character '/', so
+  # you should use a suffix ending in '/' if you want a site that represents a subdirectory.
+
+  # TODO(someday): Allow registering dynamaic handlers.
+
+  # TODO(someday): Allow transactionally changing a bunch of things at once.
+}
+
+interface WebResource {
+  # Represents an HTTP resource. Although StaticResource is an interface, an implementation must
+  # be immutable, returning exactly the same data any time its methods are called -- even after
+  # being saved and then restored. The only reason StaticResource is an interface and not a struct
+  # is to allow the caller to choose to fetch only a subset of the content and to re-fetch content
+  # later.
+
+  getEntities @0 (cacheHandle :Handle) -> (entities :List(Entity));
+  # Gets a list of entities representing the resource. Different entities may have e.g. different
+  # types, languages, or encodings, and the best entity to return to a client may be chosen based
+  # on the `Accept-*` headers sent by the client.
+
+  struct Entity {
+    encoding @0 :Text;  # Content-Encoding header (optional).
+    language @1 :Text;  # Content-Language header (optional).
+    mimeType @2 :Text;  # Content-Type header.
+
+    content @3 :Data;
+  }
+
+  getChild @1 (name :Text, cacheHandle :Handle) -> (resource :WebResource);
+  listChildren @2 (cacheHandle :Handle) -> (children :List(Child));
+
+  struct Child {
+    name @0 :Text;
+    resource @1 :WebResource;
+  }
+}

--- a/src/sandstorm/web-publishing.capnp
+++ b/src/sandstorm/web-publishing.capnp
@@ -79,32 +79,3 @@ interface WebSite {
 
   # TODO(someday): Allow transactionally changing a bunch of things at once.
 }
-
-interface WebResource {
-  # Represents an HTTP resource. Although StaticResource is an interface, an implementation must
-  # be immutable, returning exactly the same data any time its methods are called -- even after
-  # being saved and then restored. The only reason StaticResource is an interface and not a struct
-  # is to allow the caller to choose to fetch only a subset of the content and to re-fetch content
-  # later.
-
-  getEntities @0 (cacheHandle :Handle) -> (entities :List(Entity));
-  # Gets a list of entities representing the resource. Different entities may have e.g. different
-  # types, languages, or encodings, and the best entity to return to a client may be chosen based
-  # on the `Accept-*` headers sent by the client.
-
-  struct Entity {
-    encoding @0 :Text;  # Content-Encoding header (optional).
-    language @1 :Text;  # Content-Language header (optional).
-    mimeType @2 :Text;  # Content-Type header.
-
-    content @3 :Data;
-  }
-
-  getChild @1 (name :Text, cacheHandle :Handle) -> (resource :WebResource);
-  listChildren @2 (cacheHandle :Handle) -> (children :List(Child));
-
-  struct Child {
-    name @0 :Text;
-    resource @1 :WebResource;
-  }
-}


### PR DESCRIPTION
Note that while the outgoing-HTTP and email drivers may be implemented as pseudo-drivers, I think that the web publishing driver may have no such luck, as it needs to store significant amounts of data and we will want to charge that against the user's quota. Plus we don't have a great place to store the data if not in a grain.

@zarvox @jparyani 