### PR TITLE
Request Access button

### DIFF
--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -1572,11 +1572,14 @@ ul.identity-card-list {
 }
 
 .identity-card {
+  display: inline-block;
   position: relative;
   height: 52px;
   width: 218px;
   text-align: left;
   margin-bottom: 0;
+  color: black;
+  font-family: "Source Sans Pro", sans-serif;
   background-color: white;
   background-repeat: no-repeat;
   background-position: 50px 30px;

--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -1,7 +1,7 @@
 let counter = 0;
 
 GrainView = class GrainView {
-  constructor(grainId, path, tokenInfo, parentElement) {
+  constructor(grainId, path, tokenInfo, parentElement, initialPopup) {
     // `path` starts with a slash and includes the query and fragment.
     //
     // Owned grains:
@@ -52,6 +52,10 @@ GrainView = class GrainView {
     this._blazeView = Blaze.renderWithData(Template.grainView, this, parentElement);
 
     this.id = counter++;
+
+    if (initialPopup) {
+      globalTopbar.openPopup(initialPopup);
+    }
   }
 
   reset(identityId) {
@@ -84,7 +88,12 @@ GrainView = class GrainView {
     const grainId = this.grainId();
     if (currentIdentityId === identityId) return;
     const _this = this;
-    if (this._token) {
+    if (this._status === 'error') {
+      // This case applies when the user switches their identity before clicking on the
+      // "request access" button.
+      this._userIdentityId.set(identityId);
+    } else if (this._token) {
+      // We're currently viewing the grain incognito.
       _this.reset(identityId);
       _this.openSession();
     } else if (this.isOwner()) {
@@ -470,7 +479,7 @@ GrainView = class GrainView {
     Meteor.call("openSession", _this._grainId, identityId, _this._sessionSalt, (error, result) => {
       if (error) {
         console.error("openSession error", error);
-        _this._error = error.message;
+        _this._error = error;
         _this._status = "error";
         _this._dep.changed();
       } else {
@@ -509,7 +518,7 @@ GrainView = class GrainView {
         openSessionArg, identityId, _this._sessionSalt, (error, result) => {
           if (error) {
             console.log("openSessionFromApiToken error");
-            _this._error = error.message;
+            _this._error = error;
             _this._status = "error";
             _this._dep.changed();
           } else if (result.redirectToGrain) {

--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -89,7 +89,7 @@ GrainView = class GrainView {
     const grainId = this.grainId();
     if (currentIdentityId === identityId) return;
     const _this = this;
-    if (this._status === 'error') {
+    if (this._status === "error") {
       // This case applies when the user switches their identity before clicking on the
       // "request access" button.
       this._userIdentityId.set(identityId);

--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -64,6 +64,7 @@ GrainView = class GrainView {
     this._dep.changed();
     this.destroy();
     this._hasLoaded = undefined;
+    this._error = undefined;
     this._hostId = undefined;
     this._sessionId = null;
     this._sessionSalt = null;

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -202,7 +202,9 @@ limitations under the License.
          <p>Sending your request...</p>
       {{/if}}
       {{#if success}}
-         <p>Your request has been sent.</p>
+        <p>
+          Your request has been sent. You will receive an email if your request gets approved.
+        </p>
       {{/if}}
       {{#with error}}
         <p>Your request failed because: {{.}}</p>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -192,7 +192,7 @@ limitations under the License.
 
 <template name="requestAccess">
   <div class="grain-interstitial">
-  <p>You currently do not have permission to access this grain.</p>
+  <p>You do not have permission to access this grain.</p>
   {{#if currentUser}}
     {{#with status}}
       {{#if showButton}}

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -141,7 +141,11 @@ limitations under the License.
   {{#with unpackedGrainState}}
     <div class="grain-container {{#if active}}active-grain{{else}}inactive-grain{{/if}}">
     {{#if error}}
-      <pre>{{error}}</pre>
+      {{#if unauthorized}}
+        {{> requestAccess}}
+      {{else}}
+        <pre>{{error}}</pre>
+      {{/if}}
     {{else}}
     {{#if appOrigin}}
       {{!-- Selenium requires iframes to have an id in order to select them. id="grain-frame" is only
@@ -152,14 +156,14 @@ limitations under the License.
       {{/if}}
     {{else}}
     {{#if interstitial.chooseIdentity}}
-      <div class="interstitial-button-box">
+      <div class="grain-interstitial">
         <p>With which of your identities would you like to open this grain?</p>
         {{> identityPicker identityPickerData}}
         <button class="incognito-button" data-token="{{token}}">Open in Incognito Mode</button>
       </div>
     {{else}}
       {{#if interstitial.directShare}}
-        <div class="direct-share-denied">
+        <div class="grain-interstitial">
           <p>
             Access through this URL is restricted to this identity:
           </p>
@@ -184,6 +188,30 @@ limitations under the License.
     {{/if}}
     </div>
   {{/with}}
+</template>
+
+<template name="requestAccess">
+  <div class="grain-interstitial">
+  <p>You currently do not have permission to access this grain.</p>
+  {{#if currentUser}}
+    {{#with status}}
+      {{#if showButton}}
+        <button class="request-access">Request Access</button>
+      {{/if}}
+      {{#if waiting}}
+         <p>Sending your request...</p>
+      {{/if}}
+      {{#if success}}
+         <p>Your request has been sent.</p>
+      {{/if}}
+      {{#with error}}
+        <p>Your request failed because: {{.}}</p>
+      {{/with}}
+    {{/with}}
+  {{else}}
+    Please sign in to request access.
+  {{/if}}
+  </div>
 </template>
 
 <template name="invalidToken">
@@ -486,7 +514,7 @@ limitations under the License.
   <form class="email-invite">
     <p>
     <img class="inline-icon" src="/people-m.svg" role="presentation">
-    {{> contactInputBox contacts=contacts}}
+    {{> contactInputBox contacts=contacts preselectedIdentityId=preselectedIdentityId}}
     {{> selectRole viewInfo=viewInfo}}
     </p>
     <div>
@@ -655,6 +683,16 @@ limitations under the License.
   {{#if showPowerboxOffer}}
     {{>sandstormTopbarItem name="offer" topbar=globalTopbar template="grainPowerboxOffer"
         startOpen=true popupTemplate="grainPowerboxOfferPopup" data=powerboxOfferData}}
+  {{/if}}
+</template>
+
+<template name="share">
+  {{#if currentUser}}
+    {{#with grainNotFound}}
+      No grain found with ID {{.}}. Maybe you need to sign in to a different account?
+    {{/with}}
+  {{else}}
+    You must be signed in to grant access to a grain.
   {{/if}}
 </template>
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -210,7 +210,7 @@ limitations under the License.
       {{/if}}
       {{#if success}}
         <p>
-          Your request has been sent. You will receive an email if your request gets approved.
+          Your request has been sent. You will receive an email if your request is approved.
         </p>
       {{/if}}
       {{#with error}}

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -196,7 +196,14 @@ limitations under the License.
   {{#if currentUser}}
     {{#with status}}
       {{#if showButton}}
-        <button class="request-access">Request Access</button>
+        <button class="request-access" title="Request access">
+          Request Access
+        </button>
+      {{/if}}
+      {{#if chooseIdentity}}
+        <p>Requesting access will reveal your identity to the grain owner.</p>
+        <p> {{chooseIdentityText}} </p>
+        {{> identityPicker identityPickerData}}
       {{/if}}
       {{#if waiting}}
          <p>Sending your request...</p>

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -184,13 +184,13 @@ button.revoke-token, button.revoke-access {
   color: red;
 }
 
-.main-content .interstitial-button-box,.direct-share-denied {
+.main-content .grain-interstitial {
   text-align: center;
   background-color: $default-content-background-color;
   .identity-card {
     display: inline-block;
   }
-  & button.incognito-button {
+  button.incognito-button, button.request-access {
     font-family: inherit;
     font-size: inherit;
     font-weight: 600;

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -187,20 +187,12 @@ button.revoke-token, button.revoke-access {
 .main-content .grain-interstitial {
   text-align: center;
   background-color: $default-content-background-color;
-  .identity-card {
-    display: inline-block;
-  }
-  button.incognito-button, button.request-access {
-    font-family: inherit;
-    font-size: inherit;
+  button.request-access, button.incognito-button {
+    @extend %button-base;
+    @extend %button-primary;
     font-weight: 600;
-    background-color: $sandstorm-purple-color;
     padding: 8px;
     line-height: 1.33;
-    border-radius: 4px;
-    border: none;
-    color: white;
-    cursor: pointer;
   }
 }
 

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -99,6 +99,9 @@ if (Meteor.isServer) {
 //   storageUsage: Number of bytes this user is currently storing.
 //   payments: Object defined by payments module, if loaded.
 //   dailySentMailCount: Number of emails sent by this user today; used to limit spam.
+//   accessRequests: Object containing the following fields; used to limit spam.
+//       count: Number of "request access" emails during sent during the current interval.
+//       resetAt: Date when the count should be reset.
 //   referredByComplete: ID of the Account that referred this Account. If this is set, we
 //                        stop writing new referredBy values onto Identities for this account.
 //   referredCompleteDate: The Date at which the completed referral occurred.

--- a/shell/packages/sandstorm-email/email.js
+++ b/shell/packages/sandstorm-email/email.js
@@ -142,6 +142,7 @@ const smtpSend = function (pool, mc) {
  * @param {String} [options.smtpUrl] SMTP server to use. Otherwise defaults to configured one.
  * @param {Object} [options.attachments] Attachments. See:
  *   https://github.com/nodemailer/mailcomposer/tree/v0.1.15#add-attachments
+ * @param {String} [options.envelopeFrom] Envelope sender.
  */
 SandstormEmail.send = function (options) {
   const mc = new MailComposer();
@@ -157,6 +158,14 @@ SandstormEmail.send = function (options) {
     text: options.text,
     html: options.html,
   });
+
+  if (options.envelopeSender) {
+    const envelope = mc.getEnvelope();
+    envelope.from = options.envelopeFrom;
+    mc.setMessageOption({
+      envelope: envelope,
+    });
+  }
 
   _.each(options.headers, function (value, name) {
     mc.addHeader(name, value);

--- a/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
+++ b/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
@@ -4,9 +4,9 @@ Template.contactInputBox.onCreated(function () {
   this.selectedContacts = this.data.contacts;
   this.selectedContactsIds = new ReactiveVar([]);
   this.highlightedContact = new ReactiveVar({ _id: null });
-  this.subscribe("contactProfiles", {onReady: () => {
+  this.subscribe("contactProfiles", { onReady: () => {
     if (this.data.preselectedIdentityId) {
-      const contact = ContactProfiles.findOne({_id: this.data.preselectedIdentityId});
+      const contact = ContactProfiles.findOne({ _id: this.data.preselectedIdentityId });
       if (contact) {
         const contacts = this.selectedContacts.get();
         contacts.push(contact);
@@ -17,7 +17,8 @@ Template.contactInputBox.onCreated(function () {
         this.selectedContactsIds.set(ids);
       }
     }
-  }});
+  }, });
+
   this.randomId = Random.id();  // For use with aria requiring ids in html
   this.autoCompleteContacts = new ReactiveVar([]);
   this.autorun(generateAutoCompleteContacts.bind(this, this));

--- a/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
+++ b/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
@@ -4,7 +4,20 @@ Template.contactInputBox.onCreated(function () {
   this.selectedContacts = this.data.contacts;
   this.selectedContactsIds = new ReactiveVar([]);
   this.highlightedContact = new ReactiveVar({ _id: null });
-  this.subscribe("contactProfiles");
+  this.subscribe("contactProfiles", {onReady: () => {
+    if (this.data.preselectedIdentityId) {
+      const contact = ContactProfiles.findOne({_id: this.data.preselectedIdentityId});
+      if (contact) {
+        const contacts = this.selectedContacts.get();
+        contacts.push(contact);
+        this.selectedContacts.set(contacts);
+
+        const ids = this.selectedContactsIds.get();
+        ids.push(contact._id);
+        this.selectedContactsIds.set(ids);
+      }
+    }
+  }});
   this.randomId = Random.id();  // For use with aria requiring ids in html
   this.autoCompleteContacts = new ReactiveVar([]);
   this.autorun(generateAutoCompleteContacts.bind(this, this));

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -479,7 +479,7 @@ Meteor.methods({
         to: emailAddress,
         envelopeFrom: envelopeFrom,
         from: fromEmail,
-        subject: "Request for access to " + grain.title,
+        subject: grain.title + " - Request for access",
         text: message + "\n\nFollow this link to share access:\n\n" + url,
         html: html,
       });

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -468,7 +468,7 @@ Meteor.methods({
       }
 
       const message = identity.profile.name + identityNote +
-            " has requested access to your grain: " + grain.title + ".";
+            " is requesting access to your grain: " + grain.title + ".";
 
       const url = origin + "/share/" + grainId + "/" + identityId;
 


### PR DESCRIPTION
When a user visits a grain they are unauthorized to access, displays a button that requests access from the grain owner. The button looks like this:

<img width="1009" alt="requestaccess0" src="https://cloud.githubusercontent.com/assets/495768/12686751/957ac97a-c699-11e5-8cfa-71741b4c68e1.png">

After the button is clicked, the grain owner gets an email that looks like this:

<img width="932" alt="requestaccess" src="https://cloud.githubusercontent.com/assets/495768/12686754/9a490d9a-c699-11e5-88f6-d2062d5a695d.png">

The "Open Sharing Menu" button is a link to `/share/:grainId/:identityId`, which redirects to the grain with the sharing menu popped up and prepopulated with the requester's identity.

The `replyTo` field in the email is the address of the access-requester.
