### PR TITLE
Fix compilation against clang-3.7+

### DIFF
--- a/src/sandstorm/backend.c++
+++ b/src/sandstorm/backend.c++
@@ -243,7 +243,7 @@ kj::Promise<void> BackendImpl::deleteGrain(DeleteGrainContext context) {
   if (iter != supervisors.end()) {
     shutdownPromise = iter->second.promise.addBranch()
         .then([context](Supervisor::Client client) mutable {
-      return client.shutdownRequest().send().then([](auto) {});
+      return client.shutdownRequest().send().ignoreResult();
     }).then([]() -> kj::Promise<void> {
       return KJ_EXCEPTION(FAILED, "expected shutdown() to throw disconnected exception");
     }, [](kj::Exception&& e) -> kj::Promise<void> {

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -211,7 +211,7 @@ public:
         auto request = responseStream.writeRequest();
         auto dst = request.initData(body.size());
         memcpy(dst.begin(), body.begin(), body.size());
-        taskSet.add(request.send().then([](auto x){}));
+        taskSet.add(request.send().ignoreResult());
         body.resize(0);
       }
 
@@ -458,7 +458,7 @@ private:
         KJ_FAIL_ASSERT("Failed to parse HTTP response from sandboxed app.", error);
       } else if (messageComplete || actual == 0) {
         // The parser is done or the stream has closed.
-        taskSet.add(responseStream.doneRequest().send().then([](auto x){}));
+        taskSet.add(responseStream.doneRequest().send().ignoreResult());
         return kj::READY_NOW;
       } else {
         taskSet.add(pumpStreamInternal(kj::mv(stream)));
@@ -592,7 +592,7 @@ private:
       auto request = responseStream.writeRequest();
       auto dst = request.initData(data.size());
       memcpy(dst.begin(), data.begin(), data.size());
-      taskSet.add(request.send().then([](auto x){}));
+      taskSet.add(request.send().ignoreResult());
     } else {
       body.addAll(data);
     }
@@ -692,7 +692,7 @@ public:
     auto request = clientStream.sendBytesRequest(
         capnp::MessageSize { data.size() / sizeof(capnp::word) + 8, 0 });
     request.setMessage(data);
-    tasks.add(request.send().then([](auto response) {}));
+    tasks.add(request.send().ignoreResult());
   }
 
 protected:

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1589,7 +1589,7 @@ public:
     req.setParent(parentToken);
     req.setOwner(owner);
     req.setRequirements(requirements);
-    return req.send().then([context](auto args) mutable {
+    return req.send().then([context](auto args) mutable -> void {
       context.getResults().setSturdyRef(args.getToken());
     });
   }
@@ -1622,7 +1622,7 @@ public:
       req.getRef().setAppRef(response.getObjectId());
       req.setOwner(owner);
       // TODO(someday): Set requirements. This will require membranes to work properly.
-      return req.send().then([context](auto response) mutable {
+      return req.send().then([context](auto response) mutable -> void {
         context.getResults().setSturdyRef(response.getToken());
       });
      });
@@ -1684,11 +1684,11 @@ public:
 
     kj::Promise<void> cancel(CancelContext context) override {
       cancel();
-      return ongoingNotification.cancelRequest().send().then([](auto args) {});
+      return ongoingNotification.cancelRequest().send().ignoreResult();
     }
 
     kj::Promise<void> save(SaveContext context) override {
-      return wakelockSet.save(ongoingNotification).then([context] (auto args) mutable {
+      return wakelockSet.save(ongoingNotification).then([context] (auto args) mutable -> void {
         context.getResults().setSturdyRef(args.getToken());
       });
     }
@@ -1772,7 +1772,7 @@ public:
     auto grainOwner = req.getSealFor().initGrain();
     grainOwner.setGrainId(grainId);
     grainOwner.setSaveLabel(args.getLabel());
-    return req.send().then([this, context](auto args) mutable {
+    return req.send().then([this, context](auto args) mutable -> void {
       context.getResults().setToken(args.getSturdyRef());
     });
   }
@@ -1781,7 +1781,7 @@ public:
     auto req = sandstormCore.restoreRequest();
     req.setToken(context.getParams().getToken());
     req.setRequiredPermissions(context.getParams().getRequiredPermissions());
-    return req.send().then([context](auto args) mutable {
+    return req.send().then([context](auto args) mutable -> void {
       context.getResults().setCap(args.getCap());
     });
   }
@@ -1789,7 +1789,7 @@ public:
   kj::Promise<void> drop(DropContext context) override {
     auto req = sandstormCore.dropRequest();
     req.setToken(context.getParams().getToken());
-    return req.send().then([](auto args) {});
+    return req.send().ignoreResult();
   }
 
 //  kj::Promise<void> deleted(DeletedContext context) override {
@@ -1840,7 +1840,7 @@ public:
       auto grainOwner = req.getSealFor().initGrain();
       grainOwner.setGrainId(grainId);
       grainOwner.getSaveLabel().setDefaultText("ongoing notification handle");
-      return req.send().then([this, context](auto args) mutable {
+      return req.send().then([this, context](auto args) mutable -> void {
         SANDSTORM_LOG("Grain has enabled backgrounding.");
         context.getResults().setHandle(kj::heap<WakelockHandle>(args.getSturdyRef(), *this));
       });
@@ -1853,7 +1853,7 @@ private:
     req.setToken(sturdyRef);
     // TODO(someday): Handle failures for drop? Currently, if the the frontend never drops the
     // notification or calls cancel on it, then this handle will essentially leak.
-    tasks.add(req.send().then([](auto args) {}));
+    tasks.add(req.send().ignoreResult());
   }
 
   void taskFailed(kj::Exception&& exception) override {
@@ -1956,7 +1956,7 @@ public:
       case SupervisorObjectId<>::APP_REF: {
         auto req = mainView.restoreRequest();
         req.setObjectId(objectId.getAppRef());
-        return req.send().then([this, params, context](auto args) mutable {
+        return req.send().then([this, params, context](auto args) mutable -> void {
           context.getResults().setCap(kj::heap<SaveWrapper>(
             args.getCap().template castAs<AppPersistent<>>(), params.getRequirements(), params.getParentToken(), sandstormCore));
         });
@@ -2096,7 +2096,7 @@ private:
         }
         req.adoptData(kj::mv(orphan));
 
-        tasks.add(req.send().then([](auto) {}));
+        tasks.add(req.send().ignoreResult());
 
         if (done) break;
       }


### PR DESCRIPTION
We make use of the new `kj::Promise.ignoreResult()` where possible.

We still need some additional type hints for clang to figure out the return
type of the functions where we have side-effects, but don't return anything.

Closes #1132
Closes #936