### PR TITLE
Fix vestigial references to userId that should be identityId

### DIFF
--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -588,7 +588,7 @@ GrainView = class GrainView {
       // Case 2
       const apiToken = ApiTokens.findOne({
         grainId: this._grainId,
-        'owner.user.userId': Meteor.userId(),
+        'owner.user.identityId': this.identityId(),
       }, {
         sort: {created: 1},
       });

--- a/shell/shared/stats.js
+++ b/shell/shared/stats.js
@@ -79,7 +79,7 @@ if (Meteor.isServer) {
 
       var counts = ApiTokens.aggregate([
         {$match: {"owner.user.lastUsed": timeConstraint, "grainId": {$in: grainIds}}},
-        {$group: {_id: "$owner.user.userId"}},
+        {$group: {_id: "$owner.user.identityId"}},
         {$group: {_id: "count", count: {$sum: 1}}}
       ]);
 


### PR DESCRIPTION
When ApiTokens migrated from using `userId` to using `identityId`, we appear to
have missed a couple of places we used the old value.

As usual, this could have been caught by a typechecker and a strongly-typed
interface.

Fixes #1449.