### PR TITLE
tests: deal with more guided tour failure possibilities

### DIFF
--- a/tests/commands/disableGuidedTour.js
+++ b/tests/commands/disableGuidedTour.js
@@ -1,0 +1,30 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+exports.command = function (callback) {
+  var self = this;
+  var ret = this
+    .execute(function () {
+      Session.set('dismissedGrainTableGuidedTour', true);
+    })
+  if (typeof callback === "function") {
+    return ret.status(callback);
+  } else {
+    return ret;
+  }
+};

--- a/tests/commands/installApp.js
+++ b/tests/commands/installApp.js
@@ -36,11 +36,9 @@ exports.command = function(url, packageId, appId, dontStartGrain, callback) {
 
   if (!dontStartGrain) {
     ret = ret
-      .execute(function ()  {
-        // The introjs overlay often doesn't destroy itself fast enough and intercepts
-        // clicks that we don't want it to intercept. So we manually disable it here.
-        Session.set('dismissedGrainTableGuidedTour', true);
-      })
+      // The introjs overlay often doesn't destroy itself fast enough and intercepts
+      // clicks that we don't want it to intercept. So we manually disable it here.
+      .disableGuidedTour()
       .click(appSelector(appId))
       .waitForElementVisible(actionSelector, short_wait)
       .click(actionSelector)

--- a/tests/tests/backup-restore.js
+++ b/tests/tests/backup-restore.js
@@ -93,17 +93,8 @@ module.exports["Test backup and restore"] = function(browser) {
   //v0: /install/9111a8c70938276d28a00468a18a25c7?url=https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-0.spk
   //v1: /install/f5fe6aa9fcbccc690fd36a86efe02b8a?url=https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-1.spk
   browser
-    .loginDevAccount()
     // sandstorm-test-python, v0
-    .url(browser.launch_url + "/install/9111a8c70938276d28a00468a18a25c7?url=https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-0.spk")
-    .waitForElementVisible('#step-confirm', very_long_wait)
-    .click('#confirmInstall')
-    .url(browser.launch_url + "/apps/rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh")
-    .waitForElementVisible(appDetailsTitleSelector, short_wait)
-    .assert.containsText(appDetailsTitleSelector, 'Test App')
-    .waitForElementVisible(actionSelector, short_wait)
-    .click(actionSelector)
-    .waitForElementVisible('#grainTitle', medium_wait)
+    .installApp("https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-0.spk", "9111a8c70938276d28a00468a18a25c7", "rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh")
     .assert.containsText('#grainTitle', 'Untitled Test App test page')
     .waitForElementVisible('.grain-frame', short_wait)
     .frame('grain-frame')

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -117,6 +117,7 @@ module.exports = utils.testAllLogins({
   "Test remote install" : function (browser) {
     browser
       .url(browser.launch_url + "/install/ca690ad886bf920026f8b876c19539c1?url=http://sandstorm.io/apps/ssjekyll8.spk")
+      .disableGuidedTour()
       .waitForElementVisible('#step-confirm', very_long_wait)
       .click('#confirmInstall')
       .waitForElementVisible(appDetailsTitleSelector, short_wait)

--- a/tests/tests/postmessage-api.js
+++ b/tests/tests/postmessage-api.js
@@ -29,17 +29,10 @@ module.exports = {
 
 module.exports['Install and launch test app'] = function (browser) {
   browser
-    .loginDevAccount()
+    .init()
     // test-3 introduces the JSON-formatted renderTemplate output
-    .url(browser.launch_url + '/install/072f8f84638d03e4de150e8fc4d3bd15?url=https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-3.spk')
-    .waitForElementVisible('#step-confirm', very_long_wait)
-    .click('#confirmInstall')
-    .url(browser.launch_url + "/apps/rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh")
-    .waitForElementVisible(appDetailsTitleSelector, short_wait)
-    .assert.containsText(appDetailsTitleSelector, 'Test App')
-    .waitForElementVisible(actionSelector, short_wait)
-    .click(actionSelector)
-    .waitForElementVisible('#grainTitle', medium_wait)
+    .installApp("https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-3.spk", "072f8f84638d03e4de150e8fc4d3bd15", "rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh")
+
     .assert.containsText('#grainTitle', 'Untitled Test App test page')
     .frame('grain-frame')
       .waitForElementPresent('#randomId', medium_wait)


### PR DESCRIPTION
Extract `disableGuidedTour` into a helper command, since we want to use it in a
couple places.  Use `installApp` in more places.