### PR TITLE
add PATCH http method support

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -2065,6 +2065,7 @@ const errorCodes = {
   requestUriTooLong:     { id: 414, title: 'Request-URI Too Long' },
   unsupportedMediaType:  { id: 415, title: 'Unsupported Media Type' },
   imATeapot:             { id: 418, title: 'I\'m a teapot' },
+  unprocessableEntity:   { id: 422, title: 'Unprocessable Entity' },
 };
 
 ResponseStream = class ResponseStream {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -853,7 +853,7 @@ tryProxyRequest = (hostId, req, res) => {
       // overly complicated.
 
       const accessControlHeaders = {
-        'Access-Control-Allow-Methods': 'GET, HEAD, POST, PUT, DELETE',
+        'Access-Control-Allow-Methods': 'GET, HEAD, POST, PUT, PATCH, DELETE',
         'Access-Control-Max-Age': '3600',
       };
 
@@ -866,7 +866,7 @@ tryProxyRequest = (hostId, req, res) => {
       // Add the requested method to the allowed methods list, if it's not there already.
       const requestedMethod = req.headers['access-control-request-method'];
       if (requestedMethod &&
-          !(_.contains(['GET', 'HEAD', 'POST', 'PUT', 'DELETE'], requestedMethod))) {
+          !(_.contains(['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'], requestedMethod))) {
         accessControlHeaders['Access-Control-Allow-Methods'] += ', ' + requestedMethod;
       }
 
@@ -1611,6 +1611,8 @@ Proxy = class Proxy {
         return session.post(path, requestContent(), context);
       } else if (request.method === 'PUT') {
         return session.put(path, requestContent(), context);
+      } else if (request.method === 'PATCH') {
+        return session.patch(path, requestContent(), context);
       } else if (request.method === 'DELETE') {
         return session.delete(path, context);
       } else if (request.method === 'PROPFIND') {
@@ -1646,7 +1648,7 @@ Proxy = class Proxy {
           // Return no response; we already handled everything.
         });
       } else {
-        throw new Error('Sandstorm only supports the following methods: GET, POST, PUT, DELETE, HEAD, PROPFIND, PROPPATCH, MKCOL, COPY, MOVE, LOCK, UNLOCK, ACL, REPORT, and OPTIONS.');
+        throw new Error('Sandstorm only supports the following methods: GET, POST, PUT, PATCH, DELETE, HEAD, PROPFIND, PROPPATCH, MKCOL, COPY, MOVE, LOCK, UNLOCK, ACL, REPORT, and OPTIONS.');
       }
     }).then((rpcResponse) => {
       if (rpcResponse !== undefined) {  // Will be undefined for OPTIONS request.

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -952,6 +952,16 @@ public:
     return sendRequest(toBytes(httpRequest, content.getContent()), context);
   }
 
+  kj::Promise<void> patch(PatchContext context) override {
+    PatchParams::Reader params = context.getParams();
+    auto content = params.getContent();
+    kj::String httpRequest = makeHeaders("PATCH", params.getPath(), params.getContext(),
+      kj::str("Content-Type: ", content.getMimeType()),
+      kj::str("Content-Length: ", content.getContent().size()),
+      content.hasEncoding() ? kj::str("Content-Encoding: ", content.getEncoding()) : nullptr);
+    return sendRequest(toBytes(httpRequest, content.getContent()), context);
+  }
+
   kj::Promise<void> delete_(DeleteContext context) override {
     DeleteParams::Reader params = context.getParams();
     kj::String httpRequest = makeHeaders("DELETE", params.getPath(), params.getContext());

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -258,6 +258,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       requestUriTooLong     @8 $httpStatus(id = 414, title = "Request-URI Too Long");
       unsupportedMediaType  @9 $httpStatus(id = 415, title = "Unsupported Media Type");
       imATeapot            @10 $httpStatus(id = 418, title = "I'm a teapot");
+      unprocessableEntity  @12 $httpStatus(id = 422, title = "Unprocessable Entity");
 
       # Not applicable:
       #   401 Unauthorized:  We don't do HTTP authentication.

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -64,7 +64,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   post @1 (path :Text, content :PostContent, context :Context) -> Response;
   put @3 (path :Text, content :PutContent, context :Context) -> Response;
   delete @4 (path :Text, context :Context) -> Response;
-  patch @17 (path :Text, content :PatchContent, context :Context) -> Response;
+  patch @17 (path :Text, content :PostContent, context :Context) -> Response;
 
   postStreaming @5 (path :Text, mimeType :Text, context :Context, encoding :Text)
       -> (stream :RequestStream);
@@ -166,14 +166,6 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   }
 
   struct PutContent {
-    # TODO(apibump): Remove this and replace it with `PostContent` (renamed to `Content`).
-
-    mimeType @0 :Text;
-    content @1 :Data;
-    encoding @2 :Text;  # Content-Encoding header (optional).
-  }
-
-  struct PatchContent {
     # TODO(apibump): Remove this and replace it with `PostContent` (renamed to `Content`).
 
     mimeType @0 :Text;

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -64,6 +64,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   post @1 (path :Text, content :PostContent, context :Context) -> Response;
   put @3 (path :Text, content :PutContent, context :Context) -> Response;
   delete @4 (path :Text, context :Context) -> Response;
+  patch @17 (path :Text, content :PatchContent, context :Context) -> Response;
 
   postStreaming @5 (path :Text, mimeType :Text, context :Context, encoding :Text)
       -> (stream :RequestStream);
@@ -165,6 +166,14 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   }
 
   struct PutContent {
+    # TODO(apibump): Remove this and replace it with `PostContent` (renamed to `Content`).
+
+    mimeType @0 :Text;
+    content @1 :Data;
+    encoding @2 :Text;  # Content-Encoding header (optional).
+  }
+
+  struct PatchContent {
     # TODO(apibump): Remove this and replace it with `PostContent` (renamed to `Content`).
 
     mimeType @0 :Text;


### PR DESCRIPTION
From sandstorm's perspective, PATCH and PUT are functionally equivalent. PATCH RFC: https://tools.ietf.org/html/rfc5789

Addresses https://github.com/sandstorm-io/sandstorm/issues/1218.