### PR TITLE
Fix hovertext for referral notification.

### DIFF
--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -945,9 +945,11 @@ if (Meteor.isClient) {
     titleHelperText: function () {
       if (this.admin) {
         return "Dismiss this system notification";
+      } else if (this.referral) {
+        return "Dismiss this referral notification";
+      } else {
+        return "Stop the background app";
       }
-
-      return "Stops the background app";
     },
     dismissText: function () {
       if (this.admin && this.admin.type === "reportStats") {


### PR DESCRIPTION
Currently the referral notification's "dismiss" button has hovertext "Stops the background app", which is the default for such buttons.

This patch changes the default to "Dismiss this notification". To help do this, we push to the client the `ongoing` field. That field contains an ApiToken with owner `{frontend: null}`. It would be nice if we did not need to share this token with the client, because we really only care whether it's present or not. However, I don't think it's that big of a deal, since only the frontend can do anything with the token.