### PR TITLE
Allow revocation of direct shares in the Who Has Access view.

### DIFF
--- a/shell/.meteor/packages
+++ b/shell/.meteor/packages
@@ -38,6 +38,7 @@ reactive-var
 sandstorm-autoupdate-apps
 sandstorm-db
 sandstorm-backend
+sandstorm-contacts
 sandstorm-identicons
 sandstorm-permissions
 sandstorm-ui-topbar

--- a/shell/.meteor/versions
+++ b/shell/.meteor/versions
@@ -84,6 +84,7 @@ sandstorm-accounts-packages@0.1.0
 sandstorm-accounts-ui@0.1.0
 sandstorm-autoupdate-apps@0.1.0
 sandstorm-backend@0.1.0
+sandstorm-contacts@0.1.0
 sandstorm-db@0.1.0
 sandstorm-email@0.1.0
 sandstorm-identicons@0.1.0

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -368,7 +368,7 @@ limitations under the License.
             <span class="token-petname" data-token-id="{{_id}}">
               {{petname}} ({{dateString created}})
             </span>
-            <button class="revoke-token" title="revoke" data-token-id="{{_id}}">revoke</button>
+            <button class="revoke-token" title="Revoke" data-token-id="{{_id}}">revoke</button>
           </li>
         {{/if}}
       {{/each}}
@@ -405,7 +405,7 @@ limitations under the License.
                   <li>
                     {{displayName identityId}}
                     {{#if isCurrentIdentity identityId}}
-                      <button class="revoke-access" title="revoke" data-recipient="{{../recipient}}">
+                      <button class="revoke-access" title="Revoke" data-recipient="{{../recipient}}">
                         revoke
                       </button>
                     {{/if}}
@@ -448,7 +448,7 @@ limitations under the License.
                 {{/if}}
               </td>
               <td>
-                <button class="revoke-token" title="revoke" data-token-id="{{_id}}">revoke</button>
+                <button class="revoke-token" title="Revoke" data-token-id="{{_id}}">revoke</button>
               </td>
             </tr>
           {{/if}}

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -401,8 +401,15 @@ limitations under the License.
             <td> {{displayName recipient}} </td>
             <td> added by
               <ul>
-                {{#each shares}}
-                  <li>{{displayName identityId}}</li>
+                {{#each dedupedShares}}
+                  <li>
+                    {{displayName identityId}}
+                    {{#if isCurrentIdentity identityId}}
+                      <button class="revoke-access" title="revoke" data-recipient="{{../recipient}}">
+                        revoke
+                      </button>
+                    {{/if}}
+                  </li>
                 {{/each}}
               </ul>
             </td>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -368,7 +368,7 @@ limitations under the License.
             <span class="token-petname" data-token-id="{{_id}}">
               {{petname}} ({{dateString created}})
             </span>
-            <button class="revoke-token" title="Revoke" data-token-id="{{_id}}">revoke</button>
+            <button class="revoke-token" title="Revoke" data-token-id="{{_id}}">Revoke</button>
           </li>
         {{/if}}
       {{/each}}
@@ -406,7 +406,7 @@ limitations under the License.
                     {{displayName identityId}}
                     {{#if isCurrentIdentity identityId}}
                       <button class="revoke-access" title="Revoke" data-recipient="{{../recipient}}">
-                        revoke
+                        Revoke
                       </button>
                     {{/if}}
                   </li>
@@ -448,7 +448,7 @@ limitations under the License.
                 {{/if}}
               </td>
               <td>
-                <button class="revoke-token" title="Revoke" data-token-id="{{_id}}">revoke</button>
+                <button class="revoke-token" title="Revoke" data-token-id="{{_id}}">Revoke</button>
               </td>
             </tr>
           {{/if}}

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -90,7 +90,7 @@ a.copy-me {
   background-color: #888;
 }
 
-button.revoke-token {
+button.revoke-token, button.revoke-access {
   background-position: center;
   background-repeat: no-repeat;
   background-size: contain;

--- a/shell/packages/sandstorm-contacts/contacts-client.js
+++ b/shell/packages/sandstorm-contacts/contacts-client.js
@@ -1,5 +1,5 @@
 // Sandstorm - Personal Cloud Sandbox
-// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
 // All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +14,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-Package.describe({
-  summary: "Sandstorm UI autocomplete input",
-  version: "0.1.0"
-});
+function transform(contact) {
+  SandstormDb.fillInPictureUrl(contact);
+  return contact;
+}
 
-Package.onUse(function (api) {
-  api.use(["check", "reactive-var", "reload", "templating", "tracker", "underscore", "sandstorm-ui-topbar", "sandstorm-autoupdate-apps", "mongo"], "client");
-  api.use(["sandstorm-db", "sandstorm-contacts"], ["client", "server"]);
-  api.addFiles(["autocomplete.html", "autocomplete-client.js"], "client");
-});
+ContactProfiles = new Mongo.Collection("contactProfiles", {transform: transform});
+// A psuedo-collection used to store the results of joining Contacts with identity profiles.
+//
+// Each contains:
+//   _id: the id of identity (from Meteor.users collection)
+//   profile: the profile of the identity (see db.js for fields in this object) with profile
+//     default values, `intrinsicName`, and `pictureUrl` filled in.

--- a/shell/packages/sandstorm-contacts/contacts-server.js
+++ b/shell/packages/sandstorm-contacts/contacts-server.js
@@ -1,4 +1,20 @@
-Meteor.publish("userContacts", function () {
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Meteor.publish("contactProfiles", function () {
   var db = this.connection.sandstormDb;
   var self = this;
 
@@ -13,12 +29,12 @@ Meteor.publish("userContacts", function () {
         SandstormDb.fillInProfileDefaults(user);
         SandstormDb.fillInIntrinsicName(user);
         var filteredUser = _.pick(user, "_id", "profile");
-        self.added("userContacts", user._id, filteredUser);
+        self.added("contactProfiles", user._id, filteredUser);
       }
       contactIdentities[contact.identityId] =
         Meteor.users.find({_id: contact.identityId}, {fields: {profile: 1}}).observeChanges({
           changed: function (id, fields) {
-            self.changed("userContacts", id, fields);
+            self.changed("contactProfiles", id, fields);
           }
         });
     }
@@ -33,7 +49,7 @@ Meteor.publish("userContacts", function () {
       addIdentityOfContact(contact);
     },
     removed: function (contact) {
-      self.removed("userContacts", contact.identityId);
+      self.removed("contactProfiles", contact.identityId);
       contactIdentities[contact.identityId].stop();
       delete contactIdentities[contact.identityId];
     },

--- a/shell/packages/sandstorm-contacts/package.js
+++ b/shell/packages/sandstorm-contacts/package.js
@@ -1,5 +1,5 @@
 // Sandstorm - Personal Cloud Sandbox
-// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
 // All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,12 +15,14 @@
 // limitations under the License.
 
 Package.describe({
-  summary: "Sandstorm UI autocomplete input",
+  summary: "Sandstorm Contacts",
   version: "0.1.0"
 });
 
 Package.onUse(function (api) {
-  api.use(["check", "reactive-var", "reload", "templating", "tracker", "underscore", "sandstorm-ui-topbar", "sandstorm-autoupdate-apps", "mongo"], "client");
-  api.use(["sandstorm-db", "sandstorm-contacts"], ["client", "server"]);
-  api.addFiles(["autocomplete.html", "autocomplete-client.js"], "client");
+  api.use(["check", "tracker", "underscore", "mongo"], "client");
+  api.use(["sandstorm-db"], ["client", "server"]);
+  api.addFiles(["contacts-client.js"], "client");
+  api.addFiles(["contacts-server.js"], "server");
+  api.export("ContactProfiles");
 });

--- a/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
+++ b/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
@@ -1,11 +1,3 @@
-var UserContacts = new Mongo.Collection("userContacts");
-// A psuedo-collection used to store the results of joining Contacts with identity profiles
-//
-// Each contains:
-//   _id: the id of identity (from Meteor.users collection)
-//   profile: the profile of the identity (see db.js for fields in this object) with profile
-//     default values and `intrinsicName` added.
-
 Template.contactInputBox.onCreated(function () {
   var self = this;
   this.currentText = new ReactiveVar(null);
@@ -13,7 +5,7 @@ Template.contactInputBox.onCreated(function () {
   this.selectedContacts = this.data.contacts;
   this.selectedContactsIds = new ReactiveVar([]);
   this.highlightedContact = new ReactiveVar({_id: null});
-  this.subscribe("userContacts");
+  this.subscribe("contactProfiles");
   this.randomId = Random.id();  // For use with aria requiring ids in html
   this.autoCompleteContacts = new ReactiveVar([]);
   this.autorun(generateAutoCompleteContacts.bind(this, this));
@@ -41,7 +33,7 @@ function generateAutoCompleteContacts(template) {
   }
   currentText = currentText.toLowerCase();
   var selectedContactsIds = template.selectedContactsIds.get();
-  var contacts = UserContacts.find({_id: {$nin: selectedContactsIds}}).fetch();
+  var contacts = ContactProfiles.find({_id: {$nin: selectedContactsIds}}).fetch();
   var results;
   if (currentText.lastIndexOf("@", 0) === 0) {
     var textWithoutAt = currentText.slice(1);
@@ -55,9 +47,6 @@ function generateAutoCompleteContacts(template) {
         contact.profile.intrinsicName.toLowerCase().indexOf(currentText) !== -1;
     });
   }
-  results.forEach(function (contact) {
-    SandstormDb.fillInPictureUrl(contact);
-  })
   template.autoCompleteContacts.set(defaults.concat(results));
   if (results.length > 0) {
     template.highlightedContact.set(results[0]);

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -982,7 +982,7 @@ if (Meteor.isClient) {
       // Two cases:
       // 1. All of the tokens are direct shares. Easy. Just revoke them.
       // 2. Some of the links are child tokens. For each, we walk up the chain of parents to the
-      //    root. Then we walk downwards to see whether an other identities would be immediately
+      //    root. Then we walk downwards to see whether any other identities would be immediately
       //    affected by revoking those roots. We then collect that data and display it in a
       //    confirmation dialog.
 


### PR DESCRIPTION
Baby steps towards a more fully-featured Who Has Access view.

This change adds a revoke button for each time the current user appears in the "added by" column. It looks like:

<img width="492" alt="whohasaccess" src="https://cloud.githubusercontent.com/assets/495768/12853140/75a256b0-cc00-11e5-91db-ed5bfabe66f0.png">

Clicking the button revokes the share. If the share went through a sharing link, a confirmation dialog is displayed that explains who else might also be affected by the revocation.
