### PR TITLE
Remove the `sandstorm reset-oauth` command.

### DIFF
--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -481,15 +481,6 @@ public:
               return alternateMain->getMain();
             },
             "Manipulate spk files.")
-        .addSubCommand("reset-oauth",
-            [this]() {
-              return kj::MainBuilder(context, VERSION,
-                      "Resets the OAuth configuration of Meteor by deleting the configuration "
-                      "that is stored in Mongo.")
-                  .callAfterParsing(KJ_BIND_METHOD(*this, resetOauth))
-                  .build();
-            },
-            "Reset OAuth configuration.")
         .addSubCommand("continue",
             [this]() {
               return kj::MainBuilder(context, VERSION,
@@ -826,24 +817,6 @@ public:
     } else {
       context.exitInfo("Update complete.");
     }
-  }
-
-  kj::MainBuilder::Validity resetOauth() {
-    changeToInstallDir();
-
-    // Verify that Sandstorm is running.
-    if (getRunningPid() == nullptr) {
-      context.exitError("Sandstorm is not running.");
-    }
-
-    const Config config = readConfig();
-
-    // We'll run under the chroot.
-    enterChroot(false);
-
-    mongoCommand(config, kj::str("db.meteor_accounts_loginServiceConfiguration.remove({})"));
-
-    context.exitInfo(kj::str("reset OAuth configuration"));
   }
 
   kj::MainBuilder::Validity adminToken() {

--- a/tests/unittests/cli.js
+++ b/tests/unittests/cli.js
@@ -55,14 +55,6 @@ module.exports = {
       done();
     });
   },
-  "sandstorm reset-oauth" : function (client, done) {
-    execSandstorm(["reset-oauth"], function (err, stdout, stderr) {
-      if (err) throw err;
-
-      assert.include(stdout, "reset OAuth configuration", "`reset-oauth` contains the expected output");
-      done();
-    });
-  },
 };
 
 


### PR DESCRIPTION
The `sandstorm reset-oauth` command was useful back when we had no admin settings page and when changing the `BASE_URL` didn't not automatically clear the oauth config. Nowadays, however, I think its existence is a net negative.

@mrdomino reported invoking the command, expecting it to log out all currently logged-in users, but instead getting into a state with broken config and then not noticing until a rather long time later that nobody could log in. Had he visited the admin/settings page instead of invoking `sandstorm reset-oauth`, this confusion would likely have been averted. (Note that our admin/settings page has both "reconfigure" and "log out all users of this provider" options.) The situation was made worse by the fact that `db.meteor_accounts_loginServiceConfiguration.remove({})` leaves the database in a weird state. It would be better if the reset did something like we do [here](https://github.com/sandstorm-io/sandstorm/blob/4e679e43fa29148fb9024f7b1fbe9dd87c60d4f7/shell/server/startup.js#L30-L36), but that would be somewhat nontrivial to do from run-bundle.c++; I think it would at least require us to enumerate the oauth login providers there, which would be sad.