### PR TITLE
Remove remaining reset-oauth mention in docs

### DIFF
--- a/docs/administering/faq.md
+++ b/docs/administering/faq.md
@@ -14,13 +14,6 @@ the default recommendation. If not, remove the `sudo` from the
 instructions below.
 
 * Use e.g. `ssh` to log into the server running Sandstorm.
-* Run this command to deconfigure all existing OAuth-based login providers.
-
-        sudo sandstorm reset-oauth
-
-  On success, it will print:
-
-      reset OAuth configuration
 
 * Run this command to generate a token you can use to log in as an admin, for emergency administration.
 


### PR DESCRIPTION
#1478 removes the command, so let's just stop mentioning it.

The admin UI will step the user through any further steps they need.

Thanks to @mrdomino for using this command which we realized was sort of useless so we deleted it, and to @dwrensha and @kentonv for deleting it.