### PR TITLE
Share Access popup for incognito grainviews.

### DIFF
--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -68,7 +68,9 @@ GrainView = class GrainView {
 
     this._status = 'closed';
     this._userIdentityId = new ReactiveVar(undefined);
-    this.revealIdentity(identityId);
+    if (identityId) {
+      this.revealIdentity(identityId);
+    }
     // We want the iframe to receive the most recently-set path whenever we rerender.
     this._originalPath = this._path;
     this._blazeView = Blaze.renderWithData(Template.grainView, this, this._parentElement);

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -570,7 +570,29 @@ limitations under the License.
 </template>
 
 <template name="grainSharePopup">
-  {{> shareWithOthers grain=currentGrain}}
+  {{#if incognito}}
+    <p>
+      You are viewing this grain anonymously.
+    </p>
+    <p>
+      To share access, copy this link:
+      {{#with currentTokenUrl}}
+        <a id="share-token-text" class="copy-me" href="{{.}}">{{.}}</a>
+      {{/with}}
+    </p>
+    <p>
+      {{#if currentUser}}
+        For more sharing options, you must
+        <a class="open-non-anonymously" href="{{currentTokenUrl}}">
+          open this grain non-anonymously
+        </a>.
+      {{else}}
+        For more sharing options, please sign in.
+      {{/if}}
+    </p>
+  {{else}}
+    {{> shareWithOthers grain=currentGrain}}
+  {{/if}}
 </template>
 
 <template name="grainPowerboxRequest">
@@ -610,9 +632,9 @@ limitations under the License.
 
   {{setGrainWindowTitle}}
 
+  {{>sandstormTopbarItem name="share" topbar=globalTopbar template="grainShareButton"
+      popupTemplate="grainSharePopup"}}
   {{#if currentUser}}
-    {{>sandstormTopbarItem name="share" topbar=globalTopbar
-          template="grainShareButton" popupTemplate="grainSharePopup"}}
     {{>sandstormTopbarItem name="delete" topbar=globalTopbar template="grainDeleteButton"}}
   {{/if}}
   {{#if isOwner}}

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -634,6 +634,12 @@ if (Meteor.isClient) {
     "click #privatize-grain": function (event) {
       Meteor.call("privatizeGrain", getActiveGrain(globalGrains.get()).grainId());
     },
+    "click a.open-non-anonymously": function (event) {
+      event.preventDefault();
+      globalTopbar.closePopup();
+      getActiveGrain(globalGrains.get()).reset();
+      getActiveGrain(globalGrains.get()).openSession();
+    }
   });
 
   Template.shareWithOthers.onRendered(function () {
@@ -803,6 +809,12 @@ if (Meteor.isClient) {
   });
 
   Template.grainSharePopup.helpers({
+    "incognito": function () {
+      return !Accounts.getCurrentIdentityId();
+    },
+    "currentTokenUrl": function() {
+      return getOrigin() + "/shared/" + getActiveGrain(globalGrains.get()).token();
+    },
     "currentGrain": function() {
       return getActiveGrain(globalGrains.get());
     }


### PR DESCRIPTION
Fixes #1474.

Presents the Share Access button to everyone, including signed-out users. For incognito users, the popup looks like:

<img width="425" alt="incognito" src="https://cloud.githubusercontent.com/assets/495768/12890513/f7617dea-ce51-11e5-8288-2e95bb4eb7fc.png">


For signed-out users, it looks like:


<img width="425" alt="signedout" src="https://cloud.githubusercontent.com/assets/495768/12890516/fd11ad3c-ce51-11e5-9d44-c2aa3905828e.png">

