### PR TITLE
Fix bug with the 'last active' time of 'shared with me' grains.

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -399,7 +399,7 @@ Meteor.methods({
     const session = Sessions.findAndModify({
       query: {_id: sessionId},
       update: {$set: {timestamp: new Date().getTime()}},
-      fields: {grainId: 1},
+      fields: {grainId: 1, identityId: 1},
     });
 
     if (session) {


### PR DESCRIPTION
The third argument of `globalBackend.updateLastActive(grainId, this.userId, session.identityId)` ends up undefined, which causes the 'last active' time to not get updated.

I believe this bug was introduced in the accounts/identities split. It became more exposed after #1448 got merged.