### PR TITLE
On admin screen, detect misconfigured WILDCARD_HOST & show warning

### DIFF
--- a/shell/client/_admin.scss
+++ b/shell/client/_admin.scss
@@ -219,3 +219,16 @@ button#offer-ipnetwork, button#offer-ipinterface {
   font-size: 14px;
   min-height: 32px;
 }
+
+.wildcard-host-warning {
+  min-height: 3em;
+  width: 100%;
+  padding: 0.3em;
+  background-color: red;
+  color: white;
+
+  a {
+    color: white;
+    text-decoration: underline;
+  }
+}

--- a/shell/client/_admin.scss
+++ b/shell/client/_admin.scss
@@ -221,9 +221,10 @@ button#offer-ipnetwork, button#offer-ipinterface {
 }
 
 .wildcard-host-warning {
+  box-sizing: border-box;
   min-height: 3em;
   width: 100%;
-  padding: 0.3em;
+  padding: 0.5em;
   background-color: red;
   color: white;
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -843,11 +843,12 @@ limitations under the License.
 
   {{#if wildcardHostSeemsBroken}}
   <div class="wildcard-host-warning">
-    WARNING: This server seems to have its WILDCARD_HOST misconfigured.  As a result, you will not
-    be able to use any apps.
+    WARNING: This server seems to have its WILDCARD_HOST misconfigured.  Until you fix it, you will
+    not be able to use any apps.
     <a href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
-      Learn more.</a>  You'll need to adjust DNS or edit the sandstorm.conf file. Once you fix the
-    issue, reload this page. If you're still having problems, email us at support@sandstorm.io.
+      Learn more.</a>  You'll need to adjust DNS or edit the sandstorm.conf file. Once you have
+    addressed the issue, reload this page. If you're still having problems, email us at
+    support@sandstorm.io.
   </div>
   {{/if}}
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -841,6 +841,16 @@ limitations under the License.
 <template name="admin">
   {{>title "Admin Settings"}}
 
+  {{#if wildcardHostSeemsBroken}}
+  <div class="wildcard-host-warning">
+    WARNING: Your Sandstorm install seems to have its WILDCARD_HOST misconfigured. Please see
+    the <a href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
+    documentation on wildcard hosts.</a>  Once you fix the issue, you can re-run this self-test by
+    reloading this webpage. Email support@sandstorm.io for further help; we want to help you
+    succeed.
+  </div>
+  {{/if}}
+
   {{> _adminConfigureLoginServiceDialog}}
   <div id="admin-settings" class="centered-box">
     {{#if isUserPermitted}}

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -843,8 +843,8 @@ limitations under the License.
 
   {{#if wildcardHostSeemsBroken}}
   <div class="wildcard-host-warning">
-    WARNING: This server seems to have its WILDCARD_HOST misconfigured.  This will break the
-    Sandstorm's most important functionality, the ability to launch grains.
+    WARNING: This server seems to have its WILDCARD_HOST misconfigured.  This will break Sandstorm's
+    most important functionality: the ability to launch grains.
     <a href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
       Learn more.</a>  You'll need to adjust DNS or edit the sandstorm.conf file. Once you fix the
     issue, reload this page. If you're still having problems, email us at support@sandstorm.io.

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -843,8 +843,8 @@ limitations under the License.
 
   {{#if wildcardHostSeemsBroken}}
   <div class="wildcard-host-warning">
-    WARNING: This server seems to have its WILDCARD_HOST misconfigured.  This will break Sandstorm's
-    most important functionality: the ability to launch grains.
+    WARNING: This server seems to have its WILDCARD_HOST misconfigured.  As a result, you will not
+    be able to use any apps.
     <a href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
       Learn more.</a>  You'll need to adjust DNS or edit the sandstorm.conf file. Once you fix the
     issue, reload this page. If you're still having problems, email us at support@sandstorm.io.

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -843,11 +843,11 @@ limitations under the License.
 
   {{#if wildcardHostSeemsBroken}}
   <div class="wildcard-host-warning">
-    WARNING: Your Sandstorm install seems to have its WILDCARD_HOST misconfigured. Please see
-    the <a href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
-    documentation on wildcard hosts.</a>  Once you fix the issue, you can re-run this self-test by
-    reloading this webpage. Email support@sandstorm.io for further help; we want to help you
-    succeed.
+    WARNING: This server seems to have its WILDCARD_HOST misconfigured.  This will break the
+    Sandstorm's most important functionality, the ability to launch grains.
+    <a href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
+      Learn more.</a>  You'll need to adjust DNS or edit the sandstorm.conf file. Once you fix the
+    issue, reload this page. If you're still having problems, email us at support@sandstorm.io.
   </div>
   {{/if}}
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -845,7 +845,8 @@ limitations under the License.
   <div class="wildcard-host-warning">
     WARNING: This server seems to have its WILDCARD_HOST misconfigured.  Until you fix it, you will
     not be able to use any apps.
-    <a href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
+    <a target="_blank"
+       href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
       Learn more.</a>  You'll need to adjust DNS or edit the sandstorm.conf file. Once you have
     addressed the issue, reload this page. If you're still having problems, email us at
     support@sandstorm.io.

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -778,7 +778,7 @@ matchWildcardHost = function(host) {
       host.indexOf(suffix, -suffix.length) >= 0 &&
       host.length >= prefix.length + suffix.length) {
     var id = host.slice(prefix.length, -suffix.length);
-    if (id.match(/^[a-z0-9]*$/)) {
+    if (id.match(/^[-a-z0-9]*$/)) {
       return id;
     }
   }

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -211,7 +211,7 @@ function checkMagic(buf, magic) {
 }
 
 function serveSelfTest(req, res) {
-  inMeteor(() => {
+  try {
     if (req.method === 'GET' &&
         req.url === '/') {
       const content = new Buffer("Self-test OK.");
@@ -226,7 +226,9 @@ function serveSelfTest(req, res) {
       res.end('Bad request to self-test subdomain.');
       return;
     }
-  });
+  } catch (err) {
+    console.log("WARNING: An error occurred while serving self-test; proceeding anyway:", err);
+  }
 }
 
 function serveStaticAsset(req, res) {

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -214,11 +214,13 @@ function serveSelfTest(req, res) {
   inMeteor(() => {
     if (req.method === 'GET' &&
         req.url === '/') {
-      return serveStaticAsset(req, res, {
-        content: new Buffer("Self-test OK.")
+      const content = new Buffer("Self-test OK.");
+      res.writeHead(200, {
+        'Content-Type': 'text/plain',
+        'Content-Length': content.length,
+        'Access-Control-Allow-Origin': process.env.ROOT_URL,
       });
-    } else if (req.method === 'OPTIONS') {
-      return serveStaticAsset(req, res);
+      res.end(content);
     } else {
       res.writeHead(400, { 'Content-Type': 'text/plain' });
       res.end('Bad request to self-test subdomain.');
@@ -227,7 +229,7 @@ function serveSelfTest(req, res) {
   });
 }
 
-function serveStaticAsset(req, res, overrideAsset) {
+function serveStaticAsset(req, res) {
   inMeteor(() => {
     if (req.method === 'GET') {
       // jscs:disable validateQuoteMarks
@@ -247,13 +249,8 @@ function serveStaticAsset(req, res, overrideAsset) {
         return;
       }
 
-      let asset;
-      if (overrideAsset) {
-        asset = overrideAsset;
-      } else {
-        const url = Url.parse(req.url);
-        asset = globalDb.getStaticAsset(url.pathname.slice(1));
-      }
+      const url = Url.parse(req.url);
+      const asset = globalDb.getStaticAsset(url.pathname.slice(1));
 
       if (asset) {
         const headers = {

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -490,8 +490,9 @@ Meteor.startup(() => {
         return;
       }
 
-      if (id.match(/^selftest/)) {
-        // Self test domain pattern.
+      if (id.match(/^selftest-/)) {
+        // Self test domain pattern. Starts w/ hyphen to avoid ambiguity with grain session/static
+        // publishing wildcard hosts.
         serveSelfTest(req, res);
         return;
       }

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -47,7 +47,7 @@ var adminRoute = RouteController.extend({
 
   action: function () {
     // Test the WILDCARD_HOST for sanity.
-    Deps.nonreactive(function() {
+    Tracker.nonreactive(() => {
       if (Session.get("alreadyTestedWildcardHost")) {
         return;
       }

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -51,22 +51,22 @@ var adminRoute = RouteController.extend({
       if (Session.get("alreadyTestedWildcardHost")) {
         return;
       }
-      let req = new XMLHttpRequest();
-      req.timeout = 2000;
-      const fail = () => {
-        Session.set("alreadyTestedWildcardHost", true);
-        Session.set("wildcardHostWorks", false);
-      };
-      const succeed = () => {
-        Session.set("alreadyTestedWildcardHost", true);
-        Session.set("wildcardHostWorks", true);
-      };
-      req.addEventListener("load", succeed);
-      req.addEventListener("error", fail);
-      req.addEventListener("abort", fail);
-      req.open("GET", "//" + makeWildcardHost("selftest" + Random.hexString(20)));
-      req.overrideMimeType('text/plain');
-      req.send();
+      HTTP.call('GET', "//" + makeWildcardHost("selftest" + Random.hexString(20)),
+                {timeout: 2000}, (error, response) => {
+                  Session.set("alreadyTestedWildcardHost", true);
+                  let looksGood;
+                  if (error) {
+                    looksGood = false;
+                  } else {
+                    if (response.statusCode === 200) {
+                      looksGood = true;
+                    } else {
+                      console.log("Surpring status code from self test domain", response.statusCode);
+                      looksGood = false;
+                    }
+                  }
+                  Session.set("wildcardHostWorks", looksGood);
+                });
     });
 
     var state = this.state;

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -51,7 +51,7 @@ var adminRoute = RouteController.extend({
       if (Session.get("alreadyTestedWildcardHost")) {
         return;
       }
-      HTTP.call('GET', "//" + makeWildcardHost("selftest" + Random.hexString(20)),
+      HTTP.call('GET', "//" + makeWildcardHost("selftest-" + Random.hexString(20)),
                 {timeout: 2000}, (error, response) => {
                   Session.set("alreadyTestedWildcardHost", true);
                   let looksGood;


### PR DESCRIPTION
This is some fairly minimal changes for showing information to the admin about a misconfigured `WILDCARD_HOST`.

Screenshot of what admin looks like when this warning is visible:

![wildcard-host-warning](https://cloud.githubusercontent.com/assets/25457/12904521/da2ac9ba-ce84-11e5-9baa-d354b58375ec.png)


Review request from:

- @neynah and/or @zarvox - please sanity-check my proposed text

Review & merge requested from:

- @kentonv

Note for Kenton: This adds a new subdomain pattern, `selftest*`.

Note that this _only_ affects `/admin/*` routes. That means that people can still get a forever-spinning grain spinner.

From my perspective, @jadeqwang and I want to limit how much time I spend on this particular bit of self-testing, so I'd like to declare making the `grain-frame` provide warning text as out-of-scope for this pull request. IMHO the most important thing is that people see this when they are doing initial setup.

Testing done:

- Set my `BASE_URL` and `WILDCARD_HOST` to point at `mouse-potato.com` which is a domain that resolves to 127.0.0.1 Verified that I saw the message.

- Fixed my `WILDCARD_HOST` and loaded the page up via `local.sandstorm.io`.

Rationale for new subdomain type:

- When I was manually testing this in Firefox, Firefox would cache the CORS result from a broken domain - and the CORS result from a broken domain is "no, CORS is not OK". Once I realized that, I realized that I needed each self-test to be on its own domain. So I created a new subdomain type.