### PR TITLE
Define userfaultfd syscall number if it is not already defined.

### DIFF
--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1101,6 +1101,9 @@ void SupervisorMain::setupSeccomp() {
   CHECK_SECCOMP(seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EINVAL), SCMP_SYS(prctl), 1,
       SCMP_A0(SCMP_CMP_EQ, PR_SET_SECCOMP)));
   CHECK_SECCOMP(seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOSYS), SCMP_SYS(seccomp), 0));
+#ifndef __NR_bpf
+#define __NR_bpf 321
+#endif
   CHECK_SECCOMP(seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOSYS), SCMP_SYS(bpf), 0));
 
   // New syscalls that don't seem useful to Sandstorm apps therefore we will disallow them.

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1100,6 +1100,9 @@ void SupervisorMain::setupSeccomp() {
   // that run in-kernel (albeit with a very limited instruction set).
   CHECK_SECCOMP(seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EINVAL), SCMP_SYS(prctl), 1,
       SCMP_A0(SCMP_CMP_EQ, PR_SET_SECCOMP)));
+#ifndef __NR_seccomp
+#define __NR_seccomp 317
+#endif
   CHECK_SECCOMP(seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOSYS), SCMP_SYS(seccomp), 0));
 #ifndef __NR_bpf
 #define __NR_bpf 321

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1106,6 +1106,9 @@ void SupervisorMain::setupSeccomp() {
   // New syscalls that don't seem useful to Sandstorm apps therefore we will disallow them.
   // TODO(cleanup): Can we somehow specify "disallow all calls greater than N" to preemptively
   //   disable things until we've reviewed them?
+#ifndef __NR_userfaultfd
+#define __NR_userfaultfd 323
+#endif
   CHECK_SECCOMP(seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOSYS), SCMP_SYS(userfaultfd), 0));
 
   // TOOD(someday): See if we can get away with turning off mincore, madvise, sysinfo etc.


### PR DESCRIPTION
[323 is the correct value for x86_64](https://github.com/torvalds/linux/blob/cb4c4e8091e86e08cb2d48e7ae6bf454245c36cb/arch/x86/entry/syscalls/syscall_64.tbl#L332).