### PR TITLE
docs: Fork theme; add separate sandstorm.io link to nav

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -1,0 +1,41 @@
+.wy-side-nav-search>.home-and-project {
+    display: flex;
+    text-align: left;
+}
+
+.home-and-project>a.docs-home {
+    /* Push anything else in the flexbox as far right as possible. */
+    flex: 1 0;
+}
+
+
+.wy-side-nav-search>.home-and-project>a {
+    /* Fix vertical alignment problem */
+    line-height: initial;
+    /* Use default A styling for .wy-side-nav-search from theme.css */
+    color: #fcfcfc;
+    font-size: 100%;
+    font-weight: bold;
+    display: inline-block;
+    padding: 4px 6px;
+    margin-bottom: 0.809em;
+}
+
+.wy-side-nav-search>.home-and-project>a:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+@media screen and (max-width: 768px) {
+    .wy-nav-top {
+        text-align: left;
+        display: flex;
+    }
+}
+
+.wy-nav-top>.nav-toggle-and-docs-home-link {
+    flex: 1 0;
+}
+.wy-nav-top>.nav-toggle-and-docs-home-link>* {
+    float: none;
+    vertical-align: middle;
+}

--- a/docs/sandstorm_readthedocs_modified_theme/README.md
+++ b/docs/sandstorm_readthedocs_modified_theme/README.md
@@ -1,0 +1,7 @@
+This directory started out as a snapshot from the github.com/mkdocs/mkdocs
+repository on 2016-01-29.
+
+It has the following changes:
+
+- "Docs home" vs. "Project home" separation, per
+  https://github.com/sandstorm-io/sandstorm/issues/1405

--- a/docs/sandstorm_readthedocs_modified_theme/base.html
+++ b/docs/sandstorm_readthedocs_modified_theme/base.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {% if page_description %}<meta name="description" content="{{ page_description }}">{% endif %}
+  {% if site_author %}<meta name="author" content="{{ site_author }}">{% endif %}
+  {% block htmltitle %}
+  <title>{% if page_title %}{{ page_title }} - {% endif %}{{ site_name }}</title>
+  {% endblock %}
+
+  {% if favicon %}<link rel="shortcut icon" href="{{ favicon }}">
+  {% else %}<link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">{% endif %}
+
+  {# CSS #}
+  <link href='https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>
+
+  <link rel="stylesheet" href="{{ base_url }}/css/theme.css" type="text/css" />
+  <link rel="stylesheet" href="{{ base_url }}/css/theme_extra.css" type="text/css" />
+  <link rel="stylesheet" href="{{ base_url }}/css/highlight.css">
+  {%- for path in extra_css %}
+  <link href="{{ path }}" rel="stylesheet">
+  {%- endfor %}
+
+  {% if current_page %}
+  <script>
+    // Current page data
+    var mkdocs_page_name = "{{ page_title }}";
+    var mkdocs_page_input_path = "{{ current_page.input_path }}";
+    var mkdocs_page_url = "{{ current_page.abs_url }}";
+  </script>
+  {% endif %}
+  <script src="{{ base_url }}/js/jquery-2.1.1.min.js"></script>
+  <script src="{{ base_url }}/js/modernizr-2.8.3.min.js"></script>
+  <script type="text/javascript" src="{{ base_url }}/js/highlight.pack.js"></script>
+  <script src="{{ base_url }}/js/theme.js"></script>
+
+  {%- block extrahead %} {% endblock %}
+
+  {%- for path in extra_javascript %}
+  <script src="{{ path }}"></script>
+  {%- endfor %}
+
+  {% if google_analytics %}
+  <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', '{{ google_analytics[0] }}', '{{ google_analytics[1] }}');
+      ga('send', 'pageview');
+  </script>
+  {% endif %}
+</head>
+
+<body class="wy-body-for-nav" role="document">
+
+  <div class="wy-grid-for-nav">
+
+    {# SIDE NAV, TOGGLES ON MOBILE #}
+    <nav data-toggle="wy-nav-shift" class="wy-nav-side stickynav">
+      <div class="wy-side-nav-search">
+        <div class="home-and-project">
+          <a href="{{ homepage_url }}" class="icon icon-home docs-home"> {{ site_name }}</a>
+          <a href="https://sandstorm.io/" class="project-home">Sandstorm.io &raquo;</a>
+        </div>
+        {% include "searchbox.html" %}
+      </div>
+
+      <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
+        <ul class="current">
+          {% for nav_item in nav %}
+            <li>{% include "toc.html" %}<li>
+          {% endfor %}
+        </ul>
+      </div>
+      &nbsp;
+    </nav>
+
+    <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
+
+      {# MOBILE NAV, TRIGGLES SIDE NAV ON TOGGLE #}
+      <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
+        <span class="nav-toggle-and-docs-home-link">
+          <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
+          <a href="{{ homepage_url }}" class="docs-home">{{ site_name }}</a>
+        </span>
+        <a href="https://sandstorm.io/" class="project-home">Sandstorm.io &raquo;</a>
+      </nav>
+
+      {# PAGE CONTENT #}
+      <div class="wy-nav-content">
+        <div class="rst-content">
+          {% include "breadcrumbs.html" %}
+          <div role="main">
+            <div class="section">
+              {% block content %}
+                {{ content }}
+              {% endblock %}
+            </div>
+          </div>
+	  {%- block footer %}
+          {% include "footer.html" %}
+	  {% endblock %}
+        </div>
+      </div>
+
+    </section>
+
+  </div>
+
+{% include "versions.html" %}
+
+</body>
+</html>
+{% if current_page and current_page.is_homepage %}
+<!--
+MkDocs version : {{ mkdocs_version }}
+Build Date UTC : {{ build_date_utc }}
+-->
+{% endif %}

--- a/docs/sandstorm_readthedocs_modified_theme/js/theme.js
+++ b/docs/sandstorm_readthedocs_modified_theme/js/theme.js
@@ -1,0 +1,55 @@
+$( document ).ready(function() {
+
+    // Shift nav in mobile when clicking the menu.
+    $(document).on('click', "[data-toggle='wy-nav-top']", function() {
+      $("[data-toggle='wy-nav-shift']").toggleClass("shift");
+      $("[data-toggle='rst-versions']").toggleClass("shift");
+    });
+
+    // Close menu when you click a link.
+    $(document).on('click', ".wy-menu-vertical .current ul li a", function() {
+      $("[data-toggle='wy-nav-shift']").removeClass("shift");
+      $("[data-toggle='rst-versions']").toggleClass("shift");
+    });
+
+    $(document).on('click', "[data-toggle='rst-current-version']", function() {
+      $("[data-toggle='rst-versions']").toggleClass("shift-up");
+    });
+
+    // Make tables responsive
+    $("table.docutils:not(.field-list)").wrap("<div class='wy-table-responsive'></div>");
+
+    hljs.initHighlightingOnLoad();
+
+    $('table').addClass('docutils');
+});
+
+window.SphinxRtdTheme = (function (jquery) {
+    var stickyNav = (function () {
+        var navBar,
+            win,
+            stickyNavCssClass = 'stickynav',
+            applyStickNav = function () {
+                if (navBar.height() <= win.height()) {
+                    navBar.addClass(stickyNavCssClass);
+                } else {
+                    navBar.removeClass(stickyNavCssClass);
+                }
+            },
+            enable = function () {
+                applyStickNav();
+                win.on('resize', applyStickNav);
+            },
+            init = function () {
+                navBar = jquery('nav.wy-nav-side:first');
+                win    = jquery(window);
+            };
+        jquery(init);
+        return {
+            enable : enable
+        };
+    }());
+    return {
+        StickyNav : stickyNav
+    };
+}($));

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,11 @@
-site_name: Sandstorm
+site_name: Docs
+theme_dir: 'docs/sandstorm_readthedocs_modified_theme'
 theme: 'readthedocs'
 repo_url: https://github.com/sandstorm-io/sandstorm/tree/master/docs
 markdown_extensions:
     - inline_graphviz
+extra_css:
+    - "extra.css"
 pages:
 - "Home": "index.md"
 - Using:


### PR DESCRIPTION
This commit:

- Forks base.html from the mkdocs readthedocs theme.

- Copies in the Javascript unmodified, since I was having problems with the JS
  not executing locally otherwise.

- Adds a README.md to this directory.

- Uses extra_css.

- Adjusts mkdocs.yml to point at the customizations.

- Uses flexbox to add a "sandstorm.io" link so people can get to
  the sandstorm.io home.

- Adjusts mkdocs.yml to rename this project to just "Docs" rather tha
  "Sandstorm" or "Sandstorm Docs" so that the navigation link in the top
  is clearer.

- Tells mkdocs to ignore the env/ directory, which contains a
  virtualenv.

Close #1405