### PR TITLE
Support If-None-Match: *.

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1928,6 +1928,10 @@ const parsePreconditionHeader = (request) => {
   }
 
   if (request.headers['if-none-match']) {
+    if (request.headers['if-none-match'].trim() === '*') {
+      return { doesntExist: null };
+    }
+
     const noneMatches = parseETagList(request.headers['if-none-match']);
     if (noneMatches.length > 0) {
       return { matchesNoneOf: noneMatches };

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -1258,6 +1258,9 @@ private:
       case WebSession::Context::ETagPrecondition::EXISTS:
         lines.add(kj::str("If-Match: *"));
         break;
+      case WebSession::Context::ETagPrecondition::DOESNT_EXIST:
+        lines.add(kj::str("If-None-Match: *"));
+        break;
       case WebSession::Context::ETagPrecondition::MATCHES_ONE_OF:
         lines.add(kj::str("If-Match: ", kj::strArray(
               KJ_MAP(e, eTagPrecondition.getMatchesOneOf()) {

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -130,6 +130,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
     eTagPrecondition :union {
       none @4 :Void;  # No precondition.
       exists @5 :Void;  # If-Match: *
+      doesntExist @8 :Void;  # If-None-Match: *
       matchesOneOf @6 :List(ETag);  # If-Match
       matchesNoneOf @7 :List(ETag);  # If-None-Match
     }


### PR DESCRIPTION
Fixes #1437

Closes #1491

Note that https://github.com/kentonv/node-capnp/commit/10e269d298189236881d038413950b0302610e9a is also needed for `*` to work correctly (for both `If-Match` and `If-None-Match`).