### PR TITLE
Use `box-sizing: border-box;` everywhere

### DIFF
--- a/shell/client/_about.scss
+++ b/shell/client/_about.scss
@@ -88,12 +88,14 @@
         img {
           padding: 0 16px;
           display: block;
-          max-width: 122px;
+          box-sizing: border-box;
+          max-width: 154px;
           max-height: 121px;
         }
         .uniregistry-image {
           @extend %pseudo-img-tag;
-          width: 122px;
+          width: 154px;
+          box-sizing: border-box;
           height: 121px;
           background-image: url("/logos/uniregistry.svg");
         }
@@ -102,13 +104,16 @@
   }
 
   >section.developers {
-    max-width: 616px;
+    max-width: 632px;
+    box-sizing: border-box;
   }
   >section.advisors {
-    max-width: 462px;
+    max-width: 478px;
+    box-sizing: border-box;
   }
   >section.corporate, >section.individual {
-    width: 539px;
+    box-sizing: border-box;
+    width: 555px;
     @media (max-width: 560px) {
       width: auto;
     }
@@ -260,7 +265,8 @@
   color: #191919;
 
   padding: 64px;
-  max-width: 1110px;
+  max-width: 1238px;
+  box-sizing: border-box;
   @media #{$mobile} {
     padding: 8px;
   }

--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -460,7 +460,8 @@ body>.main-content>.account {
 
   h3.title-bar {
     background-color: white;
-    width: 650px;
+    width: 660px;
+    box-sizing: border-box;
     margin-bottom: 5px;
     border: none;
     font-size: 12pt;
@@ -565,17 +566,19 @@ body>.main-content>.account {
           white-space: nowrap;
           margin-top: 4px;
           span.email {
+            box-sizing: border-box;
             line-height: 30px;
             overflow: hidden;
             text-overflow: ellipsis;
             padding-left: 3%;
             float: left;
-            width: 63%;
+            width: 66%;
           }
           button.make-primary {
             @extend %button-base;
             @extend %button-secondary;
-            width: 32%;
+            box-sizing: border-box;
+            width: 33%;
             height: 26px;
             margin-top: 2px;
           }
@@ -600,7 +603,7 @@ body>.main-content>.account {
       }
       input[name="email"] {
         width: 200px;
-        height: 20px;
+        height: 26px;
       }
       div.button-box {
         display: inline-block;
@@ -619,12 +622,13 @@ div.billing {
   >section.payment-methods {
     display: inline-block;
     vertical-align: top;
+    box-sizing: border-box;
 
     h3 {
       margin: 0.5em 0;
     }
 
-    max-width: 400px;
+    max-width: 432px;
     padding: 0 16px;
 
     >.balance {
@@ -773,12 +777,13 @@ div.billing {
     display: inline-block;
     vertical-align: top;
     margin-right: 32px;
+    box-sizing: border-box;
 
     h3 {
       margin: 0.5em 0;
     }
 
-    max-width: 450px;
+    max-width: 482px;
     padding: 0 16px;
 
     span.plan-name {
@@ -908,7 +913,8 @@ div.billing {
 }
 
 div.identity-editor {
-  width: 391px;
+  width: 435px;
+  box-sizing: border-box;
   background-color: white;
   padding: 15px 22px;
 
@@ -1137,9 +1143,10 @@ body>.popup.billing-prompt>.frame, .first-time-billing-prompt {
   }
 
   >p.success-note {
+    box-sizing: border-box;
     background-color: #cff4c6;
     padding: 32px;
-    max-width: 500px;
+    max-width: 564px;
     margin: 1em auto;
 
     >strong {

--- a/shell/client/_grainlist.scss
+++ b/shell/client/_grainlist.scss
@@ -127,7 +127,8 @@
         }
       }
       &.td-app-icon {
-        width: 48px;
+        box-sizing: border-box;
+        width: 64px;
         padding-left: 16px;
       }
     }
@@ -148,7 +149,7 @@
           width: 24px;
           height: 24px;
         }
-        width: 48px;
+        width: 64px;
         padding-left: 16px;
       }
       &.last-used {

--- a/shell/client/shell.scss
+++ b/shell/client/shell.scss
@@ -30,6 +30,7 @@
 html {
   width: 100%;
   height: 100%;
+  box-sizing: border-box;
 }
 
 body {
@@ -40,6 +41,10 @@ body {
   font-family: "Source Sans Pro", sans-serif;
   font-weight: normal;
   background-color: white;
+}
+
+*, *:before, *:after {
+  box-sizing: inherit;
 }
 
 // Styles used by sandstorm-ui-topbar


### PR DESCRIPTION
This changeset switches to border-box box-sizing for everything by default.  This is widely considered best practice: http://www.paulirish.com/2012/box-sizing-border-box-ftw/

I did my best to audit our codebase for places where box-sizing would affect layout -- namely, elements with both a `width` or `max-width` and a `margin` or `border`.  To discover sites where layout would be affected, I manually added the rules in the last commit in Chrome to a tab open to oasis.sandstorm.io (to ensure that I discovered issues that only exist when e.g. payments are enabled), and toggled the rule on the `<html>` tag.  Where things changed appearance, I adjusted element sizes.

While there may be some subtle changes in layout that I have missed, I believe they should be generally inconsequential.

Things I specifically tested:

* Account page
* Notifications
* Referrals page
* About page
* App list page
* Grain list page
* App details page

If we discover a situation where we require `content-box` layout, we can specify `box-sizing: content-box;` on that element, which will give us the default browser behavior.