### PR TITLE
Powerbox IP capabilities

### DIFF
--- a/shell/client/_powerbox.scss
+++ b/shell/client/_powerbox.scss
@@ -43,20 +43,20 @@ body>.popup.request>.frame {
       }
     }
   }
-  >ul.candidate-grains {
+  >ul.candidate-cards {
     flex: 1;
     overflow-y: auto;
     padding: 0px;
     margin: 10px;
     margin-top: 10px;
-    >li.grain-card {
-      @extend %grain-card;
+    >li.powerbox-card {
+      @extend %powerbox-card;
     }
   }
-  >.selected-grain {
+  >.selected-card {
     flex: none;
     box-sizing: border-box;
-    >div.grain-card {
+    >div.powerbox-card {
       box-sizing: border-box;
       border: 1px solid #dddddd;
       background-color: #eeeeee;
@@ -90,7 +90,7 @@ body>.popup.request>.frame {
   }
 }
 
-%grain-card {
+%powerbox-card {
   border-top: 1px solid #dddddd;
   border-left: 1px solid #dddddd;
   border-right: 1px solid #dddddd;
@@ -101,7 +101,7 @@ body>.popup.request>.frame {
   display: block;
   vertical-align: middle;
   height: 32px;
-  >button.grain-button {
+  >button.card-button {
     @extend %unstyled-button;
     @extend %overflow-ellipsis;
     width: 100%;

--- a/shell/packages/sandstorm-ui-powerbox/package.js
+++ b/shell/packages/sandstorm-ui-powerbox/package.js
@@ -21,6 +21,8 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.use(["ecmascript", "check", "reactive-var", "templating", "tracker", "underscore", "sandstorm-db", "sandstorm-ui-topbar"], "client");
+  api.use(["ecmascript", "check"], "server");
   api.addFiles(["powerbox.html", "powerbox-client.js"], "client");
+  api.addFiles(["powerbox-server.js"], "server");
   api.export("SandstormPowerboxRequest");
 });

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -368,7 +368,7 @@ Template.powerboxRequest.onRendered(function () {
 });
 
 Template.powerboxRequest.helpers({
-  grains: function () {
+  cards: function () {
     const ref = Template.instance().data.get();
     return ref && ref.filteredCardData() || [];
   },
@@ -471,8 +471,8 @@ Template.powerboxProviderUiView.events({
   },
 });
 
-Template.grainCardButton.events({
-  "click .grain-button": function (event) {
+Template.powerboxCardButton.events({
+  "click .card-button": function (event) {
     const ref = Template.instance().data;
     ref && ref.onClick && ref.onClick();
   },

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -1,0 +1,38 @@
+Meteor.methods({
+  newFrontendRef(sessionId, frontendRefVariety) {
+    // Checks if the requester is an admin, and if so, provides a new frontendref of the desired
+    // variety, provided by the requesting user, owned by the grain for this session.
+    check(sessionId, String);
+    check(frontendRefVariety, Match.OneOf(
+      { ipNetwork: Boolean },
+      { ipInterface: Boolean },
+    ));
+
+    const db = this.connection.sandstormDb;
+    if (!db.isAdmin(this.userId)) {
+      throw new Meteor.Error(403, "User must be an admin to powerbox offer frontendrefs");
+    }
+
+    const session = db.collections.sessions.findOne(sessionId);
+    if (!session) {
+      throw new Meteor.Error(403, "Invalid session ID");
+    }
+
+    const grainId = session.grainId;
+    const apiTokenOwner = {
+      grain: {
+        grainId: grainId,
+        saveLabel: {defaultText: "Admin-provided raw outgoing network access"},
+        introducerIdentity: session.identityId,
+      },
+    };
+
+    const requirements = [{
+      userIsAdmin: Meteor.userId(),
+    }];
+
+    // TODO: refactor: reaches out into core.js
+    const sturdyRef = waitPromise(saveFrontendRef(frontendRefVariety, apiTokenOwner, requirements)).sturdyRef;
+    return sturdyRef.toString();
+  },
+});

--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -26,6 +26,8 @@
         <li class="powerbox-card">
           {{>powerboxCardButton title=title iconSrc=iconSrc id=_id onClick=callback}}
         </li>
+      {{else}}
+        <p>No grains can provide the requested interface.</p>
       {{/each}}
       </ul>
       {{else}}

--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -21,10 +21,10 @@
           <input class="search-bar" type="text" placeholder="search" value="{{ searchText }}">
         </label>
       </div>
-      <ul class="candidate-grains">
-      {{#each grains}}
-        <li class="grain-card">
-          {{>grainCardButton title=title iconSrc=iconSrc id=_id onClick=callback}}
+      <ul class="candidate-cards">
+      {{#each cards}}
+        <li class="powerbox-card">
+          {{>powerboxCardButton title=title iconSrc=iconSrc id=_id onClick=callback}}
         </li>
       {{/each}}
       </ul>
@@ -35,38 +35,39 @@
   {{/if}}
 </template>
 
-<template name="grainCardButton">
+<template name="powerboxCardButton">
   {{!-- Pure template. Expects:
-        title: String     The grain title to show in the button.
+        title: String     The title to show in the button.
       iconSrc: String     The URL for the icon image.
-           id: String     The grain id associated with this grain.  Used primarily for tests.
+           id: String     The card id associated with this card.  Used primarily for tests.
       onClick: Function   A parameterless callback function triggered on button activation.
                           Note that Blaze will unhelpfully invoke the function if it's in the data
                           context, so you may need to use a function which returns your actual
                           callback function.
   --}}
-    <button class="grain-button" data-grain-id="{{ id }}" style="background-image: url({{ iconSrc }});">{{ title }}</button>
+    <button class="card-button" data-card-id="{{ id }}" style="background-image: url({{ iconSrc }});">{{ title }}</button>
 </template>
 
-<template name="grainCard">
+<template name="powerboxCard">
   {{!-- Pure template  Expects:
-        title: String  The grain title to show in the button.
-           id: String  The grain id associated with this grain.  Used primarily for tests.
+        title: String  The title to show in the button.
+           id: String  The card id associated with this card.  Used primarily for tests.
       iconSrc: String  The URL for the icon image.
   --}}
-    <div class="grain-card" data-grain-id="{{ id }}" style="background-image: url({{ iconSrc }});">{{ title }}</div>
+    <div class="powerbox-card" data-card-id="{{ id }}" style="background-image: url({{ iconSrc }});">{{ title }}</div>
 </template>
 
 <template name="powerboxProviderUiView">
   {{!-- Pure template.  Expects:
-             _id: String     Grain ID.
-           title: String     Grain title.
-         iconSrc: String     URL to grain's app icon.
+             _id: String     Card ID.
+           title: String     Selected grain title.
+         iconSrc: String     URL to app icon.
+        viewInfo: Object     JSON rendition of Grain.UiView.ViewInfo.
       onComplete: Function   Takes a single argument, which is a roleAssignment.  Called when the
                              form is submitted.
   --}}
-  <div class="selected-grain">
-    {{>grainCard id=_id title=title iconSrc=iconSrc}}
+  <div class="selected-card">
+    {{>powerboxCard id=_id title=title iconSrc=iconSrc}}
     <form>
     <p>with permissions:</p>
     {{#each role in viewInfo.roles}}

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1460,6 +1460,7 @@ if (Meteor.isClient) {
           saveLabel: powerboxRequest.saveLabel,
           // These data come from the grain
 
+          sessionId: senderGrain.sessionId(),
           grainId: senderGrain.grainId(),
           identityId: senderGrain.identityId(),
           // Attach grain context to the request.

--- a/src/sandstorm/ip.capnp
+++ b/src/sandstorm/ip.capnp
@@ -44,7 +44,7 @@ using Util = import "util.capnp";
 using SystemPersistent = import "supervisor.capnp".SystemPersistent;
 using PowerboxCapability = import "grain.capnp".PowerboxCapability;
 
-interface IpNetwork {
+interface IpNetwork @0xa982576b7a2a2040 {
   # Capability to connect or send messages to arbitrary destinations on an IP network.
   #
   # A driver app can request this from the Powerbox in order to request "full outbound network
@@ -77,7 +77,7 @@ struct IpAddress {
   #     dest.setUpper64(0);
 }
 
-interface IpInterface {
+interface IpInterface @0xe32c506ee93ed6fa {
   # Capability to accept connections / messages on a particular network interface.
   #
   # In practice this could represent a single physical network interface, a single local IP
@@ -97,7 +97,7 @@ interface IpInterface {
   # sent to the port.
 }
 
-interface IpRemoteHost {
+interface IpRemoteHost @0x905dd76b298b3130 {
   # Capability to connect / send messages to a particular remote host accessed over an IP network.
   #
   # A driver app can request this form the Powerbox in order to request "permission to connect to
@@ -114,7 +114,7 @@ interface IpRemoteHost {
   getUdpPort @1 (portNum :UInt16) -> (port :UdpPort);
 }
 
-interface TcpPort {
+interface TcpPort @0xeab20e1af07806b4 {
   # Capability to connect to a remote network port.
   #
   # An application may request a TcpPort from the Powerbox in order to request permission to
@@ -133,7 +133,7 @@ interface TcpPort {
   # bytes via pipelining immediately.
 }
 
-interface UdpPort {
+interface UdpPort @0xc6212e1217d001ce {
   # Like `TcpPort` but for datagrams.
 
   send @0 (message :Data, returnPort :UdpPort);


### PR DESCRIPTION
Adds support for requesting `IpNetwork` and `IpInterface` capabilities.

https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-5.spk is capable of requesting and (minimally) testing both IpNetwork and IpInterface.

The IpNetwork test will make an HTTP request to http://zarvox.org/ and return the page contents.  You can see this (and indeed, the page content) in the network tab of the Chrome Dev Tools.

The IpInterface test will listen on port 8888, and write "Hello world!\n" to the first client that connects, then close the connection and provide an empty 200 response to the HTTP request that triggered it.  node will continue listening on port 8888 until the grain is stopped or deleted; I think this may be a bug in pycapnp: https://github.com/jparyani/pycapnp/issues/90