### PR TITLE
Add the Origin header in sandstorm-http-bridge.

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -1213,9 +1213,12 @@ private:
     }
     lines.add(kj::str("X-Sandstorm-Permissions: ", permissions));
     if (basePath.size() > 0) {
+      auto host = extractHostFromUrl(basePath);
+      auto protocol = extractProtocolFromUrl(basePath);
       lines.add(kj::str("X-Sandstorm-Base-Path: ", basePath));
-      lines.add(kj::str("Host: ", extractHostFromUrl(basePath)));
-      lines.add(kj::str("X-Forwarded-Proto: ", extractProtocolFromUrl(basePath)));
+      lines.add(kj::str("Host: ", host));
+      lines.add(kj::str("X-Forwarded-Proto: ", protocol));
+      lines.add(kj::str("Origin: ", protocol, "://", host));
     } else {
       // Dummy value. Some API servers (e.g. git-http-backend) fail if Host is not present.
       lines.add(kj::str("Host: sandbox"));


### PR DESCRIPTION
This adds an Origin header to every request that goes through `WebSession`.

See the [Origin RFC](http://tools.ietf.org/html/rfc6454#section-7.3), the [WebSocket RFC](https://tools.ietf.org/html/rfc6455#section-10.2), and [this discussion on sandstorm-dev](https://groups.google.com/forum/#!topic/sandstorm-dev/MaFW3v3Refw).