### PR TITLE
Add ldap login support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -70,6 +70,13 @@ shell/packages/introjs/client/*
     License URL: https://github.com/usablica/intro.js/blob/master/README.md
                  (at bottom)
 
+shell/packages/accounts-ldap/*
+    What: intro.js
+    Source URL: https://github.com/typ90/meteor-accounts-ldap
+    Copyright: Eric Typaldos
+    License: MIT
+    License URL: https://github.com/typ90/meteor-accounts-ldap/blob/master/LICENSE
+
 src/joyent-http/*
     What: Node.js HTTP parsing library
     Source URL: https://github.com/joyent/http-parser
@@ -301,4 +308,3 @@ Google's Android.
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/LICENSE
+++ b/LICENSE
@@ -71,7 +71,7 @@ shell/packages/introjs/client/*
                  (at bottom)
 
 shell/packages/accounts-ldap/*
-    What: intro.js
+    What: Meteor accounts-ldap package
     Source URL: https://github.com/typ90/meteor-accounts-ldap
     Copyright: Eric Typaldos
     License: MIT

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ IMAGES= \
     shell/public/github.svg \
     shell/public/google.svg \
     shell/public/key.svg \
+    shell/public/ldap.svg \
     shell/public/link.svg \
     shell/public/menu.svg \
     shell/public/notification.svg \

--- a/shell/.meteor/packages
+++ b/shell/.meteor/packages
@@ -26,6 +26,7 @@ sandstorm-accounts-ui
 sandstorm-accounts-packages
 sandstorm-email
 accounts-email-token
+accounts-ldap
 email
 accounts-identity
 simplesmtp

--- a/shell/.meteor/versions
+++ b/shell/.meteor/versions
@@ -1,6 +1,7 @@
 accounts-base@1.2.2
 accounts-email-token@0.1.0
 accounts-identity@0.1.0
+accounts-ldap@1.0.1
 accounts-oauth@1.1.8
 application-configuration@1.0.4
 autoupdate@1.2.4
@@ -106,6 +107,7 @@ standard-minifiers@1.0.2
 templating@1.1.5
 templating-tools@1.0.0
 tracker@1.0.9
+typ:ldapjs@0.7.3
 ui@1.0.8
 underscore@1.0.4
 url@1.0.5

--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -211,7 +211,7 @@ body>.popup.account>.frame {
     background-repeat: no-repeat;
   }
 
-  >form.email {
+  >form.email, >form.ldap {
     line-height: 32px;
     height: auto;
     background-size: 24px 24px;
@@ -247,6 +247,20 @@ body>.popup.account>.frame {
       line-height: normal;
     }
 
+    .info {
+      margin-top: 7px;
+      margin-bottom: -2px;
+
+      border-radius: 50%;
+      background-color: #444;
+      color: white;
+      width: 10px;
+      height: 10px;
+      font-size: 10px;
+      display: inline-block;
+      text-align: center;
+    }
+
     .button-box {
       text-align: right;
       padding: 0 6px;
@@ -280,20 +294,6 @@ body>.popup.account>.frame {
 
   >a {
     line-height: 24px;
-  }
-
-  .email .info {
-    margin-top: 7px;
-    margin-bottom: -2px;
-
-    border-radius: 50%;
-    background-color: #444;
-    color: white;
-    width: 10px;
-    height: 10px;
-    font-size: 10px;
-    display: inline-block;
-    text-align: center;
   }
 
   .login-button-form-submit { margin-top: 8px; }

--- a/shell/client/_account.scss
+++ b/shell/client/_account.scss
@@ -152,6 +152,12 @@ body>.popup.account>.frame {
       background-image: url("/email-m.svg");
     }
   }
+  >form.ldap {
+    background-image: url("/ldap.svg");
+    &:hover {
+      background-image: url("/ldap-m.svg");
+    }
+  }
   >a.troubleshooting {
     background-image: url("/troubleshoot.svg");
     &:hover {
@@ -401,7 +407,7 @@ body>.popup.account>.frame {
       background-position: 48px 0px;
     }
 
-    >form.email {
+    >form.email, >form.ldap {
       background-position: 48px 4px;
 
       .button-box {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -973,10 +973,10 @@ limitations under the License.
         <label>
           <input type="checkbox" name="ldapLogin" value="value" checked={{ldapEnabled}}> Enable LDAP Login
         </label><br>
-          LDAP Url: <input id="ldapUrl" type="text" name="ldapUrl" value="{{ldapUrl}}">
-          LDAP DN Pattern ($USERNAME will be replaced): <input id="ldapDnPattern" type="text" name="ldapDnPattern" value="{{ldapDnPattern}}">
-          LDAP Base Search Dn: <input id="ldapBase" type="text" name="ldapBase" value="{{ldapBase}}">
-          LDAP Name Field: <input id="ldapNameField" type="text" name="ldapNameField" value="{{ldapNameField}}">
+          <label>LDAP Url: <input id="ldapUrl" type="text" name="ldapUrl" value="{{ldapUrl}}"></label>
+          <label>LDAP DN Pattern ($USERNAME will be replaced): <input id="ldapDnPattern" type="text" name="ldapDnPattern" value="{{ldapDnPattern}}"></label>
+          <label>LDAP Base Search Dn: <input id="ldapBase" type="text" name="ldapBase" value="{{ldapBase}}"></label>
+          <label>LDAP Name Field: <input id="ldapNameField" type="text" name="ldapNameField" value="{{ldapNameField}}"></label>
         <hr>
       {{/if}}
       <span class="details">Choose which services users may use to identify themselves. Anyone can log in, but only users you {{#linkTo route="adminInvites" data=getToken}}invite{{/linkTo}} will be able to install apps or create files.</span></p>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -968,6 +968,17 @@ limitations under the License.
         </p>
       {{/with}}
       <label><input type="checkbox" name="emailTokenLogin" value="value" checked={{emailTokenEnabled}}> Enable Passwordless Email Login</label><br>
+      {{#if isFeatureKeyValid}}
+        <hr>
+        <label>
+          <input type="checkbox" name="ldapLogin" value="value" checked={{ldapEnabled}}> Enable LDAP Login
+        </label><br>
+          LDAP Url: <input id="ldapUrl" type="text" name="ldapUrl" value="{{ldapUrl}}">
+          LDAP DN Pattern ($USERNAME will be replaced): <input id="ldapDnPattern" type="text" name="ldapDnPattern" value="{{ldapDnPattern}}">
+          LDAP Base Search Dn: <input id="ldapBase" type="text" name="ldapBase" value="{{ldapBase}}">
+          LDAP Name Field: <input id="ldapNameField" type="text" name="ldapNameField" value="{{ldapNameField}}">
+        <hr>
+      {{/if}}
       <span class="details">Choose which services users may use to identify themselves. Anyone can log in, but only users you {{#linkTo route="adminInvites" data=getToken}}invite{{/linkTo}} will be able to install apps or create files.</span></p>
     <p>SMTP Url: <button id="admin-settings-send-toggle">Test</button><input id="smptUrl" type="text" name="smtpUrl" value="{{smtpUrl}}"><br>
       <span class="details">Address of an SMTP relay server, like <code>smtp://user:pass@host:port</code>, which will be used by email apps and to send {{#linkTo route="adminInvites" data=getToken}}email invites{{/linkTo}}. The SMTP server should be configured to allow sending email from your Sandstorm domain and from email addresses that will be used to send invites. Read the <a href="https://docs.sandstorm.io/en/latest/administering/email/#outgoing-smtp">docs</a> for more details.</span>

--- a/shell/lib/db-deprecated.js
+++ b/shell/lib/db-deprecated.js
@@ -69,6 +69,8 @@ if (Meteor.isServer) {
   });
 
   Meteor.startup(() => { globalDb.migrateToLatest(); });
+  LDAP_DEFAULTS.url = globalDb.getLdapUrl();
+  LDAP_DEFAULTS.base = globalDb.getLdapBase();
 }
 
 if (Meteor.isClient) {

--- a/shell/packages/accounts-email-token/token_server.js
+++ b/shell/packages/accounts-email-token/token_server.js
@@ -52,8 +52,13 @@ function consumeToken(user, token) {
 
 // Handler to login with a token.
 Accounts.registerLoginHandler("email", function (options) {
-  if (!options.email)
+  if (!options.email) {
     return undefined; // don't handle
+  }
+
+  if (!Accounts.identityServices.email.isEnabled()) {
+    throw new Meteor.Error(403, "Email identity service is disabled.");
+  }
 
   options = options.email;
   check(options, {

--- a/shell/packages/accounts-ldap/LICENSE
+++ b/shell/packages/accounts-ldap/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/shell/packages/accounts-ldap/README.md
+++ b/shell/packages/accounts-ldap/README.md
@@ -1,0 +1,168 @@
+Meteor Package accounts-ldap
+============================
+
+This is inspired by [emgee3's Accounts Ldap for meteor package](https://github.com/emgee3/meteor-accounts-ldap). emgee3's package is a proof of concept - this package is an attempt to move past proof of concept and create something production ready and tested.
+
+
+Installation
+------------
+
+You can add this package through Atmosphere by typing:
+
+`meteor add typ:accounts-ldap` from the command line.
+
+**OR if you'd like to customize it a bit:**
+
+Clone this repo and copy it to `/packages` in your Meteor project.
+
+
+Usage
+-----
+
+#### Server Side Configuration
+The package exposes a global variable called `LDAP_DEFAULTS` on the server side. You **must** specify the `LDAP_DEFAULTS.url` at a minimum. Other options for the defaults are as follows:
+
+##### Defaults
+
+`LDAP_DEFAULTS.port`: Default port is the ldap default of 389.
+
+`LDAP_DEFAULTS.dn`: The ldap dn you want to authenticate on and search. **Chances are you'll want to set this when calling Meteor.loginWithLdap() from client side. See Client Side Configuration for more details**
+
+`LDAP_DEFAULTS.createNewUser`: Boolean value with a default of `true`. This will create a new Meteor.user if the user has not yet been created with the entered ldap email/username.
+
+`LDAP_DFAULTS.defaultDomain`: Specify the email domain to be used when creating a new user on login. Defaults to `false` - so if the user has entered xyz@site.com and `defaultDomain` is not set, then their email will be saved as xyz@site.com.
+
+`LDAP_DEFAULTS.searchResultsProfileMap`: This can be used if there are attributes at your specified dn that you'd like to use to set properties when creating a new user's profile.
+
+For example, if the results had a 'cn' value of the user's name and a 'tn' value of their phone number, you'd set the `searchResultsProfileMap` to this:
+
+```
+LDAP_DEFAULTS.searchResultsProfileMap = [{
+  resultKey: 'cn',
+  profileProperty: 'name'
+}, {
+  resultKey: 'tn',
+  profileProperty: 'phoneNumber'
+}],
+
+// This would create a user profile object that looks like this:
+user.profile = {
+    name: 'Whatever the cn value was',
+    phoneNumber: 'Whatever the tn value was'
+}
+```
+
+`LDAP_DEFAULTS.base`: This is the base dn used for searches if the searchResultsProfileMap is set.
+
+
+#### LDAPS Support
+
+If you want to use `ldaps` to implement secure authentication, you also need to provide an SSL certificate
+(e.g. in the shape of a `ssl.pem` file)
+
+Simply set the following defaults in some server-side code:
+
+```
+LDAP_DEFAULTS.ldapsCertificate = Assets.getText('ldaps/ssl.pem'); // asset location of the SSL certificate
+LDAP_DEFAULTS.port = 636; // default port for LDAPS
+LDAP_DEFAULTS.url = 'ldaps://my-ldap-host.com'; // ldaps protocol
+```
+
+This example configuration will require the `ssl.pem` file to be located in `<your-project-root>/private/ldap/ssl.pem`.
+
+#### Client Side Configuration
+
+The package exposes a new Meteor login method `Meteor.loginWithLDAP()` which can be called from the client. The usual user and password are required. The third parameter is for custom LDAP options. You'll most likely want to pass in the customLdapOptions.dn on the options object.
+
+An example login call might look like this:
+
+```
+Meteor.loginWithLDAP(username, password, {
+    // The dn value depends on what you want to search/auth against
+    // The structure will depend on how your ldap server
+    // is configured or structured.
+  dn: "uid=" + username + ",cn=users,dc=whatever,dc=valuesyouneed",
+    // The search value is optional. Set it if your search does not
+    // work with the bind dn.
+  search: "(objectclass=*)"
+}, function(err) {
+  if (err)
+    console.log(err.reason);
+});
+```
+
+#### Search Before Bind
+
+In some scenarios, your login names might not directly correspond to the `dn` of the LDAP record.
+This requires to search for the `dn`, before you can authenticate.
+
+If you don't know the `dn`, simply provide the attribute to search for to determine the `dn` (e.g. searching by email):
+
+```
+Meteor.loginWithLDAP(email, password, {
+		// search by email (all other options are configured server side)
+		searchBeforeBind: {
+			mail: email
+		}
+    }, function(err) {
+    	if (err) {
+    		// login failed
+		}
+		else {
+			// login successful
+		}
+    }
+);
+```
+
+In above example the LDAP record needs to have an attribute `mail` which will be searched for. The first matching record
+will be used to determine the `dn` of the LDAP record. Then the binding will be executed using the provided password
+and the `dn` retrieved via the search.
+
+If you provide the `dn` as option for the `loginWithLDAP` call, the search will NOT be executed. Also don't configure
+the `LDAP_DEFAULTS.dn` as it has the same effect.
+
+
+Issues + Notes
+-----
+* If your app requires that only LDAP authorized users should be able to login, it is strongly recommended that you
+include the following server-side code to prevent a user from gaining access through Accounts.createUser() on the client, which will otherwise automatically login a newly created (non-LDAP) user:
+```
+//on the server
+Meteor.startup(function () {
+  Accounts.config({
+  	forbidClientAccountCreation: true
+  });
+});
+```
+* The LDAP dn is specific to your Active Directory. Talk to whoever manages it to figure out what would work best.
+* ***Because the package binds/authenticates with LDAP server-side, the user/password are sent to the server unencrypted. I still need to figure out a solution for this.***
+* Right now Node throws a warning on meteor startup: `{ [Error: Cannot find module './build/Debug/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }` because optional dependencies are missing. It doesn't seem to affect the ldapjs functionality, but I'm still trying to figure out how to squelch it. See [this thread](https://github.com/mcavage/node-ldapjs/issues/64). As a workaround, you can re-install the included dtrace-provider NPM package: `<project-root>/.meteor/local/build/programs/server/npm/typ_ldapjs/node_modules/ldapjs$ sudo npm install dtrace-provider`
+
+
+Active Directory
+-----
+
+Using AD you can bind using domain\username. This example works for me:
+
+```
+//on the server
+LDAP_DEFAULTS.base = 'OU=User,DC=your,DC=company,DC=com';
+
+//on the client
+var domain = "yourDomain";
+
+Meteor.loginWithLDAP(user, password,
+  { dn: domain + '\\' + user, search: '(sAMAccountName=' + user + ')' } , function(err, result) { ... }
+);
+```
+
+
+Going Forward
+-----
+Please feel free to fork and help improve the repo. I'm very unfamiliar with LDAP and built this package in a way that is probably really specific to my LDAP server configuration. I'm sure configurations vary for everyone, so any suggestions as to how I can make the package more agnostic are **much appreciated**.
+
+
+Roadmap
+-----
+TODO - need to figure out what features are missing and might make sense to add...

--- a/shell/packages/accounts-ldap/ldap_client.js
+++ b/shell/packages/accounts-ldap/ldap_client.js
@@ -1,0 +1,43 @@
+// Pass in username, password as normal
+// customLdapOptions should be passed in if you want to override LDAP_DEFAULTS
+// on any particular call (if you have multiple ldap servers you'd like to connect to)
+// You'll likely want to set the dn value here {dn: "..."}
+Meteor.loginWithLDAP = function (user, password, customLdapOptions, callback) {
+    // Retrieve arguments as array
+    var args = [];
+    for (var i = 0; i < arguments.length; i++) {
+        args.push(arguments[i]);
+    }
+    // Pull username and password
+    user = args.shift();
+    password = args.shift();
+
+    // Check if last argument is a function
+    // if it is, pop it off and set callback to it
+    if (typeof args[args.length - 1] == 'function') callback = args.pop(); else callback = null;
+
+    // if args still holds options item, grab it
+    if (args.length > 0) customLdapOptions = args.shift(); else customLdapOptions = {};
+
+    // Set up loginRequest object
+    var loginRequest = _.defaults({
+        username: user,
+        ldapPass: password
+    }, {
+        ldap: true,
+        ldapOptions: customLdapOptions
+    });
+
+    Accounts.callLoginMethod({
+        // Call login method with ldap = true
+        // This will hook into our login handler for ldap
+        methodArguments: [loginRequest],
+        userCallback: function (error, result) {
+            if (error) {
+                callback && callback(error);
+            } else {
+                callback && callback();
+            }
+        }
+    });
+};

--- a/shell/packages/accounts-ldap/ldap_client.js
+++ b/shell/packages/accounts-ldap/ldap_client.js
@@ -3,41 +3,41 @@
 // on any particular call (if you have multiple ldap servers you'd like to connect to)
 // You'll likely want to set the dn value here {dn: "..."}
 Meteor.loginWithLDAP = function (user, password, customLdapOptions, callback) {
-    // Retrieve arguments as array
-    var args = [];
-    for (var i = 0; i < arguments.length; i++) {
-        args.push(arguments[i]);
-    }
-    // Pull username and password
-    user = args.shift();
-    password = args.shift();
+  // Retrieve arguments as array
+  var args = [];
+  for (var i = 0; i < arguments.length; i++) {
+    args.push(arguments[i]);
+  }
+  // Pull username and password
+  user = args.shift();
+  password = args.shift();
 
-    // Check if last argument is a function
-    // if it is, pop it off and set callback to it
-    if (typeof args[args.length - 1] == 'function') callback = args.pop(); else callback = null;
+  // Check if last argument is a function
+  // if it is, pop it off and set callback to it
+  if (typeof args[args.length - 1] == "function") callback = args.pop(); else callback = null;
 
-    // if args still holds options item, grab it
-    if (args.length > 0) customLdapOptions = args.shift(); else customLdapOptions = {};
+  // if args still holds options item, grab it
+  if (args.length > 0) customLdapOptions = args.shift(); else customLdapOptions = {};
 
-    // Set up loginRequest object
-    var loginRequest = _.defaults({
-        username: user,
-        ldapPass: password
-    }, {
-        ldap: true,
-        ldapOptions: customLdapOptions
-    });
+  // Set up loginRequest object
+  var loginRequest = _.defaults({
+    username: user,
+    ldapPass: password,
+  }, {
+    ldap: true,
+    ldapOptions: customLdapOptions,
+  });
 
-    Accounts.callLoginMethod({
-        // Call login method with ldap = true
-        // This will hook into our login handler for ldap
-        methodArguments: [loginRequest],
-        userCallback: function (error, result) {
-            if (error) {
-                callback && callback(error);
-            } else {
-                callback && callback();
-            }
-        }
-    });
+  Accounts.callLoginMethod({
+    // Call login method with ldap = true
+    // This will hook into our login handler for ldap
+    methodArguments: [loginRequest],
+    userCallback: function (error, result) {
+      if (error) {
+        callback && callback(error);
+      } else {
+        callback && callback();
+      }
+    },
+  });
 };

--- a/shell/packages/accounts-ldap/ldap_client.js
+++ b/shell/packages/accounts-ldap/ldap_client.js
@@ -4,8 +4,8 @@
 // You'll likely want to set the dn value here {dn: "..."}
 Meteor.loginWithLDAP = function (user, password, customLdapOptions, callback) {
   // Retrieve arguments as array
-  var args = [];
-  for (var i = 0; i < arguments.length; i++) {
+  let args = [];
+  for (let i = 0; i < arguments.length; i++) {
     args.push(arguments[i]);
   }
   // Pull username and password
@@ -20,7 +20,7 @@ Meteor.loginWithLDAP = function (user, password, customLdapOptions, callback) {
   if (args.length > 0) customLdapOptions = args.shift(); else customLdapOptions = {};
 
   // Set up loginRequest object
-  var loginRequest = _.defaults({
+  let loginRequest = _.defaults({
     username: user,
     ldapPass: password,
   }, {

--- a/shell/packages/accounts-ldap/ldap_server.js
+++ b/shell/packages/accounts-ldap/ldap_server.js
@@ -1,21 +1,21 @@
-Future = Npm.require('fibers/future');
+Future = Npm.require("fibers/future");
 
 // At a minimum, set up LDAP_DEFAULTS.url and .dn according to
 // your needs. url should appear as 'ldap://your.url.here'
 // dn should appear in normal ldap format of comma separated attribute=value
 // e.g. 'uid=someuser,cn=users,dc=somevalue'
 LDAP_DEFAULTS = {
-    url: false,
-    port: '389',
-    dn: false,
-    searchDN: false,
-    searchCredentials: false,
-    createNewUser: true,
-    defaultDomain: false,
-    searchResultsProfileMap: false,
-    base: null,
-    search: '(objectclass=*)',
-    ldapsCertificate: false
+  url: false,
+  port: "389",
+  dn: false,
+  searchDN: false,
+  searchCredentials: false,
+  createNewUser: true,
+  defaultDomain: false,
+  searchResultsProfileMap: false,
+  base: null,
+  search: "(objectclass=*)",
+  ldapsCertificate: false,
 };
 
 /**
@@ -23,22 +23,22 @@ LDAP_DEFAULTS = {
  @constructor
  */
 var LDAP = function (options) {
-    // Set options
-    this.options = _.defaults(options, LDAP_DEFAULTS);
+  // Set options
+  this.options = _.defaults(options, LDAP_DEFAULTS);
 
-    // Make sure options have been set
-    try {
-        check(this.options.url, String);
-        //check(this.options.dn, String);
-    } catch (e) {
-        throw new Meteor.Error('Bad Defaults', 'Options not set. Make sure to set LDAP_DEFAULTS.url and LDAP_DEFAULTS.dn!');
-    }
+  // Make sure options have been set
+  try {
+    check(this.options.url, String);
+    //check(this.options.dn, String);
+  } catch (e) {
+    throw new Meteor.Error("Bad Defaults", "Options not set. Make sure to set LDAP_DEFAULTS.url and LDAP_DEFAULTS.dn!");
+  }
 
-    // Because NPM ldapjs module has some binary builds,
-    // We had to create a wraper package for it and build for
-    // certain architectures. The package typ:ldap-js exports
-    // 'MeteorWrapperLdapjs' which is a wrapper for the npm module
-    this.ldapjs = MeteorWrapperLdapjs;
+  // Because NPM ldapjs module has some binary builds,
+  // We had to create a wraper package for it and build for
+  // certain architectures. The package typ:ldap-js exports
+  // 'MeteorWrapperLdapjs' which is a wrapper for the npm module
+  this.ldapjs = MeteorWrapperLdapjs;
 };
 
 /**
@@ -53,312 +53,306 @@ var LDAP = function (options) {
  */
 LDAP.prototype.ldapCheck = function (options) {
 
-    var self = this;
+  var self = this;
 
-    options = options || {};
+  options = options || {};
 
-    if (options.hasOwnProperty('username') && options.hasOwnProperty('ldapPass')) {
+  if (options.hasOwnProperty("username") && options.hasOwnProperty("ldapPass")) {
 
-        var ldapAsyncFut = new Future();
+    var ldapAsyncFut = new Future();
 
+    // Create ldap client
+    var fullUrl = self.options.url + ":" + self.options.port;
+    var client = null;
 
-        // Create ldap client
-        var fullUrl = self.options.url + ':' + self.options.port;
-        var client = null;
-
-        if (self.options.url.indexOf('ldaps://') === 0) {
-            client = self.ldapjs.createClient({
-                url: fullUrl,
-                tlsOptions: {
-                    ca: [self.options.ldapsCertificate]
-                }
-            });
-        }
-        else {
-            client = self.ldapjs.createClient({
-                url: fullUrl
-            });
-        }
-
-
-        // Slide @xyz.whatever from username if it was passed in
-        // and replace it with the domain specified in defaults
-        var emailSliceIndex = options.username.indexOf('@');
-        var username;
-        var domain = self.options.defaultDomain;
-
-        // If user appended email domain, strip it out
-        // And use the defaults.defaultDomain if set
-        if (emailSliceIndex !== -1) {
-            username = options.username.substring(0, emailSliceIndex);
-            domain = domain || options.username.substring((emailSliceIndex + 1), options.username.length);
-        } else {
-            username = options.username;
-        }
-
-
-        // If DN is provided, use it to bind
-        if (self.options.dn) {
-            // Attempt to bind to ldap server with provided info
-            client.bind(self.options.searchDN || self.options.dn, self.options.searchCredentials || options.ldapPass, function (err) {
-                try {
-                    if (err) {
-                        // Bind failure, return error
-                        throw new Meteor.Error(err.code, err.message);
-                    }
-
-                    var handleSearchProfile = function (retObject, bindAfterSearch) {
-                        retObject.emptySearch = true;
-
-                        // construct list of ldap attributes to fetch
-                        var attributes = [];
-                        if (self.options.searchResultsProfileMap) {
-                            self.options.searchResultsProfileMap.map(function (item) {
-                                attributes.push(item.resultKey);
-                            });
-                        }
-
-                        // use base if given, else the dn for the ldap search
-                        var searchBase = self.options.base || self.options.dn;
-                        var searchOptions = {
-                            scope: 'sub',
-                            sizeLimit: 1,
-                            attributes: attributes,
-                            filter: self.options.search
-                        };
-
-                        client.search(searchBase, searchOptions, function (err, res) {
-                            if (err) {
-                                ldapAsyncFut.return({
-                                    error: err
-                                });
-                            }
-
-                            res.on('searchEntry', function (entry) {
-                                retObject.emptySearch = false;
-                                // Add entry results to return object
-                                retObject.searchResults = entry.object;
-                                if (bindAfterSearch) {
-                                    client.bind(retObject.searchResults.dn, options.ldapPass, function (err) {
-                                        try {
-                                            if (err) {
-                                                throw new Meteor.Error(err.code, err.message);
-                                            }
-                                            ldapAsyncFut.return(retObject);
-                                        } catch (e) {
-                                            ldapAsyncFut.return({
-                                                error: e
-                                            });
-                                        }
-                                    })
-                                } else ldapAsyncFut.return(retObject);
-                            });
-
-                            res.on('end', function () {
-                                ldapAsyncFut.return(retObject);
-                            });
-
-                        });
-                    };
-
-                    var retObject = {
-                        username: username,
-                        searchResults: null,
-                        email: domain ? username + '@' + domain : false
-                    };
-
-                    if (self.options.searchDN) {
-                        handleSearchProfile(retObject, true);
-                    } else if (self.options.searchResultsProfileMap) {
-                        handleSearchProfile(retObject, false);
-                    } else {
-                        ldapAsyncFut.return(retObject);
-                    }
-
-                } catch (e) {
-                    ldapAsyncFut.return({
-                        error: e
-                    });
-                }
-            });
-        }
-        // DN not provided, search for DN and use result to bind
-        else if (typeof self.options.searchBeforeBind !== undefined) {
-            // initialize result
-            var retObject = {
-                username: username,
-                email: domain ? username + '@' + domain : false,
-                emptySearch: true,
-                searchResults: {}
-            };
-
-            // compile attribute list to return
-            var searchAttributes = ['dn'];
-            self.options.searchResultsProfileMap.map(function (item) {
-                searchAttributes.push(item.resultKey);
-            });
-
-
-            var filter = self.options.search;
-            Object.keys(options.ldapOptions.searchBeforeBind).forEach(function (searchKey) {
-                filter = '&' + filter + '(' + searchKey + '=' + options.ldapOptions.searchBeforeBind[searchKey] + ')';
-            });
-            var searchOptions = {
-                scope: 'sub',
-                sizeLimit: 1,
-                filter: filter
-            };
-
-            // perform LDAP search to determine DN
-            client.search(self.options.base, searchOptions, function (err, res) {
-                retObject.emptySearch = true;
-                res.on('searchEntry', function (entry) {
-                    retObject.dn = entry.objectName;
-                    retObject.username = retObject.dn;
-                    retObject.emptySearch = false;
-
-                    // Return search results if specified
-                    if (self.options.searchResultsProfileMap) {
-                        // construct list of ldap attributes to fetch
-                        self.options.searchResultsProfileMap.map(function (item) {
-                            retObject.searchResults[item.resultKey] = entry.object[item.resultKey];
-                        });
-                    }
-
-                    // use the determined DN to bind
-                    client.bind(entry.objectName, options.ldapPass, function (err) {
-                        try {
-                            if (err) {
-                                throw new Meteor.Error(err.code, err.message);
-                            }
-                            else {
-                                ldapAsyncFut.return(retObject);
-                            }
-                        }
-                        catch (e) {
-                            ldapAsyncFut.return({
-                                error: e
-                            });
-                        }
-                    });
-                });
-                // If no dn is found, return as is.
-                res.on('end', function (result) {
-                    if (retObject.dn === undefined) {
-                        ldapAsyncFut.return(retObject);
-                    }
-                });
-            });
-        }
-
-        return ldapAsyncFut.wait();
-
-    } else {
-        throw new Meteor.Error(403, 'Missing LDAP Auth Parameter');
+    if (self.options.url.indexOf("ldaps://") === 0) {
+      client = self.ldapjs.createClient({
+        url: fullUrl,
+        tlsOptions: {
+          ca: [self.options.ldapsCertificate],
+        },
+      });
+    }    else {
+      client = self.ldapjs.createClient({
+        url: fullUrl,
+      });
     }
 
-};
+    // Slide @xyz.whatever from username if it was passed in
+    // and replace it with the domain specified in defaults
+    var emailSliceIndex = options.username.indexOf("@");
+    var username;
+    var domain = self.options.defaultDomain;
 
+    // If user appended email domain, strip it out
+    // And use the defaults.defaultDomain if set
+    if (emailSliceIndex !== -1) {
+      username = options.username.substring(0, emailSliceIndex);
+      domain = domain || options.username.substring((emailSliceIndex + 1), options.username.length);
+    } else {
+      username = options.username;
+    }
+
+    // If DN is provided, use it to bind
+    if (self.options.dn) {
+      // Attempt to bind to ldap server with provided info
+      client.bind(self.options.searchDN || self.options.dn, self.options.searchCredentials ||
+          options.ldapPass,
+          function (err) {
+        try {
+          if (err) {
+            // Bind failure, return error
+            throw new Meteor.Error(err.code, err.message);
+          }
+
+          var handleSearchProfile = function (retObject, bindAfterSearch) {
+            retObject.emptySearch = true;
+
+            // construct list of ldap attributes to fetch
+            var attributes = [];
+            if (self.options.searchResultsProfileMap) {
+              self.options.searchResultsProfileMap.map(function (item) {
+                attributes.push(item.resultKey);
+              });
+            }
+
+            // use base if given, else the dn for the ldap search
+            var searchBase = self.options.base || self.options.dn;
+            var searchOptions = {
+              scope: "sub",
+              sizeLimit: 1,
+              attributes: attributes,
+              filter: self.options.search,
+            };
+
+            client.search(searchBase, searchOptions, function (err, res) {
+              if (err) {
+                ldapAsyncFut.return({
+                  error: err,
+                });
+              }
+
+              res.on("searchEntry", function (entry) {
+                retObject.emptySearch = false;
+                // Add entry results to return object
+                retObject.searchResults = entry.object;
+                if (bindAfterSearch) {
+                  client.bind(retObject.searchResults.dn, options.ldapPass, function (err) {
+                    try {
+                      if (err) {
+                        throw new Meteor.Error(err.code, err.message);
+                      }
+
+                      ldapAsyncFut.return(retObject);
+                    } catch (e) {
+                      ldapAsyncFut.return({
+                        error: e,
+                      });
+                    }
+                  });
+                } else ldapAsyncFut.return(retObject);
+              });
+
+              res.on("end", function () {
+                ldapAsyncFut.return(retObject);
+              });
+
+            });
+          };
+
+          var retObject = {
+            username: username,
+            searchResults: null,
+            email: domain ? username + "@" + domain : false,
+          };
+
+          if (self.options.searchDN) {
+            handleSearchProfile(retObject, true);
+          } else if (self.options.searchResultsProfileMap) {
+            handleSearchProfile(retObject, false);
+          } else {
+            ldapAsyncFut.return(retObject);
+          }
+
+        } catch (e) {
+          ldapAsyncFut.return({
+            error: e,
+          });
+        }
+      });
+    }
+    // DN not provided, search for DN and use result to bind
+    else if (typeof self.options.searchBeforeBind !== undefined) {
+      // initialize result
+      var retObject = {
+        username: username,
+        email: domain ? username + "@" + domain : false,
+        emptySearch: true,
+        searchResults: {},
+      };
+
+      // compile attribute list to return
+      var searchAttributes = ["dn"];
+      self.options.searchResultsProfileMap.map(function (item) {
+        searchAttributes.push(item.resultKey);
+      });
+
+      var filter = self.options.search;
+      Object.keys(options.ldapOptions.searchBeforeBind).forEach(function (searchKey) {
+        filter = "&" + filter + "(" + searchKey + "=" + options.ldapOptions.searchBeforeBind[searchKey] + ")";
+      });
+
+      var searchOptions = {
+        scope: "sub",
+        sizeLimit: 1,
+        filter: filter,
+      };
+
+      // perform LDAP search to determine DN
+      client.search(self.options.base, searchOptions, function (err, res) {
+        retObject.emptySearch = true;
+        res.on("searchEntry", function (entry) {
+          retObject.dn = entry.objectName;
+          retObject.username = retObject.dn;
+          retObject.emptySearch = false;
+
+          // Return search results if specified
+          if (self.options.searchResultsProfileMap) {
+            // construct list of ldap attributes to fetch
+            self.options.searchResultsProfileMap.map(function (item) {
+              retObject.searchResults[item.resultKey] = entry.object[item.resultKey];
+            });
+          }
+
+          // use the determined DN to bind
+          client.bind(entry.objectName, options.ldapPass, function (err) {
+            try {
+              if (err) {
+                throw new Meteor.Error(err.code, err.message);
+              }              else {
+                ldapAsyncFut.return(retObject);
+              }
+            }
+            catch (e) {
+              ldapAsyncFut.return({
+                error: e,
+              });
+            }
+          });
+        });
+        // If no dn is found, return as is.
+        res.on("end", function (result) {
+          if (retObject.dn === undefined) {
+            ldapAsyncFut.return(retObject);
+          }
+        });
+      });
+    }
+
+    return ldapAsyncFut.wait();
+
+  } else {
+    throw new Meteor.Error(403, "Missing LDAP Auth Parameter");
+  }
+
+};
 
 // Register login handler with Meteor
 // Here we create a new LDAP instance with options passed from
 // Meteor.loginWithLDAP on client side
 // @param {Object} loginRequest will consist of username, ldapPass, ldap, and ldapOptions
-Accounts.registerLoginHandler('ldap', function (loginRequest) {
-    // If 'ldap' isn't set in loginRequest object,
-    // then this isn't the proper handler (return undefined)
-    if (!loginRequest.ldap) {
-        return undefined;
+Accounts.registerLoginHandler("ldap", function (loginRequest) {
+  // If 'ldap' isn't set in loginRequest object,
+  // then this isn't the proper handler (return undefined)
+  if (!loginRequest.ldap) {
+    return undefined;
+  }
+
+  // Instantiate LDAP with options
+  var userOptions = loginRequest.ldapOptions || {};
+  var ldapObj = new LDAP(userOptions);
+
+  // Call ldapCheck and get response
+  var ldapResponse = ldapObj.ldapCheck(loginRequest);
+
+  if (ldapResponse.error) {
+    return {
+      userId: null,
+      error: ldapResponse.error,
+    };
+  }  else if (ldapResponse.emptySearch) {
+    return {
+      userId: null,
+      error: new Meteor.Error(403, "User not found in LDAP"),
+    };
+  }  else {
+    // Set initial userId and token vals
+    var userId = null;
+    var stampedToken = {
+      token: null,
+    };
+
+    // Look to see if user already exists
+    var user = Meteor.users.findOne({
+      username: ldapResponse.username,
+    });
+
+    // Login user if they exist
+    if (user) {
+      userId = user._id;
+
+      // Create hashed token so user stays logged in
+      stampedToken = Accounts._generateStampedLoginToken();
+      var hashStampedToken = Accounts._hashStampedToken(stampedToken);
+      // Update the user's token in mongo
+      Meteor.users.update(userId, {
+        $push: {
+          "services.resume.loginTokens": hashStampedToken,
+        },
+      });
     }
+    // Otherwise create user if option is set
+    else if (ldapObj.options.createNewUser) {
+      var userObject = {
+        username: ldapResponse.username,
+      };
+      // Set email
+      if (ldapResponse.email) userObject.email = ldapResponse.email;
 
-    // Instantiate LDAP with options
-    var userOptions = loginRequest.ldapOptions || {};
-    var ldapObj = new LDAP(userOptions);
+      // Set profile values if specified in searchResultsProfileMap
+      if (ldapResponse.searchResults && ldapObj.options.searchResultsProfileMap.length > 0) {
 
-    // Call ldapCheck and get response
-    var ldapResponse = ldapObj.ldapCheck(loginRequest);
+        var profileMap = ldapObj.options.searchResultsProfileMap;
+        var profileObject = {};
 
-    if (ldapResponse.error) {
-        return {
-            userId: null,
-            error: ldapResponse.error
-        };
-    }
-    else if (ldapResponse.emptySearch) {
-        return {
-            userId: null,
-            error: new Meteor.Error(403, 'User not found in LDAP')
-        };
-    }
-    else {
-        // Set initial userId and token vals
-        var userId = null;
-        var stampedToken = {
-            token: null
-        };
+        // Loop through profileMap and set values on profile object
+        for (var i = 0; i < profileMap.length; i++) {
+          var resultKey = profileMap[i].resultKey;
 
-        // Look to see if user already exists
-        var user = Meteor.users.findOne({
-            username: ldapResponse.username
-        });
+          // If our search results have the specified property, set the profile property to its value
+          if (ldapResponse.searchResults.hasOwnProperty(resultKey)) {
+            profileObject[profileMap[i].profileProperty] = ldapResponse.searchResults[resultKey];
+          }
 
-        // Login user if they exist
-        if (user) {
-            userId = user._id;
-
-            // Create hashed token so user stays logged in
-            stampedToken = Accounts._generateStampedLoginToken();
-            var hashStampedToken = Accounts._hashStampedToken(stampedToken);
-            // Update the user's token in mongo
-            Meteor.users.update(userId, {
-                $push: {
-                    'services.resume.loginTokens': hashStampedToken
-                }
-            });
         }
-        // Otherwise create user if option is set
-        else if (ldapObj.options.createNewUser) {
-            var userObject = {
-                username: ldapResponse.username
-            };
-            // Set email
-            if (ldapResponse.email) userObject.email = ldapResponse.email;
+        // Set userObject profile
+        userObject.profile = profileObject;
+      }
 
-            // Set profile values if specified in searchResultsProfileMap
-            if (ldapResponse.searchResults && ldapObj.options.searchResultsProfileMap.length > 0) {
-
-                var profileMap = ldapObj.options.searchResultsProfileMap;
-                var profileObject = {};
-
-                // Loop through profileMap and set values on profile object
-                for (var i = 0; i < profileMap.length; i++) {
-                    var resultKey = profileMap[i].resultKey;
-
-                    // If our search results have the specified property, set the profile property to its value
-                    if (ldapResponse.searchResults.hasOwnProperty(resultKey)) {
-                        profileObject[profileMap[i].profileProperty] = ldapResponse.searchResults[resultKey];
-                    }
-
-                }
-                // Set userObject profile
-                userObject.profile = profileObject;
-            }
-
-
-            userId = Accounts.createUser(userObject);
-        } else {
-            // Ldap success, but no user created
-            console.log('LDAP Authentication succeeded for ' + ldapResponse.username + ', but no user exists in Meteor. Either create the user manually or set LDAP_DEFAULTS.createNewUser to true');
-            return {
-                userId: null,
-                error: new Meteor.Error(403, 'User found in LDAP but not in application')
-            };
-        }
-
-        return {
-            userId: userId,
-            token: stampedToken.token
-        };
+      userId = Accounts.createUser(userObject);
+    } else {
+      // Ldap success, but no user created
+      console.log("LDAP Authentication succeeded for " + ldapResponse.username + ", but no user exists in Meteor. Either create the user manually or set LDAP_DEFAULTS.createNewUser to true");
+      return {
+        userId: null,
+        error: new Meteor.Error(403, "User found in LDAP but not in application"),
+      };
     }
+
+    return {
+      userId: userId,
+      token: stampedToken.token,
+    };
+  }
 
 });

--- a/shell/packages/accounts-ldap/ldap_server.js
+++ b/shell/packages/accounts-ldap/ldap_server.js
@@ -1,0 +1,364 @@
+Future = Npm.require('fibers/future');
+
+// At a minimum, set up LDAP_DEFAULTS.url and .dn according to
+// your needs. url should appear as 'ldap://your.url.here'
+// dn should appear in normal ldap format of comma separated attribute=value
+// e.g. 'uid=someuser,cn=users,dc=somevalue'
+LDAP_DEFAULTS = {
+    url: false,
+    port: '389',
+    dn: false,
+    searchDN: false,
+    searchCredentials: false,
+    createNewUser: true,
+    defaultDomain: false,
+    searchResultsProfileMap: false,
+    base: null,
+    search: '(objectclass=*)',
+    ldapsCertificate: false
+};
+
+/**
+ @class LDAP
+ @constructor
+ */
+var LDAP = function (options) {
+    // Set options
+    this.options = _.defaults(options, LDAP_DEFAULTS);
+
+    // Make sure options have been set
+    try {
+        check(this.options.url, String);
+        //check(this.options.dn, String);
+    } catch (e) {
+        throw new Meteor.Error('Bad Defaults', 'Options not set. Make sure to set LDAP_DEFAULTS.url and LDAP_DEFAULTS.dn!');
+    }
+
+    // Because NPM ldapjs module has some binary builds,
+    // We had to create a wraper package for it and build for
+    // certain architectures. The package typ:ldap-js exports
+    // 'MeteorWrapperLdapjs' which is a wrapper for the npm module
+    this.ldapjs = MeteorWrapperLdapjs;
+};
+
+/**
+ * Attempt to bind (authenticate) ldap
+ * and perform a dn search if specified
+ *
+ * @method ldapCheck
+ *
+ * @param {Object} options  Object with username, ldapPass and overrides for LDAP_DEFAULTS object.
+ * Additionally the searchBeforeBind parameter can be specified, which is used to search for the DN
+ * if not provided.
+ */
+LDAP.prototype.ldapCheck = function (options) {
+
+    var self = this;
+
+    options = options || {};
+
+    if (options.hasOwnProperty('username') && options.hasOwnProperty('ldapPass')) {
+
+        var ldapAsyncFut = new Future();
+
+
+        // Create ldap client
+        var fullUrl = self.options.url + ':' + self.options.port;
+        var client = null;
+
+        if (self.options.url.indexOf('ldaps://') === 0) {
+            client = self.ldapjs.createClient({
+                url: fullUrl,
+                tlsOptions: {
+                    ca: [self.options.ldapsCertificate]
+                }
+            });
+        }
+        else {
+            client = self.ldapjs.createClient({
+                url: fullUrl
+            });
+        }
+
+
+        // Slide @xyz.whatever from username if it was passed in
+        // and replace it with the domain specified in defaults
+        var emailSliceIndex = options.username.indexOf('@');
+        var username;
+        var domain = self.options.defaultDomain;
+
+        // If user appended email domain, strip it out
+        // And use the defaults.defaultDomain if set
+        if (emailSliceIndex !== -1) {
+            username = options.username.substring(0, emailSliceIndex);
+            domain = domain || options.username.substring((emailSliceIndex + 1), options.username.length);
+        } else {
+            username = options.username;
+        }
+
+
+        // If DN is provided, use it to bind
+        if (self.options.dn) {
+            // Attempt to bind to ldap server with provided info
+            client.bind(self.options.searchDN || self.options.dn, self.options.searchCredentials || options.ldapPass, function (err) {
+                try {
+                    if (err) {
+                        // Bind failure, return error
+                        throw new Meteor.Error(err.code, err.message);
+                    }
+
+                    var handleSearchProfile = function (retObject, bindAfterSearch) {
+                        retObject.emptySearch = true;
+
+                        // construct list of ldap attributes to fetch
+                        var attributes = [];
+                        if (self.options.searchResultsProfileMap) {
+                            self.options.searchResultsProfileMap.map(function (item) {
+                                attributes.push(item.resultKey);
+                            });
+                        }
+
+                        // use base if given, else the dn for the ldap search
+                        var searchBase = self.options.base || self.options.dn;
+                        var searchOptions = {
+                            scope: 'sub',
+                            sizeLimit: 1,
+                            attributes: attributes,
+                            filter: self.options.search
+                        };
+
+                        client.search(searchBase, searchOptions, function (err, res) {
+                            if (err) {
+                                ldapAsyncFut.return({
+                                    error: err
+                                });
+                            }
+
+                            res.on('searchEntry', function (entry) {
+                                retObject.emptySearch = false;
+                                // Add entry results to return object
+                                retObject.searchResults = entry.object;
+                                if (bindAfterSearch) {
+                                    client.bind(retObject.searchResults.dn, options.ldapPass, function (err) {
+                                        try {
+                                            if (err) {
+                                                throw new Meteor.Error(err.code, err.message);
+                                            }
+                                            ldapAsyncFut.return(retObject);
+                                        } catch (e) {
+                                            ldapAsyncFut.return({
+                                                error: e
+                                            });
+                                        }
+                                    })
+                                } else ldapAsyncFut.return(retObject);
+                            });
+
+                            res.on('end', function () {
+                                ldapAsyncFut.return(retObject);
+                            });
+
+                        });
+                    };
+
+                    var retObject = {
+                        username: username,
+                        searchResults: null,
+                        email: domain ? username + '@' + domain : false
+                    };
+
+                    if (self.options.searchDN) {
+                        handleSearchProfile(retObject, true);
+                    } else if (self.options.searchResultsProfileMap) {
+                        handleSearchProfile(retObject, false);
+                    } else {
+                        ldapAsyncFut.return(retObject);
+                    }
+
+                } catch (e) {
+                    ldapAsyncFut.return({
+                        error: e
+                    });
+                }
+            });
+        }
+        // DN not provided, search for DN and use result to bind
+        else if (typeof self.options.searchBeforeBind !== undefined) {
+            // initialize result
+            var retObject = {
+                username: username,
+                email: domain ? username + '@' + domain : false,
+                emptySearch: true,
+                searchResults: {}
+            };
+
+            // compile attribute list to return
+            var searchAttributes = ['dn'];
+            self.options.searchResultsProfileMap.map(function (item) {
+                searchAttributes.push(item.resultKey);
+            });
+
+
+            var filter = self.options.search;
+            Object.keys(options.ldapOptions.searchBeforeBind).forEach(function (searchKey) {
+                filter = '&' + filter + '(' + searchKey + '=' + options.ldapOptions.searchBeforeBind[searchKey] + ')';
+            });
+            var searchOptions = {
+                scope: 'sub',
+                sizeLimit: 1,
+                filter: filter
+            };
+
+            // perform LDAP search to determine DN
+            client.search(self.options.base, searchOptions, function (err, res) {
+                retObject.emptySearch = true;
+                res.on('searchEntry', function (entry) {
+                    retObject.dn = entry.objectName;
+                    retObject.username = retObject.dn;
+                    retObject.emptySearch = false;
+
+                    // Return search results if specified
+                    if (self.options.searchResultsProfileMap) {
+                        // construct list of ldap attributes to fetch
+                        self.options.searchResultsProfileMap.map(function (item) {
+                            retObject.searchResults[item.resultKey] = entry.object[item.resultKey];
+                        });
+                    }
+
+                    // use the determined DN to bind
+                    client.bind(entry.objectName, options.ldapPass, function (err) {
+                        try {
+                            if (err) {
+                                throw new Meteor.Error(err.code, err.message);
+                            }
+                            else {
+                                ldapAsyncFut.return(retObject);
+                            }
+                        }
+                        catch (e) {
+                            ldapAsyncFut.return({
+                                error: e
+                            });
+                        }
+                    });
+                });
+                // If no dn is found, return as is.
+                res.on('end', function (result) {
+                    if (retObject.dn === undefined) {
+                        ldapAsyncFut.return(retObject);
+                    }
+                });
+            });
+        }
+
+        return ldapAsyncFut.wait();
+
+    } else {
+        throw new Meteor.Error(403, 'Missing LDAP Auth Parameter');
+    }
+
+};
+
+
+// Register login handler with Meteor
+// Here we create a new LDAP instance with options passed from
+// Meteor.loginWithLDAP on client side
+// @param {Object} loginRequest will consist of username, ldapPass, ldap, and ldapOptions
+Accounts.registerLoginHandler('ldap', function (loginRequest) {
+    // If 'ldap' isn't set in loginRequest object,
+    // then this isn't the proper handler (return undefined)
+    if (!loginRequest.ldap) {
+        return undefined;
+    }
+
+    // Instantiate LDAP with options
+    var userOptions = loginRequest.ldapOptions || {};
+    var ldapObj = new LDAP(userOptions);
+
+    // Call ldapCheck and get response
+    var ldapResponse = ldapObj.ldapCheck(loginRequest);
+
+    if (ldapResponse.error) {
+        return {
+            userId: null,
+            error: ldapResponse.error
+        };
+    }
+    else if (ldapResponse.emptySearch) {
+        return {
+            userId: null,
+            error: new Meteor.Error(403, 'User not found in LDAP')
+        };
+    }
+    else {
+        // Set initial userId and token vals
+        var userId = null;
+        var stampedToken = {
+            token: null
+        };
+
+        // Look to see if user already exists
+        var user = Meteor.users.findOne({
+            username: ldapResponse.username
+        });
+
+        // Login user if they exist
+        if (user) {
+            userId = user._id;
+
+            // Create hashed token so user stays logged in
+            stampedToken = Accounts._generateStampedLoginToken();
+            var hashStampedToken = Accounts._hashStampedToken(stampedToken);
+            // Update the user's token in mongo
+            Meteor.users.update(userId, {
+                $push: {
+                    'services.resume.loginTokens': hashStampedToken
+                }
+            });
+        }
+        // Otherwise create user if option is set
+        else if (ldapObj.options.createNewUser) {
+            var userObject = {
+                username: ldapResponse.username
+            };
+            // Set email
+            if (ldapResponse.email) userObject.email = ldapResponse.email;
+
+            // Set profile values if specified in searchResultsProfileMap
+            if (ldapResponse.searchResults && ldapObj.options.searchResultsProfileMap.length > 0) {
+
+                var profileMap = ldapObj.options.searchResultsProfileMap;
+                var profileObject = {};
+
+                // Loop through profileMap and set values on profile object
+                for (var i = 0; i < profileMap.length; i++) {
+                    var resultKey = profileMap[i].resultKey;
+
+                    // If our search results have the specified property, set the profile property to its value
+                    if (ldapResponse.searchResults.hasOwnProperty(resultKey)) {
+                        profileObject[profileMap[i].profileProperty] = ldapResponse.searchResults[resultKey];
+                    }
+
+                }
+                // Set userObject profile
+                userObject.profile = profileObject;
+            }
+
+
+            userId = Accounts.createUser(userObject);
+        } else {
+            // Ldap success, but no user created
+            console.log('LDAP Authentication succeeded for ' + ldapResponse.username + ', but no user exists in Meteor. Either create the user manually or set LDAP_DEFAULTS.createNewUser to true');
+            return {
+                userId: null,
+                error: new Meteor.Error(403, 'User found in LDAP but not in application')
+            };
+        }
+
+        return {
+            userId: userId,
+            token: stampedToken.token
+        };
+    }
+
+});

--- a/shell/packages/accounts-ldap/package.js
+++ b/shell/packages/accounts-ldap/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name: 'typ:accounts-ldap',
+  name: 'accounts-ldap',
   version: '1.0.1',
   summary: 'Accounts login for LDAP using ldapjs. Supports anonymous DN search & LDAPS.',
   git: 'https://github.com/typ90/meteor-accounts-ldap',
@@ -15,7 +15,7 @@ Package.onUse(function(api) {
 
 
   api.use('accounts-base', 'server');
-  api.imply('accounts-base', 'accounts-password', ['client', 'server']);
+  api.imply('accounts-base', ['client', 'server']);
 
   api.use('check');
 
@@ -24,4 +24,7 @@ Package.onUse(function(api) {
 
   api.export('LDAP', 'server');
   api.export('LDAP_DEFAULTS', 'server');
+
+  api.use('underscore');
+  api.use('ecmascript');
 });

--- a/shell/packages/accounts-ldap/package.js
+++ b/shell/packages/accounts-ldap/package.js
@@ -1,0 +1,27 @@
+Package.describe({
+  name: 'typ:accounts-ldap',
+  version: '1.0.1',
+  summary: 'Accounts login for LDAP using ldapjs. Supports anonymous DN search & LDAPS.',
+  git: 'https://github.com/typ90/meteor-accounts-ldap',
+  documentation: 'README.md'
+});
+
+
+Package.onUse(function(api) {
+  api.versionsFrom('1.0.3.1');
+
+  api.use(['templating'], 'client');
+  api.use(['typ:ldapjs@0.7.3'], 'server');
+
+
+  api.use('accounts-base', 'server');
+  api.imply('accounts-base', 'accounts-password', ['client', 'server']);
+
+  api.use('check');
+
+  api.addFiles(['ldap_client.js'], 'client');
+  api.addFiles(['ldap_server.js'], 'server');
+
+  api.export('LDAP', 'server');
+  api.export('LDAP_DEFAULTS', 'server');
+});

--- a/shell/packages/accounts-ldap/package.js
+++ b/shell/packages/accounts-ldap/package.js
@@ -1,30 +1,28 @@
 Package.describe({
-  name: 'accounts-ldap',
-  version: '1.0.1',
-  summary: 'Accounts login for LDAP using ldapjs. Supports anonymous DN search & LDAPS.',
-  git: 'https://github.com/typ90/meteor-accounts-ldap',
-  documentation: 'README.md'
+  name: "accounts-ldap",
+  version: "1.0.1",
+  summary: "Accounts login for LDAP using ldapjs. Supports anonymous DN search & LDAPS.",
+  git: "https://github.com/typ90/meteor-accounts-ldap",
+  documentation: "README.md",
 });
 
+Package.onUse(function (api) {
+  api.versionsFrom("1.0.3.1");
 
-Package.onUse(function(api) {
-  api.versionsFrom('1.0.3.1');
+  api.use(["templating"], "client");
+  api.use(["typ:ldapjs@0.7.3"], "server");
 
-  api.use(['templating'], 'client');
-  api.use(['typ:ldapjs@0.7.3'], 'server');
+  api.use("accounts-base", "server");
+  api.imply("accounts-base", ["client", "server"]);
 
+  api.use("check");
 
-  api.use('accounts-base', 'server');
-  api.imply('accounts-base', ['client', 'server']);
+  api.addFiles(["ldap_client.js"], "client");
+  api.addFiles(["ldap_server.js"], "server");
 
-  api.use('check');
+  api.export("LDAP", "server");
+  api.export("LDAP_DEFAULTS", "server");
 
-  api.addFiles(['ldap_client.js'], 'client');
-  api.addFiles(['ldap_server.js'], 'server');
-
-  api.export('LDAP', 'server');
-  api.export('LDAP_DEFAULTS', 'server');
-
-  api.use('underscore');
-  api.use('ecmascript');
+  api.use("underscore");
+  api.use("ecmascript");
 });

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -199,12 +199,12 @@
     with ldap
 
     <label class="username">username
-      <span title="Passwordless E-mail Login allows you to log in using an e-mail address. No password is required; instead, every time you log in, we send you a new email confirmation code. You will only need to log in once per device." class="info">i</span>
+      <span title="This is your LDAP username. It will be the name that you normally use to login to other internal services at your company." class="info">i</span>
       <input name="username" type="text">
     </label>
 
     <label class="password">password
-      <span title="Passwordless E-mail Login allows you to log in using an e-mail address. No password is required; instead, every time you log in, we send you a new email confirmation code. You will only need to log in once per device." class="info">i</span>
+      <span title="This is your LDAP password. It will be the password that you normally use to login to other internal services at your company." class="info">i</span>
       <input name="password" type="password">
     </label>
     <div class="button-box">

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -194,6 +194,25 @@
   </form>
 </template>
 
+<template name="ldapLoginForm">
+  <form class="ldap">
+    with ldap
+
+    <label class="username">username
+      <span title="Passwordless E-mail Login allows you to log in using an e-mail address. No password is required; instead, every time you log in, we send you a new email confirmation code. You will only need to log in once per device." class="info">i</span>
+      <input name="username" type="text">
+    </label>
+
+    <label class="password">password
+      <span title="Passwordless E-mail Login allows you to log in using an e-mail address. No password is required; instead, every time you log in, we send you a new email confirmation code. You will only need to log in once per device." class="info">i</span>
+      <input name="password" type="password">
+    </label>
+    <div class="button-box">
+      <button class="login email">Login</button>
+    </div>
+  </form>
+</template>
+
 <template name="_loginButtonsSeparator">
   <div class="or">
     <span class="hline">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -281,10 +281,10 @@ Template.emailAuthenticationForm.helpers({
 Template.ldapLoginForm.events({
   "submit form": function (event, instance) {
     event.preventDefault();
-    var form = event.currentTarget;
+    const form = event.currentTarget;
 
-    var username = form.username.value;
-    var password = form.password.value;
+    const username = form.username.value;
+    const password = form.password.value;
 
     Meteor.loginWithLDAP(username, password, {}, function (err) {
       if (err) {

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -278,6 +278,22 @@ Template.emailAuthenticationForm.helpers({
   },
 });
 
+Template.ldapLoginForm.events({
+  "submit form": function (event, instance) {
+    event.preventDefault();
+    var form = event.currentTarget;
+
+    var username = form.username.value;
+    var password = form.password.value;
+
+    Meteor.loginWithLDAP(username, password, {}, function (err) {
+      if (err) {
+        loginButtonsSession.errorMessage(err.reason || "Unknown error");
+      }
+    });
+  },
+});
+
 Template.devLoginForm.onCreated(function () {
   this._expanded = new ReactiveVar(false);
 });

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1106,6 +1106,30 @@ _.extend(SandstormDb.prototype, {
     const setting = Settings.findOne({ _id: "returnAddress" });
     return setting ? setting.value : "";  // empty if subscription is not ready.
   },
+
+  isFeatureKeyValid: function () {
+    return Meteor.settings.public.isFeatureKeyValid;
+  },
+
+  getLdapUrl: function () {
+    const setting = Settings.findOne({ _id: "ldapUrl" });
+    return setting ? setting.value : "";  // empty if subscription is not ready.
+  },
+
+  getLdapBase: function () {
+    const setting = Settings.findOne({ _id: "ldapBase" });
+    return setting ? setting.value : "";  // empty if subscription is not ready.
+  },
+
+  getLdapDnPattern: function () {
+    const setting = Settings.findOne({ _id: "ldapDnPattern" });
+    return setting ? setting.value : "";  // empty if subscription is not ready.
+  },
+
+  getLdapNameField: function () {
+    const setting = Settings.findOne({ _id: "ldapNameField" });
+    return setting ? setting.value : "";  // empty if subscription is not ready.
+  },
 });
 
 const appNameFromPackage = function (packageObj) {

--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -228,7 +228,7 @@ SandstormDb.fillInIntrinsicName = function (user) {
   } else if (profile.service === "demo") {
     profile.intrinsicName = "demo on " + user.createdAt.toISOString().substring(0, 10);
   } else if (profile.service === "ldap") {
-    profile.intrinsicName = user.services.ldap.username || "ldap user";
+    profile.intrinsicName = user.services.ldap.username;
   } else {
     throw new Error("unrecognized identity service: ", profile.service);
   }

--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -78,6 +78,9 @@ if (Meteor.isServer) {
         "services.github.username":1,
 
         "services.email.email":1,
+
+        "services.ldap.id":1,
+        "services.ldap.rawAttrs":1,
       }, });
   }),
 
@@ -199,6 +202,11 @@ SandstormDb.fillInProfileDefaults = function (user) {
   } else if (profile.service === "demo") {
     profile.name = profile.name || "Demo User";
     profile.handle = profile.handle || "demo";
+  } else if (profile.service === "ldap") {
+    var setting = Settings.findOne({_id: "ldapNameField"});
+    var key = setting ? setting.value : "";
+    profile.name = profile.name || user.services.ldap.rawAttrs[key] || "Name Unknown";
+    profile.handle = profile.handle || filterHandle(profile.name);
   } else {
     throw new Error("unrecognized identity service: ", profile.service);
   }
@@ -219,6 +227,8 @@ SandstormDb.fillInIntrinsicName = function (user) {
     profile.intrinsicName = user.services.dev.name;
   } else if (profile.service === "demo") {
     profile.intrinsicName = "demo on " + user.createdAt.toISOString().substring(0, 10);
+  } else if (profile.service === "ldap") {
+    profile.intrinsicName = user.services.ldap.username || "ldap user";
   } else {
     throw new Error("unrecognized identity service: ", profile.service);
   }

--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -203,8 +203,8 @@ SandstormDb.fillInProfileDefaults = function (user) {
     profile.name = profile.name || "Demo User";
     profile.handle = profile.handle || "demo";
   } else if (profile.service === "ldap") {
-    var setting = Settings.findOne({_id: "ldapNameField"});
-    var key = setting ? setting.value : "";
+    const setting = Settings.findOne({ _id: "ldapNameField" });
+    const key = setting ? setting.value : "";
     profile.name = profile.name || user.services.ldap.rawAttrs[key] || "Name Unknown";
     profile.handle = profile.handle || filterHandle(profile.name);
   } else {

--- a/shell/packages/sandstorm-db/user.js
+++ b/shell/packages/sandstorm-db/user.js
@@ -144,6 +144,9 @@ Accounts.onCreateUser(function (options, user) {
   } else if (user.services && "github" in user.services) {
     serviceUserId = user.services.github.id;
     user.profile.service = "github";
+  } else if (user.services && "ldap" in user.services) {
+    serviceUserId = user.services.ldap.id;
+    user.profile.service = "ldap";
   } else {
     throw new Meteor.Error(400, "user does not have a recognized identity provider: " +
                            JSON.stringify(user));

--- a/shell/run-dev.sh
+++ b/shell/run-dev.sh
@@ -82,7 +82,8 @@ cat > $SETTINGS << __EOF__
     "isTesting": true,
     "wildcardHost": "$WILDCARD_HOST",
     "quotaEnabled": ${QUOTA_ENABLED:-false},
-    "stripePublicKey": "${STRIPE_PUBLIC_KEY:-}"
+    "stripePublicKey": "${STRIPE_PUBLIC_KEY:-}",
+    "isFeatureKeyValid": true
   },
   "home": "$SANDSTORM_HOME",
   "stripeKey": "${STRIPE_KEY:-}",

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -16,10 +16,10 @@
 
 const ADMIN_TOKEN_EXPIRATION_TIME = 15 * 60 * 1000;
 const publicAdminSettings = [
-  "google", "github", "emailToken", "splashUrl", "signupDialog",
+  "google", "github", "ldap", "emailToken", "splashUrl", "signupDialog",
   "adminAlert", "adminAlertTime", "adminAlertUrl", "termsUrl",
   "privacyUrl", "appMarketUrl", "appIndexUrl", "appUpdatesEnabled",
-  "serverTitle", "returnAddress",
+  "serverTitle", "returnAddress", "ldapNameField",
 ];
 
 DEFAULT_SIGNUP_DIALOG = "You've been invited to join this Sandstorm server!";
@@ -300,7 +300,11 @@ if (Meteor.isClient) {
       const state = Iron.controller().state;
       const token = this.token;
       resetResult(state);
-      state.set("numSettings", 4);
+      if (globalDb.isFeatureKeyValid()) {
+        state.set("numSettings", 9);
+      } else {
+        state.set("numSettings", 4);
+      }
 
       const handleErrorBound = handleError.bind(state);
       if (event.target.emailTokenLogin.checked && !event.target.smtpUrl.value) {
@@ -313,6 +317,13 @@ if (Meteor.isClient) {
       Meteor.call("setAccountSetting", token, "github", event.target.githubLogin.checked, handleErrorBound);
       Meteor.call("setAccountSetting", token, "emailToken", event.target.emailTokenLogin.checked, handleErrorBound);
       Meteor.call("setSetting", token, "smtpUrl", event.target.smtpUrl.value, handleErrorBound);
+      if (globalDb.isFeatureKeyValid()) {
+        Meteor.call("setAccountSetting", token, "ldap", event.target.ldapLogin.checked, handleErrorBound);
+        Meteor.call("setLdapSetting", token, "Url", event.target.ldapUrl.value, handleErrorBound);
+        Meteor.call("setLdapSetting", token, "Base", event.target.ldapBase.value, handleErrorBound);
+        Meteor.call("setSetting", token, "ldapDnPattern", event.target.ldapDnPattern.value, handleErrorBound);
+        Meteor.call("setSetting", token, "ldapNameField", event.target.ldapNameField.value, handleErrorBound);
+      }
       return false;
     },
   });
@@ -339,6 +350,27 @@ if (Meteor.isClient) {
       }
     },
 
+    ldapEnabled: function () {
+      var setting = Settings.findOne({_id: "ldap"});
+      if (setting) {
+        return setting.value;
+      } else {
+        return false;
+      }
+    },
+    ldapUrl: function () {
+      return globalDb.getLdapUrl() || "ldap://localhost:389";
+    },
+    ldapBase: function () {
+      return globalDb.getLdapBase() || "OU=People,DC=example,DC=com";
+    },
+    ldapDnPattern: function () {
+      return globalDb.getLdapDnPattern() || "uid=$USERNAME,OU=People,DC=example,DC=com";
+    },
+    ldapNameField: function () {
+      return globalDb.getLdapNameField() || "cn";
+    },
+
     smtpUrl: function () {
       return Iron.controller().state.get("smtpUrl");
     },
@@ -348,6 +380,9 @@ if (Meteor.isClient) {
     },
 
     getToken: getToken,
+    isFeatureKeyValid: function () {
+      return globalDb.isFeatureKeyValid();
+    },
   });
 
   Template.adminUsers.onCreated(function () {
@@ -977,6 +1012,14 @@ if (Meteor.isServer) {
       Settings.upsert({ _id: name }, { $set: { value: value } });
     },
 
+    setLdapSetting: function (token, name, value) {
+      checkAuth(token);
+      check(name, String);
+      check(value, Match.OneOf(null, String, Date, Boolean));
+
+      Settings.upsert({_id: "ldap" + name}, {$set: {value: value}});
+      LDAP_DEFAULTS[name.toLowerCase()] = value;
+    },
     getSmtpUrl: function (token) {
       checkAuth(token);
 
@@ -1368,6 +1411,17 @@ Accounts.identityServices.email = {
 
   loginTemplate: {
     name: "emailLoginForm",
-    priority: 10, // Put it at the bottom of the list.
+    priority: 10,
+  },
+}
+
+
+Accounts.identityServices.ldap = {
+  isEnabled: function () {
+    return serviceEnabled("ldap") && globalDb.isFeatureKeyValid();
+  },
+  loginTemplate: {
+    name: "ldapLoginForm",
+    priority: 20, // Put it at the bottom of the list.
   },
 };

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -324,6 +324,7 @@ if (Meteor.isClient) {
         Meteor.call("setSetting", token, "ldapDnPattern", event.target.ldapDnPattern.value, handleErrorBound);
         Meteor.call("setSetting", token, "ldapNameField", event.target.ldapNameField.value, handleErrorBound);
       }
+
       return false;
     },
   });
@@ -351,22 +352,26 @@ if (Meteor.isClient) {
     },
 
     ldapEnabled: function () {
-      var setting = Settings.findOne({_id: "ldap"});
+      const setting = Settings.findOne({ _id: "ldap" });
       if (setting) {
         return setting.value;
       } else {
         return false;
       }
     },
+
     ldapUrl: function () {
       return globalDb.getLdapUrl() || "ldap://localhost:389";
     },
+
     ldapBase: function () {
       return globalDb.getLdapBase() || "OU=People,DC=example,DC=com";
     },
+
     ldapDnPattern: function () {
       return globalDb.getLdapDnPattern() || "uid=$USERNAME,OU=People,DC=example,DC=com";
     },
+
     ldapNameField: function () {
       return globalDb.getLdapNameField() || "cn";
     },
@@ -1017,9 +1022,10 @@ if (Meteor.isServer) {
       check(name, String);
       check(value, Match.OneOf(null, String, Date, Boolean));
 
-      Settings.upsert({_id: "ldap" + name}, {$set: {value: value}});
+      Settings.upsert({ _id: "ldap" + name }, { $set: { value: value } });
       LDAP_DEFAULTS[name.toLowerCase()] = value;
     },
+
     getSmtpUrl: function (token) {
       checkAuth(token);
 
@@ -1413,13 +1419,13 @@ Accounts.identityServices.email = {
     name: "emailLoginForm",
     priority: 10,
   },
-}
-
+};
 
 Accounts.identityServices.ldap = {
   isEnabled: function () {
     return serviceEnabled("ldap") && globalDb.isFeatureKeyValid();
   },
+
   loginTemplate: {
     name: "ldapLoginForm",
     priority: 20, // Put it at the bottom of the list.

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -319,8 +319,8 @@ if (Meteor.isClient) {
       Meteor.call("setSetting", token, "smtpUrl", event.target.smtpUrl.value, handleErrorBound);
       if (globalDb.isFeatureKeyValid()) {
         Meteor.call("setAccountSetting", token, "ldap", event.target.ldapLogin.checked, handleErrorBound);
-        Meteor.call("setLdapSetting", token, "Url", event.target.ldapUrl.value, handleErrorBound);
-        Meteor.call("setLdapSetting", token, "Base", event.target.ldapBase.value, handleErrorBound);
+        Meteor.call("setSetting", token, "ldapUrl", event.target.ldapUrl.value, handleErrorBound);
+        Meteor.call("setSetting", token, "ldapBase", event.target.ldapBase.value, handleErrorBound);
         Meteor.call("setSetting", token, "ldapDnPattern", event.target.ldapDnPattern.value, handleErrorBound);
         Meteor.call("setSetting", token, "ldapNameField", event.target.ldapNameField.value, handleErrorBound);
       }
@@ -1015,15 +1015,13 @@ if (Meteor.isServer) {
       check(value, Match.OneOf(null, String, Date, Boolean));
 
       Settings.upsert({ _id: name }, { $set: { value: value } });
-    },
-
-    setLdapSetting: function (token, name, value) {
-      checkAuth(token);
-      check(name, String);
-      check(value, Match.OneOf(null, String, Date, Boolean));
-
-      Settings.upsert({ _id: "ldap" + name }, { $set: { value: value } });
-      LDAP_DEFAULTS[name.toLowerCase()] = value;
+      if (name.lastIndexOf("ldap", 0) === 0) {
+        // some ldap settings need to be set for the accounts-ldap package
+        const ldapSetting = name.slice(4);
+        if (ldapSetting === "Url" || ldapSetting === "Base") {
+          LDAP_DEFAULTS[ldapSetting.toLowerCase()] = value;
+        }
+      }
     },
 
     getSmtpUrl: function (token) {


### PR DESCRIPTION
This is in a rough state, but it seems to be working (tested extensively with OpenLDAP, see https://help.ubuntu.com/lts/serverguide/openldap-server.html#openldap-server-populate for how to setup a local server).

In order to enable this functionality, a Meteor settings variable named `isFeatureKeyValid` must be true. This is set in `run-dev.sh` for testing purposes.