### PR TITLE
Add install & uninstall docs

### DIFF
--- a/docs/administering/backups.md
+++ b/docs/administering/backups.md
@@ -32,13 +32,16 @@ snapshots you can make a quick backup by running:
 
     cp -a /opt/sandstorm $HOME/sandstorm-snapshot-from-$(date -I)
 
-Alternatively one can make a backup using tar
+Alternatively, one can make a backup using tar.
 
     tar -cf $HOME/sandstorm-snapshot-from-$(date -I).tar /opt/sandstorm
 
 Then restart Sandstorm to end the interruption:
 
     sudo service start sandstorm
+
+This guide uses `$(date -I)`, which is a way to embed the current date into a filename, in a format
+such as `2005-10-30`.
 
 ### To restore a Sandstorm server backup
 

--- a/docs/administering/backups.md
+++ b/docs/administering/backups.md
@@ -36,7 +36,7 @@ Alternatively one can make a backup using tar
 
     tar -cf $HOME/sandstorm-snapshot-from-$(date -I).tar /opt/sandstorm
 
-Then restart sandstorm to end the interruption:
+Then restart Sandstorm to end the interruption:
 
     sudo service start sandstorm
 

--- a/docs/administering/backups.md
+++ b/docs/administering/backups.md
@@ -1,19 +1,59 @@
-You can back up an individual grain by clicking the download backup
-icon at the top of your sandstorm app. The entire sandstorm
-installation can be backed up safely by stopping sandstorm:
+# Backups
 
+You can manually perform backups of Sandstorm data via the web interface and/or via the command line.
+In the long run, we'd like to enable automated backups as well.
+
+## To back up one individual grain
+
+If you're the owner of a grain on Sandstorm, you can back up an individual grain by clicking the
+download icon in the [top bar](../using/top-bar.md). This will give you a ZIP file of the grain's
+contents. This contains the full writable state of the app, so you can restore it to any Sandstorm
+server.
+
+If you want to get crafty, you can modify a backup to point to a different app ID, allowing you to
+migrate data between apps, or use your data with an experimental app with a different app ID. You
+can also change the contents of the backup before restoring it.
+
+In this way, Sandstorm gives every app a fully-functional import/export system.
+
+## To back up the entire Sandstorm server
+
+Sandstorm stores all its data in `/opt/sandstorm`, plus two symbolic links in `/usr/local/bin`, plus
+a service file for systemd or sysvinit.
+
+If you run your own Sandstorm server, you can back up the entire Sandstorm installation safely by
+stopping the service:
+
+    sudo sandstorm stop
     sudo service stop sandstorm
 
-and taking a filesystem snapshot of `/opt/sandstorm`. If your
-filesystem doesn't support online snapshots you can make a quick
-backup by running:
+and taking a filesystem snapshot of `/opt/sandstorm`. If your filesystem doesn't support online
+snapshots you can make a quick backup by running:
 
-    cp -a /opt/sandstorm [the destination of your backup]
+    cp -a /opt/sandstorm $HOME/sandstorm-snapshot-from-$(date -I)
 
 Alternatively one can make a backup using tar
 
-    tar -cf [location of tar archive] /opt/sandstorm
+    tar -cf $HOME/sandstorm-snapshot-from-$(date -I).tar /opt/sandstorm
 
 Then restart sandstorm to end the interruption:
 
     sudo service start sandstorm
+
+### To restore a Sandstorm server backup
+
+If you have a tar-based backup of `/opt/sandstorm`, the easiest way to restore it is to:
+
+- Run the install script, and allow it to configure a systemd/sysvinit service.
+
+- Stop the Sandstorm service, e.g. `sudo sandstorm stop`
+
+- Move the `/opt/sandstorm` directory to `/opt/sandstorm.empty`
+
+- Copy your backup into `/opt/sandstorm`
+
+- Start the Sandstorm service, e.g. `sudo service sandstorm start`
+
+- Visit your Sandstorm server and make sure everything still works.
+
+- Remove the now-useless `/opt/sandstorm.empty` directory.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,12 +1,28 @@
-# Installation
+# Installation and removal
 
-There are many options for installing Sandstorm with various trade-offs. Choose the one that is most comfortable for you.
+There are many options for installing Sandstorm with various trade-offs. Choose the one that is most comfortable for you. This document also covers [uninstallation](#uninstall).
 
 Sandstorm requires Linux x86_64, with kernel version 3.13 or later.
 
 ## Option 1: HTTPS-verified install
 
 The easiest way to install Sandstorm is by running:
+
+```bash
+curl https://install.sandstorm.io | bash
+```
+
+If you accept the defaults, this will:
+
+- Create a directory, `/opt/sandstorm`, that contains Sandstorm and all data created within Sandstorm. Therefore, this is the most essential directory when performing [backups](administering/backups.md).
+- Download (and verify) the current release of Sandstorm, place it into `/opt/sandstorm`, and enable auto-updates.
+- Create two symbolic links in `/usr/local/bin` to add `spk` and `sandstorm` to your $PATH.
+- Create a service (using `sysvinit` or `systemd`) to make Sandstorm start on system boot.
+- Enable free HTTPS and dynamic DNS if you choose to use a [sandcats.io](administering/sandcats.md) subdomain, which we hope you do!
+- Run a small process as root for containerization and binding to ports, and run the rest of Sandstorm as a non-root user.
+- Listen on port 80 & 443 if available, otherwise a different port.
+
+You can read more about [administering Sandstorm](administering.md). Or you can jump straight into the install by running:
 
 ```bash
 curl https://install.sandstorm.io | bash
@@ -183,3 +199,63 @@ If you suspect you'll be hacking on Sandstorm's dependencies as well, you may wa
 
 * If you want HTTPS/SSL, consider using our [free SSL certificate & dynamic DNS service](administering/ssl.md) or
   setting up a [reverse proxy](administering/reverse-proxy.md).
+
+# Uninstall
+
+If you installed Sandstorm with default options, the following actions will fully remove
+Sandstorm. If you customized the install, you'll need to change these commands accordingly.
+
+If you want to _change settings_, you can edit `/opt/sandstorm/sandstorm.conf`.
+
+- Stop the service.
+
+```bash
+sudo sandstorm stop
+sudo service sandstorm stop
+```
+
+- Remove the service file(s).
+
+For systemd:
+
+```bash
+sudo systemctl disable sandstorm.service
+sudo rm -f /etc/systemd/system/sandstorm.service
+sudo systemctl daemon-reload
+```
+
+For sysvinit:
+
+```bash
+sudo update-rc.d sandstorm remove
+sudo rm -f /etc/init.d/sandstorm
+```
+
+- Remove the two symlinks Sandstorm creates.
+
+```bash
+sudo rm -f /usr/local/bin/spk
+sudo rm -f /usr/local/bin/sandstorm
+```
+
+- Edit `/etc/sysctl.conf` to remove any changes. `install.sh` can optionally customize that file. It
+  will leave behind a comment indicating that it did so, if it did so.
+
+```bash
+sudo nano /etc/sysctl.conf
+```
+
+- Remove the sandstorm user ID and group ID.
+
+```bash
+sudo groupdel sandstorm
+sudo userdel sandstorm
+
+```
+- Finally, remove Sandstorm and all its files.
+
+```bash
+sudo rm -rf /opt/sandstorm
+```
+
+Thanks for using Sandstorm!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ pages:
 - Developing apps:
     - "Overview": "developing.md"
     - "Overview of vagrant-spk": "vagrant-spk/index.md"
-    - "Installation": "vagrant-spk/installation.md"
+    - "Installing vagrant-spk for package dev": "vagrant-spk/installation.md"
     - "Packaging tutorial": "vagrant-spk/packaging-tutorial.md"
     - "Packaging tutorial (Meteor)": "vagrant-spk/packaging-tutorial-meteor.md"
     - "App publishing guide": "developing/publishing-apps.md"
@@ -41,7 +41,7 @@ pages:
     - "Raw integration of pure client apps": "developing/raw-pure-client-apps.md"
 - Administering:
     - "Overview": "administering.md"
-    - "Installation": "install.md"
+    - "Installation & uninstall": "install.md"
     - "Administrator's guide": "administering/guide.md"
     - "Sandcats dynamic DNS": "administering/sandcats.md"
     - "Email": "administering/email.md"


### PR DESCRIPTION
People sometimes want to know how to uninstall Sandstorm. There isn't a script, but there is now a complete guide.

I also took the liberty of improving the backups docs at the same time.

I also took the liberty of explaining what the install script actually does. I think this would have addressed @glyph's questions when he asked me things on IRC. I'll go check with him after pushing this.