### PR TITLE
Tell people mongod failure could be due to low disk free

### DIFF
--- a/docs/administering/faq.md
+++ b/docs/administering/faq.md
@@ -313,3 +313,23 @@ not by a member of the Sandstorm team. If you want to run your own wildcard DNS 
 xip.io inside your own organization, you can do so by [downloading
 xipd](https://github.com/sstephenson/xipd) which Sam generously licenses as open source software.
 You can also set up your own `*.sandstorm.example.com` subdomain within your organization's domain.
+
+## mongod failed to start. What's going on?
+
+If your Sandstorm server isn't working, and you find this text in `/opt/sandstorm/var/log/sandstorm.log`:
+
+```
+**mongod failed to start. Initial exit code: 100, bailing out now.
+```
+
+then MongoDB is unable to start. Sandstorm operates an embedded MongoDB database instance to store
+information like what user accounts exist and what permissions they have. Keep the following in mind
+to address the issue.
+
+- Your system might not have enough free disk space. Sandstorm requires about 500 MB available space
+  to start successfully.
+
+- If your system _does_ have 500 MB available space, your Sandstorm database (stored in
+  `/opt/sandstorm/var/mongo`) might be corrupted. You can likely recover from this issue. Please
+  email support@sandstorm.io so we can help you. Keep in mind that grain data is safely stored
+  separately from this database.

--- a/docs/administering/faq.md
+++ b/docs/administering/faq.md
@@ -329,7 +329,20 @@ to address the issue.
 - Your system might not have enough free disk space. Sandstorm requires about 500 MB available space
   to start successfully.
 
-- If your system _does_ have 500 MB available space, your Sandstorm database (stored in
-  `/opt/sandstorm/var/mongo`) might be corrupted. You can likely recover from this issue. Please
-  email support@sandstorm.io so we can help you. Keep in mind that grain data is safely stored
-  separately from this database.
+- You can read `/opt/sandstorm/var/log/mongo.log` to find out MongoDB's true error
+  message. Specifically, the file will be in `var/log/mongo.log` underneath wherever Sandstorm is
+  installed; most Sandstorm installations are at `/opt/sandstorm`.
+
+- You might be running into a bug in Sandstorm where it is unable to start MongoDB successfully. If
+  so, this is a bug in Sandstorm that probably affects many, many people, and if you report this
+  issue, we will be grateful; your bug report could lead to a code change that fixes many people's
+  Sandstorm servers. To do that, we need to hear from you.
+
+- In theory, this error message can occur if your Sandstorm database (stored in
+  `/opt/sandstorm/var/mongo`) has become corrupted. So far, we have seen no instances of this in the
+  wild. If it does occur, you can likely recover from the situation. Even if there is a problem with
+  the Sandstorm MongoDB instance, note that grain data is safely stored separately, so any grain data
+  would not be affected.
+
+To get further help, please email support@sandstorm.io. Please include the most recent 100 lines
+from the MongoDB log file, if you can.

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1693,7 +1693,7 @@ private:
     KJ_FAIL_ASSERT("**mongod failed to start. Initial exit code: ", status,
                    "bailing out now. For troubleshooting, read "
                    "/opt/sandstorm/var/log/mongo.log (or var/log/mongo.log within your Sandstorm "
-                   " if installed to a different place) and visit: "
+                   "if installed to a different place) and visit: "
                    "https://docs.sandstorm.io/en/latest/search.html?q=mongod+failed+to+start");
     return 0;
   }

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1691,7 +1691,10 @@ private:
     // If we got here, mongod either exited non-zero, or has no PID in its pidfile. In that case,
     // we do not know how proceed.
     KJ_FAIL_ASSERT("**mongod failed to start. Initial exit code: ", status,
-                   "bailing out now. For troubleshooting, visit: https://docs.sandstorm.io/en/latest/search.html?q=mongod+failed+to+start");
+                   "bailing out now. For troubleshooting, read "
+                   "/opt/sandstorm/var/log/mongo.log (or var/log/mongo.log within your Sandstorm "
+                   " if installed to a different place) and visit: "
+                   "https://docs.sandstorm.io/en/latest/search.html?q=mongod+failed+to+start");
     return 0;
   }
 

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1691,7 +1691,7 @@ private:
     // If we got here, mongod either exited non-zero, or has no PID in its pidfile. In that case,
     // we do not know how proceed.
     KJ_FAIL_ASSERT("**mongod failed to start. Initial exit code: ", status,
-                   "bailing out now.");
+                   "bailing out now. Note: MongoDB needs about 500MB of disk free to operate!");
     return 0;
   }
 

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1691,7 +1691,7 @@ private:
     // If we got here, mongod either exited non-zero, or has no PID in its pidfile. In that case,
     // we do not know how proceed.
     KJ_FAIL_ASSERT("**mongod failed to start. Initial exit code: ", status,
-                   "bailing out now. Note: MongoDB needs about 500MB of disk free to operate!");
+                   "bailing out now. Note: Sandstorm needs about 500MB of disk free to operate!");
     return 0;
   }
 

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1691,7 +1691,7 @@ private:
     // If we got here, mongod either exited non-zero, or has no PID in its pidfile. In that case,
     // we do not know how proceed.
     KJ_FAIL_ASSERT("**mongod failed to start. Initial exit code: ", status,
-                   "bailing out now. Note: Sandstorm needs about 500MB of disk free to operate!");
+                   "bailing out now. For troubleshooting, visit: https://docs.sandstorm.io/en/latest/search.html?q=mongod+failed+to+start");
     return 0;
   }
 


### PR DESCRIPTION
Having a better log message could have helped @sanderant debug this without assistance, I believe.

We found ~350MB triggered the error case, but 500MB free resulted in success.

Requesting review/merge from @kentonv 