### PR TITLE
JSCS compliance for `shell/packages/*`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,9 @@ test: sandstorm-$(BUILD)-fast.tar.xz
 installer-test:
 	(cd installer-tests && bash prepare-for-tests.sh && PYTHONUNBUFFERED=yes TERM=xterm SLOW_TEXT_TIMEOUT=120 ~/.local/bin/stodgy-tester --plugin stodgy_tester.plugins.sandstorm_installer_tests --on-vm-start=uninstall_sandstorm --rsync)
 
+stylecheck:
+	cd shell && jscs .
+
 # ====================================================================
 # Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ installer-test:
 	(cd installer-tests && bash prepare-for-tests.sh && PYTHONUNBUFFERED=yes TERM=xterm SLOW_TEXT_TIMEOUT=120 ~/.local/bin/stodgy-tester --plugin stodgy_tester.plugins.sandstorm_installer_tests --on-vm-start=uninstall_sandstorm --rsync)
 
 stylecheck:
+	@which jscs > /dev/null 2>&1 || ( echo "You need jscs installed. Consider installing with e.g."; echo ; echo "npm -g install jscs"; echo ; exit 1)
 	cd shell && jscs .
 
 # ====================================================================

--- a/shell/packages/accounts-identity/accounts-identity-client.js
+++ b/shell/packages/accounts-identity/accounts-identity-client.js
@@ -24,10 +24,10 @@ var LoginIdentitiesOfLinkedAccounts = new Mongo.Collection("loginIdentitiesOfLin
 //   sourceIdentityId: Identity ID of the source identity.
 
 Template.identityLoginInterstitial.onCreated(function () {
-  this._state = new ReactiveVar({justLoggingIn: true});
+  this._state = new ReactiveVar({ justLoggingIn: true });
   var token = sessionStorage.getItem("linkingIdentityLoginToken");
   if (token) {
-    this._state.set({linkingIdentity: true});
+    this._state.set({ linkingIdentity: true });
     sessionStorage.removeItem("linkingIdentityLoginToken");
     Meteor.call("linkIdentityToAccount", token, function (err, result) {
       if (err) {
@@ -36,26 +36,27 @@ Template.identityLoginInterstitial.onCreated(function () {
       } else {
         Session.set("linkingIdentityError");
       }
+
       Meteor.loginWithToken(token);
     });
   } else {
     var self = this;
     var sub = this.subscribe("accountsOfIdentity", Meteor.userId());
-    this.autorun(function() {
+    this.autorun(function () {
       if (sub.ready()) {
         var loginAccount =
-            LoginIdentitiesOfLinkedAccounts.findOne({sourceIdentityId: Meteor.userId(),
-                                                     _id: Meteor.userId()});
+            LoginIdentitiesOfLinkedAccounts.findOne({ sourceIdentityId: Meteor.userId(),
+                                                     _id: Meteor.userId(), });
         if (loginAccount) {
           Meteor.loginWithIdentity(loginAccount.loginAccountId);
-        } else if (!LoginIdentitiesOfLinkedAccounts.findOne({sourceIdentityId: Meteor.userId()})) {
-          Meteor.call("createAccountForIdentity", function(err, result) {
+        } else if (!LoginIdentitiesOfLinkedAccounts.findOne({ sourceIdentityId: Meteor.userId() })) {
+          Meteor.call("createAccountForIdentity", function (err, result) {
             if (err) {
               console.log("error", err);
             }
           });
         } else if ("justLoggingIn" in self._state.get()) {
-          self._state.set({needInput: true});
+          self._state.set({ needInput: true });
         }
       }
     });
@@ -66,9 +67,11 @@ Template.identityLoginInterstitial.helpers({
   needInput: function () {
     return "needInput" in Template.instance()._state.get();
   },
+
   linkingIdentity: function () {
     return "linkingIdentity" in Template.instance()._state.get();
   },
+
   currentIdentity: function () {
     var identity = Meteor.user();
     SandstormDb.fillInProfileDefaults(identity);
@@ -76,6 +79,7 @@ Template.identityLoginInterstitial.helpers({
     SandstormDb.fillInPictureUrl(identity);
     return identity;
   },
+
   nonloginAccounts: function () {
     return LoginIdentitiesOfLinkedAccounts.find().fetch().map(function (identity) {
       SandstormDb.fillInPictureUrl(identity);
@@ -88,11 +92,12 @@ Template.identityLoginInterstitial.events({
   "click button.logout": function () {
     Meteor.logout();
   },
+
   "click button.unlink": function () {
-    var userId = event.target.getAttribute("data-user-id")
+    var userId = event.target.getAttribute("data-user-id");
     var user = Meteor.user();
     var identityId = user && user._id;
-    var loginIdentity = LoginIdentitiesOfLinkedAccounts.findOne({loginAccountId: userId});
+    var loginIdentity = LoginIdentitiesOfLinkedAccounts.findOne({ loginAccountId: userId });
     var name = loginIdentity.profile.name;
     if (window.confirm("Are you sure you want to unlink your identity from the account of " +
                        name + " ?")) {
@@ -124,9 +129,9 @@ Template.identityManagementButtons.events({
     var identityId = event.target.getAttribute("data-identity-id");
     Meteor.call("setIdentityAllowsLogin", identityId, event.target.checked, function (err, result) {
       if (err) {
-        instance.data.setActionCompleted({error: err});
+        instance.data.setActionCompleted({ error: err });
       } else {
-        instance.data.setActionCompleted({success: "changed login ability of identity"});
+        instance.data.setActionCompleted({ success: "changed login ability of identity" });
       }
     });
   },
@@ -136,24 +141,26 @@ Template.identityManagementButtons.helpers({
   disableToggleLogin: function () {
     if (this.isLogin) {
       if (Meteor.user().loginIdentities.length <= 1) {
-        return {why: "You must have at least one login identity."}
+        return { why: "You must have at least one login identity." };
       }
     } else {
-      if (LoginIdentitiesOfLinkedAccounts.findOne({sourceIdentityId: this._id,
-                                                   loginAccountId: {$ne: Meteor.userId()}})) {
-        return {why: "A shared identity is not allowed to be promoted to a login identity."}
+      if (LoginIdentitiesOfLinkedAccounts.findOne({ sourceIdentityId: this._id,
+                                                   loginAccountId: { $ne: Meteor.userId() }, })) {
+        return { why: "A shared identity is not allowed to be promoted to a login identity." };
       }
+
       if (this.isDemo) {
-        return {why: "Demo identities cannot be used to log in."}
+        return { why: "Demo identities cannot be used to log in." };
       }
     }
   },
 });
 
-Template.loginIdentitiesOfLinkedAccounts.onCreated(function() {
+Template.loginIdentitiesOfLinkedAccounts.onCreated(function () {
   if (this.data._id) {
     this.subscribe("accountsOfIdentity", this.data._id);
   }
+
   this._showOtherAccounts = new ReactiveVar(false);
 });
 
@@ -161,28 +168,31 @@ Template.loginIdentitiesOfLinkedAccounts.helpers({
   showOtherAccounts: function () {
     return Template.instance()._showOtherAccounts.get();
   },
-  getOtherAccounts: function() {
+
+  getOtherAccounts: function () {
     var id = Template.instance().data._id;
-    return LoginIdentitiesOfLinkedAccounts.find({sourceIdentityId: id,
-                                                 loginAccountId: {$ne: Meteor.userId()}})
+    return LoginIdentitiesOfLinkedAccounts.find({ sourceIdentityId: id,
+                                                 loginAccountId: { $ne: Meteor.userId() }, })
         .fetch().map(function (identity) {
       SandstormDb.fillInPictureUrl(identity);
       return identity;
     });
-  }
+  },
 });
 
 Template.loginIdentitiesOfLinkedAccounts.events({
-  "click button.show-other-accounts": function(event, instance) {
+  "click button.show-other-accounts": function (event, instance) {
     instance._showOtherAccounts.set(true);
   },
-  "click button.hide-other-accounts": function(event, instance) {
+
+  "click button.hide-other-accounts": function (event, instance) {
     instance._showOtherAccounts.set(false);
   },
+
   "click button.unlink": function (event, instance) {
-    var userId = event.target.getAttribute("data-user-id")
+    var userId = event.target.getAttribute("data-user-id");
     var identityId = instance.data._id;
-    var loginIdentity = LoginIdentitiesOfLinkedAccounts.findOne({loginAccountId: userId});
+    var loginIdentity = LoginIdentitiesOfLinkedAccounts.findOne({ loginAccountId: userId });
     var name = loginIdentity.profile.name;
     if (window.confirm("Are you sure you want to unlink this identity from the account of " +
                        name + " ?")) {
@@ -197,7 +207,7 @@ Template.loginIdentitiesOfLinkedAccounts.events({
 
 Template.identityPicker.events({
   "click button.pick-identity": function (event, instance) {
-    instance.data.onPicked(event.currentTarget.getAttribute("data-identity-id"))
+    instance.data.onPicked(event.currentTarget.getAttribute("data-identity-id"));
   },
 });
 
@@ -208,7 +218,7 @@ Template.identityPicker.helpers({
 });
 
 Template.identityCard.helpers({
-  intrinsicName: function() {
+  intrinsicName: function () {
     if (this.privateIntrinsicName) {
       return this.privateIntrinsicName;
     } else {
@@ -233,9 +243,10 @@ Meteor.loginWithIdentity = function (accountId, callback) {
         if (identity.profile.service !== "demo") {
           Accounts.setCurrentIdentityId(identity._id);
         }
+
         callback && callback();
       }
-    }
+    },
   });
 };
 
@@ -245,7 +256,7 @@ Accounts.getCurrentIdentityId = function () {
   // TODO(cleanup): `globalGrains` is only in scope here because of a Meteor bug. We should figure
   //   out a better way to track a reference to it.
   var grainList = globalGrains.get();
-  for (var i = 0; i < grainList.length ; i++) {
+  for (var i = 0; i < grainList.length; i++) {
     if (grainList[i].isActive()) {
       return grainList[i].identityId();
     }
@@ -266,11 +277,11 @@ Accounts.setCurrentIdentityId = function (identityId) {
   // TODO(cleanup): `globalGrains` is only in scope here because of a Meteor bug. We should figure
   //   out a better way to track a reference to it.
   var grainList = globalGrains.get();
-  for (var i = 0; i < grainList.length ; i++) {
+  for (var i = 0; i < grainList.length; i++) {
     if (grainList[i].isActive()) {
       return grainList[i].switchIdentity(identityId);
     }
   }
 
   Session.set(CURRENT_IDENTITY_KEY, identityId);
-}
+};

--- a/shell/packages/accounts-identity/accounts-identity-server.js
+++ b/shell/packages/accounts-identity/accounts-identity-server.js
@@ -23,7 +23,7 @@ function linkIdentityToAccountInternal(db, backend, identityId, accountId) {
   check(identityId, String);
   check(accountId, String);
 
-  var accountUser = Meteor.users.findOne({_id: accountId});
+  var accountUser = Meteor.users.findOne({ _id: accountId });
   if (!accountUser) {
     throw new Meteor.Error(404, "No account found with ID " + accountId);
   }
@@ -32,12 +32,12 @@ function linkIdentityToAccountInternal(db, backend, identityId, accountId) {
     throw new Meteor.Error(400, "Cannot link an identity to another identity.");
   }
 
-  if (!!_.findWhere(accountUser.loginIdentities, {id: identityId}) ||
-      !!_.findWhere(accountUser.nonloginIdentities, {id: identityId})) {
+  if (!!_.findWhere(accountUser.loginIdentities, { id: identityId }) ||
+      !!_.findWhere(accountUser.nonloginIdentities, { id: identityId })) {
     throw new Meteor.Error(400, "Cannot link an identity that's alread linked to this account.");
   }
 
-  var identityUser = Meteor.users.findOne({_id: identityId});
+  var identityUser = Meteor.users.findOne({ _id: identityId });
 
   if (!identityUser) {
     throw new Meteor.Error(404, "No identity found with ID " + identityId);
@@ -48,48 +48,48 @@ function linkIdentityToAccountInternal(db, backend, identityId, accountId) {
   }
 
   db.deleteUnusedAccount(backend, identityUser._id);
-  if (Meteor.users.findOne({"loginIdentities.id": identityUser._id})) {
+  if (Meteor.users.findOne({ "loginIdentities.id": identityUser._id })) {
     throw new Meteor.Error(403,
                            "Cannot link an identity that can already log into another account");
   }
 
   var modifier;
   if (accountUser.expires) {
-    if (Meteor.users.findOne({"nonloginIdentities.id": identityUser._id})) {
+    if (Meteor.users.findOne({ "nonloginIdentities.id": identityUser._id })) {
       throw new Meteor.Error(403, "Cannot create an account for an identity that's " +
                                   "already linked to another account.");
     }
 
-    modifier = {$push: {loginIdentities: {id: identityUser._id}},
-                $unset: {expires: 1},
-                $set: {upgradedFromDemo: Date.now()}};
+    modifier = { $push: { loginIdentities: { id: identityUser._id } },
+                $unset: { expires: 1 },
+                $set: { upgradedFromDemo: Date.now() }, };
     if (Meteor.settings.public.quotaEnabled) {
       // Demo users never got the referral notification. Send it now:
       db.sendReferralProgramNotification(accountUser._id);
     }
 
   } else {
-    modifier = {$push: {nonloginIdentities: {id: identityUser._id}}};
+    modifier = { $push: { nonloginIdentities: { id: identityUser._id } } };
   }
 
   // Make sure not to add the same identity twice.
-  Meteor.users.update({_id: accountUser._id, "nonloginIdentities.id": {$ne: identityUser._id},
-                       "loginIdentities.id": {$ne: identityUser._id}},
+  Meteor.users.update({ _id: accountUser._id, "nonloginIdentities.id": { $ne: identityUser._id },
+                       "loginIdentities.id": { $ne: identityUser._id }, },
                       modifier);
 
   if (accountUser.expires) {
     var demoIdentityId = SandstormDb.getUserIdentityIds(accountUser)[0];
-    Meteor.users.update({_id: demoIdentityId},
-                        {$unset: {expires: 1},
-                         $set: {upgradedFromDemo: Date.now()}});
+    Meteor.users.update({ _id: demoIdentityId },
+                        { $unset: { expires: 1 },
+                         $set: { upgradedFromDemo: Date.now() }, });
 
     // Mark the demo identity as nonlogin. It'd be nicer if the identity started out as nonlogin,
     // but to get that to work we would need to adjust the account creation and first login logic.
-    Meteor.users.update({_id: accountUser._id,
+    Meteor.users.update({ _id: accountUser._id,
                          "loginIdentities.id": demoIdentityId,
-                         "nonloginIdentities.id": {$not: {$eq: demoIdentityId}}},
-                        {$pull: {loginIdentities: {id: demoIdentityId}},
-                         $push: {nonloginIdentities: {id: demoIdentityId}}});
+                         "nonloginIdentities.id": { $not: { $eq: demoIdentityId } }, },
+                        { $pull: { loginIdentities: { id: demoIdentityId } },
+                         $push: { nonloginIdentities: { id: demoIdentityId } }, });
 
   }
 }
@@ -114,7 +114,7 @@ Meteor.methods({
       throw new Meteor.Error(404, "No such user found: " + accountUserId);
     }
 
-    var linkedIdentity = _.findWhere(accountUser.loginIdentities, {id: identityUser._id});
+    var linkedIdentity = _.findWhere(accountUser.loginIdentities, { id: identityUser._id });
 
     if (!linkedIdentity) {
       throw new Meteor.Error(403, "Current identity is not a login identity for account "
@@ -125,7 +125,7 @@ Meteor.methods({
                                  "identity", function () { return { userId: accountUserId }; });
   },
 
-  createAccountForIdentity: function() {
+  createAccountForIdentity: function () {
     // Creates a new account for the currently-logged-in identity.
 
     var user = Meteor.user();
@@ -133,19 +133,20 @@ Meteor.methods({
       throw new Meteor.Error(403, "Must be logged in as an identity in order to create an account.");
     }
 
-    if (Meteor.users.findOne({$or: [{"loginIdentities.id": user._id},
-                                    {"nonloginIdentities.id": user._id}]})) {
+    if (Meteor.users.findOne({ $or: [{ "loginIdentities.id": user._id },
+                                    { "nonloginIdentities.id": user._id },], })) {
       throw new Meteor.Error(403, "Cannot create an account for an identity that's already " +
                                   "linked to another account.");
     }
 
-    var newUser = {loginIdentities: [{id: user._id}],
-                   nonloginIdentities: []};
+    var newUser = { loginIdentities: [{ id: user._id }],
+                   nonloginIdentities: [], };
     if (user.services.dev) {
       newUser.signupKey = "devAccounts";
       if (user.services.dev.isAdmin) {
         newUser.isAdmin = true;
       }
+
       if (user.services.dev.hasCompletedSignup) {
         newUser.hasCompletedSignup = true;
       }
@@ -156,6 +157,7 @@ Meteor.methods({
         newUser.appDemoId = user.appDemoId;
       }
     }
+
     var options = {};
 
     // This will throw an error if the identity has been added as a login identity to some
@@ -163,7 +165,7 @@ Meteor.methods({
     return Accounts.insertUserDoc(options, newUser);
   },
 
-  linkIdentityToAccount: function(token) {
+  linkIdentityToAccount: function (token) {
     // Links the identity of the current user to the account that has `token` as a resume token.
     // If the account is a demo account, makes the account durable and gives the identity login
     // access to it.
@@ -173,8 +175,9 @@ Meteor.methods({
     if (!this.userId) {
       throw new Meteor.Error(403, "Cannot link to account if not logged in.");
     }
+
     var hashed = Accounts._hashLoginToken(token);
-    var accountUser = Meteor.users.findOne({"services.resume.loginTokens.hashedToken": hashed});
+    var accountUser = Meteor.users.findOne({ "services.resume.loginTokens.hashedToken": hashed });
 
     linkIdentityToAccountInternal(this.connection.sandstormDb, this.connection.sandstormBackend,
                                   this.userId, accountUser._id);
@@ -189,17 +192,18 @@ Meteor.methods({
     if (!this.userId) {
       throw new Meteor.Error(403, "Not logged in.");
     }
+
     if (!this.connection.sandstormDb.userHasIdentity(this.userId, identityId)) {
       throw new Meteor.Error(403, "Current user does not own identity " + identityId);
     }
 
-    var identityUser = Meteor.users.findOne({_id: identityId});
-    Meteor.users.update({_id: accountUserId},
-                        {$pull: {nonloginIdentities: {id: identityId},
-                                 loginIdentities: {id: identityId}}});
+    var identityUser = Meteor.users.findOne({ _id: identityId });
+    Meteor.users.update({ _id: accountUserId },
+                        { $pull: { nonloginIdentities: { id: identityId },
+                                 loginIdentities: { id: identityId }, }, });
   },
 
-  setIdentityAllowsLogin: function(identityId, allowLogin) {
+  setIdentityAllowsLogin: function (identityId, allowLogin) {
     // Sets whether the current account allows the identity with ID `identityId` to log in.
 
     check(identityId, String);
@@ -207,34 +211,35 @@ Meteor.methods({
     if (!this.userId) {
       throw new Meteor.Error(403, "Not logged in.");
     }
+
     if (!this.connection.sandstormDb.userHasIdentity(this.userId, identityId)) {
       throw new Meteor.Error(403, "Current user does not own identity " + identityId);
     }
 
     if (allowLogin) {
-      Meteor.users.update({_id: this.userId,
+      Meteor.users.update({ _id: this.userId,
                            "nonloginIdentities.id": identityId,
-                           "loginIdentities.id": {$not: {$eq: identityId}}},
-                          {$pull: {nonloginIdentities: {id: identityId}},
-                           $push: {loginIdentities: {id: identityId}}});
+                           "loginIdentities.id": { $not: { $eq: identityId } }, },
+                          { $pull: { nonloginIdentities: { id: identityId } },
+                           $push: { loginIdentities: { id: identityId } }, });
     } else {
-      Meteor.users.update({_id: this.userId,
+      Meteor.users.update({ _id: this.userId,
                            "loginIdentities.id": identityId,
-                           "nonloginIdentities.id": {$not: {$eq: identityId}}},
-                          {$pull: {loginIdentities: {id: identityId}},
-                           $push: {nonloginIdentities: {id: identityId}}});
+                           "nonloginIdentities.id": { $not: { $eq: identityId } }, },
+                          { $pull: { loginIdentities: { id: identityId } },
+                           $push: { nonloginIdentities: { id: identityId } }, });
     }
   },
 
-  logoutIdentitiesOfCurrentAccount: function() {
+  logoutIdentitiesOfCurrentAccount: function () {
     // Logs out all identities that are allowed to log in to the current account.
     var user = Meteor.user();
     if (user && user.loginIdentities) {
-      user.loginIdentities.forEach(function(identity) {
-        Meteor.users.update({_id: identity.id}, {$set: {"services.resume.loginTokens": []}});
+      user.loginIdentities.forEach(function (identity) {
+        Meteor.users.update({ _id: identity.id }, { $set: { "services.resume.loginTokens": [] } });
       });
     }
-  }
+  },
 });
 
 Accounts.linkIdentityToAccount = function (db, backend, identityId, accountId) {
@@ -245,7 +250,7 @@ Accounts.linkIdentityToAccount = function (db, backend, identityId, accountId) {
   check(identityId, String);
   check(accountId, String);
   linkIdentityToAccountInternal(db, backend, identityId, accountId);
-}
+};
 
 Meteor.publish("accountsOfIdentity", function (identityId) {
   check(identityId, String);
@@ -256,9 +261,9 @@ Meteor.publish("accountsOfIdentity", function (identityId) {
 
   var self = this;
   function addIdentitiesOfAccount(account) {
-    account.loginIdentities.forEach(function(identity) {
+    account.loginIdentities.forEach(function (identity) {
       if (!(identity.id in loginIdentities)) {
-        var user = Meteor.users.findOne({_id: identity.id});
+        var user = Meteor.users.findOne({ _id: identity.id });
         if (user) {
           SandstormDb.fillInProfileDefaults(user);
           SandstormDb.fillInIntrinsicName(user);
@@ -267,27 +272,31 @@ Meteor.publish("accountsOfIdentity", function (identityId) {
           filteredUser.sourceIdentityId = identityId;
           self.added("loginIdentitiesOfLinkedAccounts", user._id, filteredUser);
         }
+
         loginIdentities[identity.id] =
-          Meteor.users.find({_id: identity.id}, {fields: {profile: 1}}).observeChanges({
+          Meteor.users.find({ _id: identity.id }, { fields: { profile: 1 } }).observeChanges({
             changed: function (id, fields) {
               self.changed("loginIdentitiesOfLinkedAccounts", id, fields);
-            }
+            },
           });
       }
     });
   }
-  var cursor = Meteor.users.find({$or: [{"loginIdentities.id": identityId},
-                                        {"nonloginIdentities.id": identityId}]});
+
+  var cursor = Meteor.users.find({ $or: [{ "loginIdentities.id": identityId },
+                                        { "nonloginIdentities.id": identityId },], });
 
   var handle = cursor.observe({
     added: function (account) {
       addIdentitiesOfAccount(account);
     },
+
     changed: function (newAccount, oldAccount) {
       addIdentitiesOfAccount(newAccount);
     },
+
     removed: function (account) {
-      account.loginIdentities.forEach(function(identity) {
+      account.loginIdentities.forEach(function (identity) {
         if (identity.id in loginIdentities) {
           self.removed("loginIdentitiesOfLinkedAccounts", identity.id);
           loginIdentities[identity.id].stop();
@@ -298,9 +307,9 @@ Meteor.publish("accountsOfIdentity", function (identityId) {
   });
   this.ready();
 
-  this.onStop(function() {
+  this.onStop(function () {
     handle.stop();
-    Object.keys(loginIdentities).forEach(function(identityId) {
+    Object.keys(loginIdentities).forEach(function (identityId) {
       loginIdentities[identityId].stop();
       delete loginIdentities[identityId];
     });

--- a/shell/packages/accounts-identity/package.js
+++ b/shell/packages/accounts-identity/package.js
@@ -20,6 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.use(["underscore", "random", "sandstorm-db", "sandstorm-backend", "mongo"]);
   api.use("accounts-base", ["client", "server"]);
   api.use(["session", "templating"], ["client"]);

--- a/shell/packages/accounts-identity/package.js
+++ b/shell/packages/accounts-identity/package.js
@@ -16,7 +16,7 @@
 
 Package.describe({
   summary: "Accounts with multiple associated identities.",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {

--- a/shell/packages/bignum/package.js
+++ b/shell/packages/bignum/package.js
@@ -1,7 +1,7 @@
 Npm.depends({
-    "bignum": "0.9.0",
+  bignum: "0.9.0",
 });
 
-Package.onUse(function(api) {
+Package.onUse(function (api) {
   api.addFiles("import.js", "server");
 });

--- a/shell/packages/connect/package.js
+++ b/shell/packages/connect/package.js
@@ -1,6 +1,6 @@
 // Please keep this updated to match the version used by Meteor. Ugh.
-Npm.depends({"connect": "2.9.0"});
+Npm.depends({ connect: "2.9.0" });
 
-Package.onUse(function(api) {
+Package.onUse(function (api) {
   api.addFiles("import.js", "server");
 });

--- a/shell/packages/introjs/client/intro.js
+++ b/shell/packages/introjs/client/intro.js
@@ -5,6 +5,7 @@
  *
  * Copyright (C) 2013 usabli.ca - A weekend project by Afshin Mehrabani (@afshinmeh)
  */
+// jscs:disable
 
 (function (root, factory) {
   if (typeof exports === 'object') {

--- a/shell/packages/introjs/package.js
+++ b/shell/packages/introjs/package.js
@@ -1,14 +1,14 @@
 Package.describe({
-  name: 'introjs',
-  version: '2.0.0',
-  summary: 'A copy of introjs, packaged as a Meteor package',
-  git: '',
-  documentation: 'README.md'
+  name: "introjs",
+  version: "2.0.0",
+  summary: "A copy of introjs, packaged as a Meteor package",
+  git: "",
+  documentation: "README.md",
 });
 
-Package.onUse(function(api) {
-  api.versionsFrom('1.2.1');
-  api.use('ecmascript');
-  api.addFiles('client/intro.js', 'client');
-  api.addFiles('client/introjs.css', 'client');
+Package.onUse(function (api) {
+  api.versionsFrom("1.2.1");
+  api.use("ecmascript");
+  api.addFiles("client/intro.js", "client");
+  api.addFiles("client/introjs.css", "client");
 });

--- a/shell/packages/meteor-node-forge/package.js
+++ b/shell/packages/meteor-node-forge/package.js
@@ -1,7 +1,7 @@
 Npm.depends({
-    "node-forge": "0.6.34"
+  "node-forge": "0.6.34",
 });
 
-Package.onUse(function(api) {
+Package.onUse(function (api) {
   api.addFiles("import.js", "server");
 });

--- a/shell/packages/npm-request/package.js
+++ b/shell/packages/npm-request/package.js
@@ -1,14 +1,14 @@
 Package.describe({
   summary: "Export the 'request' package from npm",
   version: "2.67.0",
-  name: "npm-request"
+  name: "npm-request",
 });
 
-Package.onUse(function(api) {
+Package.onUse(function (api) {
   api.export("Request", "server");
   api.addFiles("server.js", "server");
 });
 
 Npm.depends({
-  'request': '2.67.0'
+  request: "2.67.0",
 });

--- a/shell/packages/npm-request/server.js
+++ b/shell/packages/npm-request/server.js
@@ -1,1 +1,1 @@
-Request = Npm.require('request');
+Request = Npm.require("request");

--- a/shell/packages/sandstorm-accounts-packages/accounts.js
+++ b/shell/packages/sandstorm-accounts-packages/accounts.js
@@ -1,7 +1,7 @@
 if (Meteor.isClient) {
-  Meteor.loginWithGoogle = function(options, callback) {
+  Meteor.loginWithGoogle = function (options, callback) {
     // support a callback without options
-    if (! callback && typeof options === "function") {
+    if (!callback && typeof options === "function") {
       callback = options;
       options = null;
     }
@@ -9,9 +9,10 @@ if (Meteor.isClient) {
     var credentialRequestCompleteCallback = Accounts.oauth.credentialRequestCompleteHandler(callback);
     Google.requestCredential(options, credentialRequestCompleteCallback);
   };
-  Meteor.loginWithGithub = function(options, callback) {
+
+  Meteor.loginWithGithub = function (options, callback) {
     // support a callback without options
-    if (! callback && typeof options === "function") {
+    if (!callback && typeof options === "function") {
       callback = options;
       options = null;
     }

--- a/shell/packages/sandstorm-accounts-packages/accounts.js
+++ b/shell/packages/sandstorm-accounts-packages/accounts.js
@@ -6,7 +6,7 @@ if (Meteor.isClient) {
       options = null;
     }
 
-    var credentialRequestCompleteCallback = Accounts.oauth.credentialRequestCompleteHandler(callback);
+    const credentialRequestCompleteCallback = Accounts.oauth.credentialRequestCompleteHandler(callback);
     Google.requestCredential(options, credentialRequestCompleteCallback);
   };
 
@@ -17,7 +17,7 @@ if (Meteor.isClient) {
       options = null;
     }
 
-    var credentialRequestCompleteCallback = Accounts.oauth.credentialRequestCompleteHandler(callback);
+    const credentialRequestCompleteCallback = Accounts.oauth.credentialRequestCompleteHandler(callback);
     Github.requestCredential(options, credentialRequestCompleteCallback);
   };
 }

--- a/shell/packages/sandstorm-accounts-packages/package.js
+++ b/shell/packages/sandstorm-accounts-packages/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Sandstorm package that provides hooks to activate many Account services",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -24,7 +24,7 @@ Template.sandstormAccountSettings.onCreated(function () {
   this._isLinkingNewIdentity = new ReactiveVar(false);
   this._selectedIdentityId = new ReactiveVar();
   this._actionCompleted = new ReactiveVar();
-  var self = this;
+  const _this = this;
 
   // TODO(cleanup): Figure out a better way to pass in this data. Perhaps it should be part of
   //   the URL?
@@ -36,13 +36,13 @@ Template.sandstormAccountSettings.onCreated(function () {
 
   this.autorun(function () {
     // Reset the selected identity ID when appropriate.
-    var user = Meteor.user();
+    const user = Meteor.user();
     if (user && user.loginIdentities) {
-      var identities = user.loginIdentities.concat(user.nonloginIdentities);
-      var currentlySelected = self._selectedIdentityId.get();
+      const identities = user.loginIdentities.concat(user.nonloginIdentities);
+      const currentlySelected = _this._selectedIdentityId.get();
       if (!currentlySelected || !_.findWhere(identities, { id: currentlySelected })) {
         if (identities.length > 0) {
-          self._selectedIdentityId.set(identities[0].id);
+          _this._selectedIdentityId.set(identities[0].id);
         }
       }
     }
@@ -51,14 +51,14 @@ Template.sandstormAccountSettings.onCreated(function () {
 
 GENDERS = { male: "male", female: "female", neutral: "neutral", robot: "robot" };
 
-var helpers = {
+const helpers = {
   setDocumentTitle: function () {
     document.title = "Account settings · " + Template.instance().data._db.getServerTitle();
   },
 
   identities: function () {
     return SandstormDb.getUserIdentityIds(Meteor.user()).map(function (id) {
-      var identity = Meteor.users.findOne({ _id: id });
+      const identity = Meteor.users.findOne({ _id: id });
       if (identity) {
         SandstormDb.fillInProfileDefaults(identity);
         SandstormDb.fillInIntrinsicName(identity);
@@ -133,12 +133,12 @@ Template.sandstormAccountSettings.helpers({
   },
 
   setActionCompleted: function () {
-    var actionCompleted = Template.instance()._actionCompleted;
+    const actionCompleted = Template.instance()._actionCompleted;
     return function (x) { actionCompleted.set(x); };
   },
 
   linkingNewIdentityData: function () {
-    var instance = Template.instance();
+    const instance = Template.instance();
     return {
       doneCallback: function () {
         instance._isLinkingNewIdentity.set(false);
@@ -148,11 +148,11 @@ Template.sandstormAccountSettings.helpers({
   },
 
   emailLoginFormData: function () {
-    var instance = Template.instance();
+    const instance = Template.instance();
     return {
       linkingNewIdentity: {
         doneCallback: function () {
-          var input = instance.find("input[name='email']");
+          const input = instance.find("input[name='email']");
           if (input) {
             input.value = "";
           };
@@ -167,14 +167,14 @@ Template.sandstormAccountSettings.helpers({
 
 Template._accountProfileEditor.helpers({
   hasCompletedSignup: function () {
-    var user = Meteor.user();
+    const user = Meteor.user();
     return user && user.hasCompletedSignup;
   },
 
   identityManagementButtonsData: function () {
     if (this.identity) {
-      var user = Meteor.user();
-      var identityId = this.identity._id;
+      const user = Meteor.user();
+      const identityId = this.identity._id;
       return {
         _id: identityId,
         isLogin: user.loginIdentities && !!_.findWhere(user.loginIdentities, { id: identityId }),
@@ -192,7 +192,7 @@ Template._accountProfileEditor.helpers({
 
   emailDetails: function () {
     if (this.identity) {
-      var emails = SandstormDb.getVerifiedEmails(this.identity);
+      const emails = SandstormDb.getVerifiedEmails(this.identity);
       if (emails.length == 0) {
         return "This identity has no attached e-mail.";
       } else if (emails.length == 1) {
@@ -241,8 +241,8 @@ Template.sandstormAccountSettings.events({
 
 Template.sandstormAccountsFirstSignIn.helpers({
   identityToConfirm: function () {
-    var identityId = SandstormDb.getUserIdentityIds(Meteor.user())[0];
-    var identity = Meteor.users.findOne({ _id: identityId });
+    const identityId = SandstormDb.getUserIdentityIds(Meteor.user())[0];
+    const identity = Meteor.users.findOne({ _id: identityId });
     if (identity) {
       SandstormDb.fillInProfileDefaults(identity);
       SandstormDb.fillInIntrinsicName(identity);
@@ -252,7 +252,7 @@ Template.sandstormAccountsFirstSignIn.helpers({
   },
 
   termsAndPrivacy: function () {
-    var result = {
+    const result = {
       termsUrl: Template.currentData()._db.getSetting("termsUrl"),
       privacyUrl: Template.currentData()._db.getSetting("privacyUrl"),
     };
@@ -264,16 +264,16 @@ Template.sandstormAccountsFirstSignIn.helpers({
   },
 });
 
-var submitProfileForm = function (event, cb) {
+const submitProfileForm = function (event, cb) {
   event.preventDefault();
-  var form = Template.instance().find("form");
+  const form = Template.instance().find("form");
 
   if (form.agreedToTerms && !form.agreedToTerms.checked) {
     alert("You must agree to the terms to continue.");
     return;
   }
 
-  var newProfile = {
+  const newProfile = {
     name: form.nameInput.value,
     handle: form.handle.value,
     pronoun: form.pronoun.value,
@@ -291,7 +291,7 @@ var submitProfileForm = function (event, cb) {
     return;
   }
 
-  var identityId = form.getAttribute("data-identity-id");
+  const identityId = form.getAttribute("data-identity-id");
 
   Meteor.call("updateProfile", identityId, newProfile, function (err) {
     if (err) {
@@ -349,16 +349,16 @@ Template._accountProfileEditor.events({
   "click .picture button": function (event, instance) {
     event.preventDefault();
 
-    var staticHost = Template.currentData().staticHost;
+    const staticHost = Template.currentData().staticHost;
     if (!staticHost) throw new Error("missing _staticHost");
 
     // TODO(cleanup): Share code with "restore backup" and other upload buttons.
-    var input = instance.find("input[name='picture']");
+    const input = instance.find("input[name='picture']");
 
-    var file = undefined;
-    var token = undefined;
+    let file = undefined;
+    let token = undefined;
 
-    var doUpload = function () {
+    const doUpload = function () {
       HTTP.post(staticHost + "/" + token, { content: file, }, function (err, result) {
         if (err) {
           alert("Upload failed: " + err.message);

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -18,7 +18,7 @@ SandstormAccountSettingsUi = function (topbar, db, staticHost) {
   this._topbar = topbar;
   this._db = db;
   this._staticHost = staticHost;
-}
+};
 
 Template.sandstormAccountSettings.onCreated(function () {
   this._isLinkingNewIdentity = new ReactiveVar(false);
@@ -30,7 +30,7 @@ Template.sandstormAccountSettings.onCreated(function () {
   //   the URL?
   if (Session.get("linkingIdentityError")) {
     this._actionCompleted.set(
-      {error: "Error linking identity: " + Session.get("linkingIdentityError")});
+      { error: "Error linking identity: " + Session.get("linkingIdentityError") });
     Session.set("linkingIdentityError");
   }
 
@@ -40,7 +40,7 @@ Template.sandstormAccountSettings.onCreated(function () {
     if (user && user.loginIdentities) {
       var identities = user.loginIdentities.concat(user.nonloginIdentities);
       var currentlySelected = self._selectedIdentityId.get();
-      if (!currentlySelected || !_.findWhere(identities, {id: currentlySelected})) {
+      if (!currentlySelected || !_.findWhere(identities, { id: currentlySelected })) {
         if (identities.length > 0) {
           self._selectedIdentityId.set(identities[0].id);
         }
@@ -49,15 +49,16 @@ Template.sandstormAccountSettings.onCreated(function () {
   });
 });
 
-GENDERS = {male: "male", female: "female", neutral: "neutral", robot: "robot"};
+GENDERS = { male: "male", female: "female", neutral: "neutral", robot: "robot" };
 
 var helpers = {
   setDocumentTitle: function () {
     document.title = "Account settings · " + Template.instance().data._db.getServerTitle();
   },
+
   identities: function () {
     return SandstormDb.getUserIdentityIds(Meteor.user()).map(function (id) {
-      var identity = Meteor.users.findOne({_id: id});
+      var identity = Meteor.users.findOne({ _id: id });
       if (identity) {
         SandstormDb.fillInProfileDefaults(identity);
         SandstormDb.fillInIntrinsicName(identity);
@@ -66,12 +67,17 @@ var helpers = {
       }
     });
   },
+
   isNeutral: function () {
     return this.pronoun === "neutral" || !(this.pronoun in GENDERS);
   },
+
   isMale: function () { return this.pronoun === "male"; },
+
   isFemale: function () { return this.pronoun === "female"; },
+
   isRobot: function () { return this.pronoun === "robot"; },
+
   isPaymentsEnabled: function () {
     try {
       BlackrockPayments; // This checks that BlackrockPayments is defined.
@@ -81,9 +87,10 @@ var helpers = {
     }
   },
 
-  isAccountUser: function() {
+  isAccountUser: function () {
     return Meteor.user() && !!Meteor.user().loginIdentities;
   },
+
   profileSaved: function () {
     return Meteor.user() && Meteor.user().hasCompletedSignup &&
       Template.instance()._profileSaved.get();
@@ -99,54 +106,63 @@ Template.sandstormAccountSettings.helpers(helpers);
 Template._accountProfileEditor.helpers(helpers);
 
 Template.sandstormAccountSettings.helpers({
-  isIdentitySelected: function(id) {
+  isIdentitySelected: function (id) {
     return Template.instance()._selectedIdentityId.get() === id;
   },
-  isIdentityHidden: function(id) {
+
+  isIdentityHidden: function (id) {
     return Template.instance()._selectedIdentityId.get() != id;
   },
-  isLinkingNewIdentity: function() {
-    return Template.instance()._isLinkingNewIdentity.get()
+
+  isLinkingNewIdentity: function () {
+    return Template.instance()._isLinkingNewIdentity.get();
   },
+
   verifiedEmails: function () {
     return Meteor.user() && SandstormDb.getUserEmails(Meteor.user())
       .filter(function (e) { return !!e.verified; });
   },
+
   needsVerifiedEmail: function () {
     return Meteor.user() && SandstormDb.getUserEmails(Meteor.user())
       .filter(function (e) { return !!e.verified; }).length == 0;
   },
+
   actionCompleted: function () {
     return Template.instance()._actionCompleted.get();
   },
+
   setActionCompleted: function () {
     var actionCompleted = Template.instance()._actionCompleted;
     return function (x) { actionCompleted.set(x); };
   },
+
   linkingNewIdentityData: function () {
     var instance = Template.instance();
     return {
       doneCallback: function () {
         instance._isLinkingNewIdentity.set(false);
-        instance._actionCompleted.set({success: "identity added"});
-      }
+        instance._actionCompleted.set({ success: "identity added" });
+      },
     };
   },
+
   emailLoginFormData: function () {
     var instance = Template.instance();
     return {
       linkingNewIdentity: {
-        doneCallback: function() {
+        doneCallback: function () {
           var input = instance.find("input[name='email']");
           if (input) {
             input.value = "";
           };
-          instance._actionCompleted.set({success: "identity added"});
-        }
+
+          instance._actionCompleted.set({ success: "identity added" });
+        },
       },
       sendButtonText: "Confirm",
-    }
-  }
+    };
+  },
 });
 
 Template._accountProfileEditor.helpers({
@@ -154,23 +170,26 @@ Template._accountProfileEditor.helpers({
     var user = Meteor.user();
     return user && user.hasCompletedSignup;
   },
+
   identityManagementButtonsData: function () {
     if (this.identity) {
       var user = Meteor.user();
       var identityId = this.identity._id;
       return {
         _id: identityId,
-        isLogin: user.loginIdentities && !!_.findWhere(user.loginIdentities, {id: identityId}),
+        isLogin: user.loginIdentities && !!_.findWhere(user.loginIdentities, { id: identityId }),
         isDemo: this.identity.profile.service === "demo",
         setActionCompleted: Template.instance()._setActionCompleted,
       };
     }
   },
-  verifiedEmails: function() {
+
+  verifiedEmails: function () {
     if (this.identity) {
       return SandstormDb.getVerifiedEmails(this.identity);
     }
   },
+
   emailDetails: function () {
     if (this.identity) {
       var emails = SandstormDb.getVerifiedEmails(this.identity);
@@ -182,31 +201,33 @@ Template._accountProfileEditor.helpers({
         return "E-mails attached to this identity";
       }
     }
-  }
+  },
 });
 
 Template.sandstormAccountSettings.events({
-  "click [role='tab']": function(event, instance) {
+  "click [role='tab']": function (event, instance) {
     instance._actionCompleted.set();
     instance._selectedIdentityId.set(event.currentTarget.getAttribute("data-identity-id"));
   },
-  "click button.link-new-identity": function(event, instance) {
+
+  "click button.link-new-identity": function (event, instance) {
     instance._isLinkingNewIdentity.set(true);
   },
-  "click button.cancel-link-new-identity": function(event, instance) {
+
+  "click button.cancel-link-new-identity": function (event, instance) {
     instance._isLinkingNewIdentity.set(false);
   },
 
-  "click button.logout-other-sessions": function(event, instance) {
-    Meteor.logoutOtherClients(function(err) {
+  "click button.logout-other-sessions": function (event, instance) {
+    Meteor.logoutOtherClients(function (err) {
       if (err) {
-        instance._actionCompleted.set({error: err});
+        instance._actionCompleted.set({ error: err });
       } else {
-        Meteor.call("logoutIdentitiesOfCurrentAccount", function(err) {
+        Meteor.call("logoutIdentitiesOfCurrentAccount", function (err) {
           if (err) {
-            instance._actionCompleted.set({error: err});
+            instance._actionCompleted.set({ error: err });
           } else {
-            instance._actionCompleted.set({success: "logged out other sessions"});
+            instance._actionCompleted.set({ success: "logged out other sessions" });
           }
         });
       }
@@ -218,11 +239,10 @@ Template.sandstormAccountSettings.events({
   },
 });
 
-
 Template.sandstormAccountsFirstSignIn.helpers({
   identityToConfirm: function () {
     var identityId = SandstormDb.getUserIdentityIds(Meteor.user())[0];
-    var identity = Meteor.users.findOne({_id: identityId});
+    var identity = Meteor.users.findOne({ _id: identityId });
     if (identity) {
       SandstormDb.fillInProfileDefaults(identity);
       SandstormDb.fillInIntrinsicName(identity);
@@ -230,6 +250,7 @@ Template.sandstormAccountsFirstSignIn.helpers({
       return identity;
     }
   },
+
   termsAndPrivacy: function () {
     var result = {
       termsUrl: Template.currentData()._db.getSetting("termsUrl"),
@@ -269,6 +290,7 @@ var submitProfileForm = function (event, cb) {
           "underscores, and must not start with a digit.");
     return;
   }
+
   var identityId = form.getAttribute("data-identity-id");
 
   Meteor.call("updateProfile", identityId, newProfile, function (err) {
@@ -288,16 +310,17 @@ var submitProfileForm = function (event, cb) {
 
   // Pass off to payments module.
   BlackrockPayments.processOptins(form);
-}
+};
 
 Template._accountProfileEditor.events({
   "submit form.account-profile-editor": function (event, instance) {
     submitProfileForm(event, function () {
       instance._profileSaved.set(true);
-      instance._setActionCompleted({success: "profile saved"});
+      instance._setActionCompleted({ success: "profile saved" });
     });
   },
-  "change": function (event, instance) {
+
+  change: function (event, instance) {
     // Pictures get saved right away.
     //
     // TODO(someday): Upload pictures to a staging area, perhaps allowing the user to resize
@@ -306,13 +329,15 @@ Template._accountProfileEditor.events({
 
     instance._profileSaved.set(false);
   },
+
   "input input": function () { Template.instance()._profileSaved.set(false); },
-  "keypress": function () { Template.instance()._profileSaved.set(false); },
+
+  keypress: function () { Template.instance()._profileSaved.set(false); },
 
   "click .logout": function (event, instance) {
     event.preventDefault();
     Meteor.logout();
-  }
+  },
 });
 
 Template._accountProfileEditor.onCreated(function () {
@@ -340,10 +365,10 @@ Template._accountProfileEditor.events({
         } else if (result.statusCode >= 400) {
           alert("Upload failed: " + result.statusCode + " " + result.content);
         } else {
-          instance._setActionCompleted({success: "picture updated"});
+          instance._setActionCompleted({ success: "picture updated" });
         }
       });
-    }
+    };
 
     Meteor.call("uploadProfilePicture", instance.data.identity._id, function (err, result) {
       if (err) {
@@ -359,7 +384,8 @@ Template._accountProfileEditor.events({
       file = event.currentTarget.files[0];
       if (file && token) doUpload();
     }
+
     input.addEventListener("change", listener);
     input.click();
-  }
+  },
 });

--- a/shell/packages/sandstorm-accounts-ui/accounts-ui-methods.js
+++ b/shell/packages/sandstorm-accounts-ui/accounts-ui-methods.js
@@ -31,18 +31,18 @@ Meteor.methods({
       name: String,
       handle: ValidHandle,
       pronoun: Match.OneOf("male", "female", "neutral", "robot"),
-      unverifiedEmail: Match.Optional(String)
+      unverifiedEmail: Match.Optional(String),
     });
 
     if (!this.userId) {
       throw new Meteor.Error(403, "not logged in");
     }
 
-    var userToUpdate = Meteor.users.findOne({_id: identityId});
+    var userToUpdate = Meteor.users.findOne({ _id: identityId });
 
     if (!this.isSimulation &&
         !this.connection.sandstormDb.userHasIdentity(this.userId, identityId)) {
-      throw new Meteor.Error(403, "identity is not linked to current user: "+ identityId);
+      throw new Meteor.Error(403, "identity is not linked to current user: " + identityId);
     }
 
     var newValues = {
@@ -51,10 +51,10 @@ Meteor.methods({
       "profile.pronoun": profile.pronoun,
     };
 
-    Meteor.users.update({_id: userToUpdate._id}, {$set: newValues});
+    Meteor.users.update({ _id: userToUpdate._id }, { $set: newValues });
 
     if (!Meteor.user().hasCompletedSignup) {
-      Meteor.users.update({_id: this.userId}, {$set: {hasCompletedSignup: true}});
+      Meteor.users.update({ _id: this.userId }, { $set: { hasCompletedSignup: true } });
     }
   },
 
@@ -63,14 +63,14 @@ Meteor.methods({
       throw new Meteor.Error(403, "not logged in");
     }
 
-    Meteor.users.update(this.userId, {$unset: {hasCompletedSignup: ""}});
+    Meteor.users.update(this.userId, { $unset: { hasCompletedSignup: "" } });
   },
 });
 
 if (Meteor.isClient) {
   window.testFirstSignup = function () {
     Meteor.call("testFirstSignup");
-  }
+  };
 }
 
 if (Meteor.isServer) {
@@ -84,7 +84,7 @@ if (Meteor.isServer) {
       }
 
       return this.connection.sandstormDb.newAssetUpload({
-        profilePicture: { userId: this.userId, identityId: identityId }
+        profilePicture: { userId: this.userId, identityId: identityId },
       });
     },
 
@@ -93,17 +93,18 @@ if (Meteor.isServer) {
       this.connection.sandstormDb.fulfillAssetUpload(id);
     },
 
-    setPrimaryEmail: function(email) {
+    setPrimaryEmail: function (email) {
       check(email, String);
       if (!this.userId) {
         throw new Meteor.Error(403, "Not logged in.");
       }
+
       var emails = SandstormDb.getUserEmails(Meteor.user());
-      if (!_.findWhere(emails, {email: email, verified: true})) {
+      if (!_.findWhere(emails, { email: email, verified: true })) {
         throw new Meteor.Error(403, "Not a verified email of the current user: " + email);
       }
 
-      Meteor.users.update({_id: this.userId}, {$set: {primaryEmail: email}});
+      Meteor.users.update({ _id: this.userId }, { $set: { primaryEmail: email } });
     },
   });
 }

--- a/shell/packages/sandstorm-accounts-ui/accounts-ui-methods.js
+++ b/shell/packages/sandstorm-accounts-ui/accounts-ui-methods.js
@@ -17,7 +17,7 @@
 // This file contains method definitions which are available on both client and server (on the
 // client for prediction purposes, on the server for actual execution).
 
-var ValidHandle = Match.Where(function (handle) {
+const ValidHandle = Match.Where(function (handle) {
   check(handle, String);
   return !!handle.match(/^[a-z_][a-z0-9_]*$/);
 });
@@ -38,14 +38,14 @@ Meteor.methods({
       throw new Meteor.Error(403, "not logged in");
     }
 
-    var userToUpdate = Meteor.users.findOne({ _id: identityId });
+    const userToUpdate = Meteor.users.findOne({ _id: identityId });
 
     if (!this.isSimulation &&
         !this.connection.sandstormDb.userHasIdentity(this.userId, identityId)) {
       throw new Meteor.Error(403, "identity is not linked to current user: " + identityId);
     }
 
-    var newValues = {
+    const newValues = {
       "profile.name": profile.name,
       "profile.handle": profile.handle,
       "profile.pronoun": profile.pronoun,
@@ -99,7 +99,7 @@ if (Meteor.isServer) {
         throw new Meteor.Error(403, "Not logged in.");
       }
 
-      var emails = SandstormDb.getUserEmails(Meteor.user());
+      const emails = SandstormDb.getUserEmails(Meteor.user());
       if (!_.findWhere(emails, { email: email, verified: true })) {
         throw new Meteor.Error(403, "Not a verified email of the current user: " + email);
       }

--- a/shell/packages/sandstorm-accounts-ui/accounts-ui-server.js
+++ b/shell/packages/sandstorm-accounts-ui/accounts-ui-server.js
@@ -17,9 +17,12 @@
 // Meteor permits users to modify their own profile by default, for some reason.
 Meteor.users.deny({
   insert: function () { return true; },
+
   update: function () { return true; },
+
   remove: function () { return true; },
-  fetch: []
+
+  fetch: [],
 });
 
 Meteor.publish("getMyUsage", function () {
@@ -32,5 +35,6 @@ Meteor.publish("getMyUsage", function () {
       pseudoUsage: usage,
     });
   }
+
   this.ready();
 });

--- a/shell/packages/sandstorm-accounts-ui/accounts-ui-server.js
+++ b/shell/packages/sandstorm-accounts-ui/accounts-ui-server.js
@@ -26,11 +26,11 @@ Meteor.users.deny({
 });
 
 Meteor.publish("getMyUsage", function () {
-  var db = this.connection.sandstormDb;
+  const db = this.connection.sandstormDb;
   if (this.userId) {
     // TODO(someday): Make this reactive.
-    var user = Meteor.users.findOne(this.userId);
-    var usage = db.getMyUsage(user);
+    const user = Meteor.users.findOne(this.userId);
+    const usage = db.getMyUsage(user);
     this.added("users", this.userId, {
       pseudoUsage: usage,
     });

--- a/shell/packages/sandstorm-accounts-ui/accounts_ui.js
+++ b/shell/packages/sandstorm-accounts-ui/accounts_ui.js
@@ -3,5 +3,5 @@ AccountsUi = function (db) {
   // and `loginButtonsPopup` templates.
 
   this._db = db;
-}
+};
 

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -5,9 +5,10 @@ var helpers = {
   isCurrentRoute: function (routeName) {
     return Router.current().route.getName() == routeName;
   },
+
   isDemoUser: function () {
     return this._db.isDemoUser();
-  }
+  },
 };
 
 Template.loginButtons.helpers(helpers);
@@ -15,24 +16,24 @@ Template.loginButtonsPopup.helpers(helpers);
 Template._loginButtonsLoggedOutDropdown.helpers(helpers);
 Template._loginButtonsLoggedInDropdown.helpers(helpers);
 
-Template.loginButtonsPopup.onRendered(function() {
+Template.loginButtonsPopup.onRendered(function () {
   this.find(".login-buttons-list :first-child").focus();
 });
 
-Template.accountButtonsPopup.onRendered(function() {
+Template.accountButtonsPopup.onRendered(function () {
   this.find(".account-buttons-list :first-child").focus();
 });
 
 Template.accountButtonsPopup.events({
-  'click button.logout': function() {
+  "click button.logout": function () {
     // TODO(cleanup): Don't rely on global var set in outermost package!
     logoutSandstorm();
-  }
+  },
 });
 
 var displayName = function () {
   var currentIdentityId = Accounts.getCurrentIdentityId();
-  var user = Meteor.users.findOne({_id: currentIdentityId});
+  var user = Meteor.users.findOne({ _id: currentIdentityId });
   if (!user) return "(incognito)";
 
   SandstormDb.fillInProfileDefaults(user);
@@ -40,12 +41,12 @@ var displayName = function () {
 };
 
 Template.accountButtons.helpers({
-  displayName: displayName
+  displayName: displayName,
 });
 
 function getServices() {
   return _.keys(Accounts.identityServices).map(function (key) {
-    return _.extend(Accounts.identityServices[key], {name: key});
+    return _.extend(Accounts.identityServices[key], { name: key });
   }).filter(function (service) {
     return service.isEnabled() && !!service.loginTemplate;
   }).sort(function (s1, s2) { return s1.loginTemplate.priority - s2.loginTemplate.priority; });
@@ -53,14 +54,14 @@ function getServices() {
 
 Template._loginButtonsMessages.helpers({
   errorMessage: function () {
-    return loginButtonsSession.get('errorMessage');
-  }
+    return loginButtonsSession.get("errorMessage");
+  },
 });
 
 Template._loginButtonsMessages.helpers({
   infoMessage: function () {
-    return loginButtonsSession.get('infoMessage');
-  }
+    return loginButtonsSession.get("infoMessage");
+  },
 });
 
 var loginResultCallback = function (serviceName, err) {
@@ -91,12 +92,12 @@ Accounts.onPageLoadLogin(function (attemptInfo) {
 });
 
 // XXX from http://epeli.github.com/underscore.string/lib/underscore.string.js
-var capitalize = function(str){
-  str = str == null ? '' : String(str);
+var capitalize = function (str) {
+  str = str == null ? "" : String(str);
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
 
-Template._loginButtonsLoggedOutDropdown.onCreated(function() {
+Template._loginButtonsLoggedOutDropdown.onCreated(function () {
   this._topbar = Template.parentData(3);
   this._choseLogin = new ReactiveVar(false);
 });
@@ -104,7 +105,7 @@ Template._loginButtonsLoggedOutDropdown.onCreated(function() {
 Template._loginButtonsLoggedOutDropdown.helpers({
   choseLogin: function () {
     return Template.instance()._choseLogin.get();
-  }
+  },
 });
 
 Template._loginButtonsLoggedOutDropdown.events({
@@ -114,24 +115,26 @@ Template._loginButtonsLoggedOutDropdown.events({
 
   "click .login-suggestion>button.dismiss": function (event, instance) {
     instance._topbar.closePopup();
-  }
+  },
 });
 
-Template._loginButtonsLoggedInDropdown.onCreated(function() {
+Template._loginButtonsLoggedInDropdown.onCreated(function () {
   this._identitySwitcherExpanded = new ReactiveVar(false);
 });
 
 Template._loginButtonsLoggedInDropdown.helpers({
   displayName: displayName,
-  showIdentitySwitcher: function() {
+  showIdentitySwitcher: function () {
     return SandstormDb.getUserIdentityIds(Meteor.user()).length > 1;
   },
+
   identitySwitcherExpanded: function () {
     return Template.instance()._identitySwitcherExpanded.get();
   },
+
   identitySwitcherData: function () {
     var identities = SandstormDb.getUserIdentityIds(Meteor.user()).map(function (id) {
-      var identity = Meteor.users.findOne({_id: id});
+      var identity = Meteor.users.findOne({ _id: id });
       if (identity) {
         SandstormDb.fillInProfileDefaults(identity);
         SandstormDb.fillInIntrinsicName(identity);
@@ -139,25 +142,26 @@ Template._loginButtonsLoggedInDropdown.helpers({
         return identity;
       }
     });
+
     function onPicked(identityId) {
       Accounts.setCurrentIdentityId(identityId);
     }
-    return { identities: identities, onPicked: onPicked,
-             currentIdentityId: Accounts.getCurrentIdentityId() };
-  },
 
+    return { identities: identities, onPicked: onPicked,
+             currentIdentityId: Accounts.getCurrentIdentityId(), };
+  },
 
 });
 
 Template._loginButtonsLoggedInDropdown.events({
-  "click button.switch-identity" : function (event, instance) {
+  "click button.switch-identity": function (event, instance) {
     instance._identitySwitcherExpanded.set(!instance._identitySwitcherExpanded.get());
   },
 });
 
 var sendEmail = function (email, linkingNewIdentity) {
   loginButtonsSession.infoMessage("Sending email...");
-  Accounts.createAndEmailTokenForUser(email, linkingNewIdentity, function(err) {
+  Accounts.createAndEmailTokenForUser(email, linkingNewIdentity, function (err) {
     if (err) {
       loginButtonsSession.errorMessage(err.reason || "Unknown error");
       if (err.error === 409) {
@@ -188,12 +192,12 @@ var loginWithToken = function (email, token) {
 Template.loginButtonsDialog.helpers({
   allowUninvited: function () {
     return Meteor.settings.public.allowUninvited;
-  }
+  },
 });
 
-Template.loginButtonsList.onCreated(function() {
+Template.loginButtonsList.onCreated(function () {
   if (isDemoUser()) {
-    this._linkingNewIdentity = { doneCallback: function() {} };
+    this._linkingNewIdentity = { doneCallback: function () {} };
   } else if (Template.parentData(1).linkingNewIdentity) {
     this._linkingNewIdentity = Template.parentData(1).linkingNewIdentity;
   }
@@ -218,7 +222,7 @@ Template.oauthLoginButton.events({
 
 Template.loginButtonsList.helpers({
   configured: function () {
-    return !!ServiceConfiguration.configurations.findOne({service: this.name}) ||
+    return !!ServiceConfiguration.configurations.findOne({ service: this.name }) ||
            Template.instance().data._services.get(this.name);
   },
 
@@ -231,7 +235,7 @@ Template.loginButtonsList.helpers({
 
   linkingNewIdentity: function () {
     return Template.instance()._linkingNewIdentity;
-  }
+  },
 });
 
 Template.emailAuthenticationForm.events({
@@ -268,8 +272,9 @@ Template.emailAuthenticationForm.helpers({
   disabled: function () {
     return !(Accounts.identityServices.email && Accounts.identityServices.email.isEnabled());
   },
+
   awaitingToken: function () {
-    return loginButtonsSession.get('inSignupFlow');
+    return loginButtonsSession.get("inSignupFlow");
   },
 });
 
@@ -280,13 +285,14 @@ Template.devLoginForm.onCreated(function () {
 Template.devLoginForm.helpers({
   expanded: function () {
     return Template.instance()._expanded.get();
-  }
+  },
 });
 
 function loginDevHelper(name, isAdmin, linkingNewIdentity) {
   if (linkingNewIdentity) {
     sessionStorage.setItem("linkingIdentityLoginToken", Accounts._storedLoginToken());
   }
+
   loginDevAccount(name, isAdmin);
 }
 
@@ -295,18 +301,21 @@ Template.devLoginForm.events({
     event.preventDefault();
     instance._expanded.set(true);
   },
+
   "click button.unexpand": function (event, instance) {
     event.preventDefault();
     instance._expanded.set(false);
   },
+
   "click button.login-dev-account": function (event, instance) {
     var displayName = event.currentTarget.getAttribute("data-name");
     var isAdmin = !!event.currentTarget.getAttribute("data-is-admin");
     loginDevHelper(displayName, isAdmin, instance.data.linkingNewIdentity);
   },
+
   "submit form": function (event, instance) {
     event.preventDefault();
     var form = instance.find("form");
     loginDevHelper(form.name.value, false, instance.data.linkingNewIdentity);
-  }
+  },
 });

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -1,7 +1,7 @@
 // for convenience
-var loginButtonsSession = Accounts._loginButtonsSession;
+const loginButtonsSession = Accounts._loginButtonsSession;
 
-var helpers = {
+const helpers = {
   isCurrentRoute: function (routeName) {
     return Router.current().route.getName() == routeName;
   },
@@ -31,9 +31,9 @@ Template.accountButtonsPopup.events({
   },
 });
 
-var displayName = function () {
-  var currentIdentityId = Accounts.getCurrentIdentityId();
-  var user = Meteor.users.findOne({ _id: currentIdentityId });
+const displayName = function () {
+  const currentIdentityId = Accounts.getCurrentIdentityId();
+  const user = Meteor.users.findOne({ _id: currentIdentityId });
   if (!user) return "(incognito)";
 
   SandstormDb.fillInProfileDefaults(user);
@@ -64,12 +64,12 @@ Template._loginButtonsMessages.helpers({
   },
 });
 
-var loginResultCallback = function (serviceName, err) {
+const loginResultCallback = function (serviceName, err) {
   if (!err) {
     loginButtonsSession.closeDropdown();
   } else if (err instanceof Accounts.LoginCancelledError) {
     // do nothing
-  } else if (err instanceof ServiceConfiguration.ConfigError) {
+  } else if (err instanceof ServiceConfiguration.ConfigError) { // jscs:ignore disallowEmptyBlocks
     loginButtonsSession.errorMessage(
       "Configuration problem: " + err.message + ". Please visit the Admin Settings page within " +
       "Sandstorm, or ask your administrator to do so. You may need an admin token. Read more by " +
@@ -92,7 +92,7 @@ Accounts.onPageLoadLogin(function (attemptInfo) {
 });
 
 // XXX from http://epeli.github.com/underscore.string/lib/underscore.string.js
-var capitalize = function (str) {
+const capitalize = function (str) {
   str = str == null ? "" : String(str);
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
@@ -133,8 +133,8 @@ Template._loginButtonsLoggedInDropdown.helpers({
   },
 
   identitySwitcherData: function () {
-    var identities = SandstormDb.getUserIdentityIds(Meteor.user()).map(function (id) {
-      var identity = Meteor.users.findOne({ _id: id });
+    const identities = SandstormDb.getUserIdentityIds(Meteor.user()).map(function (id) {
+      const identity = Meteor.users.findOne({ _id: id });
       if (identity) {
         SandstormDb.fillInProfileDefaults(identity);
         SandstormDb.fillInIntrinsicName(identity);
@@ -159,7 +159,7 @@ Template._loginButtonsLoggedInDropdown.events({
   },
 });
 
-var sendEmail = function (email, linkingNewIdentity) {
+const sendEmail = function (email, linkingNewIdentity) {
   loginButtonsSession.infoMessage("Sending email...");
   Accounts.createAndEmailTokenForUser(email, linkingNewIdentity, function (err) {
     if (err) {
@@ -177,7 +177,7 @@ var sendEmail = function (email, linkingNewIdentity) {
   });
 };
 
-var loginWithToken = function (email, token) {
+const loginWithToken = function (email, token) {
   loginButtonsSession.infoMessage("Logging in...");
   Meteor.loginWithEmailToken(email, token, function (err) {
     if (err) {
@@ -211,9 +211,9 @@ Template.oauthLoginButton.events({
 
     loginButtonsSession.resetMessages();
 
-    var loginWithService = Meteor[instance.data.data.method];
+    const loginWithService = Meteor[instance.data.data.method];
 
-    var serviceName = instance.data.data.displayName;
+    const serviceName = instance.data.data.displayName;
     loginWithService({}, function (err) {
       loginResultCallback(serviceName, err);
     });
@@ -241,8 +241,8 @@ Template.loginButtonsList.helpers({
 Template.emailAuthenticationForm.events({
   "submit form": function (event, instance) {
     event.preventDefault();
-    var form = event.currentTarget;
-    var email = loginButtonsSession.get("inSignupFlow");
+    const form = event.currentTarget;
+    const email = loginButtonsSession.get("inSignupFlow");
     if (email) {
       if (instance.data.linkingNewIdentity) {
         Meteor.call("linkEmailIdentityToAccount", email, form.token.value, function (err, result) {
@@ -308,14 +308,14 @@ Template.devLoginForm.events({
   },
 
   "click button.login-dev-account": function (event, instance) {
-    var displayName = event.currentTarget.getAttribute("data-name");
-    var isAdmin = !!event.currentTarget.getAttribute("data-is-admin");
+    const displayName = event.currentTarget.getAttribute("data-name");
+    const isAdmin = !!event.currentTarget.getAttribute("data-is-admin");
     loginDevHelper(displayName, isAdmin, instance.data.linkingNewIdentity);
   },
 
   "submit form": function (event, instance) {
     event.preventDefault();
-    var form = instance.find("form");
+    const form = instance.find("form");
     loginDevHelper(form.name.value, false, instance.data.linkingNewIdentity);
   },
 });

--- a/shell/packages/sandstorm-accounts-ui/login_buttons_dialogs.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons_dialogs.js
@@ -1,28 +1,28 @@
 // for convenience
 var loginButtonsSession = Accounts._loginButtonsSession;
 
-
 //
 // configureLoginServiceDialog template
 //
 
 Template._configureLoginServiceDialog.events({
-  'click .configure-login-service-dismiss-button': function () {
-    loginButtonsSession.set('configureLoginServiceDialogVisible', false);
+  "click .configure-login-service-dismiss-button": function () {
+    loginButtonsSession.set("configureLoginServiceDialogVisible", false);
   },
-  'click #configure-login-service-dialog-save-configuration': function () {
-    if (loginButtonsSession.get('configureLoginServiceDialogVisible') &&
-        ! loginButtonsSession.get('configureLoginServiceDialogSaveDisabled')) {
+
+  "click #configure-login-service-dialog-save-configuration": function () {
+    if (loginButtonsSession.get("configureLoginServiceDialogVisible") &&
+        !loginButtonsSession.get("configureLoginServiceDialogSaveDisabled")) {
       // Prepare the configuration document for this login service
-      var serviceName = loginButtonsSession.get('configureLoginServiceDialogServiceName');
+      var serviceName = loginButtonsSession.get("configureLoginServiceDialogServiceName");
       var configuration = {
-        service: serviceName
+        service: serviceName,
       };
 
       // Fetch the value of each input field
-      _.each(configurationFields(), function(field) {
+      _.each(configurationFields(), function (field) {
         configuration[field.property] = document.getElementById(
-          'configure-login-service-dialog-' + field.property).value
+          "configure-login-service-dialog-" + field.property).value
           .replace(/^\s*|\s*$/g, ""); // trim() doesnt work on IE8;
       });
 
@@ -37,7 +37,7 @@ Template._configureLoginServiceDialog.events({
             Meteor._debug("Error configuring login service " + serviceName,
                           error);
           else
-            loginButtonsSession.set('configureLoginServiceDialogVisible',
+            loginButtonsSession.set("configureLoginServiceDialogVisible",
                                     false);
         });
     }
@@ -45,35 +45,35 @@ Template._configureLoginServiceDialog.events({
   // IE8 doesn't support the 'input' event, so we'll run this on the keyup as
   // well. (Keeping the 'input' event means that this also fires when you use
   // the mouse to change the contents of the field, eg 'Cut' menu item.)
-  'input, keyup input': function (event) {
+  "input, keyup input": function (event) {
     // if the event fired on one of the configuration input fields,
     // check whether we should enable the 'save configuration' button
-    if (event.target.id.indexOf('configure-login-service-dialog') === 0)
+    if (event.target.id.indexOf("configure-login-service-dialog") === 0)
       updateSaveDisabled();
-  }
+  },
 });
 
 // check whether the 'save configuration' button should be enabled.
 // this is a really strange way to implement this and a Forms
 // Abstraction would make all of this reactive, and simpler.
 var updateSaveDisabled = function () {
-  var anyFieldEmpty = _.any(configurationFields(), function(field) {
+  var anyFieldEmpty = _.any(configurationFields(), function (field) {
     return document.getElementById(
-      'configure-login-service-dialog-' + field.property).value === '';
+      "configure-login-service-dialog-" + field.property).value === "";
   });
 
-  loginButtonsSession.set('configureLoginServiceDialogSaveDisabled', anyFieldEmpty);
+  loginButtonsSession.set("configureLoginServiceDialogSaveDisabled", anyFieldEmpty);
 };
 
 // Returns the appropriate template for this login service.  This
 // template should be defined in the service's package
 var configureLoginServiceDialogTemplateForService = function () {
-  var serviceName = loginButtonsSession.get('configureLoginServiceDialogServiceName');
+  var serviceName = loginButtonsSession.get("configureLoginServiceDialogServiceName");
   // XXX Service providers should be able to specify their configuration
   // template name.
-  return Template['configureLoginServiceDialogFor' +
-                  (serviceName === 'meteor-developer' ?
-                   'MeteorDeveloper' :
+  return Template["configureLoginServiceDialogFor" +
+                  (serviceName === "meteor-developer" ?
+                   "MeteorDeveloper" :
                    capitalize(serviceName))];
 };
 
@@ -86,20 +86,23 @@ Template._configureLoginServiceDialog.helpers({
   configurationFields: function () {
     return configurationFields();
   },
+
   visible: function () {
-    return loginButtonsSession.get('configureLoginServiceDialogVisible');
+    return loginButtonsSession.get("configureLoginServiceDialogVisible");
   },
+
   configurationSteps: function () {
     // renders the appropriate template
     return configureLoginServiceDialogTemplateForService();
   },
+
   saveDisabled: function () {
-    return loginButtonsSession.get('configureLoginServiceDialogSaveDisabled');
-  }
+    return loginButtonsSession.get("configureLoginServiceDialogSaveDisabled");
+  },
 });
 
 // XXX from http://epeli.github.com/underscore.string/lib/underscore.string.js
-var capitalize = function(str){
-  str = str == null ? '' : String(str);
+var capitalize = function (str) {
+  str = str == null ? "" : String(str);
   return str.charAt(0).toUpperCase() + str.slice(1);
 };

--- a/shell/packages/sandstorm-accounts-ui/login_buttons_dialogs.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons_dialogs.js
@@ -1,5 +1,5 @@
 // for convenience
-var loginButtonsSession = Accounts._loginButtonsSession;
+const loginButtonsSession = Accounts._loginButtonsSession;
 
 //
 // configureLoginServiceDialog template
@@ -14,8 +14,8 @@ Template._configureLoginServiceDialog.events({
     if (loginButtonsSession.get("configureLoginServiceDialogVisible") &&
         !loginButtonsSession.get("configureLoginServiceDialogSaveDisabled")) {
       // Prepare the configuration document for this login service
-      var serviceName = loginButtonsSession.get("configureLoginServiceDialogServiceName");
-      var configuration = {
+      const serviceName = loginButtonsSession.get("configureLoginServiceDialogServiceName");
+      const configuration = {
         service: serviceName,
       };
 
@@ -56,8 +56,8 @@ Template._configureLoginServiceDialog.events({
 // check whether the 'save configuration' button should be enabled.
 // this is a really strange way to implement this and a Forms
 // Abstraction would make all of this reactive, and simpler.
-var updateSaveDisabled = function () {
-  var anyFieldEmpty = _.any(configurationFields(), function (field) {
+const updateSaveDisabled = function () {
+  const anyFieldEmpty = _.any(configurationFields(), function (field) {
     return document.getElementById(
       "configure-login-service-dialog-" + field.property).value === "";
   });
@@ -67,8 +67,8 @@ var updateSaveDisabled = function () {
 
 // Returns the appropriate template for this login service.  This
 // template should be defined in the service's package
-var configureLoginServiceDialogTemplateForService = function () {
-  var serviceName = loginButtonsSession.get("configureLoginServiceDialogServiceName");
+const configureLoginServiceDialogTemplateForService = function () {
+  const serviceName = loginButtonsSession.get("configureLoginServiceDialogServiceName");
   // XXX Service providers should be able to specify their configuration
   // template name.
   return Template["configureLoginServiceDialogFor" +
@@ -77,8 +77,8 @@ var configureLoginServiceDialogTemplateForService = function () {
                    capitalize(serviceName))];
 };
 
-var configurationFields = function () {
-  var template = configureLoginServiceDialogTemplateForService();
+const configurationFields = function () {
+  const template = configureLoginServiceDialogTemplateForService();
   return template.fields();
 };
 
@@ -102,7 +102,7 @@ Template._configureLoginServiceDialog.helpers({
 });
 
 // XXX from http://epeli.github.com/underscore.string/lib/underscore.string.js
-var capitalize = function (str) {
+const capitalize = function (str) {
   str = str == null ? "" : String(str);
   return str.charAt(0).toUpperCase() + str.slice(1);
 };

--- a/shell/packages/sandstorm-accounts-ui/login_buttons_session.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons_session.js
@@ -1,14 +1,14 @@
 var VALID_KEYS = [
-  'dropdownVisible',
-  'inSignupFlow',
+  "dropdownVisible",
+  "inSignupFlow",
 
-  'errorMessage',
-  'infoMessage',
+  "errorMessage",
+  "infoMessage",
 
-  'configureLoginServiceDialogVisible',
-  'configureLoginServiceDialogServiceName',
-  'configureLoginServiceDialogSaveDisabled',
-  'configureOnDesktopVisible'
+  "configureLoginServiceDialogVisible",
+  "configureLoginServiceDialogServiceName",
+  "configureLoginServiceDialogSaveDisabled",
+  "configureOnDesktopVisible",
 ];
 
 var validateKey = function (key) {
@@ -20,19 +20,19 @@ var KEY_PREFIX = "Meteor.loginButtons.";
 
 // TODO(now): Don't put this under `Accounts`.
 Accounts._loginButtonsSession = {
-  set: function(key, value) {
+  set: function (key, value) {
     validateKey(key);
-    if (_.contains(['errorMessage', 'infoMessage'], key))
+    if (_.contains(["errorMessage", "infoMessage"], key))
       throw new Error("Don't set errorMessage or infoMessage directly. Instead, use errorMessage() or infoMessage().");
 
     this._set(key, value);
   },
 
-  _set: function(key, value) {
+  _set: function (key, value) {
     Session.set(KEY_PREFIX + key, value);
   },
 
-  get: function(key) {
+  get: function (key) {
     validateKey(key);
     return Session.get(KEY_PREFIX + key);
   },
@@ -42,13 +42,13 @@ Accounts._loginButtonsSession = {
     // TODO(now): Close the popup
   },
 
-  infoMessage: function(message) {
+  infoMessage: function (message) {
     this._set("errorMessage", null);
     this._set("infoMessage", message);
     this.ensureMessageVisible();
   },
 
-  errorMessage: function(message) {
+  errorMessage: function (message) {
     this._set("errorMessage", message);
     this._set("infoMessage", null);
     this.ensureMessageVisible();
@@ -64,8 +64,8 @@ Accounts._loginButtonsSession = {
   },
 
   configureService: function (name) {
-    this.set('configureLoginServiceDialogVisible', true);
-    this.set('configureLoginServiceDialogServiceName', name);
-    this.set('configureLoginServiceDialogSaveDisabled', true);
-  }
+    this.set("configureLoginServiceDialogVisible", true);
+    this.set("configureLoginServiceDialogServiceName", name);
+    this.set("configureLoginServiceDialogSaveDisabled", true);
+  },
 };

--- a/shell/packages/sandstorm-accounts-ui/login_buttons_session.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons_session.js
@@ -1,4 +1,4 @@
-var VALID_KEYS = [
+const VALID_KEYS = [
   "dropdownVisible",
   "inSignupFlow",
 
@@ -11,12 +11,12 @@ var VALID_KEYS = [
   "configureOnDesktopVisible",
 ];
 
-var validateKey = function (key) {
+const validateKey = function (key) {
   if (!_.contains(VALID_KEYS, key))
     throw new Error("Invalid key in loginButtonsSession: " + key);
 };
 
-var KEY_PREFIX = "Meteor.loginButtons.";
+const KEY_PREFIX = "Meteor.loginButtons.";
 
 // TODO(now): Don't put this under `Accounts`.
 Accounts._loginButtonsSession = {

--- a/shell/packages/sandstorm-accounts-ui/package.js
+++ b/shell/packages/sandstorm-accounts-ui/package.js
@@ -1,39 +1,39 @@
 Package.describe({
   summary: "Sandstorm fork of accounts-ui",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {
-  api.use(['check', 'tracker', 'service-configuration', 'accounts-base',
-           'underscore', 'templating', 'session', 'http', 'sandstorm-db'], 'client');
-  api.use(['check', 'accounts-base', "accounts-identity"], 'server');
+  api.use(["check", "tracker", "service-configuration", "accounts-base",
+           "underscore", "templating", "session", "http", "sandstorm-db",], "client");
+  api.use(["check", "accounts-base", "accounts-identity"], "server");
 
   // Export Accounts (etc) to packages using this one.
-  api.imply('accounts-base', ['client', 'server']);
+  api.imply("accounts-base", ["client", "server"]);
 
-  api.use('sandstorm-accounts-packages', {weak: true});
+  api.use("sandstorm-accounts-packages", { weak: true });
 
   // Allow us to check if payments are enabled
-  api.use('blackrock-payments', {weak: true});
+  api.use("blackrock-payments", { weak: true });
 
-  api.use('less', 'client');
-  api.use('reactive-dict', 'client');
+  api.use("less", "client");
+  api.use("reactive-dict", "client");
 
   api.addFiles([
-    'login_buttons.html',
-    'login_buttons.less',
-    'login_buttons_dialogs.html',
+    "login_buttons.html",
+    "login_buttons.less",
+    "login_buttons_dialogs.html",
 
-    'login_buttons_session.js',
+    "login_buttons_session.js",
 
-    'login_buttons.js',
-    'login_buttons_dialogs.js',
+    "login_buttons.js",
+    "login_buttons_dialogs.js",
 
-    'account-settings.html',
-    'account-settings.js',
-    'accounts-ui-methods.js',
+    "account-settings.html",
+    "account-settings.js",
+    "accounts-ui-methods.js",
 
-    'accounts_ui.js'], 'client');
+    "accounts_ui.js",], "client");
 
   api.addFiles(["accounts-ui-server.js", "accounts-ui-methods.js"], "server");
 

--- a/shell/packages/sandstorm-accounts-ui/package.js
+++ b/shell/packages/sandstorm-accounts-ui/package.js
@@ -4,8 +4,11 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use(["check", "tracker", "service-configuration", "accounts-base",
-           "underscore", "templating", "session", "http", "sandstorm-db",], "client");
+  api.use("ecmascript");
+  api.use([
+    "check", "tracker", "service-configuration", "accounts-base",
+    "underscore", "templating", "session", "http", "sandstorm-db",
+  ], "client");
   api.use(["check", "accounts-base", "accounts-identity"], "server");
 
   // Export Accounts (etc) to packages using this one.
@@ -33,7 +36,8 @@ Package.onUse(function (api) {
     "account-settings.js",
     "accounts-ui-methods.js",
 
-    "accounts_ui.js",], "client");
+    "accounts_ui.js",
+  ], "client");
 
   api.addFiles(["accounts-ui-server.js", "accounts-ui-methods.js"], "server");
 

--- a/shell/packages/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
+++ b/shell/packages/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
@@ -28,18 +28,18 @@ Meteor.users.remove({});
 // Note that `meteor test-packages` starts with a fresh Mongo instance. That instance, however,
 // does not automatically get cleared on hot code reload.
 
-globalDb.collections.settings.upsert({_id: "appMarketUrl"},
-                                     {$set: {value: "https://apps.sandstorm.io"}});
-globalDb.collections.settings.upsert({_id: "appIndexUrl"},
-                                     {$set: {value: "https://app-index.sandstorm.io"}});
-globalDb.collections.settings.upsert({_id: "appUpdatesEnabled"},
-                                     {$set: {value: true}});
+globalDb.collections.settings.upsert({ _id: "appMarketUrl" },
+                                     { $set: { value: "https://apps.sandstorm.io" } });
+globalDb.collections.settings.upsert({ _id: "appIndexUrl" },
+                                     { $set: { value: "https://app-index.sandstorm.io" } });
+globalDb.collections.settings.upsert({ _id: "appUpdatesEnabled" },
+                                     { $set: { value: true } });
 
-var aliceUserId = Accounts.insertUserDoc({profile: {name: "Alice"},
-                                          service: {dev: {name: "alice" + Crypto.randomBytes(10).toString("hex")}}},
+var aliceUserId = Accounts.insertUserDoc({ profile: { name: "Alice" },
+                                          service: { dev: { name: "alice" + Crypto.randomBytes(10).toString("hex") } }, },
                                          {});
-var bobUserId = Accounts.insertUserDoc({profile: {name: "Bob"},
-                                        service: {dev: {name: "Bob" + Crypto.randomBytes(10).toString("hex")}}},
+var bobUserId = Accounts.insertUserDoc({ profile: { name: "Bob" },
+                                        service: { dev: { name: "Bob" + Crypto.randomBytes(10).toString("hex") } }, },
                                        {});
 
 var packageV0 = { _id: "mock-package-id1",
@@ -54,9 +54,9 @@ var packageV0 = { _id: "mock-package-id1",
      appTitle: { defaultText: "Mock App" },
      actions: [{
        input: { none: null },
-       title: { defaultText: "New Mock App" } }],
+       title: { defaultText: "New Mock App" }, },],
      appVersion: 0,
-     minUpgradableAppVersion: 0 },
+     minUpgradableAppVersion: 0, },
   appId: "mock-app-id",
 };
 
@@ -70,9 +70,9 @@ var packageV1 = { _id: "mock-package-id2",
      maxApiVersion: 0,
      appMarketingVersion: { defaultText: "0.2" },
      appTitle: { defaultText: "Mock App" },
-     actions: [{title: { defaultText: "New Mock App" } }],
+     actions: [{ title: { defaultText: "New Mock App" } }],
      appVersion: 2,
-     minUpgradableAppVersion: 0 },
+     minUpgradableAppVersion: 0, },
   appId: "mock-app-id",
 };
 
@@ -80,7 +80,7 @@ globalDb.collections.packages.insert(packageV0);
 globalDb.collections.packages.insert(packageV1);
 
 function stubUser(test, userId) {
-  test.stub(Meteor, "userId", function() {
+  test.stub(Meteor, "userId", function () {
     return userId;
   });
 }
@@ -91,16 +91,17 @@ Tinytest.add("test update notifications", function (test) {
   globalDb.collections.notifications.remove({});
 
   sinon.test(function (test2) {
-    this.stub(Meteor, "call", function() {});
+    this.stub(Meteor, "call", function () {});
+
     stubUser(this, aliceUserId);
     this.stub(HTTP, "get", function () {
-      return {data: { apps: [{
+      return { data: { apps: [{
         appId: "mock-app-id",
         versionNumber: 1,
         version: "0.2",
         packageId: "mock-package-id2",
         name: "Mock App",
-      }]}};
+      },], }, };
     });
 
     globalDb.addUserActions("mock-package-id1");

--- a/shell/packages/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
+++ b/shell/packages/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
@@ -14,9 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var Crypto = Npm.require("crypto");
+const Crypto = Npm.require("crypto");
 
-var globalDb = new SandstormDb();
+const globalDb = new SandstormDb();
 // TODO(cleanup): Use a lightweight fake (minimongo-based?) database here and construct a clean
 // instance at the start of each test case.
 
@@ -35,14 +35,14 @@ globalDb.collections.settings.upsert({ _id: "appIndexUrl" },
 globalDb.collections.settings.upsert({ _id: "appUpdatesEnabled" },
                                      { $set: { value: true } });
 
-var aliceUserId = Accounts.insertUserDoc({ profile: { name: "Alice" },
+const aliceUserId = Accounts.insertUserDoc({ profile: { name: "Alice" },
                                           service: { dev: { name: "alice" + Crypto.randomBytes(10).toString("hex") } }, },
                                          {});
-var bobUserId = Accounts.insertUserDoc({ profile: { name: "Bob" },
+const bobUserId = Accounts.insertUserDoc({ profile: { name: "Bob" },
                                         service: { dev: { name: "Bob" + Crypto.randomBytes(10).toString("hex") } }, },
                                        {});
 
-var packageV0 = { _id: "mock-package-id1",
+const packageV0 = { _id: "mock-package-id1",
   status: "ready",
   progress: 1,
   isAutoUpdated: false,
@@ -52,15 +52,18 @@ var packageV0 = { _id: "mock-package-id1",
      maxApiVersion: 0,
      appMarketingVersion: { defaultText: "0.1" },
      appTitle: { defaultText: "Mock App" },
-     actions: [{
-       input: { none: null },
-       title: { defaultText: "New Mock App" }, },],
+     actions: [
+       {
+         input: { none: null },
+         title: { defaultText: "New Mock App" },
+       },
+     ],
      appVersion: 0,
      minUpgradableAppVersion: 0, },
   appId: "mock-app-id",
 };
 
-var packageV1 = { _id: "mock-package-id2",
+const packageV1 = { _id: "mock-package-id2",
   status: "ready",
   progress: 1,
   isAutoUpdated: false,
@@ -95,13 +98,19 @@ Tinytest.add("test update notifications", function (test) {
 
     stubUser(this, aliceUserId);
     this.stub(HTTP, "get", function () {
-      return { data: { apps: [{
-        appId: "mock-app-id",
-        versionNumber: 1,
-        version: "0.2",
-        packageId: "mock-package-id2",
-        name: "Mock App",
-      },], }, };
+      return {
+        data: {
+          apps: [
+            {
+              appId: "mock-app-id",
+              versionNumber: 1,
+              version: "0.2",
+              packageId: "mock-package-id2",
+              name: "Mock App",
+            },
+          ],
+        },
+      };
     });
 
     globalDb.addUserActions("mock-package-id1");
@@ -110,8 +119,8 @@ Tinytest.add("test update notifications", function (test) {
 
   // This blocking call to findOne was having some weird interaction with sinon.test. I've moved it,
   // and the rest of the test out of the sinon.test block.
-  var notification = globalDb.collections.notifications.findOne();
-  var appUpdate = notification.appUpdates["mock-app-id"];
+  const notification = globalDb.collections.notifications.findOne();
+  const appUpdate = notification.appUpdates["mock-app-id"];
   test.isNotNull(appUpdate);
   test.equal(appUpdate.name, "Mock App");
   test.equal(appUpdate.marketingVersion, "0.2");

--- a/shell/packages/sandstorm-autoupdate-apps/autoupdate-apps.js
+++ b/shell/packages/sandstorm-autoupdate-apps/autoupdate-apps.js
@@ -17,27 +17,27 @@
 SandstormAutoupdateApps = {};
 
 SandstormAutoupdateApps.updateAppIndex = function (db) {
-  var appUpdatesEnabledSetting = db.collections.settings.findOne({ _id: "appUpdatesEnabled" });
-  var appUpdatesEnabled = appUpdatesEnabledSetting && appUpdatesEnabledSetting.value;
+  const appUpdatesEnabledSetting = db.collections.settings.findOne({ _id: "appUpdatesEnabled" });
+  const appUpdatesEnabled = appUpdatesEnabledSetting && appUpdatesEnabledSetting.value;
   if (!appUpdatesEnabled) {
     // It's much simpler to check appUpdatesEnabled here rather than reactively deactivate the
     // timer that triggers this call.
     return;
   }
 
-  var appIndexUrl = db.collections.settings.findOne({ _id: "appIndexUrl" }).value;
-  var appIndex = db.collections.appIndex;
-  var data = HTTP.get(appIndexUrl + "/apps/index.json").data;
+  const appIndexUrl = db.collections.settings.findOne({ _id: "appIndexUrl" }).value;
+  const appIndex = db.collections.appIndex;
+  const data = HTTP.get(appIndexUrl + "/apps/index.json").data;
   data.apps.forEach(function (app) {
     app._id = app.appId;
 
-    var oldApp = appIndex.findOne({ _id: app.appId });
+    const oldApp = appIndex.findOne({ _id: app.appId });
     app.hasSentNotifications = false;
     appIndex.upsert({ _id: app._id }, app);
     if ((!oldApp || app.versionNumber > oldApp.versionNumber) &&
         db.collections.userActions.findOne({ appId: app.appId })) {
-      var pack = db.collections.packages.findOne({ _id: app.packageId });
-      var url = appIndexUrl + "/packages/" + app.packageId;
+      const pack = db.collections.packages.findOne({ _id: app.packageId });
+      const url = appIndexUrl + "/packages/" + app.packageId;
       if (pack) {
         if (pack.status === "ready") {
           if (pack.appId && pack.appId !== app.appId) {
@@ -48,7 +48,7 @@ SandstormAutoupdateApps.updateAppIndex = function (db) {
               app.version);
           }
         } else {
-          var newPack = Packages.findAndModify({
+          const newPack = Packages.findAndModify({
             query: { _id: app.packageId },
             update: { $set: { isAutoUpdated: true } },
           });
@@ -77,11 +77,11 @@ SandstormAutoupdateApps.updateAppIndex = function (db) {
 
 Meteor.methods({
   updateApps: function (appUpdates) {
-    var db = this.connection.sandstormDb;
-    var backend = this.connection.sandstormBackend;
+    const db = this.connection.sandstormDb;
+    const backend = this.connection.sandstormBackend;
 
     _.forEach(appUpdates, function (val, appId) {
-      var pack = db.collections.packages.findOne({ _id: val.packageId, appId: appId });
+      const pack = db.collections.packages.findOne({ _id: val.packageId, appId: appId });
       if (!pack || !pack.manifest) {
         console.error("Newer app not installed", val.name);
       } else {

--- a/shell/packages/sandstorm-autoupdate-apps/package.js
+++ b/shell/packages/sandstorm-autoupdate-apps/package.js
@@ -27,6 +27,6 @@ Package.onUse(function (api) {
 
 Package.onTest(function (api) {
   api.use(["http", "practicalmeteor:sinon", "accounts-base", "sandstorm-db",
-    "tinytest", "sandstorm-autoupdate-apps"], ["server"]);
+    "tinytest", "sandstorm-autoupdate-apps",], ["server"]);
   api.addFiles("autoupdate-apps-tests.js", "server");
 });

--- a/shell/packages/sandstorm-autoupdate-apps/package.js
+++ b/shell/packages/sandstorm-autoupdate-apps/package.js
@@ -20,13 +20,17 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.use("http");
   api.addFiles(["autoupdate-apps.js"], ["server"]);
   api.export("SandstormAutoupdateApps");
 });
 
 Package.onTest(function (api) {
-  api.use(["http", "practicalmeteor:sinon", "accounts-base", "sandstorm-db",
-    "tinytest", "sandstorm-autoupdate-apps",], ["server"]);
+  api.use("ecmascript");
+  api.use([
+    "http", "practicalmeteor:sinon", "accounts-base", "sandstorm-db",
+    "tinytest", "sandstorm-autoupdate-apps",
+  ], ["server"]);
   api.addFiles("autoupdate-apps-tests.js", "server");
 });

--- a/shell/packages/sandstorm-backend/package.js
+++ b/shell/packages/sandstorm-backend/package.js
@@ -20,6 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.use(["accounts-base", "sandstorm-db", "sandstorm-permissions"], ["server"]);
   api.addFiles(["sandstorm-backend.js"], ["server"]);
   api.export("SandstormBackend");

--- a/shell/packages/sandstorm-backend/package.js
+++ b/shell/packages/sandstorm-backend/package.js
@@ -16,7 +16,7 @@
 
 Package.describe({
   summary: "Sandstorm package for interacting with the backend.",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {

--- a/shell/packages/sandstorm-contacts/contacts-client.js
+++ b/shell/packages/sandstorm-contacts/contacts-client.js
@@ -19,7 +19,7 @@ function transform(contact) {
   return contact;
 }
 
-ContactProfiles = new Mongo.Collection("contactProfiles", {transform: transform});
+ContactProfiles = new Mongo.Collection("contactProfiles", { transform: transform });
 // A psuedo-collection used to store the results of joining Contacts with identity profiles.
 //
 // Each contains:

--- a/shell/packages/sandstorm-contacts/package.js
+++ b/shell/packages/sandstorm-contacts/package.js
@@ -16,7 +16,7 @@
 
 Package.describe({
   summary: "Sandstorm Contacts",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {

--- a/shell/packages/sandstorm-contacts/package.js
+++ b/shell/packages/sandstorm-contacts/package.js
@@ -20,6 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.use(["check", "tracker", "underscore", "mongo"], "client");
   api.use(["sandstorm-db"], ["client", "server"]);
   api.addFiles(["contacts-client.js"], "client");

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -23,7 +23,7 @@ if (Meteor.isServer && process.env.LOG_MONGO_QUERIES) {
   Mongo.Collection.prototype.find = function () {
     console.log(this._prefix, arguments);
     return oldFind.apply(this, arguments);
-  }
+  };
 }
 
 // Helper so that we don't have to if (Meteor.isServer) before declaring indexes.
@@ -120,16 +120,16 @@ if (Meteor.isServer) {
 //   stashedOldUser: A complete copy of this user from before the accounts/identities migration.
 //                   TODO(cleanup): Delete this field once we're sure it's safe to do so.
 
-Meteor.users.ensureIndexOnServer("services.google.email", {sparse: 1});
-Meteor.users.ensureIndexOnServer("services.github.emails.email", {sparse: 1});
-Meteor.users.ensureIndexOnServer("services.email.email", {unique: 1, sparse: 1});
-Meteor.users.ensureIndexOnServer("loginIdentities.id", {unique: 1, sparse: 1});
-Meteor.users.ensureIndexOnServer("nonloginIdentities.id", {sparse: 1});
-Meteor.users.ensureIndexOnServer("services.google.id", {unique: 1, sparse: 1});
-Meteor.users.ensureIndexOnServer("services.github.id", {unique: 1, sparse: 1});
+Meteor.users.ensureIndexOnServer("services.google.email", { sparse: 1 });
+Meteor.users.ensureIndexOnServer("services.github.emails.email", { sparse: 1 });
+Meteor.users.ensureIndexOnServer("services.email.email", { unique: 1, sparse: 1 });
+Meteor.users.ensureIndexOnServer("loginIdentities.id", { unique: 1, sparse: 1 });
+Meteor.users.ensureIndexOnServer("nonloginIdentities.id", { sparse: 1 });
+Meteor.users.ensureIndexOnServer("services.google.id", { unique: 1, sparse: 1 });
+Meteor.users.ensureIndexOnServer("services.github.id", { unique: 1, sparse: 1 });
 
 // TODO(cleanup): This index is obsolete; delete it.
-Meteor.users.ensureIndexOnServer("identities.id", {unique: 1, sparse: 1});
+Meteor.users.ensureIndexOnServer("identities.id", { unique: 1, sparse: 1 });
 
 Packages = new Mongo.Collection("packages");
 // Packages which are installed or downloading.
@@ -570,11 +570,11 @@ if (Meteor.isServer) {
 
     if (this.userId) {
       return [
-        Meteor.users.find({_id: this.userId},
-            {fields: {signupKey: 1, isAdmin: 1, expires: 1, storageUsage: 1,
+        Meteor.users.find({ _id: this.userId },
+            { fields: { signupKey: 1, isAdmin: 1, expires: 1, storageUsage: 1,
                       plan: 1, planBonus: 1, hasCompletedSignup: 1, experiments: 1,
-                      referredIdentityIds: 1}}),
-        Plans.find()
+                      referredIdentityIds: 1, }, }),
+        Plans.find(),
       ];
     } else {
       return [];
@@ -582,7 +582,7 @@ if (Meteor.isServer) {
   });
 }
 
-isDemoUser = function() {
+isDemoUser = function () {
   // Returns true if this is a demo user.
 
   var user = Meteor.user();
@@ -591,9 +591,9 @@ isDemoUser = function() {
   } else {
     return false;
   }
-}
+};
 
-isSignedUp = function() {
+isSignedUp = function () {
   // Returns true if the user has presented an invite key.
 
   var user = Meteor.user();
@@ -609,7 +609,7 @@ isSignedUp = function() {
   if (user.signupKey) return true;  // user is invited
 
   return false;
-}
+};
 
 isSignedUpOrDemo = function () {
   var user = Meteor.user();
@@ -625,9 +625,9 @@ isSignedUpOrDemo = function () {
   if (user.signupKey) return true;  // user is invited
 
   return false;
-}
+};
 
-var calculateReferralBonus = function(user) {
+var calculateReferralBonus = function (user) {
   // This function returns an object of the form:
   //
   // - {grains: 0, storage: 0}
@@ -644,30 +644,31 @@ var calculateReferralBonus = function(user) {
   successfulReferralsCount = countReferrals(user);
   if (isPaid) {
     var maxPaidStorageBonus = 30 * 1e9;
-    return {grains: 0,
+    return { grains: 0,
             storage: Math.min(
               successfulReferralsCount * 2 * 1e9,
-              maxPaidStorageBonus)};
+              maxPaidStorageBonus), };
   } else {
     var maxFreeStorageBonus = 2 * 1e9;
     var bonus = {
       storage: Math.min(
         successfulReferralsCount * 50 * 1e6,
-        maxFreeStorageBonus)
+        maxFreeStorageBonus),
     };
     if (successfulReferralsCount > 0) {
       bonus.grains = Infinity;
     } else {
       bonus.grains = 0;
     }
+
     return bonus;
   }
-}
+};
 
 var countReferrals = function (user) {
   var referredIdentityIds = user.referredIdentityIds;
   return (referredIdentityIds && referredIdentityIds.length || 0);
-}
+};
 
 getUserQuota = function (user) {
   var plan = Plans.findOne(user.plan || "free");
@@ -676,10 +677,10 @@ getUserQuota = function (user) {
   var userQuota = {
     storage: plan.storage + referralBonus.storage + (bonus.storage || 0),
     grains: plan.grains + referralBonus.grains + (bonus.grains || 0),
-    compute: plan.compute + (bonus.compute || 0)
+    compute: plan.compute + (bonus.compute || 0),
   };
   return userQuota;
-}
+};
 
 isUserOverQuota = function (user) {
   // Return false if user has quota space remaining, true if it is full. When this returns true,
@@ -692,12 +693,12 @@ isUserOverQuota = function (user) {
 
   var plan = getUserQuota(user);
   if (plan.grains < Infinity) {
-    var count = Grains.find({userId: user._id}, {fields: {}, limit: plan.grains}).count();
+    var count = Grains.find({ userId: user._id }, { fields: {}, limit: plan.grains }).count();
     if (count >= plan.grains) return "outOfGrains";
   }
 
   return plan && user.storageUsage && user.storageUsage >= plan.storage && "outOfStorage";
-}
+};
 
 isUserExcessivelyOverQuota = function (user) {
   // Return true if user is so far over quota that we should prevent their existing grains from
@@ -711,14 +712,14 @@ isUserExcessivelyOverQuota = function (user) {
 
   // quota.grains = Infinity means unlimited grains. IEEE754 defines Infinity == Infinity.
   if (quota.grains < Infinity) {
-    var count = Grains.find({userId: user._id}, {fields: {}, limit: quota.grains * 2}).count();
+    var count = Grains.find({ userId: user._id }, { fields: {}, limit: quota.grains * 2 }).count();
     if (count >= quota.grains * 2) return "outOfGrains";
   }
 
   return quota && user.storageUsage && user.storageUsage >= quota.storage * 1.2 && "outOfStorage";
-}
+};
 
-isAdmin = function() {
+isAdmin = function () {
   // Returns true if the user is the administrator.
 
   var user = Meteor.user();
@@ -727,23 +728,24 @@ isAdmin = function() {
   } else {
     return false;
   }
-}
+};
 
-isAdminById = function(id) {
+isAdminById = function (id) {
   // Returns true if the user's id is the administrator.
 
-  var user = Meteor.users.findOne({_id: id}, {fields: {isAdmin: 1}})
+  var user = Meteor.users.findOne({ _id: id }, { fields: { isAdmin: 1 } });
   if (user && user.isAdmin) {
     return true;
   } else {
     return false;
   }
-}
+};
 
 findAdminUserForToken = function (token) {
   if (!token.requirements) {
     return;
   }
+
   var requirements = token.requirements.filter(function (requirement) {
     return "userIsAdmin" in requirement;
   });
@@ -751,9 +753,11 @@ findAdminUserForToken = function (token) {
   if (requirements.length > 1) {
     return;
   }
+
   if (requirements.length === 0) {
     return;
   }
+
   return requirements[0].userIsAdmin;
 };
 
@@ -763,7 +767,7 @@ if (wildcardHost.length != 2) {
   throw new Error("Wildcard host must contain exactly one asterisk.");
 }
 
-matchWildcardHost = function(host) {
+matchWildcardHost = function (host) {
   // See if the hostname is a member of our wildcard. If so, extract the ID.
 
   var prefix = wildcardHost[0];
@@ -784,11 +788,11 @@ matchWildcardHost = function(host) {
   }
 
   return null;
-}
+};
 
 makeWildcardHost = function (id) {
   return wildcardHost[0] + id + wildcardHost[1];
-}
+};
 
 if (Meteor.isServer) {
   var Url = Npm.require("url");
@@ -808,11 +812,11 @@ if (Meteor.isServer) {
     } else {
       return protocol + "//*" + wildcardHost[1].slice(dotPos);
     }
-  }
+  };
 }
 
 allowDevAccounts = function () {
-  var setting = Settings.findOne({_id: "devAccounts"});
+  var setting = Settings.findOne({ _id: "devAccounts" });
   if (setting) {
     return setting.value;
   } else {
@@ -834,7 +838,7 @@ sendReferralProgramNotification = function (userId) {
 };
 
 roleAssignmentPattern = {
-  none : Match.Optional(null),
+  none: Match.Optional(null),
   allAccess: Match.Optional(null),
   roleId: Match.Optional(Match.Integer),
   addPermissions: Match.Optional([Boolean]),
@@ -899,16 +903,16 @@ if (Meteor.isServer) {
 // Below this point are newly-written or refactored functions.
 
 _.extend(SandstormDb.prototype, {
-  getUser: function getUser (userId) {
+  getUser: function getUser(userId) {
     check(userId, Match.OneOf(String, undefined, null));
     if (userId) {
       return Meteor.users.findOne(userId);
     }
   },
 
-  getIdentity: function getIdentity (identityId) {
+  getIdentity: function getIdentity(identityId) {
     check(identityId, String);
-    var identity = Meteor.users.findOne({_id: identityId});
+    var identity = Meteor.users.findOne({ _id: identityId });
     if (identity) {
       SandstormDb.fillInProfileDefaults(identity);
       SandstormDb.fillInIntrinsicName(identity);
@@ -927,46 +931,46 @@ _.extend(SandstormDb.prototype, {
     return SandstormDb.getUserIdentityIds(user).indexOf(identityId) != -1;
   },
 
-  userGrains: function userGrains (userId) {
+  userGrains: function userGrains(userId) {
     check(userId, Match.OneOf(String, undefined, null));
-    return this.collections.grains.find({userId: userId});
+    return this.collections.grains.find({ userId: userId });
   },
 
-  currentUserGrains: function currentUserGrains () {
+  currentUserGrains: function currentUserGrains() {
     return this.userGrains(Meteor.userId());
   },
 
-  getGrain: function getGrain (grainId) {
+  getGrain: function getGrain(grainId) {
     check(grainId, String);
     return this.collections.grains.findOne(grainId);
   },
 
-  userApiTokens: function userApiTokens (userId) {
+  userApiTokens: function userApiTokens(userId) {
     check(userId, Match.OneOf(String, undefined, null));
     var identityIds = SandstormDb.getUserIdentityIds(this.getUser(userId));
-    return this.collections.apiTokens.find({'owner.user.identityId': {$in: identityIds}});
+    return this.collections.apiTokens.find({ "owner.user.identityId": { $in: identityIds } });
   },
 
-  currentUserApiTokens: function currentUserApiTokens () {
+  currentUserApiTokens: function currentUserApiTokens() {
     return this.userApiTokens(Meteor.userId());
   },
 
-  userActions: function userActions (user) {
-    return this.collections.userActions.find({userId: user});
+  userActions: function userActions(user) {
+    return this.collections.userActions.find({ userId: user });
   },
 
-  currentUserActions: function currentUserActions () {
+  currentUserActions: function currentUserActions() {
     return this.userActions(Meteor.userId());
   },
 
-  iconSrcForPackage: function iconSrcForPackage (pkg, usage) {
+  iconSrcForPackage: function iconSrcForPackage(pkg, usage) {
     return Identicon.iconSrcForPackage(pkg, usage, this.makeWildcardHost("static"));
   },
 
   getDenormalizedGrainInfo: function getDenormalizedGrainInfo(grainId) {
     var grain = this.getGrain(grainId);
     var pkg = this.collections.packages.findOne(grain.packageId);
-    var appTitle = (pkg && pkg.manifest && pkg.manifest.appTitle) || { defaultText: ""};
+    var appTitle = (pkg && pkg.manifest && pkg.manifest.appTitle) || { defaultText: "" };
     var grainInfo = { appTitle: appTitle };
 
     if (pkg && pkg.manifest && pkg.manifest.metadata && pkg.manifest.metadata.icons) {
@@ -988,11 +992,12 @@ _.extend(SandstormDb.prototype, {
     if (!plan) {
       throw new Error("no such plan: " + id);
     }
+
     return plan;
   },
 
   listPlans: function () {
-    return Plans.find({}, {sort: {price: 1}});
+    return Plans.find({}, { sort: { price: 1 } });
   },
 
   getMyPlan: function () {
@@ -1000,7 +1005,7 @@ _.extend(SandstormDb.prototype, {
     return user && Plans.findOne(user.plan || "free");
   },
 
-  getMyReferralBonus: function(user) {
+  getMyReferralBonus: function (user) {
     // This function is called from the server and from the client, similar to getMyPlan().
     //
     // The parameter may be omitted in which case the current user is assumed.
@@ -1017,13 +1022,13 @@ _.extend(SandstormDb.prototype, {
         return user.pseudoUsage;
       } else {
         return {
-          grains: Grains.find({userId: user._id}).count(),
+          grains: Grains.find({ userId: user._id }).count(),
           storage: user.storageUsage || 0,
           compute: 0   // not tracked yet
         };
       }
     } else {
-      return {grains: 0, storage: 0, compute: 0};
+      return { grains: 0, storage: 0, compute: 0 };
     }
   },
 
@@ -1039,12 +1044,12 @@ _.extend(SandstormDb.prototype, {
     return setting && setting.value;
   },
 
-  addUserActions: function(packageId) {
+  addUserActions: function (packageId) {
     //TODO(cleanup): implement this with meteor methods rather than client-side inserts/removes.
     var pack = Packages.findOne(packageId);
     if (pack) {
       // Remove old versions.
-      UserActions.find({userId: Meteor.userId(), appId: pack.appId})
+      UserActions.find({ userId: Meteor.userId(), appId: pack.appId })
           .forEach(function (action) {
         UserActions.remove(action._id);
       });
@@ -1063,7 +1068,7 @@ _.extend(SandstormDb.prototype, {
             appVersion: pack.manifest.appVersion,
             title: action.title,
             nounPhrase: action.nounPhrase,
-            command: action.command
+            command: action.command,
           };
           UserActions.insert(userAction);
         } else {
@@ -1076,14 +1081,14 @@ _.extend(SandstormDb.prototype, {
   },
 
   sendAdminNotification: function (message, link) {
-    Meteor.users.find({isAdmin: true}, {fields: {_id: 1}}).forEach(function (user) {
+    Meteor.users.find({ isAdmin: true }, { fields: { _id: 1 } }).forEach(function (user) {
       Notifications.insert({
         admin: {
           action: link,
           type: "reportStats",
         },
         userId: user._id,
-        text: {defaultText: message},
+        text: { defaultText: message },
         timestamp: new Date(),
         isUnread: true,
       });
@@ -1095,17 +1100,17 @@ _.extend(SandstormDb.prototype, {
   },
 
   getServerTitle: function () {
-    var setting = Settings.findOne({_id: "serverTitle"});
+    var setting = Settings.findOne({ _id: "serverTitle" });
     return setting ? setting.value : "";  // empty if subscription is not ready.
   },
 
   getReturnAddress: function () {
-    var setting = Settings.findOne({_id: "returnAddress"});
+    var setting = Settings.findOne({ _id: "returnAddress" });
     return setting ? setting.value : "";  // empty if subscription is not ready.
-  }
+  },
 });
 
-var appNameFromPackage = function(packageObj) {
+var appNameFromPackage = function (packageObj) {
   // This function takes a Package object from Mongo and returns an
   // app title.
   var manifest = packageObj.manifest;
@@ -1116,7 +1121,7 @@ var appNameFromPackage = function(packageObj) {
   return appName;
 };
 
-var appNameFromActionName = function(name) {
+var appNameFromActionName = function (name) {
   // Hack: Historically we only had action titles, like "New Etherpad Document", not app
   //   titles. But for this UI we want app titles. As a transitionary measure, try to
   //   derive the app title from the action title.
@@ -1124,9 +1129,11 @@ var appNameFromActionName = function(name) {
   if (!name) {
     return "(unnamed)";
   }
+
   if (name.lastIndexOf("New ", 0) === 0) {
     name = name.slice(4);
   }
+
   if (name.lastIndexOf("Hacker CMS", 0) === 0) {
     name = "Hacker CMS";
   } else {
@@ -1135,6 +1142,7 @@ var appNameFromActionName = function(name) {
       name = name.slice(0, space);
     }
   }
+
   return name;
 };
 
@@ -1144,7 +1152,7 @@ var appShortDescriptionFromPackage = function (pkg) {
          pkg.manifest.metadata.shortDescription.defaultText;
 };
 
-var nounPhraseForActionAndAppTitle = function(action, appTitle) {
+var nounPhraseForActionAndAppTitle = function (action, appTitle) {
   // A hack to deal with legacy apps not including fields in their manifests.
   // I look forward to the day I can remove most of this code.
   // Attempt to figure out the appropriate noun that this action will create.
@@ -1166,6 +1174,7 @@ var nounPhraseForActionAndAppTitle = function(action, appTitle) {
           return "grain";
         }
       }
+
       return candidate.toLowerCase();
     }
     // Some other verb phrase was given.  Just use it verbatim, and hope the app author updates
@@ -1206,7 +1215,7 @@ if (Meteor.isServer) {
     while (denom <= n) denom <<= 1;
     var num = n * 2 - denom + 1;
     return num / denom;
-  }
+  };
 
   var stagger = computeStagger(replicaNumber);
 
@@ -1241,7 +1250,7 @@ if (Meteor.isServer) {
       callback();
       Meteor.setInterval(callback, intervalMs);
     }, first);
-  }
+  };
 
   // TODO(cleanup): Node 0.12 has a `gzipSync` but 0.10 (which Meteor still uses) does not.
   var gzipSync = Meteor.wrapAsync(Zlib.gzip, Zlib);
@@ -1251,7 +1260,7 @@ if (Meteor.isServer) {
       check(buf, Buffer);
       return buf.length < limit;
     });
-  }
+  };
 
   var DatabaseId = Match.Where(function (s) {
     check(s, String);
@@ -1269,7 +1278,7 @@ if (Meteor.isServer) {
 
     check(metadata, {
       mimeType: String,
-      encoding: Match.Optional("gzip")
+      encoding: Match.Optional("gzip"),
     });
     check(content, BufferSmallerThan(1 << 20));
 
@@ -1282,9 +1291,9 @@ if (Meteor.isServer) {
     var hash = hasher.digest("base64");
 
     var existing = StaticAssets.findAndModify({
-      query: {hash: hash, refcount: {$gte: 1}},
-      update: {$inc: {refcount: 1}},
-      fields: {_id: 1, refcount: 1},
+      query: { hash: hash, refcount: { $gte: 1 } },
+      update: { $inc: { refcount: 1 } },
+      fields: { _id: 1, refcount: 1 },
     });
     if (existing) {
       return existing._id;
@@ -1293,9 +1302,9 @@ if (Meteor.isServer) {
     return StaticAssets.insert(_.extend({
       hash: hash,
       content: content,
-      refcount: 1
+      refcount: 1,
     }, metadata));
-  }
+  };
 
   SandstormDb.prototype.addStaticAsset = addStaticAsset;
 
@@ -1309,14 +1318,14 @@ if (Meteor.isServer) {
     check(id, String);
 
     var existing = StaticAssets.findAndModify({
-      query: {hash: hash},
-      update: {$inc: {refcount: 1}},
-      fields: {_id: 1, refcount: 1},
+      query: { hash: hash },
+      update: { $inc: { refcount: 1 } },
+      fields: { _id: 1, refcount: 1 },
     });
     if (!existing) {
       throw new Error("refStaticAsset() called on asset that doesn't exist");
     }
-  }
+  };
 
   SandstormDb.prototype.unrefStaticAsset = function (id) {
     // Decrement refcount on a static asset and delete if it has reached zero.
@@ -1328,40 +1337,41 @@ if (Meteor.isServer) {
     check(id, String);
 
     var existing = StaticAssets.findAndModify({
-      query: {_id: id},
-      update: {$inc: {refcount: -1}},
-      fields: {_id: 1, refcount: 1},
+      query: { _id: id },
+      update: { $inc: { refcount: -1 } },
+      fields: { _id: 1, refcount: 1 },
       new: true,
     });
     if (!existing) {
       console.error(new Error("unrefStaticAsset() called on asset that doesn't exist").stack);
     } else if (existing.refcount <= 0) {
-      StaticAssets.remove({_id: existing._id});
+      StaticAssets.remove({ _id: existing._id });
     }
-  }
+  };
 
   SandstormDb.prototype.getStaticAsset = function (id) {
     // Get a static asset's mimeType, encoding, and raw content.
 
     check(id, String);
 
-    var asset = StaticAssets.findOne(id, {fields: {_id: 0, mimeType: 1, encoding: 1, content: 1}});
+    var asset = StaticAssets.findOne(id, { fields: { _id: 0, mimeType: 1, encoding: 1, content: 1 } });
     if (asset) {
       // TODO(perf): Mongo converts buffers to something else. Figure out a way to avoid a copy
       //   here.
       asset.content = new Buffer(asset.content);
     }
+
     return asset;
-  }
+  };
 
   SandstormDb.prototype.newAssetUpload = function (purpose) {
-    check(purpose, {profilePicture: {userId: DatabaseId, identityId: DatabaseId}});
+    check(purpose, { profilePicture: { userId: DatabaseId, identityId: DatabaseId } });
 
     return AssetUploadTokens.insert({
       purpose: purpose,
       expires: new Date(Date.now() + 300000),  // in 5 minutes
     });
-  }
+  };
 
   SandstormDb.prototype.fulfillAssetUpload = function (id) {
     // Indicates that the given asset upload has completed. It will be removed and its purpose
@@ -1370,8 +1380,8 @@ if (Meteor.isServer) {
     check(id, String);
 
     var upload = AssetUploadTokens.findAndModify({
-      query: {_id: id},
-      remove: true
+      query: { _id: id },
+      remove: true,
     });
 
     if (upload.expires.valueOf() < Date.now()) {
@@ -1379,10 +1389,10 @@ if (Meteor.isServer) {
     } else {
       return upload.purpose;
     }
-  }
+  };
 
   function cleanupExpiredAssetUploads() {
-    AssetUploadTokens.remove({expires: {$lt: Date.now()}});
+    AssetUploadTokens.remove({ expires: { $lt: Date.now() } });
   }
 
   // Cleanup tokens every hour.
@@ -1404,14 +1414,15 @@ if (Meteor.isServer) {
     if (pkg && pkg.status === "ready") {
       packageCache[packageId] = pkg;
     }
+
     return pkg;
-  }
+  };
 
   SandstormDb.prototype.sendAppUpdateNotifications = function (appId, packageId, name,
                                                                versionNumber, marketingVersion) {
     var db = this;
-    var actions = db.collections.userActions.find({appId: appId, appVersion: {$lt: versionNumber}},
-      {fields: {userId: 1}});
+    var actions = db.collections.userActions.find({ appId: appId, appVersion: { $lt: versionNumber } },
+      { fields: { userId: 1 } });
     actions.forEach(function (action) {
       var userId = action.userId;
       var updater = {
@@ -1428,10 +1439,10 @@ if (Meteor.isServer) {
         name: name,
         version: versionNumber,
       };
-      db.collections.notifications.upsert({userId: userId}, { $set: updater});
+      db.collections.notifications.upsert({ userId: userId }, { $set: updater });
     });
 
-    db.collections.appIndex.update({_id: appId}, {$set: {hasSentNotifications: true}});
+    db.collections.appIndex.update({ _id: appId }, { $set: { hasSentNotifications: true } });
 
     // In the case where we replaced a previous notification and that was the only reference to the
     // package, we need to clean it up
@@ -1449,7 +1460,7 @@ if (Meteor.isServer) {
       userId: Meteor.userId(),
       appId: appId,
       appVersion: { $lte: version },
-      packageId: { $ne: packageId }
+      packageId: { $ne: packageId },
     };
 
     if (!this.isSimulation) {
@@ -1458,16 +1469,16 @@ if (Meteor.isServer) {
       });
     }
 
-    Grains.update(selector, { $set: { appVersion: version, packageId: packageId }}, {multi: true});
+    Grains.update(selector, { $set: { appVersion: version, packageId: packageId } }, { multi: true });
   };
 
   SandstormDb.prototype.startInstall = function (packageId, url, retryFailed, isAutoUpdated) {
     // Mark package for possible installation.
 
-    var fields = {status: "download", progress: 0, url: url, isAutoUpdated: !!isAutoUpdated};
+    var fields = { status: "download", progress: 0, url: url, isAutoUpdated: !!isAutoUpdated };
 
     if (retryFailed) {
-      Packages.update({_id: packageId, status: "failed"}, {$set: fields});
+      Packages.update({ _id: packageId, status: "failed" }, { $set: fields });
     } else {
       try {
         fields._id = packageId;
@@ -1493,7 +1504,7 @@ if (Meteor.isServer) {
     HTTP.get(
         "https://keybase.io/_/api/1.0/user/lookup.json?key_fingerprint=" + keyFingerprint +
         "&fields=basics,profile,proofs_summary", {
-      timeout: 5000
+      timeout: 5000,
     }, function (err, keybaseResponse) {
       if (err) {
         console.log("keybase lookup error:", err.stack);
@@ -1511,7 +1522,7 @@ if (Meteor.isServer) {
         var record = {
           displayName: (profile.profile || {}).full_name,
           handle: (profile.basics || {}).username,
-          proofs: (profile.proofs_summary || {}).all || []
+          proofs: (profile.proofs_summary || {}).all || [],
         };
 
         record.proofs.forEach(function (proof) {
@@ -1521,7 +1532,7 @@ if (Meteor.isServer) {
             // Don't allow field names containing '.' or '$'. Also don't allow sub-objects mainly
             // because I'm too lazy to check the field names recursively (and Keybase doesn't
             // return any objects anyway).
-            if (field.match(/[.$]/) || typeof(proof[field]) === "object") {
+            if (field.match(/[.$]/) || typeof (proof[field]) === "object") {
               delete proof[field];
             }
           }
@@ -1532,7 +1543,7 @@ if (Meteor.isServer) {
           proof.status = "unverified";
         });
 
-        KeybaseProfiles.update(keyFingerprint, {$set: record}, {upsert: true});
+        KeybaseProfiles.update(keyFingerprint, { $set: record }, { upsert: true });
       } else {
         // Keybase reports no match, so remove what we know of this user. We don't want to remove
         // the item entirely from the cache as this will cause us to repeatedly re-fetch the data
@@ -1541,28 +1552,28 @@ if (Meteor.isServer) {
         // TODO(someday): We could perhaps keep the proofs if we can still verify them directly,
         //   but at present we don't have the ability to verify proofs.
         KeybaseProfiles.update(keyFingerprint,
-            {$unset: {displayName: "", handle: "", proofs: ""}}, {upsert: true});
+            { $unset: { displayName: "", handle: "", proofs: "" } }, { upsert: true });
       }
     });
   };
 
-  SandstormDb.prototype.deleteUnusedAccount = function(backend, identityId) {
+  SandstormDb.prototype.deleteUnusedAccount = function (backend, identityId) {
     // If there is an *unused* account that has `identityId` as a login identity, deletes it.
 
     check(identityId, String);
-    var account = Meteor.users.findOne({"loginIdentities.id": identityId});
+    var account = Meteor.users.findOne({ "loginIdentities.id": identityId });
     if (account &&
         account.loginIdentities.length == 1 &&
         account.nonloginIdentities.length == 0 &&
-        !Grains.findOne({userId: account._id}) &&
-        !ApiTokens.findOne({accountId: account._id}) &&
+        !Grains.findOne({ userId: account._id }) &&
+        !ApiTokens.findOne({ accountId: account._id }) &&
         (!account.plan || account.plan === "free") &&
         !account.payments &&
-        !Contacts.findOne({ownerId: account._id})) {
-      Meteor.users.remove({_id: account._id});
+        !Contacts.findOne({ ownerId: account._id })) {
+      Meteor.users.remove({ _id: account._id });
       backend.deleteUser(account._id);
     }
-  }
+  };
 
   Meteor.publish("keybaseProfile", function (keyFingerprint) {
     check(keyFingerprint, ValidKeyFingerprint);
@@ -1580,11 +1591,11 @@ if (Meteor.isServer) {
   Meteor.publish("appIndex", function (appId) {
     check(appId, String);
     var db = this.connection.sandstormDb;
-    var cursor = db.collections.appIndex.find({_id: appId});
+    var cursor = db.collections.appIndex.find({ _id: appId });
     return cursor;
   });
 
-  Meteor.publish("userPackages", function() {
+  Meteor.publish("userPackages", function () {
     // Users should be able to see packages that are either:
     // 1. referenced by one of their userActions
     // 2. referenced by one of their grains
@@ -1621,29 +1632,32 @@ if (Meteor.isServer) {
     // package source 1: packages referred to by actions
     var actions = db.userActions(this.userId);
     var actionsHandle = actions.observe({
-      added: function(newAction) {
+      added: function (newAction) {
         refPackage(newAction.packageId);
       },
-      changed: function(oldAction, newAction) {
+
+      changed: function (oldAction, newAction) {
         refPackage(newAction.packageId);
-      }
+      },
     });
 
     // package source 2: packages referred to by grains directly
     var grains = db.userGrains(this.userId);
     var grainsHandle = grains.observe({
-      added: function(newGrain) {
+      added: function (newGrain) {
         refPackage(newGrain.packageId);
       },
-      changed: function(oldGrain, newGrain) {
+
+      changed: function (oldGrain, newGrain) {
         refPackage(newGrain.packageId);
-      }
+      },
     });
 
     this.onStop(function () {
       actionsHandle.stop();
       grainsHandle.stop();
     });
+
     this.ready();
   });
 }

--- a/shell/packages/sandstorm-db/package.js
+++ b/shell/packages/sandstorm-db/package.js
@@ -16,7 +16,7 @@
 
 Package.describe({
   summary: "Sandstorm database layer",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Npm.depends({ "content-type": "1.0.1" });

--- a/shell/packages/sandstorm-db/package.js
+++ b/shell/packages/sandstorm-db/package.js
@@ -22,6 +22,7 @@ Package.describe({
 Npm.depends({ "content-type": "1.0.1" });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.use(["mongo", "random", "check", "underscore"], ["client", "server"]);
   api.use(["accounts-base", "fongandrew:find-and-modify", "http"], ["server"]);
   api.use(["sandstorm-identicons"], ["client"]);

--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -18,7 +18,7 @@ var makeIdenticon;
 var httpProtocol;
 
 if (Meteor.isServer) {
-  SandstormDb.ensureSubscriberHasIdentity = function(publishHandler, identityId) {
+  SandstormDb.ensureSubscriberHasIdentity = function (publishHandler, identityId) {
     // Helper for publish functions that need to restrict access based on whether the subscriber
     // has a given identity linked. Automatically stops the subscription if the user loses the
     // identity. Returns a boolean indicating whether the user initially has the identity.
@@ -28,28 +28,31 @@ if (Meteor.isServer) {
       return true;
     } else {
       var hasIdentityCursor =
-          Meteor.users.find({$or: [{_id: userId, "loginIdentities.id": identityId},
-                                   {_id: userId, "nonloginIdentities.id": identityId}]});
+          Meteor.users.find({ $or: [{ _id: userId, "loginIdentities.id": identityId },
+                                   { _id: userId, "nonloginIdentities.id": identityId },], });
       if (hasIdentityCursor.count() == 0) {
         publishHandler.stop();
         return false;
       }
-      var handle = hasIdentityCursor.observe({removed: function () { publishHandler.stop(); }});
+
+      var handle = hasIdentityCursor.observe({ removed: function () { publishHandler.stop(); } });
+
       publishHandler.onStop(function () { handle.stop(); });
+
       return true;
     }
-  }
+  };
 
   Meteor.publish("identityProfile", function (identityId) {
     check(identityId, String);
     if (!SandstormDb.ensureSubscriberHasIdentity(this, identityId)) return;
 
-    return Meteor.users.find({_id: identityId},
-      {fields: {
-        "profile":1,
-        "unverifiedEmail":1,
-        "expires": 1,
-        "createdAt": 1,
+    return Meteor.users.find({ _id: identityId },
+      { fields: {
+        profile:1,
+        unverifiedEmail:1,
+        expires: 1,
+        createdAt: 1,
 
         "services.dev.name":1,
 
@@ -66,7 +69,7 @@ if (Meteor.isServer) {
         "services.github.username":1,
 
         "services.email.email":1,
-      }});
+      }, });
   }),
 
   Meteor.publish("accountIdentities", function () {
@@ -75,21 +78,21 @@ if (Meteor.isServer) {
     if (!this.userId) return [];
 
     return Meteor.users.find(
-      {_id: this.userId},
-      {fields: {
-        "profile": 1,
-        "verifiedEmail": 1,
-        "loginIdentities": 1,
-        "nonloginIdentities": 1,
-        "expires": 1,
-        "primaryEmail": 1,
-      }});
+      { _id: this.userId },
+      { fields: {
+        profile: 1,
+        verifiedEmail: 1,
+        loginIdentities: 1,
+        nonloginIdentities: 1,
+        expires: 1,
+        primaryEmail: 1,
+      }, });
   });
 
   makeIdenticon = function (id) {
     // We only make identicons client-side.
     return undefined;
-  }
+  };
 
   var Url = Npm.require("url");
   httpProtocol = Url.parse(process.env.ROOT_URL).protocol;
@@ -115,12 +118,12 @@ if (Meteor.isServer) {
     var result = "data:image/png;base64," + data;
     identiconCache[id] = result;
     return result;
-  }
+  };
 
   httpProtocol = window.location.protocol;
 }
 
-var GENDERS = {male: "male", female: "female", neutral: "neutral", robot: "robot"};
+var GENDERS = { male: "male", female: "female", neutral: "neutral", robot: "robot" };
 
 function staticAssetUrl(id, staticHost) {
   if (id) {
@@ -145,12 +148,12 @@ function emailToHandle(email) {
   var parts = email.split("@");
   var base = filterHandle(parts[0].split("+")[0]);
 
-  var domain = (parts[1]||"").split(".");
+  var domain = (parts[1] || "").split(".");
   if (domain[domain.length - 1] === "name") {
     // Oh, a .name domain. Let's use
     base = filterHandle(domain.slice(0, domain.length - 1).join("."));
   } else if (_.contains(["me", "self", "contact", "admin", "administrator", "root", "info",
-                         "sandstorm", "sandstormio", "inbox", "indiegogo", "mail", "email"],
+                         "sandstorm", "sandstormio", "inbox", "indiegogo", "mail", "email",],
                          base)) {
     // This is probably an address at a vanity domain. Use the domain itself as the handle.
     base = filterHandle(domain[0]);
@@ -159,7 +162,7 @@ function emailToHandle(email) {
   return filterHandle(base);
 }
 
-SandstormDb.fillInProfileDefaults = function(user) {
+SandstormDb.fillInProfileDefaults = function (user) {
   var profile = user.profile;
   if (profile.service === "github") {
     profile.name = profile.name || user.services.github.username || "Name Unknown";
@@ -171,7 +174,7 @@ SandstormDb.fillInProfileDefaults = function(user) {
         filterHandle(profile.name);
     profile.pronoun = profile.pronoun || GENDERS[user.services.google.gender] || "neutral";
   } else if (profile.service === "email") {
-    var email = user.services.email.email
+    var email = user.services.email.email;
     profile.name = profile.name || email.split("@")[0];
     profile.handle = profile.handle || emailToHandle(email);
   } else if (profile.service === "dev") {
@@ -189,9 +192,9 @@ SandstormDb.fillInProfileDefaults = function(user) {
   }
 
   profile.pronoun = profile.pronoun || "neutral";
-}
+};
 
-SandstormDb.fillInIntrinsicName = function(user) {
+SandstormDb.fillInIntrinsicName = function (user) {
   var profile = user.profile;
   if (profile.service === "github") {
     profile.intrinsicName = user.services.github.username;
@@ -199,17 +202,17 @@ SandstormDb.fillInIntrinsicName = function(user) {
     profile.intrinsicName = user.services.google.name;
     user.privateIntrinsicName = user.services.google.email;
   } else if (profile.service === "email") {
-    profile.intrinsicName = user.services.email.email
+    profile.intrinsicName = user.services.email.email;
   } else if (profile.service === "dev") {
     profile.intrinsicName = user.services.dev.name;
   } else if (profile.service === "demo") {
-    profile.intrinsicName = "demo on " + user.createdAt.toISOString().substring(0,10);
+    profile.intrinsicName = "demo on " + user.createdAt.toISOString().substring(0, 10);
   } else {
     throw new Error("unrecognized identity service: ", profile.service);
   }
-}
+};
 
-SandstormDb.getVerifiedEmails = function(identity) {
+SandstormDb.getVerifiedEmails = function (identity) {
   if (identity.services.google && identity.services.google.email &&
       identity.services.google.verified_email) {
     return [identity.services.google.email];
@@ -217,41 +220,43 @@ SandstormDb.getVerifiedEmails = function(identity) {
     return [identity.services.email.email];
   } else if (identity.services.github && identity.services.github.emails) {
     return _.pluck(_.filter(identity.services.github.emails,
-                            function(email) { return email.verified; }),
+                            function (email) { return email.verified; }),
+
                    "email");
   }
-  return [];
-}
 
-SandstormDb.prototype.findIdentitiesByEmail = function(email) {
+  return [];
+};
+
+SandstormDb.prototype.findIdentitiesByEmail = function (email) {
   // Returns an array of identities which have the given email address as one of their verified
   // addresses.
 
   check(email, String);
 
-  return Meteor.users.find({$or: [
-    {"services.google.email": email},
-    {"services.email.email": email},
-    {"services.github.emails.email": email},
-  ]}).fetch().filter(function (identity) {
+  return Meteor.users.find({ $or: [
+    { "services.google.email": email },
+    { "services.email.email": email },
+    { "services.github.emails.email": email },
+  ], }).fetch().filter(function (identity) {
     // Verify that the email is verified, since our query doesn't technically do that.
     return SandstormDb.getVerifiedEmails(identity).indexOf(email) >= 0;
   });
-}
-
-SandstormDb.prototype.findAccountsByEmail = function(email) {
-  var identityIds = _.pluck(this.findIdentitiesByEmail(email), "_id");
-  return Meteor.users.find({$or: [
-    {"loginIdentities.id": {$in: identityIds}},
-    {"nonloginIdentities.id": {$in: identityIds}},
-  ]}).fetch();
 };
 
-SandstormDb.fillInPictureUrl = function(user) {
+SandstormDb.prototype.findAccountsByEmail = function (email) {
+  var identityIds = _.pluck(this.findIdentitiesByEmail(email), "_id");
+  return Meteor.users.find({ $or: [
+    { "loginIdentities.id": { $in: identityIds } },
+    { "nonloginIdentities.id": { $in: identityIds } },
+  ], }).fetch();
+};
+
+SandstormDb.fillInPictureUrl = function (user) {
   var staticHost = httpProtocol + "//" + makeWildcardHost("static");
   user.profile.pictureUrl = staticAssetUrl(user.profile.picture, staticHost) ||
     makeIdenticon(user._id);
-}
+};
 
 SandstormDb.getUserIdentityIds = function (user) {
   // Given an account user object, returns an array containing the ID of each identity linked to the
@@ -279,14 +284,15 @@ SandstormDb.getUserEmails = function (user) {
   unverifiedEmails = {};
 
   identityIds.forEach(function (id) {
-    var identity = Meteor.users.findOne({_id: id});
+    var identity = Meteor.users.findOne({ _id: id });
     if (identity && identity.services) {
-      SandstormDb.getVerifiedEmails(identity).forEach(function(verifiedEmail) {
+      SandstormDb.getVerifiedEmails(identity).forEach(function (verifiedEmail) {
         if (verifiedEmail) {
           verifiedEmails[verifiedEmail] = true;
         }
       });
     }
+
     if (identity && identity.unverifiedEmail) {
       unverifiedEmails[identity.unverifiedEmail] = true;
     }
@@ -294,30 +300,32 @@ SandstormDb.getUserEmails = function (user) {
 
   var result = [];
   _.keys(verifiedEmails).map(function (email) {
-    result.push({email: email,
+    result.push({ email: email,
                  verified: true,
-                 primary: email === user.primaryEmail});
+                 primary: email === user.primaryEmail, });
   });
+
   _.keys(unverifiedEmails).map(function (email) {
-    if (!(email in verifiedEmails)) { result.push({email: email, verified: false}) }
+    if (!(email in verifiedEmails)) { result.push({ email: email, verified: false }); }
   });
 
   // If `user.primaryEmail` is not among the verified emails, mark the first as primary.
   if (!(user.primaryEmail in verifiedEmails) && result.length > 0) {
     result[0].primary = true;
   }
-  return result;
-}
 
-SandstormDb.prototype.addContact = function addContact (ownerId, identityId) {
+  return result;
+};
+
+SandstormDb.prototype.addContact = function addContact(ownerId, identityId) {
   check(ownerId, String);
   check(identityId, String);
   var db = this;
   var profile = db.getIdentity(identityId).profile;
-  db.collections.contacts.upsert({ownerId: ownerId, identityId: identityId}, {
+  db.collections.contacts.upsert({ ownerId: ownerId, identityId: identityId }, {
     ownerId: ownerId,
     petname: profile && profile.name,
     created: new Date(),
     identityId: identityId,
   });
-}
+};

--- a/shell/packages/sandstorm-db/user.js
+++ b/shell/packages/sandstorm-db/user.js
@@ -14,19 +14,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var Crypto = Npm.require("crypto");
-var Future = Npm.require("fibers/future");
+const Crypto = Npm.require("crypto");
+const Future = Npm.require("fibers/future");
 
 userPictureUrl = function (user) {
   if (user.services && !(user.profile && user.profile.picture)) {
     // Try to determine user's avatar URL from login service.
 
-    var google = user.services.google;
+    const google = user.services.google;
     if (google && google.picture) {
       return google.picture;
     }
 
-    var github = user.services.github;
+    const github = user.services.github;
     if (github && github.id) {
       return "https://avatars.githubusercontent.com/u/" + github.id;
     }
@@ -40,12 +40,12 @@ userPictureUrl = function (user) {
 
 fetchPicture = function (url) {
   try {
-    var result = HTTP.get(url, {
+    const result = HTTP.get(url, {
       npmRequestOptions: { encoding: null },
       timeout: 5000,
     });
 
-    var metadata = {};
+    const metadata = {};
 
     metadata.mimeType = result.headers["content-type"];
     if (metadata.mimeType.lastIndexOf("image/png", 0) === -1 &&
@@ -53,7 +53,7 @@ fetchPicture = function (url) {
       throw new Error("unexpected Content-Type:", metadata.mimeType);
     }
 
-    var enc = result.headers["content-encoding"];
+    const enc = result.headers["content-encoding"];
     if (enc && enc !== "identity") {
       metadata.encoding = enc;
     }
@@ -64,7 +64,7 @@ fetchPicture = function (url) {
   }
 };
 
-var ValidHandle = Match.Where(function (handle) {
+const ValidHandle = Match.Where(function (handle) {
   check(handle, String);
   return !!handle.match(/^[a-z_][a-z0-9_]*$/);
 });
@@ -116,15 +116,15 @@ Accounts.onCreateUser(function (options, user) {
   user.profile = _.pick(options.profile || {}, "name", "handle", "pronouns");
 
   // Try downloading avatar.
-  var url = userPictureUrl(user);
+  const url = userPictureUrl(user);
   if (url) {
-    var assetId = fetchPicture(url);
+    const assetId = fetchPicture(url);
     if (assetId) {
       user.profile.picture = assetId;
     }
   }
 
-  var serviceUserId;
+  let serviceUserId;
   if (user.services && user.services.dev) {
     check(user.services.dev, { name: String, isAdmin: Boolean, hasCompletedSignup: Boolean });
     serviceUserId = user.services.dev.name;

--- a/shell/packages/sandstorm-db/user.js
+++ b/shell/packages/sandstorm-db/user.js
@@ -36,13 +36,13 @@ userPictureUrl = function (user) {
     // Github are different because they are actually the identity providers, so they already know
     // the user logged in.
   }
-}
+};
 
 fetchPicture = function (url) {
   try {
     var result = HTTP.get(url, {
       npmRequestOptions: { encoding: null },
-      timeout: 5000
+      timeout: 5000,
     });
 
     var metadata = {};
@@ -52,6 +52,7 @@ fetchPicture = function (url) {
         metadata.mimeType.lastIndexOf("image/jpeg", 0) === -1) {
       throw new Error("unexpected Content-Type:", metadata.mimeType);
     }
+
     var enc = result.headers["content-encoding"];
     if (enc && enc !== "identity") {
       metadata.encoding = enc;
@@ -61,7 +62,7 @@ fetchPicture = function (url) {
   } catch (err) {
     console.error("failed to fetch user profile picture:", url, err.stack);
   }
-}
+};
 
 var ValidHandle = Match.Where(function (handle) {
   check(handle, String);
@@ -71,7 +72,7 @@ var ValidHandle = Match.Where(function (handle) {
 Accounts.onCreateUser(function (options, user) {
   if (user.loginIdentities) {
     // it's an account
-    check(user, {_id: String,
+    check(user, { _id: String,
                  createdAt: Date,
                  isAdmin: Match.Optional(Boolean),
                  hasCompletedSignup: Match.Optional(Boolean),
@@ -80,13 +81,13 @@ Accounts.onCreateUser(function (options, user) {
                  signupEmail: Match.Optional(String),
                  expires: Match.Optional(Date),
                  appDemoId: Match.Optional(String),
-                 loginIdentities: [{id: String}],
-                 nonloginIdentities: [{id: String}]});
+                 loginIdentities: [{ id: String }],
+                 nonloginIdentities: [{ id: String }], });
 
     if (Meteor.settings.public.quotaEnabled) {
       user.experiments = user.experiments || {};
       user.experiments = {
-        firstTimeBillingPrompt: Math.random() < 0.5 ? "control" : "test"
+        firstTimeBillingPrompt: Math.random() < 0.5 ? "control" : "test",
       };
       if (!("expires" in user)) {
         sendReferralProgramNotification(user._id);
@@ -111,6 +112,7 @@ Accounts.onCreateUser(function (options, user) {
   if (options.unverifiedEmail) {
     user.unverifiedEmail = options.unverifiedEmail;
   }
+
   user.profile = _.pick(options.profile || {}, "name", "handle", "pronouns");
 
   // Try downloading avatar.
@@ -124,7 +126,7 @@ Accounts.onCreateUser(function (options, user) {
 
   var serviceUserId;
   if (user.services && user.services.dev) {
-    check(user.services.dev, {name: String, isAdmin: Boolean, hasCompletedSignup: Boolean});
+    check(user.services.dev, { name: String, isAdmin: Boolean, hasCompletedSignup: Boolean });
     serviceUserId = user.services.dev.name;
     user.profile.service = "dev";
   } else if ("expires" in user) {
@@ -132,8 +134,8 @@ Accounts.onCreateUser(function (options, user) {
     user.profile.service = "demo";
   } else if (user.services && user.services.email) {
     check(user.services.email,
-          {email: String,
-           tokens: [{digest: String, algorithm: String, createdAt: Date}]});
+          { email: String,
+           tokens: [{ digest: String, algorithm: String, createdAt: Date }], });
     serviceUserId = user.services.email.email;
     user.profile.service = "email";
   } else if (user.services && "google" in user.services) {
@@ -146,6 +148,7 @@ Accounts.onCreateUser(function (options, user) {
     throw new Meteor.Error(400, "user does not have a recognized identity provider: " +
                            JSON.stringify(user));
   }
+
   user._id = Crypto.createHash("sha256")
     .update(user.profile.service + ":" + serviceUserId).digest("hex");
 

--- a/shell/packages/sandstorm-email/email.js
+++ b/shell/packages/sandstorm-email/email.js
@@ -1,11 +1,11 @@
-var Future = Npm.require('fibers/future');
-var urlModule = Npm.require('url');
-var MailComposer = Npm.require('mailcomposer').MailComposer;
+var Future = Npm.require("fibers/future");
+var urlModule = Npm.require("url");
+var MailComposer = Npm.require("mailcomposer").MailComposer;
 
 SandstormEmail = {};
 
 var getSmtpUrl = function () {
-  var setting = Settings.findOne({_id: "smtpUrl"});
+  var setting = Settings.findOne({ _id: "smtpUrl" });
   if (setting) {
     return setting.value;
   } else {
@@ -15,25 +15,25 @@ var getSmtpUrl = function () {
 
 var makePool = function (mailUrlString) {
   var mailUrl = urlModule.parse(mailUrlString);
-  if (mailUrl.protocol !== 'smtp:')
+  if (mailUrl.protocol !== "smtp:")
     throw new Error("Email protocol in $MAIL_URL (" +
                     mailUrlString + ") must be 'smtp'");
 
   var port = +(mailUrl.port);
   var auth = false;
   if (mailUrl.auth) {
-    var parts = mailUrl.auth.split(':', 2);
-    auth = {user: parts[0],
-            pass: parts[1]};
+    var parts = mailUrl.auth.split(":", 2);
+    auth = { user: parts[0],
+            pass: parts[1], };
   }
 
-  var simplesmtp = Npm.require('simplesmtp');
+  var simplesmtp = Npm.require("simplesmtp");
   var pool = simplesmtp.createClientPool(
     port,  // Defaults to 25
     mailUrl.hostname,  // Defaults to "localhost"
     { secureConnection: (port === 465),
       // XXX allow maxConnections to be configured?
-      auth: auth });
+      auth: auth, });
 
   pool._future_wrapped_sendMail = _.bind(Future.wrap(pool.sendMail), pool);
   return pool;
@@ -44,17 +44,19 @@ var makePool = function (mailUrlString) {
 var pool;
 var configured = false;
 
-Meteor.startup(function() {
-  Settings.find({_id: "smtpUrl"}).observeChanges({
-    removed : function () {
+Meteor.startup(function () {
+  Settings.find({ _id: "smtpUrl" }).observeChanges({
+    removed: function () {
       configured = false;
     },
-    changed : function () {
+
+    changed: function () {
       configured = false;
     },
-    added : function () {
+
+    added: function () {
       configured = false;
-    }
+    },
   });
 
   // Accounts.emailToken is set to use "Email" by default. Change it to use our mail service.
@@ -88,12 +90,13 @@ var devModeSend = function (mc) {
   stream.write("(Mail not sent; to enable sending, set the MAIL_URL " +
                "environment variable.)\n");
   mc.streamMessage();
-  mc.pipe(stream, {end: false});
+  mc.pipe(stream, { end: false });
   var future = new Future;
-  mc.on('end', function () {
+  mc.on("end", function () {
     stream.write("====== END MAIL #" + devmode_mail_id + " ======\n");
-    future['return']();
+    future["return"]();
   });
+
   future.wait();
 };
 
@@ -151,7 +154,7 @@ SandstormEmail.send = function (options) {
     replyTo: options.replyTo,
     subject: options.subject,
     text: options.text,
-    html: options.html
+    html: options.html,
   });
 
   _.each(options.headers, function (value, name) {

--- a/shell/packages/sandstorm-email/package.js
+++ b/shell/packages/sandstorm-email/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Send email messages. Forked from meteor/email (https://github.com/meteor/meteor/tree/092b97d2da2794dcd30167e0008ab0b0a1e444fc/packages/email).",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Npm.depends({
@@ -8,11 +8,11 @@ Npm.depends({
   // much bigger. We need a better solution.
   mailcomposer: "0.1.15",
   simplesmtp: "0.3.10",
-  "stream-buffers": "0.2.5"});
+  "stream-buffers": "0.2.5", });
 
 Package.onUse(function (api) {
-  api.use('underscore', 'server');
-  api.use('application-configuration');
-  api.export('SandstormEmail', 'server');;
-  api.addFiles('email.js', 'server');
+  api.use("underscore", "server");
+  api.use("application-configuration");
+  api.export("SandstormEmail", "server");;
+  api.addFiles("email.js", "server");
 });

--- a/shell/packages/sandstorm-email/package.js
+++ b/shell/packages/sandstorm-email/package.js
@@ -11,6 +11,7 @@ Npm.depends({
   "stream-buffers": "0.2.5", });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.use("underscore", "server");
   api.use("application-configuration");
   api.export("SandstormEmail", "server");;

--- a/shell/packages/sandstorm-identicons/helpers.js
+++ b/shell/packages/sandstorm-identicons/helpers.js
@@ -1,11 +1,11 @@
-var VALID_USAGES = ["appGrid", "grain"];
-var checkUsage = function (usage) {
+const VALID_USAGES = ["appGrid", "grain"];
+const checkUsage = function (usage) {
   if (VALID_USAGES.indexOf(usage) === -1) throw new Error("Invalid icon usage.");
 };
 
-var iconFromManifest = function (manifest, usage) {
+const iconFromManifest = function (manifest, usage) {
   // TODO: select by usage location, rather than assuming appGrid
-  var icons = manifest && manifest.metadata && manifest.metadata.icons ?
+  const icons = manifest && manifest.metadata && manifest.metadata.icons ?
       manifest.metadata.icons : undefined;
   if (icons) {
     if (usage === "appGrid") {
@@ -18,15 +18,15 @@ var iconFromManifest = function (manifest, usage) {
   return undefined;
 };
 
-var hashAppIdForIdenticon = function (id) {
+const hashAppIdForIdenticon = function (id) {
   // "Hash" an app ID to a 32-digit hex string for the purpose of
   // producing an identicon. Since app IDs are already high-
   // entropy base32 strings, we simply turn each of the first
   // 32 digits to base16 by chopping off a bit.
   result = [];
-  var digits16 = "0123456789abcdef";
-  var digits32 = "0123456789acdefghjkmnpqrstuvwxyz";
-  for (var i = 0; i < 32; i++) {
+  const digits16 = "0123456789abcdef";
+  const digits32 = "0123456789acdefghjkmnpqrstuvwxyz";
+  for (let i = 0; i < 32; i++) {
     result.push(digits16[digits32.indexOf(id[i]) % 16]);
   }
 
@@ -35,33 +35,33 @@ var hashAppIdForIdenticon = function (id) {
 
 // Keep a static global cache of all app identicons produced in this way.
 // If memory usage is excessive, we can revisit this decision.
-var cachedIdenticons = {};
-var cachedIdenticon = function (hashedAppId, size) {
-  var cacheKey = hashedAppId + "-" + size;
+const cachedIdenticons = {};
+const cachedIdenticon = function (hashedAppId, size) {
+  const cacheKey = hashedAppId + "-" + size;
   if (!cachedIdenticons[cacheKey]) {
-    var data = new Identicon(hashedAppId, size).toString();
+    const data = new Identicon(hashedAppId, size).toString();
     cachedIdenticons[cacheKey] = "data:image/png;base64," + data;
   }
 
   return cachedIdenticons[cacheKey];
 };
 
-var identiconForApp = function (appId, usage) {
-  var size = (usage === "appGrid" ? 128 : 24);
+const identiconForApp = function (appId, usage) {
+  const size = (usage === "appGrid" ? 128 : 24);
   return cachedIdenticon(hashAppIdForIdenticon(appId), size);
 };
 
-var bytesToBase64 = function (bytes) {
-  var arr = new Array(bytes.length);
-  for (var i = 0; i < bytes.length; i++) {
+const bytesToBase64 = function (bytes) {
+  const arr = new Array(bytes.length);
+  for (let i = 0; i < bytes.length; i++) {
     arr[i] = String.fromCharCode(bytes[i]);
   }
   // Note that btoa is not available in IE9.  We may want to polyfill this.
-  var result = btoa(arr.join(""));
+  const result = btoa(arr.join(""));
   return result;
 };
 
-var iconSrcFor = function (appId, iconObj, staticHost, usage) {
+const iconSrcFor = function (appId, iconObj, staticHost, usage) {
   if (iconObj === undefined) {
     // Return a identicon src based on hashing appId instead.
     // (We hash the appID even though it's already a hash because it's not hex)
@@ -69,7 +69,7 @@ var iconSrcFor = function (appId, iconObj, staticHost, usage) {
   }
 
   if (iconObj.assetId) {
-    var src = window.location.protocol + "//" + staticHost + "/" + iconObj.assetId;
+    const src = window.location.protocol + "//" + staticHost + "/" + iconObj.assetId;
     return src;
   }
 
@@ -80,8 +80,8 @@ var iconSrcFor = function (appId, iconObj, staticHost, usage) {
   }
 
   if (iconObj.png) {
-    var png = iconObj.png.dpi2x || iconObj.png.dpi1x;
-    var data;
+    const png = iconObj.png.dpi2x || iconObj.png.dpi1x;
+    let data;
     if (png) {
       // png is a Uint8Array, so we need to convert it to text before calling btoa.
       // Yes, the irony is profound.
@@ -100,12 +100,12 @@ Identicon.identiconForApp = function (appId, usage) {
 Identicon.iconSrcForPackage = function (pkg, usage, staticHost) {
   checkUsage(usage);
   // N.B. only works for installed packages, for dev packages use iconSrcForDevPackage
-  var iconObj = iconFromManifest(pkg.manifest, usage);
+  const iconObj = iconFromManifest(pkg.manifest, usage);
   return iconSrcFor(pkg.appId, iconObj, staticHost, usage);
 };
 
 Identicon.iconSrcForDevPackage = function (devpkg, usage, staticHost) {
   checkUsage(usage);
-  var iconObj = iconFromManifest(devpkg.manifest, usage);
+  const iconObj = iconFromManifest(devpkg.manifest, usage);
   return iconSrcFor(devpkg._id, iconObj, staticHost, usage);
 };

--- a/shell/packages/sandstorm-identicons/helpers.js
+++ b/shell/packages/sandstorm-identicons/helpers.js
@@ -1,9 +1,9 @@
 var VALID_USAGES = ["appGrid", "grain"];
-var checkUsage = function(usage) {
+var checkUsage = function (usage) {
   if (VALID_USAGES.indexOf(usage) === -1) throw new Error("Invalid icon usage.");
 };
 
-var iconFromManifest = function(manifest, usage) {
+var iconFromManifest = function (manifest, usage) {
   // TODO: select by usage location, rather than assuming appGrid
   var icons = manifest && manifest.metadata && manifest.metadata.icons ?
       manifest.metadata.icons : undefined;
@@ -14,6 +14,7 @@ var iconFromManifest = function(manifest, usage) {
       return icons.grain || icons.appGrid;
     }
   }
+
   return undefined;
 };
 
@@ -28,29 +29,31 @@ var hashAppIdForIdenticon = function (id) {
   for (var i = 0; i < 32; i++) {
     result.push(digits16[digits32.indexOf(id[i]) % 16]);
   }
+
   return result.join("");
-}
+};
 
 // Keep a static global cache of all app identicons produced in this way.
 // If memory usage is excessive, we can revisit this decision.
 var cachedIdenticons = {};
-var cachedIdenticon = function(hashedAppId, size) {
+var cachedIdenticon = function (hashedAppId, size) {
   var cacheKey = hashedAppId + "-" + size;
   if (!cachedIdenticons[cacheKey]) {
     var data = new Identicon(hashedAppId, size).toString();
     cachedIdenticons[cacheKey] = "data:image/png;base64," + data;
   }
+
   return cachedIdenticons[cacheKey];
-}
+};
 
 var identiconForApp = function (appId, usage) {
   var size = (usage === "appGrid" ? 128 : 24);
   return cachedIdenticon(hashAppIdForIdenticon(appId), size);
 };
 
-var bytesToBase64 = function(bytes) {
+var bytesToBase64 = function (bytes) {
   var arr = new Array(bytes.length);
-  for (var i = 0; i < bytes.length ; i++) {
+  for (var i = 0; i < bytes.length; i++) {
     arr[i] = String.fromCharCode(bytes[i]);
   }
   // Note that btoa is not available in IE9.  We may want to polyfill this.
@@ -64,15 +67,18 @@ var iconSrcFor = function (appId, iconObj, staticHost, usage) {
     // (We hash the appID even though it's already a hash because it's not hex)
     return identiconForApp(appId, usage);
   }
+
   if (iconObj.assetId) {
     var src = window.location.protocol + "//" + staticHost + "/" + iconObj.assetId;
     return src;
   }
+
   if (iconObj.svg) {
     // iconObj.svg is a text string, so we can base64 it directly
     // Note that btoa is not available in IE9.  We may want to polyfill this.
     return "data:image/svg+xml;base64," + btoa(iconObj.svg);
   }
+
   if (iconObj.png) {
     var png = iconObj.png.dpi2x || iconObj.png.dpi1x;
     var data;
@@ -87,7 +93,7 @@ var iconSrcFor = function (appId, iconObj, staticHost, usage) {
   return identiconForApp(appId, usage);
 };
 
-Identicon.identiconForApp = function(appId, usage) {
+Identicon.identiconForApp = function (appId, usage) {
   return identiconForApp(appId, usage);
 };
 

--- a/shell/packages/sandstorm-identicons/identicon.js
+++ b/shell/packages/sandstorm-identicons/identicon.js
@@ -11,6 +11,7 @@
  */
 
 // (Trivially modified for Meteor context by Kenton Varda.)
+// jscs:disable
 
 Identicon = function(hash, size, margin){
     this.hash   = hash;

--- a/shell/packages/sandstorm-identicons/package.js
+++ b/shell/packages/sandstorm-identicons/package.js
@@ -16,7 +16,7 @@
 
 Package.describe({
   summary: "Sandstorm identicons package",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {

--- a/shell/packages/sandstorm-identicons/package.js
+++ b/shell/packages/sandstorm-identicons/package.js
@@ -20,6 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.addFiles(["pnglib.js", "identicon.js", "helpers.js"], "client");
   api.export(["Identicon"]);
 });

--- a/shell/packages/sandstorm-identicons/pnglib.js
+++ b/shell/packages/sandstorm-identicons/pnglib.js
@@ -11,6 +11,7 @@
 
 // (Used by identicon.js.)
 // (Trivially modified for Meteor context by Kenton Varda.)
+// jscs:disable
 
 PNGlib = (function() {
 

--- a/shell/packages/sandstorm-permissions/package.js
+++ b/shell/packages/sandstorm-permissions/package.js
@@ -16,7 +16,7 @@
 
 Package.describe({
   summary: "Sandstorm package for managing permissions of users on grains.",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {
@@ -27,5 +27,5 @@ Package.onUse(function (api) {
 
 Package.onTest(function (api) {
   api.use(["check", "random", "accounts-base", "underscore", "sandstorm-db", "tinytest", "sandstorm-permissions"], ["server"]);
-  api.addFiles('permissions-tests.js', 'server');
+  api.addFiles("permissions-tests.js", "server");
 });

--- a/shell/packages/sandstorm-permissions/permissions-tests.js
+++ b/shell/packages/sandstorm-permissions/permissions-tests.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Until David is done working on this:
+// jscs:disable
+
 var Crypto = Npm.require("crypto");
 
 var globalDb = new SandstormDb();

--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Until David is done working on this:
+// jscs:disable
+
 var Crypto = Npm.require("crypto");
 var Url = Npm.require("url");
 

--- a/shell/packages/sandstorm-ui-app-details/app-details-client.js
+++ b/shell/packages/sandstorm-ui-app-details/app-details-client.js
@@ -13,35 +13,35 @@ SandstormAppDetails = function (db, quotaEnforcer, appId) {
   this._showPublisherDetails = new ReactiveVar(false);
 };
 
-var latestPackageForAppId = function (db, appId) {
+const latestPackageForAppId = function (db, appId) {
   // Dev apps mask current package version.
-  var devPackage = db.collections.devPackages.findOne({ appId: appId });
+  const devPackage = db.collections.devPackages.findOne({ appId: appId });
   if (devPackage) {
     devPackage.dev = true;
     return devPackage;
   }
   // Look in user actions for this app
-  var firstAction = db.collections.userActions.findOne({ appId: appId });
+  const firstAction = db.collections.userActions.findOne({ appId: appId });
   return firstAction && db.collections.packages.findOne(firstAction.packageId);
 };
 
-var latestAppManifestForAppId = function (db, appId) {
-  var pkg = latestPackageForAppId(db, appId);
+const latestAppManifestForAppId = function (db, appId) {
+  const pkg = latestPackageForAppId(db, appId);
   return pkg && pkg.manifest;
 };
 
-var getAppTitle = function (appDetailsHandle) {
-  var pkg = latestPackageForAppId(appDetailsHandle._db, appDetailsHandle._appId);
+const getAppTitle = function (appDetailsHandle) {
+  const pkg = latestPackageForAppId(appDetailsHandle._db, appDetailsHandle._appId);
   return pkg && SandstormDb.appNameFromPackage(pkg) || "<unknown>";
 };
 
-var matchesGrainTitle = function (needle, grain) {
+const matchesGrainTitle = function (needle, grain) {
   return grain.title && grain.title.toLowerCase().indexOf(needle) !== -1;
 };
 
-var compileMatchFilter = function (searchString) {
+const compileMatchFilter = function (searchString) {
   // split up searchString into an array of regexes, use them to match against item
-  var searchKeys = searchString.toLowerCase()
+  const searchKeys = searchString.toLowerCase()
       .split(" ")
       .filter(function (k) { return k !== "";});
 
@@ -54,30 +54,30 @@ var compileMatchFilter = function (searchString) {
   };
 };
 
-var appGrains = function (db, appId) {
+const appGrains = function (db, appId) {
   return _.filter(db.currentUserGrains().fetch(),
                   function (grain) {return grain.appId === appId; });
 };
 
-var filteredSortedGrains = function (db, staticAssetHost, appId, appTitle, filterText) {
-  var pkg = latestPackageForAppId(db, appId);
+const filteredSortedGrains = function (db, staticAssetHost, appId, appTitle, filterText) {
+  const pkg = latestPackageForAppId(db, appId);
 
-  var grainsMatchingAppId = appGrains(db, appId);
-  var tokensForGrain = _.groupBy(db.currentUserApiTokens().fetch(), "grainId");
-  var grainIdsForApiTokens = Object.keys(tokensForGrain);
+  const grainsMatchingAppId = appGrains(db, appId);
+  const tokensForGrain = _.groupBy(db.currentUserApiTokens().fetch(), "grainId");
+  const grainIdsForApiTokens = Object.keys(tokensForGrain);
   // grainTokens is a list of all apiTokens, but guarantees at most one token per grain
-  var grainTokens = grainIdsForApiTokens.map(function (grainId) { return tokensForGrain[grainId][0]; });
+  const grainTokens = grainIdsForApiTokens.map(function (grainId) { return tokensForGrain[grainId][0]; });
 
-  var grainTokensMatchingAppTitle = grainTokens.filter(function (token) {
-    var tokenMetadata = token.owner.user.denormalizedGrainMetadata;
+  const grainTokensMatchingAppTitle = grainTokens.filter(function (token) {
+    const tokenMetadata = token.owner.user.denormalizedGrainMetadata;
     return tokenMetadata && tokenMetadata.appTitle &&
         tokenMetadata.appTitle.defaultText === appTitle;
   });
 
-  var itemsFromGrains = SandstormGrainListPage.mapGrainsToTemplateObject(grainsMatchingAppId, db);
-  var itemsFromSharedGrains = SandstormGrainListPage.mapApiTokensToTemplateObject(
+  const itemsFromGrains = SandstormGrainListPage.mapGrainsToTemplateObject(grainsMatchingAppId, db);
+  const itemsFromSharedGrains = SandstormGrainListPage.mapApiTokensToTemplateObject(
     grainTokensMatchingAppTitle, staticAssetHost);
-  var filter = compileMatchFilter(filterText);
+  const filter = compileMatchFilter(filterText);
   return _.chain([itemsFromGrains, itemsFromSharedGrains])
       .flatten()
       .filter(filter)
@@ -86,23 +86,22 @@ var filteredSortedGrains = function (db, staticAssetHost, appId, appTitle, filte
       .value();
 };
 
-var pgpFingerprint = function (pkg) {
+const pgpFingerprint = function (pkg) {
   return pkg && pkg.authorPgpKeyFingerprint;
 };
 
 Template.sandstormAppDetailsPage.onCreated(function () {
-  var ref = Template.instance().data;
-  var templateThis = this;
-  this.autorun(function () {
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
-    if (templateThis._keybaseSubscription) {
-      templateThis._keybaseSubscription.stop();
-      templateThis._keybaseSubscription = undefined;
+  const ref = Template.instance().data;
+  this.autorun(() => {
+    const pkg = latestPackageForAppId(ref._db, ref._appId);
+    if (this._keybaseSubscription) {
+      this._keybaseSubscription.stop();
+      this._keybaseSubscription = undefined;
     }
 
-    var fingerprint = pgpFingerprint(pkg);
+    const fingerprint = pgpFingerprint(pkg);
     if (fingerprint) {
-      templateThis._keybaseSubscription = Meteor.subscribe("keybaseProfile", fingerprint);
+      this._keybaseSubscription = Meteor.subscribe("keybaseProfile", fingerprint);
     }
   });
 });
@@ -114,11 +113,11 @@ Template.sandstormAppDetailsPage.onDestroyed(function () {
   }
 });
 
-var codeUrlForPackage = function (pkg) {
+const codeUrlForPackage = function (pkg) {
   return pkg && pkg.manifest && pkg.manifest.metadata && pkg.manifest.metadata.codeUrl;
 };
 
-var contactEmailForPackage = function (pkg) {
+const contactEmailForPackage = function (pkg) {
   return pkg && pkg.manifest && pkg.manifest.metadata && pkg.manifest.metadata.author &&
          pkg.manifest.metadata.author.contactEmail;
 };
@@ -129,46 +128,46 @@ Template.sandstormAppDetails.helpers({
   },
 
   appIconSrc: function () {
-    var ref = Template.instance().data;
-    var pkg = ref.pkg;
+    const ref = Template.instance().data;
+    const pkg = ref.pkg;
     return pkg && Identicon.iconSrcForPackage(pkg, "appGrid", ref.staticHost);
   },
 
   appId: function () {
-    var pkg = Template.instance().data.pkg;
+    const pkg = Template.instance().data.pkg;
     return pkg && pkg.appId;
   },
 
   appTitle: function () {
-    var pkg = Template.instance().data.pkg;
+    const pkg = Template.instance().data.pkg;
     return pkg && SandstormDb.appNameFromPackage(pkg) || "<unknown>";
   },
 
   website: function () {
-    var pkg = Template.instance().data.pkg;
+    const pkg = Template.instance().data.pkg;
     return pkg && pkg.manifest && pkg.manifest.metadata && pkg.manifest.metadata.website;
   },
 
   codeUrl: function () {
-    var pkg = Template.instance().data.pkg;
+    const pkg = Template.instance().data.pkg;
     return codeUrlForPackage(pkg);
   },
 
   contactEmail: function () {
-    var pkg = Template.instance().data.pkg;
+    const pkg = Template.instance().data.pkg;
     return contactEmailForPackage(pkg);
   },
 
   bugReportLink: function () {
-    var pkg = Template.instance().data.pkg;
+    const pkg = Template.instance().data.pkg;
     // TODO(someday): allow app manifests to include an explicit bug report link.
     // If the source code link is a github URL, then append /issues to it and use that.
-    var codeUrl = codeUrlForPackage(pkg);
+    const codeUrl = codeUrlForPackage(pkg);
     if (codeUrl && codeUrl.lastIndexOf("https://github.com/", 0) === 0) {
       return codeUrl + "/issues";
     }
     // Otherwise, provide a mailto: to the package's contact email if available.
-    var contactEmail = contactEmailForPackage(pkg);
+    const contactEmail = contactEmailForPackage(pkg);
     if (contactEmail) {
       return "mailto:" + contactEmail;
     }
@@ -177,36 +176,36 @@ Template.sandstormAppDetails.helpers({
   },
 
   authorPgpFingerprint: function () {
-    var pkg = Template.instance().data.pkg;
+    const pkg = Template.instance().data.pkg;
     return pgpFingerprint(pkg);
   },
 
   marketingVersion: function () {
-    var pkg = Template.instance().data.pkg;
+    const pkg = Template.instance().data.pkg;
     return pkg && pkg.manifest && pkg.manifest.appMarketingVersion &&
            pkg.manifest.appMarketingVersion.defaultText || "<unknown>";
   },
 
   publisherDisplayName: function () {
-    var ref = Template.instance().data;
-    var fingerprint = pgpFingerprint(ref.pkg);
-    var profile = ref.keybaseProfile;
+    const ref = Template.instance().data;
+    const fingerprint = pgpFingerprint(ref.pkg);
+    const profile = ref.keybaseProfile;
     return (profile && profile.displayName) || fingerprint;
   },
 
   publisherProofs: function () {
-    var ref = Template.instance().data;
-    var pkg = ref.pkg;
-    var fingerprint = pgpFingerprint(pkg);
+    const ref = Template.instance().data;
+    const pkg = ref.pkg;
+    const fingerprint = pgpFingerprint(pkg);
     if (!fingerprint) return [];
-    var profile = ref.keybaseProfile;
+    const profile = ref.keybaseProfile;
     if (!profile) return [];
 
-    var returnValue = [];
+    const returnValue = [];
 
     // Add the key fingerprint.
-    var keyFragments = [];
-    for (var i = 0; i <= ((fingerprint.length / 4) - 1); i++) {
+    const keyFragments = [];
+    for (let i = 0; i <= ((fingerprint.length / 4) - 1); i++) {
       keyFragments.push({ fragment: fingerprint.slice(4 * i, 4 * (i + 1)) });
     }
 
@@ -226,9 +225,10 @@ Template.sandstormAppDetails.helpers({
       });
     }
 
-    var proofs = profile.proofs;
+    // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+    const proofs = profile.proofs;
     if (proofs) {
-      var externalProofs = _.chain(proofs)
+      const externalProofs = _.chain(proofs)
           // Filter down to twitter, github, and web
           .filter(function (proof) {
             return _.contains(["twitter", "github", "dns", "https"],
@@ -243,6 +243,7 @@ Template.sandstormAppDetails.helpers({
           .value();
       externalProofs.forEach(function (proof) { returnValue.push(proof); });
     }
+    // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
 
     return returnValue;
   },
@@ -250,53 +251,53 @@ Template.sandstormAppDetails.helpers({
 
 Template.sandstormAppDetailsPage.helpers({
   setDocumentTitle: function () {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     document.title = (getAppTitle(ref) + " details · " + ref._db.getServerTitle());
   },
 
   pkg: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
+    const ref = Template.instance().data;
+    const pkg = latestPackageForAppId(ref._db, ref._appId);
     return pkg;
   },
 
   staticHost: function () {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref._staticHost;
   },
 
   isAppInDevMode: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
+    const ref = Template.instance().data;
+    const pkg = latestPackageForAppId(ref._db, ref._appId);
     return pkg && pkg.dev;
   },
 
   isAppNotInDevMode: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
+    const ref = Template.instance().data;
+    const pkg = latestPackageForAppId(ref._db, ref._appId);
     return !(pkg && pkg.dev);
   },
 
   newGrainIsLoading: function () {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref._newGrainIsLaunching.get();
   },
 
   appTitle: function () {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return getAppTitle(ref);
   },
 
   actions: function () {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     if (ref._filter.get()) return []; // Hide actions when searching.
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
+    const pkg = latestPackageForAppId(ref._db, ref._appId);
     if (!pkg) return []; // No package means no actions.
-    var appTitle = getAppTitle(ref);
+    const appTitle = getAppTitle(ref);
     if (pkg.dev) {
       // Dev mode.  Only show dev mode actions.
-      var actions = [];
-      var launchDevAction = function (actionIndex) {
+      const actions = [];
+      const launchDevAction = function (actionIndex) {
         ref._quotaEnforcer.ifQuotaAvailable(function () {
           ref._newGrainIsLaunching.set(true);
           // TODO(soon): this calls a global function in shell.js, refactor
@@ -304,7 +305,7 @@ Template.sandstormAppDetailsPage.helpers({
         });
       };
 
-      for (var i = 0; i < pkg.manifest.actions.length; i++) {
+      for (let i = 0; i < pkg.manifest.actions.length; i++) {
         actions.push({
           buttonText: "(Dev) Create new " + SandstormDb.nounPhraseForActionAndAppTitle(
             pkg.manifest.actions[i],
@@ -345,53 +346,53 @@ Template.sandstormAppDetailsPage.helpers({
   },
 
   filteredSortedGrains: function () {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return filteredSortedGrains(ref._db, ref._staticHost, ref._appId, getAppTitle(ref), ref._filter.get());
   },
 
   lastUpdated: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
+    const ref = Template.instance().data;
+    const pkg = latestPackageForAppId(ref._db, ref._appId);
     if (!pkg) return undefined;
     if (pkg.dev) return new Date(); // Might as well just indicate "now"
-    var db = ref._db;
-    var appIndexEntry = db.collections.appIndex.findOne({ packageId: pkg._id });
+    const db = ref._db;
+    const appIndexEntry = db.collections.appIndex.findOne({ packageId: pkg._id });
     return appIndexEntry && appIndexEntry.createdAt && new Date(appIndexEntry.createdAt);
   },
 
   showPublisherDetails: function () {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref._showPublisherDetails.get();
   },
 
   keybaseProfile: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
-    var fingerprint = pgpFingerprint(pkg);
-    var profile = fingerprint && ref._db.getKeybaseProfile(fingerprint);
+    const ref = Template.instance().data;
+    const pkg = latestPackageForAppId(ref._db, ref._appId);
+    const fingerprint = pgpFingerprint(pkg);
+    const profile = fingerprint && ref._db.getKeybaseProfile(fingerprint);
     return profile;
   },
 
   hasNewerVersion: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
+    const ref = Template.instance().data;
+    const pkg = latestPackageForAppId(ref._db, ref._appId);
     if (!pkg) return false;
-    var grains = appGrains(ref._db, ref._appId);
+    const grains = appGrains(ref._db, ref._appId);
     return _.some(grains, function (grain) {
       return grain.appVersion > pkg.manifest.appVersion;
     });
   },
 
   hasOlderVersion: function () {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
+    const ref = Template.instance().data;
+    const pkg = latestPackageForAppId(ref._db, ref._appId);
     if (!pkg) return false;
 
     // Don't offer upgrading grains to a dev app. The dev app already overrides the regular app
     // for all grains executed while spk dev is active.
     if (pkg.dev) return false;
 
-    var grains = appGrains(ref._db, ref._appId);
+    const grains = appGrains(ref._db, ref._appId);
     return _.some(grains, function (grain) {
       // Note that we consider a different package with the same appVersion to be "older" because
       // this usually happens when the developer is iterating on their own app and isn't bumping
@@ -407,8 +408,12 @@ Template.sandstormAppDetailsPage.helpers({
 });
 Template.sandstormAppDetailsPage.events({
   "click .restore-button": function (event, instance) {
-    var input = instance.find(".restore-button input");
-    if (input == event.target) { return; } // Click event generated by upload handler.
+    const input = instance.find(".restore-button input");
+    if (input == event.target) {
+      // Click event generated by upload handler.
+      return;
+    }
+
     instance.data._quotaEnforcer.ifQuotaAvailable(function () {
       // N.B.: this calls into a global in shell.js.
       // TODO(cleanup): refactor into a safer dependency.
@@ -421,22 +426,22 @@ Template.sandstormAppDetailsPage.events({
   },
 
   "keypress .search-bar": function (event) {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     if (event.keyCode === 13) {
       // Enter pressed.  If a single grain is shown, open it.
-      var grains = filteredSortedGrains(ref._db, ref._staticHost, ref._appId,
+      const grains = filteredSortedGrains(ref._db, ref._staticHost, ref._appId,
                                         getAppTitle(ref), ref._filter.get());
       if (grains.length === 1) {
         // Unique grain found with current filter.  Activate it!
-        var grainId = grains[0]._id;
+        const grainId = grains[0]._id;
         Router.go("grain", { grainId: grainId });
       }
     }
   },
 
   "click .uninstall-button": function (event) {
-    var ref = Template.instance().data;
-    var db = ref._db;
+    const ref = Template.instance().data;
+    const db = ref._db;
     if (window.confirm("Really uninstall " + getAppTitle(ref) + "?")) {
       // TODO(soon): make this a method on SandstormDb to uninstall an app for a user by appId/userId
       db.collections.userActions.find({ appId: ref._appId, userId: Meteor.userId() }).forEach(function (action) {
@@ -449,13 +454,13 @@ Template.sandstormAppDetailsPage.events({
   },
 
   "click .show-authorship-button": function (event) {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     ref._showPublisherDetails.set(!ref._showPublisherDetails.get());
   },
 
   "click .upgradeGrains": function (event) {
-    var ref = Template.instance().data;
-    var pkg = latestPackageForAppId(ref._db, ref._appId);
+    const ref = Template.instance().data;
+    const pkg = latestPackageForAppId(ref._db, ref._appId);
     Meteor.call("upgradeGrains", ref._appId, pkg.manifest.appVersion, pkg._id);
   },
 });

--- a/shell/packages/sandstorm-ui-app-details/package.js
+++ b/shell/packages/sandstorm-ui-app-details/package.js
@@ -20,6 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.use(["check", "reactive-var", "reload", "templating", "tracker", "underscore", "sandstorm-db", "sandstorm-identicons", "sandstorm-ui-topbar"], "client");
   api.addFiles(["app-details.html", "app-details-client.js"], "client");
   api.export("SandstormAppDetails");

--- a/shell/packages/sandstorm-ui-app-details/package.js
+++ b/shell/packages/sandstorm-ui-app-details/package.js
@@ -16,7 +16,7 @@
 
 Package.describe({
   summary: "Sandstorm UI app details page",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {

--- a/shell/packages/sandstorm-ui-app-install/install-client.js
+++ b/shell/packages/sandstorm-ui-app-install/install-client.js
@@ -1,6 +1,6 @@
-var INSTALL_STEPS = ['download', 'verify', 'unpack', 'analyze', 'ready', 'failed', 'delete'];
-var checkStep = function(step) {
-  if (INSTALL_STEPS.indexOf(step) === -1) throw new Error('Invalid step ' + step + '.');
+var INSTALL_STEPS = ["download", "verify", "unpack", "analyze", "ready", "failed", "delete"];
+var checkStep = function (step) {
+  if (INSTALL_STEPS.indexOf(step) === -1) throw new Error("Invalid step " + step + ".");
 };
 
 SandstormAppInstall = class SandstormAppInstall {
@@ -8,7 +8,7 @@ SandstormAppInstall = class SandstormAppInstall {
     this._packageId = packageId;
     this._packageUrl = packageUrl;
     this._db = db;
-    this._error = new ReactiveVar('');
+    this._error = new ReactiveVar("");
     this._recoverable = new ReactiveVar(true);
     this._keybaseSubscription = undefined;
     this._appIndexSubscription = undefined;
@@ -50,20 +50,20 @@ SandstormAppInstall = class SandstormAppInstall {
   }
 
   step() {
-    if (this._error.get() !== '') return 'error'; // Some error not associated with the package in the DB
+    if (this._error.get() !== "") return "error"; // Some error not associated with the package in the DB
     var pkg = this.pkg();
-    if (!pkg) return 'wait'; // Awaiting write access
+    if (!pkg) return "wait"; // Awaiting write access
     checkStep(pkg.status); // Expect no novel package statuses.
-    if (pkg.status !== 'ready') return pkg.status;
-    return this.isInstalled() ? 'run' : 'confirm';
+    if (pkg.status !== "ready") return pkg.status;
+    return this.isInstalled() ? "run" : "confirm";
   }
 
   isInstalled() {
-    return this._db.collections.userActions.findOne({userId: Meteor.userId(), packageId: this.packageId()});
+    return this._db.collections.userActions.findOne({ userId: Meteor.userId(), packageId: this.packageId() });
   }
 
   hasOlderVersion() {
-    var existingGrains = this._db.collections.grains.find({userId: Meteor.userId(), appId: this.appId() }).fetch();
+    var existingGrains = this._db.collections.grains.find({ userId: Meteor.userId(), appId: this.appId() }).fetch();
     var thisVersion = this.appVersion();
     for (var i in existingGrains) {
       var grain = existingGrains[i];
@@ -79,7 +79,7 @@ SandstormAppInstall = class SandstormAppInstall {
   }
 
   hasNewerVersion() {
-    var existingGrains = this._db.collections.grains.find({userId: Meteor.userId(), appId: this.appId() }).fetch();
+    var existingGrains = this._db.collections.grains.find({ userId: Meteor.userId(), appId: this.appId() }).fetch();
     var thisVersion = this.appVersion();
     for (var i in existingGrains) {
       var grain = existingGrains[i];
@@ -109,20 +109,20 @@ SandstormAppInstall = class SandstormAppInstall {
   progressText() {
     var pkg = this.pkg();
     var progress = pkg && pkg.progress;
-    if (!progress) return '';
-    if (progress < 0) return ''; // -1 means no progress to report
+    if (!progress) return "";
+    if (progress < 0) return ""; // -1 means no progress to report
     if (progress > 1) {
       // Progress outside [0,1] indicates a byte count rather than a fraction.
       // TODO(cleanup):  This is pretty ugly.  What if exactly 1 byte had been downloaded?
-      return Math.round(progress / 1024) + ' KiB';
+      return Math.round(progress / 1024) + " KiB";
     }
 
     // Value between 0 and 1 indicates fractional progress.
-    return Math.round(progress * 100) + '%';
+    return Math.round(progress * 100) + "%";
   }
 };
 
-Template.sandstormAppInstallPage.onCreated(function() {
+Template.sandstormAppInstallPage.onCreated(function () {
   var ref = Template.instance().data;
   this.autorun(() => {
     var pkg = ref.pkg();
@@ -133,17 +133,17 @@ Template.sandstormAppInstallPage.onCreated(function() {
 
     var fingerprint = pkg && pkg.authorPgpKeyFingerprint;
     if (fingerprint) {
-      ref._keybaseSubscription = Meteor.subscribe('keybaseProfile', fingerprint);
+      ref._keybaseSubscription = Meteor.subscribe("keybaseProfile", fingerprint);
     }
 
     var appId = pkg && pkg.appId;
     if (appId) {
-      ref._appIndexSubscription = Meteor.subscribe('appIndex', pkg.appId);
+      ref._appIndexSubscription = Meteor.subscribe("appIndex", pkg.appId);
     }
   });
 });
 
-Template.sandstormAppInstallPage.onDestroyed(function() {
+Template.sandstormAppInstallPage.onDestroyed(function () {
   if (this._keybaseSubscription) {
     this._keybaseSubscription.stop();
     this._keybaseSubscription = undefined;
@@ -158,7 +158,7 @@ Template.sandstormAppInstallPage.onDestroyed(function() {
 Template.sandstormAppInstallPage.helpers({
   setDocumentTitle() {
     var ref = Template.instance().data;
-    document.title = 'Installing app · ' + ref._db.getServerTitle();
+    document.title = "Installing app · " + ref._db.getServerTitle();
   },
 
   error() {
@@ -212,7 +212,7 @@ Template.sandstormAppInstallPage.helpers({
 
   staticHost() {
     var ref = Template.instance().data;
-    return ref._db.makeWildcardHost('static');
+    return ref._db.makeWildcardHost("static");
   },
 
   keybaseProfile() {
@@ -229,7 +229,7 @@ Template.sandstormAppInstallPage.helpers({
     if (!pkg) return undefined;
     if (pkg.dev) return new Date(); // Might as well just indicate 'now'
     var db = ref._db;
-    var appIndexEntry = db.collections.appIndex.findOne({packageId: pkg._id});
+    var appIndexEntry = db.collections.appIndex.findOne({ packageId: pkg._id });
     return appIndexEntry && appIndexEntry.createdAt && new Date(appIndexEntry.createdAt);
   },
 
@@ -246,18 +246,18 @@ Template.sandstormAppInstallPage.helpers({
 });
 
 Template.sandstormAppInstallPage.events({
-  'click #retry': function(event) {
+  "click #retry": function (event) {
     var ref = Template.instance().data;
-    Meteor.call('ensureInstalled', ref._packageId, ref._packageUrl, true);
+    Meteor.call("ensureInstalled", ref._packageId, ref._packageUrl, true);
   },
 
-  'click #cancelDownload': function(event) {
+  "click #cancelDownload": function (event) {
     var ref = Template.instance().data;
-    Meteor.call('cancelDownload', ref.packageId());
-    Router.go('apps');
+    Meteor.call("cancelDownload", ref.packageId());
+    Router.go("apps");
   },
 
-  'click #confirmInstall': function(event) {
+  "click #confirmInstall": function (event) {
     var ref = Template.instance().data;
     ref._db.addUserActions(ref.packageId());
   },

--- a/shell/packages/sandstorm-ui-app-install/install-client.js
+++ b/shell/packages/sandstorm-ui-app-install/install-client.js
@@ -1,5 +1,5 @@
-var INSTALL_STEPS = ["download", "verify", "unpack", "analyze", "ready", "failed", "delete"];
-var checkStep = function (step) {
+const INSTALL_STEPS = ["download", "verify", "unpack", "analyze", "ready", "failed", "delete"];
+const checkStep = function (step) {
   if (INSTALL_STEPS.indexOf(step) === -1) throw new Error("Invalid step " + step + ".");
 };
 
@@ -19,7 +19,7 @@ SandstormAppInstall = class SandstormAppInstall {
   }
 
   appId() {
-    var pkg = this.pkg();
+    const pkg = this.pkg();
     return pkg && pkg.appId;
   }
 
@@ -45,13 +45,13 @@ SandstormAppInstall = class SandstormAppInstall {
   }
 
   appVersion() {
-    var pkg = this.pkg();
+    const pkg = this.pkg();
     return pkg && pkg.manifest && pkg.manifest.appVersion;
   }
 
   step() {
     if (this._error.get() !== "") return "error"; // Some error not associated with the package in the DB
-    var pkg = this.pkg();
+    const pkg = this.pkg();
     if (!pkg) return "wait"; // Awaiting write access
     checkStep(pkg.status); // Expect no novel package statuses.
     if (pkg.status !== "ready") return pkg.status;
@@ -63,10 +63,10 @@ SandstormAppInstall = class SandstormAppInstall {
   }
 
   hasOlderVersion() {
-    var existingGrains = this._db.collections.grains.find({ userId: Meteor.userId(), appId: this.appId() }).fetch();
-    var thisVersion = this.appVersion();
-    for (var i in existingGrains) {
-      var grain = existingGrains[i];
+    const existingGrains = this._db.collections.grains.find({ userId: Meteor.userId(), appId: this.appId() }).fetch();
+    const thisVersion = this.appVersion();
+    for (let i in existingGrains) {
+      const grain = existingGrains[i];
       if (grain.packageId !== this.packageId()) {
         // Some other package version.
         if (grain.appVersion <= thisVersion) {
@@ -79,10 +79,10 @@ SandstormAppInstall = class SandstormAppInstall {
   }
 
   hasNewerVersion() {
-    var existingGrains = this._db.collections.grains.find({ userId: Meteor.userId(), appId: this.appId() }).fetch();
-    var thisVersion = this.appVersion();
-    for (var i in existingGrains) {
-      var grain = existingGrains[i];
+    const existingGrains = this._db.collections.grains.find({ userId: Meteor.userId(), appId: this.appId() }).fetch();
+    const thisVersion = this.appVersion();
+    for (let i in existingGrains) {
+      const grain = existingGrains[i];
       if (grain.packageId !== this.packageId()) {
         // Some other package version.
         if (grain.appVersion > thisVersion) {
@@ -95,20 +95,20 @@ SandstormAppInstall = class SandstormAppInstall {
   }
 
   hasFractionalProgress() {
-    var pkg = this.pkg();
-    var progress = pkg && pkg.progress;
+    const pkg = this.pkg();
+    const progress = pkg && pkg.progress;
     return (progress > 0 && progress < 1);
   }
 
   progressFraction() {
-    var pkg = this.pkg();
-    var progress = pkg && pkg.progress;
+    const pkg = this.pkg();
+    const progress = pkg && pkg.progress;
     return progress;
   }
 
   progressText() {
-    var pkg = this.pkg();
-    var progress = pkg && pkg.progress;
+    const pkg = this.pkg();
+    const progress = pkg && pkg.progress;
     if (!progress) return "";
     if (progress < 0) return ""; // -1 means no progress to report
     if (progress > 1) {
@@ -123,20 +123,20 @@ SandstormAppInstall = class SandstormAppInstall {
 };
 
 Template.sandstormAppInstallPage.onCreated(function () {
-  var ref = Template.instance().data;
+  const ref = Template.instance().data;
   this.autorun(() => {
-    var pkg = ref.pkg();
+    const pkg = ref.pkg();
     if (ref._keybaseSubscription) {
       ref._keybaseSubscription.stop();
       ref._keybaseSubscription = undefined;
     }
 
-    var fingerprint = pkg && pkg.authorPgpKeyFingerprint;
+    const fingerprint = pkg && pkg.authorPgpKeyFingerprint;
     if (fingerprint) {
       ref._keybaseSubscription = Meteor.subscribe("keybaseProfile", fingerprint);
     }
 
-    var appId = pkg && pkg.appId;
+    const appId = pkg && pkg.appId;
     if (appId) {
       ref._appIndexSubscription = Meteor.subscribe("appIndex", pkg.appId);
     }
@@ -157,17 +157,17 @@ Template.sandstormAppInstallPage.onDestroyed(function () {
 
 Template.sandstormAppInstallPage.helpers({
   setDocumentTitle() {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     document.title = "Installing app · " + ref._db.getServerTitle();
   },
 
   error() {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref.error();
   },
 
   step() {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref.step();
   },
 
@@ -176,89 +176,89 @@ Template.sandstormAppInstallPage.helpers({
   },
 
   packageId() {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref.packageId();
   },
 
   packageUrl() {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref.packageUrl();
   },
 
   isCurrentStep(step) {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref.step() === step;
   },
 
   hasFractionalProgress() {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref.hasFractionalProgress();
   },
 
   progressFraction() {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref.progressFraction();
   },
 
   progressText() {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref.progressText();
   },
 
   pkg() {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref.pkg();
   },
 
   staticHost() {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref._db.makeWildcardHost("static");
   },
 
   keybaseProfile() {
-    var ref = Template.instance().data;
-    var pkg = ref.pkg();
-    var fingerprint = pkg && pkg.authorPgpKeyFingerprint;
-    var profile = fingerprint && ref._db.getKeybaseProfile(fingerprint);
+    const ref = Template.instance().data;
+    const pkg = ref.pkg();
+    const fingerprint = pkg && pkg.authorPgpKeyFingerprint;
+    const profile = fingerprint && ref._db.getKeybaseProfile(fingerprint);
     return profile;
   },
 
   lastUpdated() {
-    var ref = Template.instance().data;
-    var pkg = ref.pkg();
+    const ref = Template.instance().data;
+    const pkg = ref.pkg();
     if (!pkg) return undefined;
     if (pkg.dev) return new Date(); // Might as well just indicate 'now'
-    var db = ref._db;
-    var appIndexEntry = db.collections.appIndex.findOne({ packageId: pkg._id });
+    const db = ref._db;
+    const appIndexEntry = db.collections.appIndex.findOne({ packageId: pkg._id });
     return appIndexEntry && appIndexEntry.createdAt && new Date(appIndexEntry.createdAt);
   },
 
   appTitle() {
-    var ref = Template.instance().data;
-    var pkg = ref.pkg();
+    const ref = Template.instance().data;
+    const pkg = ref.pkg();
     return pkg && SandstormDb.appNameFromPackage(pkg);
   },
 
   appId() {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref.appId();
   },
 });
 
 Template.sandstormAppInstallPage.events({
   "click #retry": function (event) {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     Meteor.call("ensureInstalled", ref._packageId, ref._packageUrl, true);
   },
 
   "click #cancelDownload": function (event) {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     Meteor.call("cancelDownload", ref.packageId());
     Router.go("apps");
   },
 
   "click #confirmInstall": function (event) {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     ref._db.addUserActions(ref.packageId());
   },
 });

--- a/shell/packages/sandstorm-ui-app-install/install-server.js
+++ b/shell/packages/sandstorm-ui-app-install/install-server.js
@@ -1,8 +1,8 @@
 Meteor.publish("packageInfo", function (packageId) {
   check(packageId, String);
-  var db = this.connection.sandstormDb;
-  var pkgCursor = db.collections.packages.find(packageId);
-  var pkg = pkgCursor.fetch()[0];
+  const db = this.connection.sandstormDb;
+  const pkgCursor = db.collections.packages.find(packageId);
+  const pkg = pkgCursor.fetch()[0];
   if (pkg && this.userId) {
     return [
       pkgCursor,

--- a/shell/packages/sandstorm-ui-app-install/install-server.js
+++ b/shell/packages/sandstorm-ui-app-install/install-server.js
@@ -1,4 +1,4 @@
-Meteor.publish('packageInfo', function(packageId) {
+Meteor.publish("packageInfo", function (packageId) {
   check(packageId, String);
   var db = this.connection.sandstormDb;
   var pkgCursor = db.collections.packages.find(packageId);
@@ -7,7 +7,7 @@ Meteor.publish('packageInfo', function(packageId) {
     return [
       pkgCursor,
       db.collections.userActions.find({ userId: this.userId, appId: pkg.appId }),
-      db.collections.grains.find({ userId: this.userId, appId: pkg.appId}),
+      db.collections.grains.find({ userId: this.userId, appId: pkg.appId }),
     ];
   } else {
     return pkgCursor;

--- a/shell/packages/sandstorm-ui-app-install/package.js
+++ b/shell/packages/sandstorm-ui-app-install/package.js
@@ -15,14 +15,14 @@
 // limitations under the License.
 
 Package.describe({
-  summary: 'Sandstorm UI install page',
-  version: '0.1.0',
+  summary: "Sandstorm UI install page",
+  version: "0.1.0",
 });
 
-Package.onUse(function(api) {
-  api.use(['ecmascript', 'check', 'reactive-var', 'reload', 'templating', 'tracker', 'underscore', 'sandstorm-db', 'sandstorm-ui-app-details'], 'client');
-  api.use(['ecmascript'], 'server');
-  api.addFiles(['install-server.js'], 'server');
-  api.addFiles(['install.html', 'install-client.js'], 'client');
-  api.export('SandstormAppInstall');
+Package.onUse(function (api) {
+  api.use(["ecmascript", "check", "reactive-var", "reload", "templating", "tracker", "underscore", "sandstorm-db", "sandstorm-ui-app-details"], "client");
+  api.use(["ecmascript"], "server");
+  api.addFiles(["install-server.js"], "server");
+  api.addFiles(["install.html", "install-client.js"], "client");
+  api.export("SandstormAppInstall");
 });

--- a/shell/packages/sandstorm-ui-applist/applist-client.js
+++ b/shell/packages/sandstorm-ui-applist/applist-client.js
@@ -1,11 +1,11 @@
-SandstormAppList = function(db, quotaEnforcer) {
+SandstormAppList = function (db, quotaEnforcer) {
   this._filter = new ReactiveVar("");
   this._sortOrder = new ReactiveVar([["appTitle", 1]]);
   this._staticHost = db.makeWildcardHost("static");
   this._db = db;
   this._quotaEnforcer = quotaEnforcer;
   this._uninstalling = new ReactiveVar(false);
-}
+};
 
 var matchesApp = function (needle, app) {
   var pkg = app && app.pkg;
@@ -14,9 +14,9 @@ var matchesApp = function (needle, app) {
   if (appTitle.toLowerCase().indexOf(needle) !== -1) return true;
   // ...or the metadata's shortDescription matches...
   var shortDesc = SandstormDb.appShortDescriptionFromPackage(pkg);
-  if (shortDesc && shortDesc.toLowerCase().indexOf(needle) !== -1 ) return true;
+  if (shortDesc && shortDesc.toLowerCase().indexOf(needle) !== -1) return true;
   // ...or any of the app's action's nouns match.
-  for (var i = 0 ; i < pkg.manifest.actions.length ; i++) {
+  for (var i = 0; i < pkg.manifest.actions.length; i++) {
     var nounPhrase = SandstormDb.nounPhraseForActionAndAppTitle(pkg.manifest.actions[i], appTitle);
     if (nounPhrase.toLowerCase().indexOf(needle) !== -1) return true;
   }
@@ -24,10 +24,11 @@ var matchesApp = function (needle, app) {
   return false;
 };
 
-var compileMatchFilter = function(searchString) {
+var compileMatchFilter = function (searchString) {
   var searchKeys = searchString.toLowerCase()
       .split(" ")
-      .filter(function(k) { return k !== "";});
+      .filter(function (k) { return k !== "";});
+
   return function matchFilter(item) {
     if (searchKeys.length === 0) return true;
     return _.chain(searchKeys)
@@ -37,7 +38,7 @@ var compileMatchFilter = function(searchString) {
   };
 };
 
-var appToTemplateObject = function(app) {
+var appToTemplateObject = function (app) {
   var ref = Template.instance().data;
   return {
     iconSrc: app.pkg ? ref._db.iconSrcForPackage(app.pkg, "appGrid") : "",
@@ -46,19 +47,19 @@ var appToTemplateObject = function(app) {
     appId: app.appId,
     dev: app.dev,
   };
-}
+};
 
 var matchApps = function (searchString) {
-  var filter = compileMatchFilter(searchString)
+  var filter = compileMatchFilter(searchString);
 
   var db = Template.instance().data._db;
   var allActions = db.currentUserActions().fetch();
   var appsFromUserActionsByAppId = _.chain(allActions)
-                             .groupBy('packageId')
+                             .groupBy("packageId")
                              .pairs()
-                             .map(function(pair) {
-                                var pkg = db.collections.packages.findOne(pair[0]);
-                                return {
+                             .map(function (pair) {
+                               var pkg = db.collections.packages.findOne(pair[0]);
+                               return {
                                   packageId: pair[0],
                                   actions: pair[1],
                                   appId: pkg.appId,
@@ -66,10 +67,10 @@ var matchApps = function (searchString) {
                                   dev: false,
                                 };
                              })
-                             .indexBy('appId')
+                             .indexBy("appId")
                              .value();
   var devPackagesByAppId = _.chain(db.collections.devPackages.find().fetch())
-                        .map(function(devPackage) {
+                        .map(function (devPackage) {
                           return {
                             packageId: devPackage._id,
                             actions: devPackage.manifest.actions,
@@ -78,7 +79,7 @@ var matchApps = function (searchString) {
                             dev: true,
                           };
                         })
-                        .indexBy('appId')
+                        .indexBy("appId")
                         .value();
   // Merge, making sure that dev apps overwrite user actions if they share appId
   var allApps = _.chain({})
@@ -93,19 +94,22 @@ var matchApps = function (searchString) {
 };
 
 Template.sandstormAppListPage.helpers({
-  setDocumentTitle: function() {
+  setDocumentTitle: function () {
     var ref = Template.instance().data;
     document.title = "Apps · " + ref._db.getServerTitle();
   },
-  searching: function() {
+
+  searching: function () {
     var ref = Template.instance().data;
     return ref._filter.get().length > 0;
   },
-  actionsCount: function() {
+
+  actionsCount: function () {
     var ref = Template.instance().data;
     return ref._db.currentUserActions().count();
   },
-  apps: function() {
+
+  apps: function () {
     var ref = Template.instance().data;
     var apps = matchApps(ref._filter.get());
     return _.chain(apps)
@@ -114,34 +118,40 @@ Template.sandstormAppListPage.helpers({
             .sortBy(function (appTemplateObj) { return appTemplateObj.dev ? 0 : 1; })
             .value();
   },
-  popularApps: function() {
+
+  popularApps: function () {
     var ref = Template.instance().data;
     // Count the number of grains owned by this user created by each app.
     var actions = ref._db.currentUserActions().fetch();
     var appIds = _.pluck(actions, "appId");
     var grains = ref._db.currentUserGrains().fetch();
-    var appCounts = _.countBy(grains, function(x) { return x.appId; });
+    var appCounts = _.countBy(grains, function (x) { return x.appId; });
     // Sort apps by the number of grains created, descending.
     var apps = matchApps(ref._filter.get());
     return _.chain(apps)
-        .sortBy(function(app) { return appCounts[app.appId] || 0; })
+        .sortBy(function (app) { return appCounts[app.appId] || 0; })
         .reverse()
         .map(appToTemplateObject)
         .value();
   },
-  assetPath: function(assetId) {
+
+  assetPath: function (assetId) {
     return makeWildcardHost("static") + assetId;
   },
-  appMarketUrl: function() {
-    var appMarket = Settings.findOne({_id: "appMarketUrl"});
+
+  appMarketUrl: function () {
+    var appMarket = Settings.findOne({ _id: "appMarketUrl" });
     if (!appMarket) {
       return "#";
     }
+
     return appMarket.value + "/?host=" + document.location.protocol + "//" + document.location.host;
   },
-  isSignedUpOrDemo: function() {
+
+  isSignedUpOrDemo: function () {
     return this._db.isSignedUpOrDemo();
   },
+
   showMostPopular: function () {
     // Only show if not searching, not uninstalling, and you have apps installed
     var ref = Template.instance().data;
@@ -149,9 +159,11 @@ Template.sandstormAppListPage.helpers({
            (!ref._uninstalling.get()) &&
            (ref._db.currentUserActions().count() > 0);
   },
+
   uninstalling: function () {
     return Template.instance().data._uninstalling.get();
   },
+
   appIsLoading: function () {
     return Template.instance().appIsLoading.get();
   },
@@ -165,6 +177,7 @@ Template.sandstormAppListPage.events({
           document.location.protocol + "//" + document.location.host, "_blank");
     });
   },
+
   "click .upload-button": function (event, instance) {
     var input = instance.find(instance.find(".upload-button input"));
     if (input == event.target) { return; } // Click event generated by upload handler.
@@ -174,35 +187,39 @@ Template.sandstormAppListPage.events({
       promptUploadApp(input);
     });
   },
-  "click .uninstall-action": function(event) {
+
+  "click .uninstall-action": function (event) {
     var db = Template.instance().data._db;
     var appId = this.appId;
     // Untrusted client code may only remove entries by ID.
-    db.collections.userActions.find({appId: this.appId}).forEach(function (action) {
+    db.collections.userActions.find({ appId: this.appId }).forEach(function (action) {
       db.collections.userActions.remove(action._id);
     });
+
     Meteor.call("deleteUnusedPackages", appId);
   },
-  "click button.toggle-uninstall": function(event) {
+
+  "click button.toggle-uninstall": function (event) {
     var uninstallVar = Template.instance().data._uninstalling;
     uninstallVar.set(!uninstallVar.get());
   },
   // We use keyup rather than keypress because keypress's event.currentTarget.value will not
   // have taken into account the keypress generating this event, so we'll miss a letter to
   // filter by
-  "keyup .search-bar": function(event) {
+  "keyup .search-bar": function (event) {
     Template.instance().data._filter.set(event.currentTarget.value);
   },
-  "keypress .search-bar": function(event, template) {
+
+  "keypress .search-bar": function (event, template) {
     var ref = Template.instance().data;
     if (event.keyCode === 13) {
       // Enter pressed.  If a single grain is shown, open it.
       var apps = matchApps(ref._filter.get());
       if (apps.length === 1) {
-        Router.go("appDetails", {appId: apps[0].appId});
+        Router.go("appDetails", { appId: apps[0].appId });
       }
     }
-  }
+  },
 });
 Template.sandstormAppListPage.onRendered(function () {
   // Auto-focus search bar on desktop, but not mobile (on mobile it will open the software
@@ -215,10 +232,12 @@ Template.sandstormAppListPage.onRendered(function () {
     if (db.collections.userActions.find().count() === 0) {
       return;
     }
+
     var searchbar = this.findAll(".search-bar")[0];
     if (searchbar) searchbar.focus();
   }
 });
+
 Template.sandstormAppListPage.onCreated(function () {
   this.appIsLoading = new ReactiveVar(false);
 });

--- a/shell/packages/sandstorm-ui-applist/applist-client.js
+++ b/shell/packages/sandstorm-ui-applist/applist-client.js
@@ -7,25 +7,25 @@ SandstormAppList = function (db, quotaEnforcer) {
   this._uninstalling = new ReactiveVar(false);
 };
 
-var matchesApp = function (needle, app) {
-  var pkg = app && app.pkg;
-  var appTitle = SandstormDb.appNameFromPackage(pkg);
+const matchesApp = function (needle, app) {
+  const pkg = app && app.pkg;
+  const appTitle = SandstormDb.appNameFromPackage(pkg);
   // We match if the app title is matched...
   if (appTitle.toLowerCase().indexOf(needle) !== -1) return true;
   // ...or the metadata's shortDescription matches...
-  var shortDesc = SandstormDb.appShortDescriptionFromPackage(pkg);
+  const shortDesc = SandstormDb.appShortDescriptionFromPackage(pkg);
   if (shortDesc && shortDesc.toLowerCase().indexOf(needle) !== -1) return true;
   // ...or any of the app's action's nouns match.
-  for (var i = 0; i < pkg.manifest.actions.length; i++) {
-    var nounPhrase = SandstormDb.nounPhraseForActionAndAppTitle(pkg.manifest.actions[i], appTitle);
+  for (let i = 0; i < pkg.manifest.actions.length; i++) {
+    const nounPhrase = SandstormDb.nounPhraseForActionAndAppTitle(pkg.manifest.actions[i], appTitle);
     if (nounPhrase.toLowerCase().indexOf(needle) !== -1) return true;
   }
   // Otherwise, nope.
   return false;
 };
 
-var compileMatchFilter = function (searchString) {
-  var searchKeys = searchString.toLowerCase()
+const compileMatchFilter = function (searchString) {
+  const searchKeys = searchString.toLowerCase()
       .split(" ")
       .filter(function (k) { return k !== "";});
 
@@ -38,8 +38,8 @@ var compileMatchFilter = function (searchString) {
   };
 };
 
-var appToTemplateObject = function (app) {
-  var ref = Template.instance().data;
+const appToTemplateObject = function (app) {
+  const ref = Template.instance().data;
   return {
     iconSrc: app.pkg ? ref._db.iconSrcForPackage(app.pkg, "appGrid") : "",
     appTitle: SandstormDb.appNameFromPackage(app.pkg),
@@ -49,16 +49,16 @@ var appToTemplateObject = function (app) {
   };
 };
 
-var matchApps = function (searchString) {
-  var filter = compileMatchFilter(searchString);
+const matchApps = function (searchString) {
+  const filter = compileMatchFilter(searchString);
 
-  var db = Template.instance().data._db;
-  var allActions = db.currentUserActions().fetch();
-  var appsFromUserActionsByAppId = _.chain(allActions)
+  const db = Template.instance().data._db;
+  const allActions = db.currentUserActions().fetch();
+  const appsFromUserActionsByAppId = _.chain(allActions)
                              .groupBy("packageId")
                              .pairs()
                              .map(function (pair) {
-                               var pkg = db.collections.packages.findOne(pair[0]);
+                               const pkg = db.collections.packages.findOne(pair[0]);
                                return {
                                   packageId: pair[0],
                                   actions: pair[1],
@@ -69,7 +69,7 @@ var matchApps = function (searchString) {
                              })
                              .indexBy("appId")
                              .value();
-  var devPackagesByAppId = _.chain(db.collections.devPackages.find().fetch())
+  const devPackagesByAppId = _.chain(db.collections.devPackages.find().fetch())
                         .map(function (devPackage) {
                           return {
                             packageId: devPackage._id,
@@ -82,12 +82,12 @@ var matchApps = function (searchString) {
                         .indexBy("appId")
                         .value();
   // Merge, making sure that dev apps overwrite user actions if they share appId
-  var allApps = _.chain({})
+  const allApps = _.chain({})
                  .extend(appsFromUserActionsByAppId, devPackagesByAppId)
                  .values()
                  .value();
 
-  var matchingApps = _.chain(allApps)
+  const matchingApps = _.chain(allApps)
                       .filter(filter)
                       .value();
   return matchingApps;
@@ -95,23 +95,23 @@ var matchApps = function (searchString) {
 
 Template.sandstormAppListPage.helpers({
   setDocumentTitle: function () {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     document.title = "Apps · " + ref._db.getServerTitle();
   },
 
   searching: function () {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref._filter.get().length > 0;
   },
 
   actionsCount: function () {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return ref._db.currentUserActions().count();
   },
 
   apps: function () {
-    var ref = Template.instance().data;
-    var apps = matchApps(ref._filter.get());
+    const ref = Template.instance().data;
+    const apps = matchApps(ref._filter.get());
     return _.chain(apps)
             .map(appToTemplateObject)
             .sortBy(function (appTemplateObj) { return appTemplateObj.appTitle.toLowerCase(); })
@@ -120,14 +120,14 @@ Template.sandstormAppListPage.helpers({
   },
 
   popularApps: function () {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     // Count the number of grains owned by this user created by each app.
-    var actions = ref._db.currentUserActions().fetch();
-    var appIds = _.pluck(actions, "appId");
-    var grains = ref._db.currentUserGrains().fetch();
-    var appCounts = _.countBy(grains, function (x) { return x.appId; });
+    const actions = ref._db.currentUserActions().fetch();
+    const appIds = _.pluck(actions, "appId");
+    const grains = ref._db.currentUserGrains().fetch();
+    const appCounts = _.countBy(grains, function (x) { return x.appId; });
     // Sort apps by the number of grains created, descending.
-    var apps = matchApps(ref._filter.get());
+    const apps = matchApps(ref._filter.get());
     return _.chain(apps)
         .sortBy(function (app) { return appCounts[app.appId] || 0; })
         .reverse()
@@ -140,7 +140,7 @@ Template.sandstormAppListPage.helpers({
   },
 
   appMarketUrl: function () {
-    var appMarket = Settings.findOne({ _id: "appMarketUrl" });
+    const appMarket = Settings.findOne({ _id: "appMarketUrl" });
     if (!appMarket) {
       return "#";
     }
@@ -154,7 +154,7 @@ Template.sandstormAppListPage.helpers({
 
   showMostPopular: function () {
     // Only show if not searching, not uninstalling, and you have apps installed
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     return (ref._filter.get().length === 0) &&
            (!ref._uninstalling.get()) &&
            (ref._db.currentUserActions().count() > 0);
@@ -179,8 +179,12 @@ Template.sandstormAppListPage.events({
   },
 
   "click .upload-button": function (event, instance) {
-    var input = instance.find(instance.find(".upload-button input"));
-    if (input == event.target) { return; } // Click event generated by upload handler.
+    const input = instance.find(instance.find(".upload-button input"));
+    if (input == event.target) {
+      // Click event generated by upload handler.
+      return;
+    }
+
     instance.data._quotaEnforcer.ifPlanAllowsCustomApps(function () {
       // N.B.: this calls into a global in shell.js.
       // TODO(cleanup): refactor into a safer dependency.
@@ -189,8 +193,8 @@ Template.sandstormAppListPage.events({
   },
 
   "click .uninstall-action": function (event) {
-    var db = Template.instance().data._db;
-    var appId = this.appId;
+    const db = Template.instance().data._db;
+    const appId = this.appId;
     // Untrusted client code may only remove entries by ID.
     db.collections.userActions.find({ appId: this.appId }).forEach(function (action) {
       db.collections.userActions.remove(action._id);
@@ -200,7 +204,7 @@ Template.sandstormAppListPage.events({
   },
 
   "click button.toggle-uninstall": function (event) {
-    var uninstallVar = Template.instance().data._uninstalling;
+    const uninstallVar = Template.instance().data._uninstalling;
     uninstallVar.set(!uninstallVar.get());
   },
   // We use keyup rather than keypress because keypress's event.currentTarget.value will not
@@ -211,10 +215,10 @@ Template.sandstormAppListPage.events({
   },
 
   "keypress .search-bar": function (event, template) {
-    var ref = Template.instance().data;
+    const ref = Template.instance().data;
     if (event.keyCode === 13) {
       // Enter pressed.  If a single grain is shown, open it.
-      var apps = matchApps(ref._filter.get());
+      const apps = matchApps(ref._filter.get());
       if (apps.length === 1) {
         Router.go("appDetails", { appId: apps[0].appId });
       }
@@ -228,12 +232,12 @@ Template.sandstormAppListPage.onRendered(function () {
   // clientWidth. Note that it's better to err on the side of not auto-focusing.
   if (window.orientation === undefined && window.innerWidth > 600) {
     // If there are no apps available, don't bother focusing it.
-    var db = Template.instance().data._db;
+    const db = Template.instance().data._db;
     if (db.collections.userActions.find().count() === 0) {
       return;
     }
 
-    var searchbar = this.findAll(".search-bar")[0];
+    const searchbar = this.findAll(".search-bar")[0];
     if (searchbar) searchbar.focus();
   }
 });

--- a/shell/packages/sandstorm-ui-applist/package.js
+++ b/shell/packages/sandstorm-ui-applist/package.js
@@ -20,6 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.use(["check", "reactive-var", "reload", "templating", "tracker", "underscore", "sandstorm-db", "sandstorm-ui-topbar", "sandstorm-autoupdate-apps"], "client");
   api.addFiles(["applist.html", "applist-client.js"], "client");
   api.export("SandstormAppList");

--- a/shell/packages/sandstorm-ui-applist/package.js
+++ b/shell/packages/sandstorm-ui-applist/package.js
@@ -16,7 +16,7 @@
 
 Package.describe({
   summary: "Sandstorm UI app list",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {

--- a/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
+++ b/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
@@ -1,5 +1,4 @@
 Template.contactInputBox.onCreated(function () {
-  var self = this;
   this.currentText = new ReactiveVar(null);
   this.inputActive = new ReactiveVar(false);
   this.selectedContacts = this.data.contacts;
@@ -12,14 +11,14 @@ Template.contactInputBox.onCreated(function () {
 });
 
 function generateAutoCompleteContacts(template) {
-  var currentText = template.currentText.get();
+  let currentText = template.currentText.get();
   if (!currentText) {
     template.autoCompleteContacts.set([]);
     template.highlightedContact.set({ _id: null });
     return;
   }
   // TODO(someday): handle defaults for google/github/etc
-  var defaults = [];
+  const defaults = [];
   if (currentText.indexOf("@") > 0) { // we also want to ignore starting with an @ symbol
     defaults.push({
       _id: "defaultEmail",
@@ -33,11 +32,11 @@ function generateAutoCompleteContacts(template) {
   }
 
   currentText = currentText.toLowerCase();
-  var selectedContactsIds = template.selectedContactsIds.get();
-  var contacts = ContactProfiles.find({ _id: { $nin: selectedContactsIds } }).fetch();
-  var results;
+  const selectedContactsIds = template.selectedContactsIds.get();
+  const contacts = ContactProfiles.find({ _id: { $nin: selectedContactsIds } }).fetch();
+  let results;
   if (currentText.lastIndexOf("@", 0) === 0) {
-    var textWithoutAt = currentText.slice(1);
+    const textWithoutAt = currentText.slice(1);
     results = _.filter(contacts, function (contact) {
       return contact.profile.handle.toLowerCase().indexOf(textWithoutAt) !== -1;
     });
@@ -73,8 +72,7 @@ Template.contactInputBox.helpers({
   },
 
   isCurrentlySelected: function () {
-    var selectedContactId = Template.instance().highlightedContact.get()._id;
-
+    const selectedContactId = Template.instance().highlightedContact.get()._id;
     return selectedContactId === this._id;
   },
 
@@ -93,11 +91,11 @@ function selectContact(template, highlightedContact, inputBox) {
     }
   }
 
-  var contacts = template.selectedContacts.get();
+  const contacts = template.selectedContacts.get();
   contacts.push(highlightedContact);
   template.selectedContacts.set(contacts);
 
-  var selectedContactsIds = template.selectedContactsIds.get();
+  const selectedContactsIds = template.selectedContactsIds.get();
   selectedContactsIds.push(highlightedContact._id);
   template.selectedContactsIds.set(selectedContactsIds);
 
@@ -107,15 +105,14 @@ function selectContact(template, highlightedContact, inputBox) {
 }
 
 function deleteSelected(contact, template) {
-  var self = contact;
-  var contacts = template.selectedContacts.get();
-  template.selectedContacts.set(_.filter(contacts, function (contact) {
-    return contact._id !== self._id;
+  const contacts = template.selectedContacts.get();
+  template.selectedContacts.set(_.filter(contacts, function (selectedContact) {
+    return selectedContact._id !== contact._id;
   }));
 
-  var selectedContactsIds = template.selectedContactsIds.get();
-  template.selectedContactsIds.set(_.filter(selectedContactsIds, function (id) {
-    return id !== self._id;
+  const selectedContactsIds = template.selectedContactsIds.get();
+  template.selectedContactsIds.set(_.filter(selectedContactsIds, function (selectedContactId) {
+    return selectedContactId !== contact._id;
   }));
 
   template.find("input").focus();
@@ -141,12 +138,12 @@ Template.contactInputBox.events({
       deleteSelected(this, template);
       return false;
     } else if (event.keyCode === 37 || event.keyCode === 38) { // Left or Up
-      var previous = event.target.previousElementSibling;
+      const previous = event.target.previousElementSibling;
       if (previous) {
         previous.focus();
       }
     } else if (event.keyCode === 39 || event.keyCode === 40) { // Right or Down
-      var next = event.target.nextElementSibling;
+      const next = event.target.nextElementSibling;
       if (next) {
         next.focus();
       } else {
@@ -163,7 +160,7 @@ Template.contactInputBox.events({
   "keyup input": function (event, template) {
     if (event.keyCode === 8) { // Backspace
       if (!event.target.value) {
-        var chip = template.find(".completed-contacts>li:last-child");
+        const chip = template.find(".completed-contacts>li:last-child");
         if (chip) {
           chip.focus();
         }
@@ -176,22 +173,22 @@ Template.contactInputBox.events({
   "keydown input": function (event, template) {
     if ((event.keyCode === 37 || event.keyCode === 38) && // Left or Up
         event.currentTarget.selectionStart === 0) { // Check that cursor is at beginning of input
-      var chip = template.find(".completed-contacts>li:last-child");
+      const chip = template.find(".completed-contacts>li:last-child");
       if (chip) {
         chip.focus();
       }
 
       return false;
     } else if (event.keyCode === 38) { // Up
-      var contacts = template.autoCompleteContacts.get();
+      const contacts = template.autoCompleteContacts.get();
       if (contacts.length === 0) {
         return true;
       }
 
-      var contactId = template.highlightedContact.get()._id;
-      var ids = _.pluck(contacts, "_id");
-      var index = ids.indexOf(contactId);
-      var newContact = null;
+      const contactId = template.highlightedContact.get()._id;
+      const ids = _.pluck(contacts, "_id");
+      const index = ids.indexOf(contactId);
+      let newContact = null;
       if (index >= 0) {
         if (index === 0) {
           newContact = contacts[contacts.length - 1];
@@ -205,15 +202,15 @@ Template.contactInputBox.events({
       template.highlightedContact.set(newContact);
       return false;
     } else if (event.keyCode === 40) { // Down
-      var contacts = template.autoCompleteContacts.get();
+      const contacts = template.autoCompleteContacts.get();
       if (contacts.length === 0) {
         return true;
       }
 
-      var contactId = template.highlightedContact.get()._id;
-      var ids = _.pluck(contacts, "_id");
-      var index = ids.indexOf(contactId);
-      var newContact = null;
+      const contactId = template.highlightedContact.get()._id;
+      const ids = _.pluck(contacts, "_id");
+      const index = ids.indexOf(contactId);
+      let newContact = null;
       if (index >= 0) {
         if (index + 1 >= contacts.length) {
           newContact = contacts[0];
@@ -227,7 +224,7 @@ Template.contactInputBox.events({
       template.highlightedContact.set(newContact);
       return false;
     } else if (event.keyCode === 13) { // Enter
-      var highlightedContact = template.highlightedContact.get();
+      const highlightedContact = template.highlightedContact.get();
       if (highlightedContact._id) {
         selectContact(template, highlightedContact, event.target);
       }

--- a/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
+++ b/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
@@ -4,7 +4,7 @@ Template.contactInputBox.onCreated(function () {
   this.inputActive = new ReactiveVar(false);
   this.selectedContacts = this.data.contacts;
   this.selectedContactsIds = new ReactiveVar([]);
-  this.highlightedContact = new ReactiveVar({_id: null});
+  this.highlightedContact = new ReactiveVar({ _id: null });
   this.subscribe("contactProfiles");
   this.randomId = Random.id();  // For use with aria requiring ids in html
   this.autoCompleteContacts = new ReactiveVar([]);
@@ -15,7 +15,7 @@ function generateAutoCompleteContacts(template) {
   var currentText = template.currentText.get();
   if (!currentText) {
     template.autoCompleteContacts.set([]);
-    template.highlightedContact.set({_id: null});
+    template.highlightedContact.set({ _id: null });
     return;
   }
   // TODO(someday): handle defaults for google/github/etc
@@ -26,14 +26,15 @@ function generateAutoCompleteContacts(template) {
       profile: {
         name: currentText,
         service: "email",
-        intrinsicName: "Email address"
+        intrinsicName: "Email address",
       },
       isDefault: true,
     });
   }
+
   currentText = currentText.toLowerCase();
   var selectedContactsIds = template.selectedContactsIds.get();
-  var contacts = ContactProfiles.find({_id: {$nin: selectedContactsIds}}).fetch();
+  var contacts = ContactProfiles.find({ _id: { $nin: selectedContactsIds } }).fetch();
   var results;
   if (currentText.lastIndexOf("@", 0) === 0) {
     var textWithoutAt = currentText.slice(1);
@@ -47,13 +48,14 @@ function generateAutoCompleteContacts(template) {
         contact.profile.intrinsicName.toLowerCase().indexOf(currentText) !== -1;
     });
   }
+
   template.autoCompleteContacts.set(defaults.concat(results));
   if (results.length > 0) {
     template.highlightedContact.set(results[0]);
   } else if (defaults.length > 0) {
     template.highlightedContact.set(defaults[0]);
   } else {
-    template.highlightedContact.set({_id: null});
+    template.highlightedContact.set({ _id: null });
   }
 };
 
@@ -61,20 +63,24 @@ Template.contactInputBox.helpers({
   completedContacts: function () {
     return Template.instance().selectedContacts.get();
   },
+
   autoCompleteContacts: function () {
     return Template.instance().autoCompleteContacts.get();
   },
+
   inputActive: function () {
     return Template.instance().inputActive.get();
   },
+
   isCurrentlySelected: function () {
     var selectedContactId = Template.instance().highlightedContact.get()._id;
 
     return selectedContactId === this._id;
   },
+
   templateId: function () {
     return Template.instance().randomId;
-  }
+  },
 });
 
 function selectContact(template, highlightedContact, inputBox) {
@@ -86,6 +92,7 @@ function selectContact(template, highlightedContact, inputBox) {
       highlightedContact.profile.pictureUrl = "/email.svg";
     }
   }
+
   var contacts = template.selectedContacts.get();
   contacts.push(highlightedContact);
   template.selectedContacts.set(contacts);
@@ -94,10 +101,11 @@ function selectContact(template, highlightedContact, inputBox) {
   selectedContactsIds.push(highlightedContact._id);
   template.selectedContactsIds.set(selectedContactsIds);
 
-  template.highlightedContact.set({_id: null});
+  template.highlightedContact.set({ _id: null });
   inputBox.value = "";
   template.currentText.set(null);
 }
+
 function deleteSelected(contact, template) {
   var self = contact;
   var contacts = template.selectedContacts.get();
@@ -109,6 +117,7 @@ function deleteSelected(contact, template) {
   template.selectedContactsIds.set(_.filter(selectedContactsIds, function (id) {
     return id !== self._id;
   }));
+
   template.find("input").focus();
 }
 
@@ -117,13 +126,16 @@ Template.contactInputBox.events({
     // Clicking anywhere inside the fake contact-box should focus the input
     template.find("input").focus();
   },
+
   "click .completed-contact": function (event, template) {
     // Prevent clicking on completed contacts from triggering the above focus
     return false;
   },
+
   "input input": function (event, template) {
     template.currentText.set(event.target.value);
   },
+
   "keydown .completed-contact": function (event, template) {
     if (event.keyCode === 8 || event.keyCode == 46) { // Backspace or Delete
       deleteSelected(this, template);
@@ -142,10 +154,12 @@ Template.contactInputBox.events({
       }
     }
   },
+
   "click .closer": function (event, template) {
     deleteSelected(this, template);
     return false;
   },
+
   "keyup input": function (event, template) {
     if (event.keyCode === 8) { // Backspace
       if (!event.target.value) {
@@ -153,23 +167,27 @@ Template.contactInputBox.events({
         if (chip) {
           chip.focus();
         }
+
         return false;
       }
     }
   },
-  "keydown input": function(event, template) {
+
+  "keydown input": function (event, template) {
     if ((event.keyCode === 37 || event.keyCode === 38) && // Left or Up
         event.currentTarget.selectionStart === 0) { // Check that cursor is at beginning of input
       var chip = template.find(".completed-contacts>li:last-child");
       if (chip) {
         chip.focus();
       }
+
       return false;
     } else if (event.keyCode === 38) { // Up
       var contacts = template.autoCompleteContacts.get();
       if (contacts.length === 0) {
         return true;
       }
+
       var contactId = template.highlightedContact.get()._id;
       var ids = _.pluck(contacts, "_id");
       var index = ids.indexOf(contactId);
@@ -191,6 +209,7 @@ Template.contactInputBox.events({
       if (contacts.length === 0) {
         return true;
       }
+
       var contactId = template.highlightedContact.get()._id;
       var ids = _.pluck(contacts, "_id");
       var index = ids.indexOf(contactId);
@@ -204,6 +223,7 @@ Template.contactInputBox.events({
       } else if (contacts.length > 0) {
         newContact = contacts[contacts.length - 1];
       }
+
       template.highlightedContact.set(newContact);
       return false;
     } else if (event.keyCode === 13) { // Enter
@@ -211,16 +231,20 @@ Template.contactInputBox.events({
       if (highlightedContact._id) {
         selectContact(template, highlightedContact, event.target);
       }
+
       return false;
     }
   },
-  "focus input": function(event, template) {
+
+  "focus input": function (event, template) {
     template.inputActive.set(true);
   },
-  "blur input": function(event, template) {
+
+  "blur input": function (event, template) {
     template.inputActive.set(false);
   },
-  "mousedown .autocomplete": function(event, template) {
+
+  "mousedown .autocomplete": function (event, template) {
     selectContact(template, this, template.find("input"));
     template.find("input").focus();
 

--- a/shell/packages/sandstorm-ui-autocomplete-input/package.js
+++ b/shell/packages/sandstorm-ui-autocomplete-input/package.js
@@ -16,7 +16,7 @@
 
 Package.describe({
   summary: "Sandstorm UI autocomplete input",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {

--- a/shell/packages/sandstorm-ui-autocomplete-input/package.js
+++ b/shell/packages/sandstorm-ui-autocomplete-input/package.js
@@ -20,6 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.use(["check", "reactive-var", "reload", "templating", "tracker", "underscore", "sandstorm-ui-topbar", "sandstorm-autoupdate-apps", "mongo"], "client");
   api.use(["sandstorm-db", "sandstorm-contacts"], ["client", "server"]);
   api.addFiles(["autocomplete.html", "autocomplete-client.js"], "client");

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -1,6 +1,6 @@
 SandstormGrainListPage = function (db, quotaEnforcer) {
   this._filter = new ReactiveVar("");
-  this._staticHost = db.makeWildcardHost('static');
+  this._staticHost = db.makeWildcardHost("static");
   this._db = db;
   this._quotaEnforcer = quotaEnforcer;
 };
@@ -8,14 +8,14 @@ SandstormGrainListPage = function (db, quotaEnforcer) {
 SandstormGrainListPage.mapGrainsToTemplateObject = function (grains, db) {
   // Do package lookup all at once, rather than doing N queries for N grains
   var packageIds = _.chain(grains)
-      .pluck('packageId')
+      .pluck("packageId")
       .uniq()
       .value();
   var packages = db.collections.packages.find({ _id: { $in: packageIds } }).fetch();
-  var packagesById = _.indexBy(packages, '_id');
-  return grains.map(function(grain) {
+  var packagesById = _.indexBy(packages, "_id");
+  return grains.map(function (grain) {
     var pkg = packagesById[grain.packageId];
-    var iconSrc = pkg ? db.iconSrcForPackage(pkg, 'grain') : "";
+    var iconSrc = pkg ? db.iconSrcForPackage(pkg, "grain") : "";
     var appTitle = pkg ? SandstormDb.appNameFromPackage(pkg) : "";
     return {
       _id: grain._id,
@@ -29,13 +29,13 @@ SandstormGrainListPage.mapGrainsToTemplateObject = function (grains, db) {
 };
 
 SandstormGrainListPage.mapApiTokensToTemplateObject = function (apiTokens, staticAssetHost) {
-  var tokensForGrain = _.groupBy(apiTokens, 'grainId');
+  var tokensForGrain = _.groupBy(apiTokens, "grainId");
   var grainIdsForApiTokens = Object.keys(tokensForGrain);
-  return grainIdsForApiTokens.map(function(grainId) {
+  return grainIdsForApiTokens.map(function (grainId) {
     // Pick the most recently used one.
     var token = _.sortBy(tokensForGrain[grainId], function (t) {
-      if (t.owner && t.owner.user && t.owner.user.lastUsed) { return -t.owner.user.lastUsed }
-      else {return 0; } })[0];
+      if (t.owner && t.owner.user && t.owner.user.lastUsed) { return -t.owner.user.lastUsed; }    else {return 0; } })[0];
+
     var ownerData = token.owner.user;
     var grainInfo = ownerData.denormalizedGrainMetadata;
     var appTitle = (grainInfo && grainInfo.appTitle && grainInfo.appTitle.defaultText) || "";
@@ -59,11 +59,13 @@ var matchesAppOrGrainTitle = function (needle, grain) {
   if (grain.appTitle && grain.appTitle.toLowerCase().indexOf(needle) !== -1) return true;
   return false;
 };
+
 var compileMatchFilter = function (searchString) {
   // split up searchString into an array of regexes, use them to match against item
   var searchKeys = searchString.toLowerCase()
       .split(" ")
-      .filter(function(k) { return k !== "";});
+      .filter(function (k) { return k !== "";});
+
   return function matchFilter(item) {
     if (searchKeys.length === 0) return true;
     return _.chain(searchKeys)
@@ -72,7 +74,8 @@ var compileMatchFilter = function (searchString) {
         .value();
   };
 };
-var filteredSortedGrains = function() {
+
+var filteredSortedGrains = function () {
   var ref = Template.instance().data;
   var db = ref._db;
   var grains = db.currentUserGrains().fetch();
@@ -83,34 +86,40 @@ var filteredSortedGrains = function() {
   return _.chain([itemsFromGrains, itemsFromSharedGrains])
       .flatten()
       .filter(filter)
-      .sortBy('lastUsed') // TODO: allow sorting by other columns
+      .sortBy("lastUsed") // TODO: allow sorting by other columns
       .reverse()
       .value();
 };
+
 Template.sandstormGrainListPage.helpers({
-  setDocumentTitle: function() {
+  setDocumentTitle: function () {
     document.title = "Grains · " + Template.instance().data._db.getServerTitle();
   },
+
   filteredSortedGrains: filteredSortedGrains,
-  searchText: function() {
+  searchText: function () {
     return Template.instance().data._filter.get();
   },
+
   myGrainsCount: function () {
     return Template.instance().data._db.currentUserGrains().count();
   },
-  hasAnyGrainsCreatedOrSharedWithMe: function() {
+
+  hasAnyGrainsCreatedOrSharedWithMe: function () {
     var _db = Template.instance().data._db;
-    return !! (_db.currentUserGrains().count() ||
+    return !!(_db.currentUserGrains().count() ||
                _db.currentUserApiTokens().count());
   },
+
   myGrainsSize: function () {
     // TODO(cleanup): extract prettySize and other similar helpers from globals into a package
     // TODO(cleanup): access Meteor.user() through db object
     return prettySize(Meteor.user().storageUsage);
   },
+
   onGrainClicked: function () {
     return function (grainId) {
-      Router.go("grain", {grainId: grainId});
+      Router.go("grain", { grainId: grainId });
     };
   },
 });
@@ -126,10 +135,11 @@ Template.sandstormGrainListPage.onRendered(function () {
 });
 
 Template.sandstormGrainListPage.events({
-  "input .search-bar": function(event) {
+  "input .search-bar": function (event) {
     Template.instance().data._filter.set(event.target.value);
   },
-  "keypress .search-bar": function(event) {
+
+  "keypress .search-bar": function (event) {
     if (event.keyCode === 13) {
       // Enter pressed.  If a single grain is shown, open it.
       var grains = filteredSortedGrains();
@@ -137,10 +147,10 @@ Template.sandstormGrainListPage.events({
         // Unique grain found with current filter.  Activate it!
         var grainId = grains[0]._id;
         // router.go grain/grainId?
-        Router.go("grain", {grainId: grainId});
+        Router.go("grain", { grainId: grainId });
       }
     }
-  }
+  },
 });
 
 Template.sandstormGrainListPage.events({
@@ -152,58 +162,62 @@ Template.sandstormGrainListPage.events({
       // TODO(cleanup): refactor into a safer dependency.
       promptRestoreBackup(input);
     });
-  }
+  },
 });
 
 Template.sandstormGrainTable.events({
-  "click tbody tr.action": function(event) {
+  "click tbody tr.action": function (event) {
     this && this.onClick();
   },
-  "click tbody tr.grain": function(event) {
+
+  "click tbody tr.grain": function (event) {
     var context = Template.instance().data;
     context.onGrainClicked && context.onGrainClicked(this._id);
   },
 });
 
-Template.sandstormGrainTable.onRendered(function() {
+Template.sandstormGrainTable.onRendered(function () {
   // Set up the guided tour box, via introJs, if desired.
-  if (! Template.instance().data.showHintIfEmpty) {
+  if (!Template.instance().data.showHintIfEmpty) {
     return;
   }
+
   var _db = Template.instance().data._db;
-  if (! _db) {
+  if (!_db) {
     return;
   }
-  if (Session.get('dismissedGrainTableGuidedTour')) {
+
+  if (Session.get("dismissedGrainTableGuidedTour")) {
     return;
   }
 
   // We could abort this function if (! globalSubs['grainsMenu'].ready()). However, at the moment,
   // we already waitOn the globalSubs, so that would be a no-op.
 
-  var hasGrains = !! (_db.currentUserGrains().count() ||
+  var hasGrains = !!(_db.currentUserGrains().count() ||
                       _db.currentUserApiTokens().count());
-  if (! hasGrains) {
+  if (!hasGrains) {
     var intro = Template.instance().data.intro = introJs();
     intro.setOptions({
       steps: [
         {
-          element: document.querySelector('.grain-list-table'),
-          intro: 'You can click here to create a new grain and start the app. Make as many as you want.',
-          position: 'bottom'
-        }
+          element: document.querySelector(".grain-list-table"),
+          intro: "You can click here to create a new grain and start the app. Make as many as you want.",
+          position: "bottom",
+        },
       ],
-      tooltipPosition: 'auto',
-      positionPrecedence: ['bottom', 'top', 'left', 'right'],
+      tooltipPosition: "auto",
+      positionPrecedence: ["bottom", "top", "left", "right"],
       showStepNumbers: false,
       exitOnOverlayClick: true,
       overlayOpacity: 0.7,
       showBullets: false,
-      doneLabel: 'Got it'
+      doneLabel: "Got it",
     });
-    intro.oncomplete(function() {
-      Session.set('dismissedGrainTableGuidedTour', true);
+    intro.oncomplete(function () {
+      Session.set("dismissedGrainTableGuidedTour", true);
     });
+
     intro.start();
 
     // HACK: After 2 seconds, triger window resize. This is a workaround for a problem where
@@ -215,13 +229,13 @@ Template.sandstormGrainTable.onRendered(function() {
     //
     // We could use a ResizeSensor that plays games with CSS, but that seems like more work than is
     // sensible.
-    Meteor.setTimeout(function() {
-      window.dispatchEvent(new Event('resize'));
+    Meteor.setTimeout(function () {
+      window.dispatchEvent(new Event("resize"));
     }, 2000);
   }
 });
 
-Template.sandstormGrainTable.onDestroyed(function() {
+Template.sandstormGrainTable.onDestroyed(function () {
   if (Template.instance().data.intro) {
     Template.instance().data.intro.exit();
     Template.instance().data.intro = undefined;

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -7,16 +7,16 @@ SandstormGrainListPage = function (db, quotaEnforcer) {
 
 SandstormGrainListPage.mapGrainsToTemplateObject = function (grains, db) {
   // Do package lookup all at once, rather than doing N queries for N grains
-  var packageIds = _.chain(grains)
+  const packageIds = _.chain(grains)
       .pluck("packageId")
       .uniq()
       .value();
-  var packages = db.collections.packages.find({ _id: { $in: packageIds } }).fetch();
-  var packagesById = _.indexBy(packages, "_id");
+  const packages = db.collections.packages.find({ _id: { $in: packageIds } }).fetch();
+  const packagesById = _.indexBy(packages, "_id");
   return grains.map(function (grain) {
-    var pkg = packagesById[grain.packageId];
-    var iconSrc = pkg ? db.iconSrcForPackage(pkg, "grain") : "";
-    var appTitle = pkg ? SandstormDb.appNameFromPackage(pkg) : "";
+    const pkg = packagesById[grain.packageId];
+    const iconSrc = pkg ? db.iconSrcForPackage(pkg, "grain") : "";
+    const appTitle = pkg ? SandstormDb.appNameFromPackage(pkg) : "";
     return {
       _id: grain._id,
       title: grain.title,
@@ -29,18 +29,18 @@ SandstormGrainListPage.mapGrainsToTemplateObject = function (grains, db) {
 };
 
 SandstormGrainListPage.mapApiTokensToTemplateObject = function (apiTokens, staticAssetHost) {
-  var tokensForGrain = _.groupBy(apiTokens, "grainId");
-  var grainIdsForApiTokens = Object.keys(tokensForGrain);
+  const tokensForGrain = _.groupBy(apiTokens, "grainId");
+  const grainIdsForApiTokens = Object.keys(tokensForGrain);
   return grainIdsForApiTokens.map(function (grainId) {
     // Pick the most recently used one.
-    var token = _.sortBy(tokensForGrain[grainId], function (t) {
+    const token = _.sortBy(tokensForGrain[grainId], function (t) {
       if (t.owner && t.owner.user && t.owner.user.lastUsed) { return -t.owner.user.lastUsed; }    else {return 0; } })[0];
 
-    var ownerData = token.owner.user;
-    var grainInfo = ownerData.denormalizedGrainMetadata;
-    var appTitle = (grainInfo && grainInfo.appTitle && grainInfo.appTitle.defaultText) || "";
+    const ownerData = token.owner.user;
+    const grainInfo = ownerData.denormalizedGrainMetadata;
+    const appTitle = (grainInfo && grainInfo.appTitle && grainInfo.appTitle.defaultText) || "";
     // TODO(someday): use source sets and the dpi2x value
-    var iconSrc = (grainInfo && grainInfo.icon && grainInfo.icon.assetId) ?
+    const iconSrc = (grainInfo && grainInfo.icon && grainInfo.icon.assetId) ?
         (window.location.protocol + "//" + staticAssetHost + "/" + grainInfo.icon.assetId) :
         Identicon.identiconForApp((grainInfo && grainInfo.appId) || "00000000000000000000000000000000");
     return {
@@ -54,15 +54,15 @@ SandstormGrainListPage.mapApiTokensToTemplateObject = function (apiTokens, stati
   });
 };
 
-var matchesAppOrGrainTitle = function (needle, grain) {
+const matchesAppOrGrainTitle = function (needle, grain) {
   if (grain.title && grain.title.toLowerCase().indexOf(needle) !== -1) return true;
   if (grain.appTitle && grain.appTitle.toLowerCase().indexOf(needle) !== -1) return true;
   return false;
 };
 
-var compileMatchFilter = function (searchString) {
+const compileMatchFilter = function (searchString) {
   // split up searchString into an array of regexes, use them to match against item
-  var searchKeys = searchString.toLowerCase()
+  const searchKeys = searchString.toLowerCase()
       .split(" ")
       .filter(function (k) { return k !== "";});
 
@@ -75,14 +75,14 @@ var compileMatchFilter = function (searchString) {
   };
 };
 
-var filteredSortedGrains = function () {
-  var ref = Template.instance().data;
-  var db = ref._db;
-  var grains = db.currentUserGrains().fetch();
-  var itemsFromGrains = SandstormGrainListPage.mapGrainsToTemplateObject(grains, db);
-  var apiTokens = db.currentUserApiTokens().fetch();
-  var itemsFromSharedGrains = SandstormGrainListPage.mapApiTokensToTemplateObject(apiTokens, ref._staticHost);
-  var filter = compileMatchFilter(Template.instance().data._filter.get());
+const filteredSortedGrains = function () {
+  const ref = Template.instance().data;
+  const db = ref._db;
+  const grains = db.currentUserGrains().fetch();
+  const itemsFromGrains = SandstormGrainListPage.mapGrainsToTemplateObject(grains, db);
+  const apiTokens = db.currentUserApiTokens().fetch();
+  const itemsFromSharedGrains = SandstormGrainListPage.mapApiTokensToTemplateObject(apiTokens, ref._staticHost);
+  const filter = compileMatchFilter(Template.instance().data._filter.get());
   return _.chain([itemsFromGrains, itemsFromSharedGrains])
       .flatten()
       .filter(filter)
@@ -106,7 +106,7 @@ Template.sandstormGrainListPage.helpers({
   },
 
   hasAnyGrainsCreatedOrSharedWithMe: function () {
-    var _db = Template.instance().data._db;
+    const _db = Template.instance().data._db;
     return !!(_db.currentUserGrains().count() ||
                _db.currentUserApiTokens().count());
   },
@@ -129,7 +129,7 @@ Template.sandstormGrainListPage.onRendered(function () {
   // but not desktop browsers, but some mobile browsers don't support it, so we also check
   // clientWidth. Note that it's better to err on the side of not auto-focusing.
   if (window.orientation === undefined && window.innerWidth > 600) {
-    var searchbar = this.findAll(".search-bar")[0];
+    const searchbar = this.findAll(".search-bar")[0];
     if (searchbar) searchbar.focus();
   }
 });
@@ -142,10 +142,10 @@ Template.sandstormGrainListPage.events({
   "keypress .search-bar": function (event) {
     if (event.keyCode === 13) {
       // Enter pressed.  If a single grain is shown, open it.
-      var grains = filteredSortedGrains();
+      const grains = filteredSortedGrains();
       if (grains.length === 1) {
         // Unique grain found with current filter.  Activate it!
-        var grainId = grains[0]._id;
+        const grainId = grains[0]._id;
         // router.go grain/grainId?
         Router.go("grain", { grainId: grainId });
       }
@@ -155,8 +155,12 @@ Template.sandstormGrainListPage.events({
 
 Template.sandstormGrainListPage.events({
   "click .restore-button": function (event, instance) {
-    var input = instance.find(".restore-button input");
-    if (input == event.target) { return; } // Click event generated by upload handler.
+    const input = instance.find(".restore-button input");
+    if (input == event.target) {
+      // Click event generated by upload handler.
+      return;
+    }
+
     instance.data._quotaEnforcer.ifQuotaAvailable(function () {
       // N.B.: this calls into a global in shell.js.
       // TODO(cleanup): refactor into a safer dependency.
@@ -171,7 +175,7 @@ Template.sandstormGrainTable.events({
   },
 
   "click tbody tr.grain": function (event) {
-    var context = Template.instance().data;
+    const context = Template.instance().data;
     context.onGrainClicked && context.onGrainClicked(this._id);
   },
 });
@@ -182,7 +186,7 @@ Template.sandstormGrainTable.onRendered(function () {
     return;
   }
 
-  var _db = Template.instance().data._db;
+  const _db = Template.instance().data._db;
   if (!_db) {
     return;
   }
@@ -194,10 +198,10 @@ Template.sandstormGrainTable.onRendered(function () {
   // We could abort this function if (! globalSubs['grainsMenu'].ready()). However, at the moment,
   // we already waitOn the globalSubs, so that would be a no-op.
 
-  var hasGrains = !!(_db.currentUserGrains().count() ||
+  const hasGrains = !!(_db.currentUserGrains().count() ||
                       _db.currentUserApiTokens().count());
   if (!hasGrains) {
-    var intro = Template.instance().data.intro = introJs();
+    const intro = Template.instance().data.intro = introJs();
     intro.setOptions({
       steps: [
         {

--- a/shell/packages/sandstorm-ui-grainlist/package.js
+++ b/shell/packages/sandstorm-ui-grainlist/package.js
@@ -16,7 +16,7 @@
 
 Package.describe({
   summary: "Sandstorm UI grain list",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {

--- a/shell/packages/sandstorm-ui-grainlist/package.js
+++ b/shell/packages/sandstorm-ui-grainlist/package.js
@@ -20,6 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.use(["check", "reactive-var", "reload", "templating", "tracker", "sandstorm-db", "sandstorm-identicons", "sandstorm-ui-topbar", "underscore"], "client");
   api.addFiles(["grainlist.html", "grainlist-client.js"], "client");
   api.export("SandstormGrainListPage");

--- a/shell/packages/sandstorm-ui-powerbox/package.js
+++ b/shell/packages/sandstorm-ui-powerbox/package.js
@@ -16,7 +16,7 @@
 
 Package.describe({
   summary: "Sandstorm UI Powerbox",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -34,32 +34,35 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
 
   hex64ToDecimal(n) {
     if (typeof n != "string") {
-        throw new Error("Expected string.");
+      throw new Error("Expected string.");
     }
+
     if (n.length != 18 || !n.match(/0x[0-9a-fA-F]{16}/)) {
-        throw new Error("Expected '0x' followed by 16 hexadecimal digits");
+      throw new Error("Expected '0x' followed by 16 hexadecimal digits");
     }
+
     var upper32 = parseInt(n.substring(0, 10));
     var lower32 = parseInt("0x" + n.substring(10, 18));
 
     var result = "";
-    for (var exponent = 0; exponent < 22; exponent += 1 ) {
-        var w = Math.floor(upper32 / 10);
-        var x = upper32 % 10;
+    for (var exponent = 0; exponent < 22; exponent += 1) {
+      var w = Math.floor(upper32 / 10);
+      var x = upper32 % 10;
 
-        var lowerPlusRemainder = (x * Math.pow(2, 32)) + lower32;
-        var y = Math.floor(lowerPlusRemainder / 10);
-        var z = lowerPlusRemainder % 10;
+      var lowerPlusRemainder = (x * Math.pow(2, 32)) + lower32;
+      var y = Math.floor(lowerPlusRemainder / 10);
+      var z = lowerPlusRemainder % 10;
 
-        result = z.toString() + result;
+      result = z.toString() + result;
 
-        upper32 = w;
-        lower32 = y;
+      upper32 = w;
+      lower32 = y;
 
-        if (upper32 == 0 && lower32 == 0) {
-            break;
-        }
+      if (upper32 == 0 && lower32 == 0) {
+        break;
+      }
     }
+
     return result;
   }
 
@@ -71,6 +74,7 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
         return interfaceId;
       }
     }
+
     return interfaceId;
   }
 
@@ -212,9 +216,9 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
               viewInfo: viewInfo,
               onComplete: (roleAssignment) => {
                 this.completeUiView(roleAssignment);
-              }
-            }
-          }
+              },
+            };
+          },
         });
       }
     });
@@ -289,8 +293,9 @@ const mapApiTokensToGrainCardData = function (apiTokens, db, selectApiToken) {
       // need to double-wrap this callback.
       return function () {
         selectApiToken(grainCard);
-      }
+      };
     };
+
     return grainCard;
   });
 };

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -41,17 +41,17 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
       throw new Error("Expected '0x' followed by 16 hexadecimal digits");
     }
 
-    var upper32 = parseInt(n.substring(0, 10));
-    var lower32 = parseInt("0x" + n.substring(10, 18));
+    let upper32 = parseInt(n.substring(0, 10));
+    let lower32 = parseInt("0x" + n.substring(10, 18));
 
-    var result = "";
-    for (var exponent = 0; exponent < 22; exponent += 1) {
-      var w = Math.floor(upper32 / 10);
-      var x = upper32 % 10;
+    let result = "";
+    for (let exponent = 0; exponent < 22; exponent += 1) {
+      const w = Math.floor(upper32 / 10);
+      const x = upper32 % 10;
 
-      var lowerPlusRemainder = (x * Math.pow(2, 32)) + lower32;
-      var y = Math.floor(lowerPlusRemainder / 10);
-      var z = lowerPlusRemainder % 10;
+      const lowerPlusRemainder = (x * Math.pow(2, 32)) + lower32;
+      const y = Math.floor(lowerPlusRemainder / 10);
+      const z = lowerPlusRemainder % 10;
 
       result = z.toString() + result;
 

--- a/shell/packages/sandstorm-ui-topbar/package.js
+++ b/shell/packages/sandstorm-ui-topbar/package.js
@@ -16,7 +16,7 @@
 
 Package.describe({
   summary: "Sandstorm UI top bar",
-  version: "0.1.0"
+  version: "0.1.0",
 });
 
 Package.onUse(function (api) {

--- a/shell/packages/sandstorm-ui-topbar/package.js
+++ b/shell/packages/sandstorm-ui-topbar/package.js
@@ -20,6 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.use(["check", "reactive-var", "reload", "templating", "tracker", "underscore", "sandstorm-identicons"], "client");
   api.addFiles(["topbar.html", "topbar.js"], "client");
   api.export("SandstormTopbar");

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -14,9 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var reloadBlockingCount = 0;
-var blockedReload = new ReactiveVar(null);
-var explicitlyUnblocked = false;
+let reloadBlockingCount = 0;
+const blockedReload = new ReactiveVar(null);
+let explicitlyUnblocked = false;
 Reload._onMigrate(undefined, function (retry, options) {
   if (reloadBlockingCount > 0 && !explicitlyUnblocked && !options.immediateMigration) {
     console.log("New version ready, but blocking reload because an app is open.");
@@ -28,7 +28,7 @@ Reload._onMigrate(undefined, function (retry, options) {
 });
 
 function unblockUpdate() {
-  var retry = blockedReload.get();
+  const retry = blockedReload.get();
   if (retry) {
     blockedReload.set(null);
     explicitlyUnblocked = true;
@@ -47,7 +47,7 @@ Template.sandstormTopbarBlockReload.onDestroyed(function () {
 Template.sandstormTopbar.onCreated(function () {
   Template.instance().popupPosition = new ReactiveVar(undefined, _.isEqual);
 
-  var topbar = this.data;
+  const topbar = this.data;
   this.escapeHandler = function (ev) {
     if (ev.keyCode === 27) {
       topbar.closePopup();
@@ -79,9 +79,9 @@ Template.sandstormTopbar.helpers({
   },
 
   grains: function () {
-    var topbar = Template.instance().data;
-    var grains = topbar._grains.get();
-    var data = grains.map(function (grain) {
+    const topbar = Template.instance().data;
+    const grains = topbar._grains.get();
+    const data = grains.map(function (grain) {
       grain.depend();
       return {
         grainId: grain.grainId(),
@@ -97,13 +97,13 @@ Template.sandstormTopbar.helpers({
   },
 
   grainCount: function () {
-    var topbar = Template.instance().data;
-    var grains = topbar._grains.get();
+    const topbar = Template.instance().data;
+    const grains = topbar._grains.get();
     return grains.length;
   },
 
   currentPopup: function () {
-    var name = this._expanded.get();
+    const name = this._expanded.get();
     if (name) {
       this._itemsTracker.depend();
       return this._items[name];
@@ -115,27 +115,27 @@ Template.sandstormTopbar.helpers({
   template: function () {
     // Spacebars' {{>foo bar}} passes `bar` by pushing it onto the data context stack rather than
     // passing it as a parameter. The original data context must be accessed via `parentData()`.
-    var item = Template.parentData(1);
+    const item = Template.parentData(1);
     return item.template;
   },
 
   popupTemplate: function () {
-    var item = Template.parentData(1);
+    const item = Template.parentData(1);
     return item.popupTemplate;
   },
 
   popupTemplateNested: function () {
     // Here we need parentData(2) because we've also pushed `position` onto the stack.
-    var item = Template.parentData(2);
+    const item = Template.parentData(2);
     return item.popupTemplate;
   },
 
   position: function () {
-    var instance = Template.instance();
-    var item = instance.data._items[instance.data._expanded.get()];
+    const instance = Template.instance();
+    const item = instance.data._items[instance.data._expanded.get()];
     if (item) {
       Meteor.defer(function () {
-        var element = instance.find(".topbar>.menubar>." + item.name);
+        const element = instance.find(".topbar>.menubar>." + item.name);
         if (element) {
           // This positions the popup under the topbar item that spawned it. As a hacky heuristic,
           // we position the popup from the left if the item is closer to the left of the window,
@@ -148,10 +148,10 @@ Template.sandstormTopbar.helpers({
             // account should always be flush right
             instance.popupPosition.set({ name: item.name, align: "right", px: 0 });
           } else {
-            var rect = element.getBoundingClientRect();
-            var currentWindowWidth = windowWidth.get();
-            var windowMid = currentWindowWidth / 2;
-            var itemMid = (rect.left + rect.right) / 2;
+            const rect = element.getBoundingClientRect();
+            const currentWindowWidth = windowWidth.get();
+            const windowMid = currentWindowWidth / 2;
+            const itemMid = (rect.left + rect.right) / 2;
             instance.popupPosition.set(itemMid < windowMid
                 ? { name: item.name, align: "left", px: Math.max(itemMid - 50, 0) }
                 : { name: item.name, align: "right",
@@ -161,7 +161,7 @@ Template.sandstormTopbar.helpers({
       });
     }
 
-    var result = instance.popupPosition.get();
+    const result = instance.popupPosition.get();
     if (item && result && result.name === item.name) {
       return result;
     } else {
@@ -171,14 +171,14 @@ Template.sandstormTopbar.helpers({
   },
 
   accountExpires: function () {
-    var user = Meteor.user();
+    const user = Meteor.user();
     if (!user || !Meteor.user().expires) return null;
 
-    var ms = Meteor.user().expires.getTime() - Date.now();
-    var sec = Math.floor(ms / 1000) % 60;
+    const ms = Meteor.user().expires.getTime() - Date.now();
+    let sec = Math.floor(ms / 1000) % 60;
     if (sec < 10) sec = "0" + sec;
-    var min = Math.floor(ms / 60000);
-    var comp = Tracker.currentComputation;
+    const min = Math.floor(ms / 60000);
+    const comp = Tracker.currentComputation;
     if (comp) {
       Meteor.setTimeout(comp.invalidate.bind(comp), 1000);
     }
@@ -192,7 +192,7 @@ Template.sandstormTopbar.helpers({
   },
 });
 
-var windowWidth = new ReactiveVar(window.innerWidth);
+const windowWidth = new ReactiveVar(window.innerWidth);
 window.addEventListener("resize", function () {
   windowWidth.set(window.innerWidth);
 });
@@ -203,12 +203,12 @@ Template.sandstormTopbar.events({
   },
 
   "click .topbar>.menubar>li": function (event) {
-    var data = Blaze.getData(event.currentTarget);
+    const data = Blaze.getData(event.currentTarget);
     if (data.popupTemplate) {
       event.stopPropagation();
       event.preventDefault();
 
-      var topbar = Template.instance().data;
+      const topbar = Template.instance().data;
       topbar._expanded.set(data.name);
       topbar._menuExpanded.set(false);
     }
@@ -238,27 +238,27 @@ Template.sandstormTopbar.events({
   },
 
   "click .toggle-navbar": function (event) {
-    var topbar = Template.instance().data;
+    const topbar = Template.instance().data;
     topbar._shrinkNavbar.set(!topbar._shrinkNavbar.get());
   },
 
   "click .menu-button": function (event) {
-    var topbar = Template.instance().data;
+    const topbar = Template.instance().data;
     topbar._menuExpanded.set(!topbar._menuExpanded.get());
   },
 
   "click .navbar-shrink": function (event) {
-    var topbar = Template.instance().data;
+    const topbar = Template.instance().data;
     topbar._shrinkNavbar.set(!topbar._shrinkNavbar.get());
   },
 
   "click .navbar .close-button": function (event) {
-    var grainId = event.currentTarget.parentNode.getAttribute("data-grainid");
-    var topbar = Template.instance().data;
-    var grains = topbar._grains.get();
+    const grainId = event.currentTarget.parentNode.getAttribute("data-grainid");
+    const topbar = Template.instance().data;
+    const grains = topbar._grains.get();
 
-    var activeIndex = -1;
-    var closeIndex = -1;
+    let activeIndex = -1;
+    let closeIndex = -1;
     grains.forEach(function (grain, i) {
       if (grain.isActive()) {
         activeIndex = i;
@@ -282,7 +282,7 @@ Template.sandstormTopbar.events({
 
     if (activeIndex == closeIndex) {
       // If the user closed the active grain, redirect to the next one after closing this one.
-      var newActiveIndex = (activeIndex == grains.length - 1) ? activeIndex - 1 : activeIndex;
+      const newActiveIndex = (activeIndex == grains.length - 1) ? activeIndex - 1 : activeIndex;
       // Unless the active grain was the last one, in which case redirect to the previous one.
       grains.splice(closeIndex, 1);
       grains[newActiveIndex].setActive(true);
@@ -295,14 +295,14 @@ Template.sandstormTopbar.events({
   },
 
   "click .demo-notice .sign-in": function (event) {
-    var topbar = Template.instance().data;
+    const topbar = Template.instance().data;
     topbar.openPopup("login");
   },
 });
 
 Template.sandstormTopbarItem.onCreated(function () {
-  var item = _.clone(this.data);
-  var topbar = item.topbar;
+  const item = _.clone(this.data);
+  const topbar = item.topbar;
   delete item.topbar;
 
   if (typeof item.template === "string") {
@@ -313,10 +313,10 @@ Template.sandstormTopbarItem.onCreated(function () {
     item.popupTemplate = Template[item.popupTemplate];
   }
 
-  var instance = Template.instance();
+  const instance = Template.instance();
 
   // Support inline definitions using {{#sandstormTopbarItem}}.
-  var view = instance.view;
+  const view = instance.view;
   if (!item.template && view.templateContentBlock) {
     item.template = view.templateContentBlock;
   }
@@ -325,7 +325,7 @@ Template.sandstormTopbarItem.onCreated(function () {
     item.popupTemplate = view.templateElseBlock;
   }
 
-  var dataVar = new ReactiveVar(null, _.isEqual);
+  const dataVar = new ReactiveVar(null, _.isEqual);
   if ("data" in item) {
     // Changes to the input data do not cause this template to get created anew, so we must
     // propagate such changes to the item.
@@ -378,12 +378,12 @@ SandstormTopbar.prototype.reset = function () {
 };
 
 SandstormTopbar.prototype.closePopup = function () {
-  var name = this._expanded.get();
+  const name = this._expanded.get();
   if (!name) return;
 
-  var item = this._items[name];
+  const item = this._items[name];
   if (item && item.onDismiss) {
-    var result = item.onDismiss();
+    const result = item.onDismiss();
     if (typeof result === "string") {
       if (result === "block") {
         return;
@@ -476,16 +476,15 @@ SandstormTopbar.prototype.addItem = function (item) {
     this._expanded.set(item.name);
   }
 
-  var self = this;
   return {
-    close: function () {
-      if (self._items[item.name] === item) {
-        if (self._expanded.get() === item.name) {
-          self._expanded.set(null);
+    close: () => {
+      if (this._items[item.name] === item) {
+        if (this._expanded.get() === item.name) {
+          this._expanded.set(null);
         }
 
-        delete self._items[item.name];
-        self._itemsTracker.changed();
+        delete this._items[item.name];
+        this._itemsTracker.changed();
       }
     },
   };

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -37,6 +37,7 @@ function unblockUpdate() {
 }
 
 Template.sandstormTopbarBlockReload.onCreated(function () { ++reloadBlockingCount; });
+
 Template.sandstormTopbarBlockReload.onDestroyed(function () {
   if (--reloadBlockingCount == 0) {
     unblockUpdate();
@@ -52,6 +53,7 @@ Template.sandstormTopbar.onCreated(function () {
       topbar.closePopup();
     }
   };
+
   document.getElementsByTagName("body")[0].addEventListener("keydown", this.escapeHandler);
 });
 
@@ -90,8 +92,10 @@ Template.sandstormTopbar.helpers({
         appTitle: grain.appTitle(),
       };
     });
+
     return data;
   },
+
   grainCount: function () {
     var topbar = Template.instance().data;
     var grains = topbar._grains.get();
@@ -142,7 +146,7 @@ Template.sandstormTopbar.helpers({
 
           if (item.name == "account") {
             // account should always be flush right
-            instance.popupPosition.set({ name: item.name, align: "right", px: 0});
+            instance.popupPosition.set({ name: item.name, align: "right", px: 0 });
           } else {
             var rect = element.getBoundingClientRect();
             var currentWindowWidth = windowWidth.get();
@@ -151,7 +155,7 @@ Template.sandstormTopbar.helpers({
             instance.popupPosition.set(itemMid < windowMid
                 ? { name: item.name, align: "left", px: Math.max(itemMid - 50, 0) }
                 : { name: item.name, align: "right",
-                    px: Math.max(currentWindowWidth - itemMid - 50, 0) });
+                    px: Math.max(currentWindowWidth - itemMid - 50, 0), });
           }
         }
       });
@@ -178,11 +182,12 @@ Template.sandstormTopbar.helpers({
     if (comp) {
       Meteor.setTimeout(comp.invalidate.bind(comp), 1000);
     }
+
     return {
       // We put zero-width spaces on either side of the : in order to allow wrapping when the
       // sidebar is shrunk.
       countdown: min + "\u200b:\u200b" + sec,
-      urgent: ms < 600000
+      urgent: ms < 600000,
     };
   },
 });
@@ -254,10 +259,11 @@ Template.sandstormTopbar.events({
 
     var activeIndex = -1;
     var closeIndex = -1;
-    grains.forEach(function(grain, i){
+    grains.forEach(function (grain, i) {
       if (grain.isActive()) {
         activeIndex = i;
       }
+
       if (grain.grainId() == grainId) {
         closeIndex = i;
         grain.destroy();
@@ -270,6 +276,7 @@ Template.sandstormTopbar.events({
       if (activeIndex == 0) {
         Router.go("grains");
       }
+
       return;
     }
 
@@ -301,6 +308,7 @@ Template.sandstormTopbarItem.onCreated(function () {
   if (typeof item.template === "string") {
     item.template = Template[item.template];
   }
+
   if (typeof item.popupTemplate === "string") {
     item.popupTemplate = Template[item.popupTemplate];
   }
@@ -312,6 +320,7 @@ Template.sandstormTopbarItem.onCreated(function () {
   if (!item.template && view.templateContentBlock) {
     item.template = view.templateContentBlock;
   }
+
   if (!item.popupTemplate && view.templateElseBlock) {
     item.popupTemplate = view.templateElseBlock;
   }
@@ -320,7 +329,7 @@ Template.sandstormTopbarItem.onCreated(function () {
   if ("data" in item) {
     // Changes to the input data do not cause this template to get created anew, so we must
     // propagate such changes to the item.
-    instance.autorun(function() {
+    instance.autorun(function () {
       dataVar.set(Template.currentData().data);
     });
   } else {
@@ -329,6 +338,7 @@ Template.sandstormTopbarItem.onCreated(function () {
       dataVar.set(Template.parentData(1));
     });
   }
+
   item.data = dataVar;
 
   instance.topbarCloser = topbar.addItem(item);
@@ -345,7 +355,7 @@ SandstormTopbar = function (db, expandedVar, grainsVar, shrinkNavbarVar) {
   // `expandedVar` is an optional object that behaves like a `ReactiveVar` and will be used to
   // track which popup is currently open. (The caller may wish to back this with a Session
   // variable.)
-  this._staticHost = db.makeWildcardHost('static');
+  this._staticHost = db.makeWildcardHost("static");
 
   this._items = {};
   this._itemsTracker = new Tracker.Dependency();
@@ -360,12 +370,12 @@ SandstormTopbar = function (db, expandedVar, grainsVar, shrinkNavbarVar) {
   this._shrinkNavbar = shrinkNavbarVar || new ReactiveVar(true);
   this._grains = grainsVar || new ReactiveVar([]);
 
-}
+};
 
 SandstormTopbar.prototype.reset = function () {
   this._menuExpanded.set(false);
   this.closePopup();
-}
+};
 
 SandstormTopbar.prototype.closePopup = function () {
   var name = this._expanded.get();
@@ -387,20 +397,20 @@ SandstormTopbar.prototype.closePopup = function () {
   }
 
   this._expanded.set(null);
-}
+};
 
 SandstormTopbar.prototype.isPopupOpen = function () {
   return !!this._expanded.get();
-}
+};
 
-SandstormTopbar.prototype.openPopup = function(name) {
+SandstormTopbar.prototype.openPopup = function (name) {
   this._expanded.set(name);
   this._menuExpanded.set(false);
-}
+};
 
 SandstormTopbar.prototype.isUpdateBlocked = function () {
   return !!blockedReload.get();
-}
+};
 
 SandstormTopbar.prototype.addItem = function (item) {
   // Adds a new item to the top bar, such as a button or a menu.
@@ -468,7 +478,7 @@ SandstormTopbar.prototype.addItem = function (item) {
 
   var self = this;
   return {
-    close: function() {
+    close: function () {
       if (self._items[item.name] === item) {
         if (self._expanded.get() === item.name) {
           self._expanded.set(null);
@@ -477,6 +487,6 @@ SandstormTopbar.prototype.addItem = function (item) {
         delete self._items[item.name];
         self._itemsTracker.changed();
       }
-    }
+    },
   };
 };

--- a/shell/packages/simplesmtp/package.js
+++ b/shell/packages/simplesmtp/package.js
@@ -1,10 +1,10 @@
 Npm.depends({
-    "simplesmtp": "0.3.35",
-    "mailparser": "0.4.2",
-    "mimelib": "0.2.14",
-    "mailcomposer": "0.2.11"
+  simplesmtp: "0.3.35",
+  mailparser: "0.4.2",
+  mimelib: "0.2.14",
+  mailcomposer: "0.2.11",
 });
 
-Package.onUse(function(api) {
+Package.onUse(function (api) {
   api.addFiles("import.js", "server");
 });

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -184,7 +184,6 @@ const capitalize = function (str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
 
-
 if (Meteor.isClient) {
   AdminToken = new Mongo.Collection("adminToken");  // see Meteor.publish("adminToken")
   AdminLog = new Meteor.Collection("adminLog");
@@ -932,7 +931,7 @@ if (Meteor.isServer) {
       Fs.unlinkSync(SANDSTORM_ADMIN_TOKEN);
       console.log("Admin token deleted.");
     }
-  }
+  };
 
   Meteor.methods({
     setAccountSetting: function (token, serviceName, value) {

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -379,7 +379,7 @@ if (Meteor.isServer) {
 const makeAccountSettingsUi = function () {
   return new SandstormAccountSettingsUi(globalTopbar, globalDb,
       window.location.protocol + "//" + makeWildcardHost("static"));
-}
+};
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 


### PR DESCRIPTION
With this branch, we can now run:

```
jscs shell/
```

and get an exit code of 0 a couple seconds later.

I specifically skipped changing `shell/packages/sandstorm-permissions` (beyond adding a comment to disable JSCS on the files in the module) since I know @dwrensha is actively working on that bit and didn't want to make massive conflicting changes.  If there are other modules people are actively working on that they'd like me to leave alone for now, comment here and I'll rebase them out.

@jparyani How do you think we should automate keeping the shell in compliance as people make future changes?  A couple ideas:

* an automated test that runs against PRs and complains about style checker violations (ideally, orthogonal to the existing functional test suite, so that style errors don't prevent functional tests from running/demonstrating success)
* a pre-commit git hook that runs jscs on `shell/`, if `jscs` is on your `$PATH`