### PR TITLE
JSCS: don't warn about line length

### DIFF
--- a/shell/.jscsrc
+++ b/shell/.jscsrc
@@ -5,6 +5,7 @@
   "fileExtensions": [".js"],
   "validateQuoteMarks": {"mark": "\"", "escape": true},
   "disallowVar": true,
+  "maximumLineLength": 10000,
   "requirePaddingNewLinesBeforeLineComments": false,
   "excludeFiles": ['.meteor', '**/node_modules']
 }


### PR DESCRIPTION
We have a bunch of places that are over 100 characters, and I don't think they
are particularly harmful to readability.  I'd welcome over-time reworking
toward a 100-character line limit, but I don't think we need to be religious
about line lengths in general.

This rule was added to the airbnb preset recently, which is why my previous
changesets did not deal with this warning.