### PR TITLE
Implement app ID replacement table.

### DIFF
--- a/src/sandstorm/app-index/app-index.c++
+++ b/src/sandstorm/app-index/app-index.c++
@@ -122,7 +122,7 @@ public:
 
         capnp::MallocMessageBuilder response;
         byte appPublicKey[crypto_sign_PUBLICKEYBYTES];
-        if (indexer.tryGetAppId(packageId, appPublicKey)) {
+        if (indexer.tryGetPublicKey(packageId, appPublicKey)) {
           KJ_ASSERT(
               crypto_sign_verify_detached(signature.begin(),
                   requestBytes.begin(), requestBytes.size(), appPublicKey) == 0,

--- a/src/sandstorm/app-index/app-index.c++
+++ b/src/sandstorm/app-index/app-index.c++
@@ -42,6 +42,7 @@
 #include <sandstorm/util.h>
 #include <sandstorm/app-index/app-index.capnp.h>
 #include <sandstorm/spk.h>
+#include <sandstorm/id-to-text.h>
 
 #include "indexer.h"
 

--- a/src/sandstorm/app-index/indexer.c++
+++ b/src/sandstorm/app-index/indexer.c++
@@ -17,6 +17,7 @@
 #include "indexer.h"
 #include <sandstorm/app-index/app-index.capnp.h>
 #include <sandstorm/spk.h>
+#include <sandstorm/id-to-text.h>
 #include <capnp/serialize.h>
 #include <stdlib.h>
 #include <map>
@@ -184,32 +185,6 @@ void Indexer::getSubmissionStatus(kj::StringPtr packageId, capnp::MessageBuilder
 // =======================================================================================
 
 namespace {
-
-class AppIdJsonHandler: public capnp::JsonCodec::Handler<spk::AppId> {
-public:
-  void encode(const capnp::JsonCodec& codec, spk::AppId::Reader input,
-              capnp::JsonValue::Builder output) const override {
-    output.setString(appIdString(input));
-  }
-
-  void decode(const capnp::JsonCodec& codec, capnp::JsonValue::Reader input,
-              spk::AppId::Builder output) const override {
-    KJ_UNIMPLEMENTED("AppIdJsonHandler::decode");
-  }
-};
-
-class PackageIdJsonHandler: public capnp::JsonCodec::Handler<spk::PackageId> {
-public:
-  void encode(const capnp::JsonCodec& codec, spk::PackageId::Reader input,
-              capnp::JsonValue::Builder output) const override {
-    output.setString(packageIdString(input));
-  }
-
-  void decode(const capnp::JsonCodec& codec, capnp::JsonValue::Reader input,
-              spk::PackageId::Builder output) const override {
-    KJ_UNIMPLEMENTED("PackageIdJsonHandler::decode");
-  }
-};
 
 class DataHandler: public capnp::JsonCodec::Handler<capnp::Data> {
 public:

--- a/src/sandstorm/app-index/indexer.h
+++ b/src/sandstorm/app-index/indexer.h
@@ -29,7 +29,8 @@ class Indexer: public AppIndex::Server {
 public:
   void addKeybaseProfile(kj::StringPtr fingerprint, capnp::MallocMessageBuilder& message);
 
-  bool tryGetAppId(kj::StringPtr packageId, byte appId[32]);
+  bool tryGetPublicKey(kj::StringPtr packageId, byte publicKey[32]);
+  // Get the public key which is allowed to submit requests modifying the given package's state.
 
   void approve(kj::StringPtr packageId, kj::StringPtr url);
   void unapprove(kj::StringPtr packageId);

--- a/src/sandstorm/appid-replacements-test.c++
+++ b/src/sandstorm/appid-replacements-test.c++
@@ -1,0 +1,131 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "appid-replacements.h"
+#include "id-to-text.h"
+#include <kj/test.h>
+#include <sandstorm/appid-replacements-test.capnp.h>
+#include <set>
+
+namespace sandstorm {
+namespace {
+
+kj::Array<kj::byte> appidBytes(kj::StringPtr id) {
+  auto result = kj::heapArray<kj::byte>(APP_ID_BYTE_SIZE);
+  KJ_REQUIRE(tryParseAppId(id, result), "invalid app ID", id);
+  return result;
+}
+
+kj::Array<kj::byte> pkgidBytes(kj::StringPtr id) {
+  auto result = kj::heapArray<kj::byte>(PACKAGE_ID_BYTE_SIZE);
+  KJ_REQUIRE(tryParsePackageId(id, result), "invalid package ID", id);
+  return result;
+}
+
+// =======================================================================================
+// Check for errors in table
+
+KJ_TEST("table: all IDs are valid") {
+  for (auto replacement: *spk::APP_ID_REPLACEMENT_LIST) {
+    {
+      auto canonical = appIdString(appidBytes(replacement.getOriginal()));
+      KJ_ASSERT(replacement.getOriginal() == canonical,
+                "original app ID is not canonical", canonical, replacement);
+    }
+    {
+      auto canonical = appIdString(appidBytes(replacement.getReplacement()));
+      KJ_ASSERT(replacement.getReplacement() == canonical,
+                "original app ID is not canonical", canonical, replacement);
+    }
+
+    for (auto pkgid: replacement.getRevokeExceptPackageIds()) {
+      auto canonical = packageIdString(pkgidBytes(pkgid));
+      KJ_ASSERT(pkgid == canonical,
+                "package ID is not canonical", pkgid, canonical);
+    }
+  }
+}
+
+KJ_TEST("table: no duplicate originals") {
+  std::set<kj::StringPtr> set;
+  for (auto replacement: *spk::APP_ID_REPLACEMENT_LIST) {
+    KJ_ASSERT(set.insert(replacement.getOriginal()).second,
+              "duplicate original app ID", replacement);
+  }
+}
+
+KJ_TEST("table: no duplicate replacements") {
+  std::set<kj::StringPtr> set;
+  for (auto replacement: *spk::APP_ID_REPLACEMENT_LIST) {
+    KJ_ASSERT(set.insert(replacement.getReplacement()).second,
+              "duplicate replacement app ID", replacement);
+  }
+}
+
+KJ_TEST("table: no duplicate packages") {
+  std::set<kj::StringPtr> set;
+  for (auto replacement: *spk::APP_ID_REPLACEMENT_LIST) {
+    for (auto pkgid: replacement.getRevokeExceptPackageIds()) {
+      KJ_ASSERT(set.insert(pkgid).second, "duplicate package ID", pkgid);
+    }
+  }
+}
+
+// =======================================================================================
+// Test table-handling logic
+
+kj::String doReplacement(kj::StringPtr appId, kj::StringPtr packageId) {
+  auto bytes = appidBytes(appId);
+  applyAppidReplacements(bytes, pkgidBytes(packageId), *TEST_APP_ID_REPLACEMENT_LIST);
+  return appIdString(bytes);
+}
+
+KJ_TEST("logic: unlisted (normal) app ID") {
+  KJ_ASSERT(doReplacement(TestIds::UNUSED_APP, TestIds::UNUSED_PKG) == TestIds::UNUSED_APP);
+}
+
+KJ_TEST("logic: revoked app ID") {
+  KJ_EXPECT_THROW(FAILED, doReplacement(TestIds::APP1, TestIds::UNUSED_PKG));
+  KJ_EXPECT_THROW(FAILED, doReplacement(TestIds::APP5, TestIds::UNUSED_PKG));
+}
+
+KJ_TEST("logic: revoked app ID, whitelisted package") {
+  KJ_ASSERT(doReplacement(TestIds::APP1, TestIds::PKG1) == TestIds::APP1);
+  KJ_ASSERT(doReplacement(TestIds::APP1, TestIds::PKG2) == TestIds::APP1);
+}
+
+KJ_TEST("logic: replacement app ID, original revoked") {
+  KJ_ASSERT(doReplacement(TestIds::APP2, TestIds::UNUSED_PKG) == TestIds::APP1);
+}
+
+KJ_TEST("logic: replacement app ID, original not revoked") {
+  KJ_ASSERT(doReplacement(TestIds::APP5, TestIds::PKG3) == TestIds::APP4);
+}
+
+KJ_TEST("logic: app ID with replacement, but not revoked") {
+  KJ_ASSERT(doReplacement(TestIds::APP4, TestIds::UNUSED_PKG) == TestIds::APP4);
+}
+
+KJ_TEST("logic: double-replacement app ID") {
+  KJ_ASSERT(doReplacement(TestIds::APP3, TestIds::UNUSED_PKG) == TestIds::APP1);
+}
+
+KJ_TEST("logic: double-replacement app ID, replacement revoked") {
+  KJ_ASSERT(doReplacement(TestIds::APP6, TestIds::UNUSED_PKG) == TestIds::APP4);
+}
+
+}  // namespace
+}  // namespace sandstorm

--- a/src/sandstorm/appid-replacements-test.c++
+++ b/src/sandstorm/appid-replacements-test.c++
@@ -93,6 +93,10 @@ kj::String doReplacement(kj::StringPtr appId, kj::StringPtr packageId) {
   return appIdString(bytes);
 }
 
+kj::String doGetPublicKey(kj::StringPtr appId) {
+  return appIdString(getPublicKeyForApp(appidBytes(appId), *TEST_APP_ID_REPLACEMENT_LIST));
+}
+
 KJ_TEST("logic: unlisted (normal) app ID") {
   KJ_ASSERT(doReplacement(TestIds::UNUSED_APP, TestIds::UNUSED_PKG) == TestIds::UNUSED_APP);
 }
@@ -125,6 +129,16 @@ KJ_TEST("logic: double-replacement app ID") {
 
 KJ_TEST("logic: double-replacement app ID, replacement revoked") {
   KJ_ASSERT(doReplacement(TestIds::APP6, TestIds::UNUSED_PKG) == TestIds::APP4);
+}
+
+KJ_TEST("logic: get public key for app") {
+  KJ_ASSERT(doGetPublicKey(TestIds::UNUSED_APP) == TestIds::UNUSED_APP);
+  KJ_ASSERT(doGetPublicKey(TestIds::APP1) == TestIds::APP3);
+  KJ_ASSERT(doGetPublicKey(TestIds::APP2) == TestIds::APP3);
+  KJ_ASSERT(doGetPublicKey(TestIds::APP3) == TestIds::APP3);
+  KJ_ASSERT(doGetPublicKey(TestIds::APP4) == TestIds::APP6);
+  KJ_ASSERT(doGetPublicKey(TestIds::APP5) == TestIds::APP6);
+  KJ_ASSERT(doGetPublicKey(TestIds::APP6) == TestIds::APP6);
 }
 
 }  // namespace

--- a/src/sandstorm/appid-replacements-test.capnp
+++ b/src/sandstorm/appid-replacements-test.capnp
@@ -1,0 +1,49 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xbee445adfb01a777;
+
+$import "/capnp/c++.capnp".namespace("sandstorm");
+using AppIdReplacement = import "appid-replacements.capnp".AppIdReplacement;
+
+struct TestIds {  # namespace only
+  const unusedApp :Text = "6pm4ujs8f5f5wugc87uhuhvhs57he09u10rv8qd2jgdup9f69yzh";
+
+  const app1 :Text = "vjvekechd398fn1t1kn1dgdnmaekqq9jkjv3zsgzymc4z913ref0";
+  const app2 :Text = "wq95qmutckc0yfmecv0ky96cqxgp156up8sv81yxvmery58q87jh";
+  const app3 :Text = "302t6c6kf8hjer1kh3469d4ch10d936g7wkwtxcs12pwh9u5axqh";
+  const app4 :Text = "5ddk4uqnstnsqvp3thc2tyed41c7wp4x5ygt20zrh3u0tnv5jqd0";
+  const app5 :Text = "jkz6yhywhp4uk5sgkc5ugwnee57a5h5wu4rfmujtahny5r8g3ych";
+  const app6 :Text = "adk6syfj42fpp3xhgqrrheqgfxkhaw8e1t11vug44ys6pzaxqugh";
+
+  const unusedPkg :Text = "7300e3448dd2b53e075d0a8481c2bc06";
+
+  const pkg1 :Text = "b5bb9d8014a0f9b1d61e21e796d78dcc";
+  const pkg2 :Text = "8613a11b8ac365cb36775a6b8ca6176c";
+  const pkg3 :Text = "77c4f45aee83e376d31a5680cdb841a2";
+}
+
+const testAppIdReplacementList :List(AppIdReplacement) = [
+  (original = TestIds.app1, replacement = TestIds.app2,
+   revokeExceptPackageIds = [TestIds.pkg1, TestIds.pkg2]),
+
+  (original = TestIds.app2, replacement = TestIds.app3),
+
+  (original = TestIds.app4, replacement = TestIds.app5),
+
+  (original = TestIds.app5, replacement = TestIds.app6,
+   revokeExceptPackageIds = [TestIds.pkg3]),
+];

--- a/src/sandstorm/appid-replacements.c++
+++ b/src/sandstorm/appid-replacements.c++
@@ -1,0 +1,77 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "appid-replacements.h"
+#include "id-to-text.h"
+
+namespace sandstorm {
+
+void applyAppidReplacements(
+    kj::ArrayPtr<kj::byte> appId, kj::ArrayPtr<const kj::byte> packageId,
+    capnp::List<spk::AppIdReplacement>::Reader replacements) {
+  // Given an input app ID that was just verified to have signed the given package ID,
+  // check appid-replacements.capnp to see if the app ID is revoked (throws exception) or the
+  // package should be treated as some other app (replaces appId).
+
+  // The logic here is slightly weird because the replacement list is organized into events --
+  // which makes it easier for people modifying it to understand what to do -- rather than into
+  // rules -- which could be more directly processed. Each event introduces one or two rules:
+  // a revocation of an original key (except for grandfathered whitelist) and a mapping of a
+  // replacement key to and original key.
+
+  KJ_REQUIRE(appId.size() == APP_ID_BYTE_SIZE);
+  KJ_REQUIRE(packageId.size() == PACKAGE_ID_BYTE_SIZE);
+
+  auto appidStr = appIdString(appId);
+  auto pkgidStr = packageIdString(packageId);
+
+  // First check if this app ID is revoked.
+  for (auto item: replacements) {
+    if (item.getOriginal() == appidStr) {
+      // The app ID matches the `original` of this entry. Check if it was revoked.
+      if (item.hasRevokeExceptPackageIds()) {
+        // This app ID is revoked, except for specific package IDs...
+        for (auto allowed: item.getRevokeExceptPackageIds()) {
+          if (pkgidStr == allowed) {
+            goto checkReplacements;  // Need to break outer loop...
+          }
+        }
+        KJ_FAIL_REQUIRE("package is signed with an app key that has been revoked",
+                        appidStr, pkgidStr);
+      }
+    }
+  }
+
+checkReplacements:
+  // Not revoked. Now check if it is a replacement.
+  for (auto item: replacements) {
+    if (item.getReplacement() == appidStr) {
+      // The app ID is a replacement. We want to make this package look like it uses the original
+      // ID, therefore we want to replace the replacement with the original.
+      KJ_ASSERT(tryParseAppId(item.getOriginal(), appId));
+
+      // We may have mapped the replacement ID back to an ID which has itself been replaced.
+      // So, we need to apply the replacements step again. We could make the rule that a second
+      // replacement for the same app should list the app's original-original ID as `original`, but
+      // this would mean that if the first replacement key needs to be revoked then two entries
+      // would need to be made, which is not intuitive.
+      appidStr = appIdString(appId);
+      goto checkReplacements;
+    }
+  }
+}
+
+}  // namespace sandstorm

--- a/src/sandstorm/appid-replacements.c++
+++ b/src/sandstorm/appid-replacements.c++
@@ -74,4 +74,23 @@ checkReplacements:
   }
 }
 
+kj::Array<kj::byte> getPublicKeyForApp(kj::ArrayPtr<const kj::byte> appId,
+    capnp::List<spk::AppIdReplacement>::Reader replacements) {
+  KJ_REQUIRE(appId.size() == APP_ID_BYTE_SIZE);
+  auto appidOwnStr = appIdString(appId);
+  kj::StringPtr appidStr = appidOwnStr;
+  auto result = kj::heapArray(appId);
+
+retry:
+  for (auto item: replacements) {
+    if (item.getOriginal() == appidStr) {
+      appidStr = item.getReplacement();
+      KJ_ASSERT(tryParseAppId(appidStr, result));
+      goto retry;
+    }
+  }
+
+  return result;
+}
+
 }  // namespace sandstorm

--- a/src/sandstorm/appid-replacements.capnp
+++ b/src/sandstorm/appid-replacements.capnp
@@ -19,9 +19,9 @@
 #
 # If you are an app developer and you have lost access to your key or suspect it may have been
 # compromised, do the following:
-# 1. Generate a new key using `spk keygen`. The new key ID will be printed.
-# 2. Use `spk getkey <key-id> > backup.key` to make a backup copy of the key. Put `backup.key`
-#    somewhere safe! Of course, do NOT make this file public!
+# 1. Generate a new key using `vagrant-spk keygen`. The new key ID will be printed.
+# 2. Use `vagrant-spk getkey <key-id> > backup.key` to make a backup copy of the key. Put
+#    `backup.key` somewhere safe! Of course, do NOT make this file public!
 # 3. Add an entry to `appIdReplacementList` below with `original` being your old key ID (app ID)
 #    and `replacement` being the new key ID (as printed when you generated it).
 # 4. PGP-sign your git commit using the `-S` flag, using the same PGP key you used to sign older
@@ -78,7 +78,7 @@ const appIdReplacementList :List(AppIdReplacement) = [
   # it was accidentally committed to the app's public git repo. Only one version ("b5bb...") had
   # ever been published.
 
-  # ---- end exmaple; real entries follow ----
+  # ---- end example; real entries follow ----
 
   # Add your entry here!
 ];

--- a/src/sandstorm/appid-replacements.capnp
+++ b/src/sandstorm/appid-replacements.capnp
@@ -1,0 +1,70 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xa53cae3f717a1676;
+# This file is used to recover from lost or stolen app keys.
+#
+# If you are an app developer and you have lost access to your key or suspect it may have been
+# compromised, add a line to this file and submit a pull request. Please either use git PGP
+# signing to sign the request, or include with the request a PGP-signed copy of the diff. Use the
+# same PGP key that you used to sign the app listing on the app market, if possible (if not, we
+# will ask for other verification).
+
+$import "/capnp/c++.capnp".namespace("sandstorm::spk");
+
+struct AppIdReplacement {
+  # Specifies that packages signed by the app ID specified in `replacement` shall henceforth be
+  # treated as if they had instead be signed by `original`. Hence, packages signed with the
+  # replacement key will be accepted as upgrades to the original and will be displayed as if
+  # they had the original ID.
+
+  original @0 :Text;
+  # The original App ID, in text format for convenience. This is the canonical ID for this app,
+  # and will remain so going forward.
+
+  replacement @1 :Text;
+  # The replacement App ID, in text format for convenience. Packages signed with this ID will be
+  # treated as if they are signed with the original ID. Omit this to revoke an ID with no
+  # replacement.
+  #
+  # Note: Do NOT distribute any packages signed with the new ID until a Sandstorm release has gone
+  # out with your app ID replacement, otherwise people who install the app too early will be unable
+  # to update it.
+
+  revokeExceptPackageIds @2 :List(Text);
+  # A list of package IDs (in text format for convenience) which were signed with the original
+  # key and are known to be authentic versions of this app. All other packages signed with the
+  # original key will be presumed malicious and rejected.
+  #
+  # Only specify this if the original key may have been compromised. If the key was merely lost
+  # (e.g. storage was destroyed with no backup) then there is no need to revoke the old key.
+  # In this case, omit this field (making it null).
+}
+
+const appIdReplacementList :List(AppIdReplacement) = [
+  # ---- example entry ----
+
+  (original = "vjvekechd398fn1t1kn1dgdnmaekqq9jkjv3zsgzymc4z913ref0",
+   replacement = "wq95qmutckc0yfmecv0ky96cqxgp156up8sv81yxvmery58q87jh",
+   revokeExceptPackageIds = ["b5bb9d8014a0f9b1d61e21e796d78dcc"]),
+  # This is the ID for My Cool Example App by Kenton Varda. The old app key was compromised when
+  # it was accidentally committed to the app's public git repo. Only one version ("b5bb...") had
+  # ever been published.
+
+  # ---- end exmaple; real entries follow ----
+
+  # Add your entry here!
+];

--- a/src/sandstorm/appid-replacements.capnp
+++ b/src/sandstorm/appid-replacements.capnp
@@ -18,10 +18,24 @@
 # This file is used to recover from lost or stolen app keys.
 #
 # If you are an app developer and you have lost access to your key or suspect it may have been
-# compromised, add a line to this file and submit a pull request. Please either use git PGP
-# signing to sign the request, or include with the request a PGP-signed copy of the diff. Use the
-# same PGP key that you used to sign the app listing on the app market, if possible (if not, we
-# will ask for other verification).
+# compromised, do the following:
+# 1. Generate a new key using `spk keygen`. The new key ID will be printed.
+# 2. Use `spk getkey <key-id> > backup.key` to make a backup copy of the key. Put `backup.key`
+#    somewhere safe! Of course, do NOT make this file public!
+# 3. Add an entry to `appIdReplacementList` below with `original` being your old key ID (app ID)
+#    and `replacement` being the new key ID (as printed when you generated it).
+# 4. PGP-sign your git commit using the `-S` flag, using the same PGP key you used to sign older
+#    versions of your app as published to the app market. (If you can't do this, we'll need to
+#    verify your identity in some other way.)
+# 5. Submit a pull request.
+#
+# Things you should NOT do:
+# * Do NOT change sandstorm-pkgdef.capnp to the new key. Once Sandstorm is updated with your PR,
+#   the spk tool will automatically use the new key where appropriate.
+# * Do NOT update your `pgpSignature` file. The signature should still assert ownership of the
+#   original app ID.
+# * Do NOT update links to the app market or anywhere else that incorporate the app ID. Your app ID
+#   is not changing; only the signing key is changing.
 
 $import "/capnp/c++.capnp".namespace("sandstorm::spk");
 

--- a/src/sandstorm/appid-replacements.h
+++ b/src/sandstorm/appid-replacements.h
@@ -31,6 +31,12 @@ void applyAppidReplacements(
 // The third argument can be used to specify an alternate replacement list for testing purposes,
 // but the intent is that production use should use the default list.
 
+kj::Array<kj::byte> getPublicKeyForApp(kj::ArrayPtr<const kj::byte> appId,
+    capnp::List<spk::AppIdReplacement>::Reader replacements = *spk::APP_ID_REPLACEMENT_LIST);
+// Gets the public key associated with the given app ID. This is the reverse operation from
+// applyAppidReplacements(): given a canonical app ID, it finds the key that is currently being
+// used to sign new versions of the app.
+
 } // namespace sandstorm
 
 #endif // SANDSTORM_APPID_REPLACEMENTS_H_

--- a/src/sandstorm/appid-replacements.h
+++ b/src/sandstorm/appid-replacements.h
@@ -1,0 +1,36 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SANDSTORM_APPID_REPLACEMENTS_H_
+#define SANDSTORM_APPID_REPLACEMENTS_H_
+
+#include <sandstorm/appid-replacements.capnp.h>
+
+namespace sandstorm {
+
+void applyAppidReplacements(
+    kj::ArrayPtr<kj::byte> appId, kj::ArrayPtr<const kj::byte> packageId,
+    capnp::List<spk::AppIdReplacement>::Reader replacements = *spk::APP_ID_REPLACEMENT_LIST);
+// Given an input app ID that was just verified to have signed the given package ID,
+// check appid-replacements.capnp to see if the app ID is revoked (throws exception) or the
+// package should be treated as some other app (replaces appId).
+//
+// The third argument can be used to specify an alternate replacement list for testing purposes,
+// but the intent is that production use should use the default list.
+
+} // namespace sandstorm
+
+#endif // SANDSTORM_APPID_REPLACEMENTS_H_

--- a/src/sandstorm/id-to-text-test.c++
+++ b/src/sandstorm/id-to-text-test.c++
@@ -1,0 +1,96 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "id-to-text.h"
+#include <kj/test.h>
+#include <capnp/message.h>
+#include <sodium/randombytes.h>
+
+namespace sandstorm {
+namespace {
+
+KJ_TEST("App IDs to text") {
+  capnp::MallocMessageBuilder builder;
+  auto id = builder.initRoot<spk::AppId>();
+  auto bytes = capnp::AnyStruct::Builder(kj::cp(id)).getDataSection();
+  auto orphan = builder.getOrphanage().newOrphan<spk::AppId>();
+  auto outId = orphan.get();
+  auto outBytes = capnp::AnyStruct::Builder(kj::cp(outId)).getDataSection();
+
+  for (uint i = 0; i < 16; i++) {
+    randombytes_buf(bytes.begin(), bytes.size());
+    KJ_ASSERT(tryParseAppId(appIdString(id), outId));
+    KJ_ASSERT(outBytes == bytes);
+  }
+
+  KJ_ASSERT(tryParseAppId("vjvekechd398fn1t1kn1dgdnmaekqq9jkjv3zsgzymc4z913ref0", outId));
+  KJ_ASSERT(appIdString(outId) == "vjvekechd398fn1t1kn1dgdnmaekqq9jkjv3zsgzymc4z913ref0");
+
+  KJ_ASSERT(tryParseAppId("wq95qmutckc0yfmecv0ky96cqxgp156up8sv81yxvmery58q87jh", outId));
+  KJ_ASSERT(appIdString(outId) == "wq95qmutckc0yfmecv0ky96cqxgp156up8sv81yxvmery58q87jh");
+
+  // Upper-case is equivalent to lower-case, and O -> 0, I -> 1, l -> 1, B -> 8.
+  KJ_ASSERT(tryParseAppId("WQ95QMUTCKCOYFMECV0KY96CQXGPi56UP8SV8LYXVMERY5bQB7JH", outId));
+  KJ_ASSERT(appIdString(outId) == "wq95qmutckc0yfmecv0ky96cqxgp156up8sv81yxvmery58q87jh");
+
+  // Error cases:
+
+  // too short
+  KJ_ASSERT(!tryParseAppId("wq95qmutckc0yfmecv0ky96cqxgp156up8sv81yxvmery58q87j", outId));
+
+  // too long
+  KJ_ASSERT(!tryParseAppId("wq95qmutckc0yfmecv0ky96cqxgp156up8sv81yxvmery58q87jhh", outId));
+
+  // not too long, but trailing nonzero bits
+  KJ_ASSERT(!tryParseAppId("wq95qmutckc0yfmecv0ky96cqxgp156up8sv81yxvmery58q87jz", outId));
+
+  // not base32
+  KJ_ASSERT(!tryParseAppId("wq95qmutckc0yfmecv0ky96cq!gp156up8sv81yxvmery58q87jh", outId));
+}
+
+KJ_TEST("Package IDs to text") {
+  capnp::MallocMessageBuilder builder;
+  auto id = builder.initRoot<spk::PackageId>();
+  auto bytes = capnp::AnyStruct::Builder(kj::cp(id)).getDataSection();
+  auto orphan = builder.getOrphanage().newOrphan<spk::PackageId>();
+  auto outId = orphan.get();
+  auto outBytes = capnp::AnyStruct::Builder(kj::cp(outId)).getDataSection();
+
+  for (uint i = 0; i < 16; i++) {
+    randombytes_buf(bytes.begin(), bytes.size());
+    KJ_ASSERT(tryParsePackageId(packageIdString(id), outId));
+    KJ_ASSERT(outBytes == bytes);
+  }
+
+  KJ_ASSERT(tryParsePackageId("b5bb9d8014a0f9b1d61e21e796d78dcc", outId));
+  KJ_ASSERT(packageIdString(outId) == "b5bb9d8014a0f9b1d61e21e796d78dcc");
+
+  KJ_ASSERT(tryParsePackageId("7d865e959b2466918c9863afca942d0f", outId));
+  KJ_ASSERT(packageIdString(outId) == "7d865e959b2466918c9863afca942d0f");
+
+  // Upper-case is equivalent to lower-case.
+  KJ_ASSERT(tryParsePackageId("7D865E959B2466918C9863AFCA942D0F", outId));
+  KJ_ASSERT(packageIdString(outId) == "7d865e959b2466918c9863afca942d0f");
+
+  // Error cases:
+
+  KJ_ASSERT(!tryParsePackageId("7d865e959b2466918c9863afca942d0", outId));  // too short
+  KJ_ASSERT(!tryParsePackageId("7d865e959b2466918c9863afca942d0ff", outId));  // too long
+  KJ_ASSERT(!tryParsePackageId("00000000000nothex000000000000000", outId));
+}
+
+}  // namespace
+}  // namespace sandstorm

--- a/src/sandstorm/id-to-text.c++
+++ b/src/sandstorm/id-to-text.c++
@@ -1,0 +1,222 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "id-to-text.h"
+#include "util.h"
+
+namespace sandstorm {
+
+namespace {
+
+// =======================================================================================
+// base32 encode/decode derived from google-authenticator code, Apache 2.0 license:
+//   https://code.google.com/p/google-authenticator/source/browse/libpam/base32.c
+//
+// Modifications:
+// - Prefer to output in lower-case letters.
+// - Use Douglas Crockford's alphabet mapping, except instead of excluding 'u', consider 'B' to
+//   be a misspelling of '8'.
+// - Use a lookup table for decoding (in addition to encoding).  Generate this table
+//   programmatically at compile time.  C++14 constexpr is awesome.
+// - Convert to KJ style.
+
+constexpr char BASE32_ENCODE_TABLE[] = "0123456789acdefghjkmnpqrstuvwxyz";
+
+kj::String base32Encode(kj::ArrayPtr<const byte> data) {
+  // We'll need a character for every 5 bits, rounded up.
+  auto result = kj::heapString((data.size() * 8 + 4) / 5);
+
+  uint count = 0;
+  if (data.size() > 0) {
+    uint buffer = data[0];
+    uint next = 1;
+    uint bitsLeft = 8;
+    while (bitsLeft > 0 || next < data.size()) {
+      if (bitsLeft < 5) {
+        if (next < data.size()) {
+          buffer <<= 8;
+          buffer |= data[next++] & 0xFF;
+          bitsLeft += 8;
+        } else {
+          // No more input; pad with zeros.
+          uint pad = 5 - bitsLeft;
+          buffer <<= pad;
+          bitsLeft += pad;
+        }
+      }
+      uint index = 0x1F & (buffer >> (bitsLeft - 5));
+      bitsLeft -= 5;
+      KJ_ASSERT(count < result.size());
+      result[count++] = BASE32_ENCODE_TABLE[index];
+    }
+  }
+
+  return result;
+}
+
+class Base32Decoder {
+public:
+  constexpr Base32Decoder(): decodeTable() {
+    // Cool, we can generate our lookup table at compile time.
+
+    for (byte& b: decodeTable) {
+      b = 255;
+    }
+
+    for (uint i = 0; i < sizeof(BASE32_ENCODE_TABLE) - 1; i++) {
+      unsigned char c = BASE32_ENCODE_TABLE[i];
+      decodeTable[c] = i;
+      if ('a' <= c && c <= 'z') {
+        decodeTable[c - 'a' + 'A'] = i;
+      }
+    }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wchar-subscripts"
+    decodeTable['o'] = decodeTable['O'] = 0;
+    decodeTable['i'] = decodeTable['I'] = 1;
+    decodeTable['l'] = decodeTable['L'] = 1;
+    decodeTable['b'] = decodeTable['B'] = 8;
+#pragma GCC diagnostic pop
+  }
+
+  constexpr bool verifyTable() const {
+    // Verify that all letters and digits have a decoding.
+    //
+    // Oh cool, this can also be done at compile time, and then checked with a static_assert below.
+    //
+    // C++14 is awesome.
+
+    for (unsigned char c = '0'; c <= '9'; c++) {
+      if (decodeTable[c] == 255) return false;
+    }
+    for (unsigned char c = 'a'; c <= 'z'; c++) {
+      if (decodeTable[c] == 255) return false;
+    }
+    for (unsigned char c = 'A'; c <= 'Z'; c++) {
+      if (decodeTable[c] == 255) return false;
+    }
+    return true;
+  }
+
+  bool tryDecode(kj::StringPtr encoded, kj::ArrayPtr<byte> output) const {
+    // We intentionally round the size down.  Leftover bits are presumably zero.
+    size_t expectedBytes = encoded.size() * 5 / 8;
+    if (output.size() != expectedBytes) return false;
+
+    uint buffer = 0;
+    uint bitsLeft = 0;
+    uint count = 0;
+    for (char c: encoded) {
+      byte decoded = decodeTable[(byte)c];
+      if (decoded > 32) return false;
+
+      buffer <<= 5;
+      buffer |= decoded;
+      bitsLeft += 5;
+      if (bitsLeft >= 8) {
+        KJ_ASSERT(count < output.size());
+        bitsLeft -= 8;
+        output[count++] = buffer >> bitsLeft;
+      }
+    }
+    KJ_ASSERT(count == output.size());
+
+    buffer &= (1 << bitsLeft) - 1;
+    if (buffer != 0) return false;  // non-zero leftover bits!
+
+    return true;
+  }
+
+private:
+  byte decodeTable[256];
+};
+
+constexpr Base32Decoder BASE32_DECODER;
+static_assert(BASE32_DECODER.verifyTable(), "Base32 decode table is incomplete.");
+
+// =======================================================================================
+
+static kj::Maybe<uint> parseHexDigit(char c) {
+  if ('0' <= c && c <= '9') {
+    return static_cast<uint>(c - '0');
+  } else if ('a' <= c && c <= 'f') {
+    return static_cast<uint>(c - 'a') + 0xa;
+  } else if ('A' <= c && c <= 'F') {
+    return static_cast<uint>(c - 'A') + 0xa;
+  } else {
+    return nullptr;
+  }
+}
+
+}  // namespace
+
+kj::String appIdString(spk::AppId::Reader appId) {
+  return appIdString(capnp::AnyStruct::Reader(appId).getDataSection());
+}
+
+kj::String appIdString(kj::ArrayPtr<const kj::byte> appId) {
+  KJ_REQUIRE(appId.size() == APP_ID_BYTE_SIZE);
+  return base32Encode(appId);
+}
+
+bool tryParseAppId(kj::StringPtr in, spk::AppId::Builder out) {
+  return tryParseAppId(in, capnp::AnyStruct::Builder(kj::mv(out)).getDataSection());
+}
+
+bool tryParseAppId(kj::StringPtr in, kj::ArrayPtr<kj::byte> out) {
+  KJ_REQUIRE(out.size() == APP_ID_BYTE_SIZE);
+  return BASE32_DECODER.tryDecode(in, out);
+}
+
+kj::String packageIdString(spk::PackageId::Reader packageId) {
+  return packageIdString(capnp::AnyStruct::Reader(packageId).getDataSection());
+}
+
+kj::String packageIdString(kj::ArrayPtr<const kj::byte> packageId) {
+  KJ_ASSERT(packageId.size() == PACKAGE_ID_BYTE_SIZE);
+  return hexEncode(packageId);
+}
+
+bool tryParsePackageId(kj::StringPtr in, spk::PackageId::Builder out) {
+  return tryParsePackageId(in, capnp::AnyStruct::Builder(kj::mv(out)).getDataSection());
+}
+
+bool tryParsePackageId(kj::StringPtr in, kj::ArrayPtr<kj::byte> out) {
+  if (in.size() != PACKAGE_ID_TEXT_SIZE) return false;
+
+  KJ_ASSERT(out.size() == PACKAGE_ID_BYTE_SIZE);
+
+  for (auto i: kj::indices(out)) {
+    byte b = 0;
+    KJ_IF_MAYBE(d, parseHexDigit(in[i*2])) {
+      b = *d << 4;
+    } else {
+      return false;
+    }
+    KJ_IF_MAYBE(d, parseHexDigit(in[i*2+1])) {
+      b |= *d;
+    } else {
+      return false;
+    }
+    out[i] = b;
+  }
+
+  return true;
+}
+
+} // namespace sandstorm
+

--- a/src/sandstorm/id-to-text.h
+++ b/src/sandstorm/id-to-text.h
@@ -1,0 +1,77 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SANDSTORM_ID_TO_TEXT_H_
+#define SANDSTORM_ID_TO_TEXT_H_
+
+#include <kj/common.h>
+#include <sandstorm/package.capnp.h>
+#include <capnp/compat/json.h>
+#include <kj/debug.h>
+
+namespace sandstorm {
+
+static const size_t APP_ID_BYTE_SIZE = 32;
+static const size_t PACKAGE_ID_BYTE_SIZE = 16;
+static const size_t APP_ID_TEXT_SIZE = 52;
+static const size_t PACKAGE_ID_TEXT_SIZE = 32;
+
+kj::String appIdString(spk::AppId::Reader appId);
+kj::String appIdString(kj::ArrayPtr<const kj::byte> appId);
+bool tryParseAppId(kj::StringPtr in, spk::AppId::Builder out);
+bool tryParseAppId(kj::StringPtr in, kj::ArrayPtr<kj::byte> out);
+
+kj::String packageIdString(spk::PackageId::Reader packageId);
+kj::String packageIdString(kj::ArrayPtr<const kj::byte> packageId);
+bool tryParsePackageId(kj::StringPtr in, spk::PackageId::Builder out);
+bool tryParsePackageId(kj::StringPtr in, kj::ArrayPtr<kj::byte> out);
+
+// =======================================================================================
+// JSON handlers for AppId and PackageId, converting them to their standard textual form.
+//
+// Declared inline to avoid a dependency on JSON library if unused.
+
+class AppIdJsonHandler: public capnp::JsonCodec::Handler<spk::AppId> {
+public:
+  void encode(const capnp::JsonCodec& codec, spk::AppId::Reader input,
+              capnp::JsonValue::Builder output) const override {
+    output.setString(appIdString(input));
+  }
+
+  void decode(const capnp::JsonCodec& codec, capnp::JsonValue::Reader input,
+              spk::AppId::Builder output) const override {
+    KJ_REQUIRE(input.isString() && tryParseAppId(input.getString(), output),
+               "invalid app ID");
+  }
+};
+
+class PackageIdJsonHandler: public capnp::JsonCodec::Handler<spk::PackageId> {
+public:
+  void encode(const capnp::JsonCodec& codec, spk::PackageId::Reader input,
+              capnp::JsonValue::Builder output) const override {
+    output.setString(packageIdString(input));
+  }
+
+  void decode(const capnp::JsonCodec& codec, capnp::JsonValue::Reader input,
+              spk::PackageId::Builder output) const override {
+    KJ_REQUIRE(input.isString() && tryParsePackageId(input.getString(), output),
+               "invalid package ID");
+  }
+};
+
+} // namespace sandstorm
+
+#endif // SANDSTORM_ID_TO_TEXT_H_

--- a/src/sandstorm/spk.h
+++ b/src/sandstorm/spk.h
@@ -38,9 +38,6 @@ kj::Maybe<kj::String> checkPgpSignature(kj::StringPtr appIdString, spk::Metadata
 // and returns the PGP key fingerprint. Returns null if there is no signature. Throws if there is
 // an invalid signature.
 
-kj::String appIdString(spk::AppId::Reader appId);
-kj::String packageIdString(spk::PackageId::Reader packageId);
-
 }  // namespace sandstorm
 
 #endif  // SANDSTORM_SPK_H_


### PR DESCRIPTION
This allows developers to recover from a lost or stolen app ID. The idea is that we compile directly into Sandstorm a mapping of lost keys and new keys that are replacing them. Apps signed with the new key will be treated by Sandstorm and all tools as if they are signed with the old key. Old keys can also optionally be revoked while specifying an exact list of known-good packages that had been signed with said keys. If the old key was merely lost but not believed to have leaked (e.g. all copies were destroyed), then revocation is not necessary.

@JamborJan in particular needs this for Paperwork.

This change is cleanly split into two commits which I recommend reading separately.

Also: Yay unit tests.