### PR TITLE
Don't call supervisor.close() in resetConnection().

### DIFF
--- a/shell/packages/sandstorm-backend/sandstorm-backend.js
+++ b/shell/packages/sandstorm-backend/sandstorm-backend.js
@@ -51,7 +51,11 @@ SANDSTORM_ALTHOME = Meteor.settings && Meteor.settings.home;
 
 SandstormBackend = function (db, backendCap) {
   this._db = db;
+
   this.runningGrains = {};
+  // Map from grain IDs to objects holding a supervisor capability. These supervisor capabilities
+  // may be shared among many `Proxy` objects.
+
   this._backendCap = backendCap;
 };
 

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1090,7 +1090,6 @@ Proxy = class Proxy {
     }
 
     if (this.supervisor) {
-      this.supervisor.close();
       delete this.supervisor;
     }
   }
@@ -1323,7 +1322,6 @@ Proxy = class Proxy {
     }
 
     if (this.supervisor) {
-      this.supervisor.close();
       delete globalBackend.runningGrains[this.grainId];
       delete this.supervisor;
     }


### PR DESCRIPTION
Conservative fix for #1550.

Note that we currently do not have a satisfactory story for how we clean up `SandstormBackend.runningGrains`. One approach might be to add a `Handle` argument to `Backend.startGrain()`, so that the frontend would get notified when a supervisor died and could then delete the appropriate entry in `runningGrains`.