### PR TITLE
Indicate which email is primary in the results of SandstormDb.getVerifiedEmails().

### DIFF
--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -186,7 +186,7 @@ Template._accountProfileEditor.helpers({
 
   verifiedEmails: function () {
     if (this.identity) {
-      return SandstormDb.getVerifiedEmails(this.identity);
+      return _.pluck(SandstormDb.getVerifiedEmails(this.identity), "email");
     }
   },
 

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -242,7 +242,7 @@ HackSessionContextImpl = class HackSessionContextImpl extends SessionContextImpl
     const identity = globalDb.getIdentity(grain.identityId);
 
     const emails = SandstormDb.getVerifiedEmails(identity);
-    const email = emails.length > 0 && emails[0] || identity.unverifiedEmail;
+    const email = _.findWhere(emails, { primary: true }) || identity.unverifiedEmail;
 
     const result = {};
     if (email) {

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -419,7 +419,8 @@ Meteor.methods({
             roleAssignment, { user: { identityId: contact._id, title: title } });
           try {
             const identity = Meteor.users.findOne({ _id: contact._id });
-            const emailAddress = SandstormDb.getVerifiedEmails(identity)[0];
+            const emailAddress = _.findWhere(SandstormDb.getVerifiedEmails(identity),
+                                             { primary: true });
             const url = origin + "/shared/" + result.token;
             if (emailAddress) {
               const intrinsicName = contact.profile.intrinsicName;
@@ -499,10 +500,10 @@ Meteor.methods({
       const senderEmails = SandstormDb.getVerifiedEmails(identity);
       if (senderEmails.length > 0) {
         const primaryEmail = Meteor.user().primaryEmail;
-        if (senderEmails.indexOf(primaryEmail) >= 0) {
+        if (_.findWhere(senderEmails, { email: primaryEmail })) {
           fromEmail = primaryEmail;
         } else {
-          fromEmail = senderEmails[0];
+          fromEmail = _.findWhere(senderEmails, { primary: true });
         }
       }
 


### PR DESCRIPTION
Fixes #1583.