### PR TITLE
Destroy all existing GrainViews on login.

### DIFF
--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -197,7 +197,7 @@ limitations under the License.
 </template>
 
 <template name="requestAccess">
-  <div class="grain-interstitial">
+  <div class="request-access grain-interstitial">
   <p>You do not have permission to access this grain.</p>
   {{#if currentUser}}
     {{#with status}}

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -2001,10 +2001,10 @@ Router.map(function () {
     },
 
     onBeforeAction: function () {
-      // Run this hook only once.
-      if (this.state.get("beforeActionHookRan")) { return this.next(); }
-
-      this.state.set("beforeActionHookRan", true);
+      // Only rerun the hook if we've logged in as a different user.
+      const userId = Meteor.userId() || "NotSignedIn";
+      if (this.state.get("beforeActionHookRanForUser") === userId) return this.next();
+      this.state.set("beforeActionHookRanForUser", userId);
       const grainId = this.params.grainId;
       let initialPopup = null;
       let shareGrain = Session.get("share-grain-" + grainId);

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -2073,9 +2073,9 @@ Router.map(function () {
       // Run this hook only once. We could accomplish the same thing by using the `onRun()` hook
       // and waiting for `this.ready()`, but for some reason that fails in the case when a user
       // logs in while visiting a /shared/ link.
-      if (this.state.get("beforeActionHookRan")) { return this.next(); }
-
-      this.state.set("beforeActionHookRan", true);
+      const userId = Meteor.userId() || "NotSignedIn";
+      if (this.state.get("beforeActionHookRanForUser") === userId) return this.next();
+      this.state.set("beforeActionHookRanForUser", userId);
 
       const token = this.params.token;
       const path = "/" + (this.params.path || "") + (this.originalUrl.match(/[#?].*$/) || "");

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -70,6 +70,31 @@ if (Meteor.isClient) {
       }
     }
   });
+
+  // export: called by sandstorm-accounts-ui/login_buttons.js
+  logoutSandstorm = function () {
+    Meteor.logout(function () {
+      sessionStorage.removeItem("linkingIdentityLoginToken");
+      Accounts._loginButtonsSession.closeDropdown();
+      globalTopbar.closePopup();
+      const openGrains = globalGrains.get();
+      openGrains.forEach(function (grain) {
+        grain.destroy();
+      });
+
+      globalGrains.set([]);
+      Router.go("root");
+    });
+  };
+
+  Accounts.onLogin(() => {
+    const openGrains = globalGrains.get();
+    openGrains.forEach(function (grain) {
+      grain.destroy();
+    });
+
+    globalGrains.set([]);
+  });
 }
 
 if (Meteor.isServer) {
@@ -530,22 +555,6 @@ const isDemoExpired = function () {
   }
 
   return false;
-};
-
-// export: called by sandstorm-accounts-ui/login_buttons.js
-logoutSandstorm = function () {
-  Meteor.logout(function () {
-    sessionStorage.removeItem("linkingIdentityLoginToken");
-    Accounts._loginButtonsSession.closeDropdown();
-    globalTopbar.closePopup();
-    const openGrains = globalGrains.get();
-    openGrains.forEach(function (grain) {
-      grain.destroy();
-    });
-
-    globalGrains.set([]);
-    Router.go("root");
-  });
 };
 
 // export: this is also used by grain.js

--- a/tests/commands/getDevName.js
+++ b/tests/commands/getDevName.js
@@ -1,0 +1,31 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(cleanup): We should remove this command. It would be better to remember the
+//   name when we first log in. Note that the `loginDevAccount` command helpfully passes the
+//   name to its continuation.
+
+'use strict';
+
+var utils = require('../utils'),
+    short_wait = utils.short_wait,
+    medium_wait = utils.medium_wait;
+
+exports.command = function(callback) {
+    return this.execute(function () {
+      return globalDb.getIdentity(Meteor.user().loginIdentities[0].id).profile.intrinsicName;
+    }, [], callback);
+};

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -199,7 +199,37 @@ module.exports["Sign in at grain URL"] = function (browser) {
             .waitForElementPresent("#publish", medium_wait)
             .assert.containsText("#publish", "Publish")
             .frame(null)
-            .end();
+            // Now try it with a /shared/ path.
+            .click('.topbar .share > .show-popup')
+            .waitForElementVisible('#shareable-link-tab-header', short_wait)
+            .click('#shareable-link-tab-header')
+            .waitForElementVisible(".new-share-token", short_wait)
+            .submitForm('.new-share-token')
+            .waitForElementVisible('#share-token-text', medium_wait)
+            .getText('#share-token-text', function(response) {
+              browser
+                .execute("window.Meteor.logout()")
+                .loginDevAccount(null, false, function (otherName) { // Generate a new user.
+                  browser
+                    .execute("window.Meteor.logout()")
+                    .url(browser.launch_url)
+                    .url(response.value)
+                    .waitForElementVisible("#grain-frame", medium_wait)
+                    .waitForElementVisible("#grainTitle", medium_wait)
+                    .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
+                    .execute(function (name) { window.loginDevAccount(name) }, [otherName])
+                    .waitForElementVisible("button.pick-identity", medium_wait)
+                    .click("button.pick-identity")
+                    .waitForElementVisible("#grain-frame", medium_wait)
+                    .waitForElementVisible("#grainTitle", medium_wait)
+                    .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
+                    .frame("grain-frame")
+                    .waitForElementPresent("#publish", medium_wait)
+                    .assert.containsText("#publish", "Publish")
+                    .frame(null)
+                    .end()
+                })
+            });
         });
     });
 }

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -177,6 +177,33 @@ module.exports["Test grain not found"] = function (browser) {
     .end()
 }
 
+module.exports["Sign in at grain URL"] = function (browser) {
+  browser
+    .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
+    .waitForElementVisible("#grainTitle", medium_wait)
+    .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
+    .getDevName(function (devName) {
+      browser
+        .url(function (grainUrl) {
+          browser
+            .execute("window.Meteor.logout()")
+            .url(browser.launch_url)
+            .url(grainUrl.value)
+            .waitForElementVisible(".request-access", medium_wait)
+            .assert.containsText(".request-access", "Please sign in to request access.")
+            .execute(function (name) { window.loginDevAccount(name) }, [devName.value])
+            .waitForElementVisible("#grain-frame", medium_wait)
+            .waitForElementVisible("#grainTitle", medium_wait)
+            .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
+            .frame("grain-frame")
+            .waitForElementPresent("#publish", medium_wait)
+            .assert.containsText("#publish", "Publish")
+            .frame(null)
+            .end();
+        });
+    });
+}
+
 module.exports["Test grain anonymous user"] = function (browser) {
   browser
     // Upload app as normal user
@@ -221,7 +248,7 @@ module.exports["Test roleless sharing"] = function (browser) {
   browser
   // Upload app as 1st user
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
-    .execute(function () { return globalDb.getIdentity(Meteor.user().loginIdentities[0].id).profile.intrinsicName; }, [], function(result) {
+    .getDevName(function (result) {
       firstUserName = result.value;
     })
     .waitForElementVisible('.grain-frame', medium_wait)
@@ -236,7 +263,7 @@ module.exports["Test roleless sharing"] = function (browser) {
     .getText('#share-token-text', function(response) {
       browser
         .loginDevAccount()
-        .execute(function () { return globalDb.getIdentity(Meteor.user().loginIdentities[0].id).profile.intrinsicName; }, [], function(result) {
+        .getDevName(function(result) {
           secondUserName = result.value;
         })
         .url(response.value)


### PR DESCRIPTION
Fixes #1581 and adds an integration test for it.

Destroying all grainviews on login used to be problematic in the case of linking an email identity, but after the identity-provider refactor of last month, I don't think it's an issue.