### PR TITLE
Subscribe to "requestingAccess" immediately on displaying the Request Access page.

### DIFF
--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -242,7 +242,7 @@ HackSessionContextImpl = class HackSessionContextImpl extends SessionContextImpl
     const identity = globalDb.getIdentity(grain.identityId);
 
     const emails = SandstormDb.getVerifiedEmails(identity);
-    const email = _.findWhere(emails, { primary: true }) || identity.unverifiedEmail;
+    const email = _.findWhere(emails, { primary: true }).email || identity.unverifiedEmail;
 
     const result = {};
     if (email) {

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -241,8 +241,8 @@ HackSessionContextImpl = class HackSessionContextImpl extends SessionContextImpl
 
     const identity = globalDb.getIdentity(grain.identityId);
 
-    const emails = SandstormDb.getVerifiedEmails(identity);
-    const email = _.findWhere(emails, { primary: true }).email || identity.unverifiedEmail;
+    const primaryEmail = _.findWhere(SandstormDb.getVerifiedEmails(identity), { primary: true });
+    const email = (primaryEmail && primaryEmail.email) || identity.unverifiedEmail;
 
     const result = {};
     if (email) {

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -422,13 +422,13 @@ Meteor.methods({
           const url = origin + "/shared/" + result.token;
           try {
             const identity = Meteor.users.findOne({ _id: contact._id });
-            const emailAddress = _.findWhere(SandstormDb.getVerifiedEmails(identity),
-                                             { primary: true }).email;
-            if (emailAddress) {
+            const email = _.findWhere(SandstormDb.getVerifiedEmails(identity),
+                                      { primary: true });
+            if (email) {
               const intrinsicName = contact.profile.intrinsicName;
               let loginNote;
               if (contact.profile.service === "google") {
-                loginNote = "Google account with address " + emailAddress;
+                loginNote = "Google account with address " + email.email;
               } else if (contact.profile.service === "github") {
                 loginNote = "Github account with username " + intrinsicName;
               } else if (contact.profile.service === "email") {
@@ -443,7 +443,7 @@ Meteor.methods({
                   "Note: You will need to log in with your " + loginNote +
                   " to access this grain.";
               SandstormEmail.send({
-                to: emailAddress,
+                to: email.email,
                 from: "Sandstorm server <no-reply@" + HOSTNAME + ">",
                 subject: sharerDisplayName + " has invited you to join a grain: " + title,
                 text: message.text + "\n\nFollow this link to open the shared grain:\n\n" + url +
@@ -500,13 +500,9 @@ Meteor.methods({
       const envelopeFrom = globalDb.getReturnAddress();
       let fromEmail = globalDb.getServerTitle() + " <" + globalDb.getReturnAddress() + ">";
       const senderEmails = SandstormDb.getVerifiedEmails(identity);
-      if (senderEmails.length > 0) {
-        const primaryEmail = Meteor.user().primaryEmail;
-        if (_.findWhere(senderEmails, { email: primaryEmail })) {
-          fromEmail = primaryEmail;
-        } else {
-          fromEmail = _.findWhere(senderEmails, { primary: true }).email;
-        }
+      const senderPrimaryEmail = _.findWhere(senderEmails, { primary: true });
+      if (senderPrimaryEmail) {
+        fromEmail = senderPrimaryEmail.email;
       }
 
       // TODO(soon): In the HTML version, we should display an identity card.

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -501,7 +501,10 @@ Meteor.methods({
       let fromEmail = globalDb.getServerTitle() + " <" + globalDb.getReturnAddress() + ">";
       const senderEmails = SandstormDb.getVerifiedEmails(identity);
       const senderPrimaryEmail = _.findWhere(senderEmails, { primary: true });
-      if (senderPrimaryEmail) {
+      const accountPrimaryEmailAddress = Meteor.user().primaryEmail;
+      if (_.findWhere(senderEmails, { email: accountPrimaryEmailAddress })) {
+        fromEmail = accountPrimaryEmailAddress;
+      } else if (senderPrimaryEmail) {
         fromEmail = senderPrimaryEmail.email;
       }
 

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -149,31 +149,33 @@ if (Meteor.isServer) {
     return;
   });
 
-  Meteor.publish("requestingAccess", function (grainId, identityId) {
+  Meteor.publish("requestingAccess", function (grainId) {
     check(grainId, String);
-    check(identityId, String);
 
     if (!this.userId) {
       throw new Meteor.Error(403, "Must be logged in to request access.");
     }
 
-    if (!globalDb.userHasIdentity(this.userId, identityId)) {
-      throw new Meteor.Error(403, "Not an identity of the current user: " + identityId);
-    }
+    const identityIds = SandstormDb.getUserIdentityIds(Meteor.users.findOne({ _id: this.userId }));
 
     const grain = globalDb.getGrain(grainId);
     if (!grain) {
       throw new Meteor.Error(404, "Grain not found.");
     }
 
+    if (grain.userId === this.userId) {
+      this.added("grantedAccessRequests",
+                 Random.id(), { grainId: grainId, identityId: grain.identityId });
+    }
+
     const _this = this;
     const query = ApiTokens.find({ grainId: grainId, accountId: grain.userId,
-                                  "owner.user.identityId": identityId,
+                                   "owner.user.identityId": { $in: identityIds },
                                   revoked: { $ne: true }, });
     const handle = query.observe({
       added(apiToken) {
         _this.added("grantedAccessRequests",
-                    Random.id(), { grainId: grainId, identityId: identityId });
+                    Random.id(), { grainId: grainId, identityId: apiToken.owner.user.identityId });
       },
     });
 
@@ -417,11 +419,11 @@ Meteor.methods({
             globalDb, { identityId: identityId, accountId: accountId }, grainId,
             "direct invitation to " + contact.profile.intrinsicName,
             roleAssignment, { user: { identityId: contact._id, title: title } });
+          const url = origin + "/shared/" + result.token;
           try {
             const identity = Meteor.users.findOne({ _id: contact._id });
             const emailAddress = _.findWhere(SandstormDb.getVerifiedEmails(identity),
-                                             { primary: true });
-            const url = origin + "/shared/" + result.token;
+                                             { primary: true }).email;
             if (emailAddress) {
               const intrinsicName = contact.profile.intrinsicName;
               let loginNote;
@@ -503,7 +505,7 @@ Meteor.methods({
         if (_.findWhere(senderEmails, { email: primaryEmail })) {
           fromEmail = primaryEmail;
         } else {
-          fromEmail = _.findWhere(senderEmails, { primary: true });
+          fromEmail = _.findWhere(senderEmails, { primary: true }).email;
         }
       }
 
@@ -1012,6 +1014,16 @@ if (Meteor.isClient) {
   Template.requestAccess.onCreated(function () {
     this._status = new ReactiveVar({ showButton: true });
     this._grain = getActiveGrain(globalGrains.get());
+
+    this.autorun(() => {
+      Meteor.userId(); // Read this value so that we resubscribe on login.
+      this.subscribe("requestingAccess", this._grain.grainId());
+      const granted = GrantedAccessRequests.findOne({ grainId: this._grain.grainId() });
+      if (granted) {
+        this._grain.reset(granted.identityId);
+        this._grain.openSession();
+      }
+    });
   });
 
   Template.requestAccess.events({
@@ -1044,15 +1056,6 @@ if (Meteor.isClient) {
             instance._status.set({ error: error });
           } else {
             instance._status.set({ success: true });
-            instance.subscribe("requestingAccess", grainId, identityId);
-            instance.autorun(() => {
-              const granted = GrantedAccessRequests.findOne({ grainId: grainId,
-                                                              identityId: identityId, });
-              if (granted) {
-                instance._grain.reset(granted.identityId);
-                instance._grain.openSession();
-              }
-            });
           }
         });
 
@@ -2002,10 +2005,9 @@ Router.map(function () {
     },
 
     onBeforeAction: function () {
-      // Only rerun the hook if we've logged in as a different user.
-      const userId = Meteor.userId() || "NotSignedIn";
-      if (this.state.get("beforeActionHookRanForUser") === userId) return this.next();
-      this.state.set("beforeActionHookRanForUser", userId);
+      // Only run the hook once.
+      if (this.state.get("beforeActionHookRan")) return this.next();
+      this.state.set("beforeActionHookRan", true);
       const grainId = this.params.grainId;
       let initialPopup = null;
       let shareGrain = Session.get("share-grain-" + grainId);
@@ -2074,9 +2076,8 @@ Router.map(function () {
       // Run this hook only once. We could accomplish the same thing by using the `onRun()` hook
       // and waiting for `this.ready()`, but for some reason that fails in the case when a user
       // logs in while visiting a /shared/ link.
-      const userId = Meteor.userId() || "NotSignedIn";
-      if (this.state.get("beforeActionHookRanForUser") === userId) return this.next();
-      this.state.set("beforeActionHookRanForUser", userId);
+      if (this.state.get("beforeActionHookRan")) return this.next();
+      this.state.set("beforeActionHookRan", true);
 
       const token = this.params.token;
       const path = "/" + (this.params.path || "") + (this.originalUrl.match(/[#?].*$/) || "");

--- a/shell/shared/shell.js
+++ b/shell/shared/shell.js
@@ -86,15 +86,6 @@ if (Meteor.isClient) {
       Router.go("root");
     });
   };
-
-  Accounts.onLogin(() => {
-    const openGrains = globalGrains.get();
-    openGrains.forEach(function (grain) {
-      grain.destroy();
-    });
-
-    globalGrains.set([]);
-  });
 }
 
 if (Meteor.isServer) {

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -218,10 +218,17 @@ module.exports["Sign in at grain URL"] = function (browser) {
                     .waitForElementVisible("#grainTitle", medium_wait)
                     .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
                     .execute(function (name) { window.loginDevAccount(name) }, [otherName])
-                    .waitForElementVisible("button.pick-identity", medium_wait)
-                    .click("button.pick-identity")
-                    .waitForElementVisible("#grain-frame", medium_wait)
+
+                    // It's unclear whether there should be an identity chooser here.
+                    // See https://github.com/sandstorm-io/sandstorm/issues/1076
+                    // .waitForElementVisible("button.pick-identity", medium_wait)
+                    // .click("button.pick-identity")
+
+                    .waitForElementNotPresent(".request-access", medium_wait)
+                    // The forget grain button only appears once we've logged in.
+                    .waitForElementVisible("#deleteGrain", medium_wait)
                     .waitForElementVisible("#grainTitle", medium_wait)
+                    .waitForElementVisible("#grain-frame", medium_wait)
                     .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
                     .frame("grain-frame")
                     .waitForElementPresent("#publish", medium_wait)


### PR DESCRIPTION
This fixes a bug in #1590 where users would see blank pages after a `sandstorm restart`.

This also fixes a few places in #1585 where I forgot to project out the `email` field.