### PR TITLE
Support adding unauthenticated options headers and resources to API hosts

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -822,9 +822,10 @@ makeWildcardHost = function (id) {
 
 const isApiHostId = function (hostId) {
   if (hostId) {
-    var split = hostId.split("-");
+    const split = hostId.split("-");
     if (split[0] === "api") return split[1];
   }
+
   return false;
 };
 
@@ -858,7 +859,7 @@ if (Meteor.isServer) {
 
 const apiHostIdForToken = function (token) {
   return "api-" + apiHostIdHashForToken(token);
-}
+};
 
 const makeApiHost = function (token) {
   return makeWildcardHost(apiHostIdForToken(token));
@@ -981,12 +982,13 @@ if (Meteor.isServer) {
     this.collections.apiTokens.find(query).forEach(function (token) {
       // Clean up ApiHosts for webkey tokens.
       if (token.hasApiHost) {
-        var hash2 = Crypto.createHash("sha256").update(token._id).digest("base64");
-        ApiHosts.remove({hash2: hash2});
+        const hash2 = Crypto.createHash("sha256").update(token._id).digest("base64");
+        ApiHosts.remove({ hash2: hash2 });
       }
     });
+
     this.collections.apiTokens.remove(query);
-  }
+  };
 }
 
 // =======================================================================================

--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -497,7 +497,7 @@ SandstormPermissions.createNewApiToken = function (db, provider, grainId, petnam
 SandstormPermissions.cleanupSelfDestructing = function (db) {
   return function () {
     var now = new Date();
-    db.collections.apiTokens.remove({expiresIfUnused: {$lt: now}});
+    db.removeApiTokens({expiresIfUnused: {$lt: now}});
   }
 }
 

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -429,7 +429,7 @@ function dropInternal(sturdyRef, ownerPattern) {
   if (token.frontendRef) {
     if (token.frontendRef.notificationHandle) {
       const notificationId = token.frontendRef.notificationHandle;
-      ApiTokens.remove({ _id: hashedSturdyRef });
+      globalDb.removeApiTokens({ _id: hashedSturdyRef });
       const anyToken = ApiTokens.findOne({ "frontendRef.notificationHandle": notificationId });
       if (!anyToken) {
         // No other tokens referencing this notification exist, so dismiss the notification

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1316,7 +1316,7 @@ class Proxy {
                       .then((session) => {
                         return session.session;
                       }, (err) => {
-                        return _this._callNewWebSession(request, userInfo);
+                        return this._callNewWebSession(request, userInfo);
                       }
     );
   };

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1123,6 +1123,7 @@ tryProxyRequest = (hostId, req, res) => {
           const dav = ((apiHost || {}).options || {}).dav || [];
           if (dav.length > 0) {
             res.setHeader("DAV", dav.join(", "));
+            res.setHeader("Access-Control-Expose-Headers", "DAV");
           }
 
           res.writeHead(200, {});
@@ -1802,7 +1803,11 @@ class Proxy {
             });
           }
 
-          if (dav.length > 0) response.setHeader('DAV', dav.join(', '));
+          if (dav.length > 0) {
+            response.setHeader("DAV", dav.join(", "));
+            response.setHeader("Access-Control-Expose-Headers", "DAV");
+          }
+
           response.end();
           // Return no response; we already handled everything.
         }, (err) => {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1794,6 +1794,13 @@ class Proxy {
           if (options.davClass1) dav.push('1');
           if (options.davClass2) dav.push('2');
           if (options.davClass3) dav.push('3');
+          if (options.davExtensions) {
+            options.davExtensions.forEach((token) => {
+              if (token.match(/^([a-zA-Z0-9!#$%&'*+.^_`|~-]+|<[\x21-\x7E]*>)$/)) {
+                dav.push(token);
+              }
+            });
+          }
           if (dav.length > 0) response.setHeader('DAV', dav.join(', '));
           response.end();
           // Return no response; we already handled everything.

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1040,7 +1040,7 @@ tryProxyRequest = (hostId, req, res) => {
   // should consider other host types, like static web publishing), or throws an error if the
   // request is definitely invalid.
 
-  var hostIdHash = globalDb.isApiHostId(hostId);
+  const hostIdHash = globalDb.isApiHostId(hostId);
   if (hostIdHash) {
     // This is a request for the API host.
 
@@ -1136,7 +1136,7 @@ tryProxyRequest = (hostId, req, res) => {
             if (resource.language) res.setHeader("Content-Language", resource.language);
             if (resource.encoding) res.setHeader("Content-Encoding", resource.encoding);
             res.writeHead(200, {
-              "Content-Type": resource.type
+              "Content-Type": resource.type,
             });
             res.end(resource.body);
           } else {
@@ -1801,6 +1801,7 @@ class Proxy {
               }
             });
           }
+
           if (dav.length > 0) response.setHeader('DAV', dav.join(', '));
           response.end();
           // Return no response; we already handled everything.

--- a/shell/shared/demo.js
+++ b/shell/shared/demo.js
@@ -57,7 +57,7 @@ if (Meteor.isServer) {
       Grains.find({ userId: user._id }, { fields: { _id: 1, lastUsed: 1, appId: 1 } })
             .forEach(function (grain) {
         console.log("delete grain: " + grain._id);
-        ApiTokens.remove({ grainId: grain._id });
+        globalDb.removeApiTokens({ grainId: grain._id });
         Grains.remove(grain._id);
         if (grain.lastUsed) {
           DeleteStats.insert({ type: "demoGrain", lastActive: grain.lastUsed, appId: grain.appId });

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1739,6 +1739,8 @@ if (Meteor.isClient) {
             roleAssignment: Match.Optional(roleAssignmentPattern),
             forSharing: Match.Optional(Boolean),
             clipboardButton: Match.Optional(Match.OneOf(undefined, null, "left", "right")),
+            static: Match.Optional(Object),
+            // Note: `static` will be validated on the server. We just pass it through here.
           });
         } catch (error) {
           event.source.postMessage({ rpcId: rpcId, error: error.toString() }, event.origin);
@@ -1775,7 +1777,8 @@ if (Meteor.isClient) {
           },
         };
 
-        const params = [provider, senderGrain.grainId(), petname, assignment, owner];
+        const params = [provider, senderGrain.grainId(), petname, assignment, owner,
+                        call.static];
 
         const memoizeKey = SHA256(JSON.stringify(params));
         let memoizeResult = memoizedNewApiToken[memoizeKey];

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -1777,8 +1777,7 @@ if (Meteor.isClient) {
           },
         };
 
-        const params = [provider, senderGrain.grainId(), petname, assignment, owner,
-                        call.static];
+        const params = [provider, senderGrain.grainId(), petname, assignment, owner, call.static];
 
         const memoizeKey = SHA256(JSON.stringify(params));
         let memoizeResult = memoizedNewApiToken[memoizeKey];

--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -265,7 +265,7 @@ Meteor.methods({
       const grain = Grains.findOne({ _id: grainId, userId: this.userId });
       if (grain) {
         Grains.remove(grainId);
-        ApiTokens.remove({
+        globalDb.removeApiTokens({
           grainId: grainId,
           $or: [
             { owner: { $exists: false } },
@@ -297,7 +297,7 @@ Meteor.methods({
     }
 
     SandstormDb.getUserIdentityIds(Meteor.user()).forEach(function (identityId) {
-      ApiTokens.remove({ grainId: grainId, "owner.user.identityId": identityId });
+      globalDb.removeApiTokens({ grainId: grainId, "owner.user.identityId": identityId });
     });
   },
 

--- a/shell/shared/testing.js
+++ b/shell/shared/testing.js
@@ -22,7 +22,7 @@ if (isTesting) {
   if (Meteor.isServer) {
     function clearUser(id) {
       UserActions.remove({ userId: id });
-      ApiTokens.remove({ userId: id });
+      globalDb.removeApiTokens({ userId: id });
       Grains.find({ userId: id }).forEach(function (grain) {
         globalBackend.deleteGrain(grain._id);
       });

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -394,6 +394,7 @@ public:
         "Sandboxed app attempted to upgrade protocol when client did not request this.");
 
     KJ_IF_MAYBE(dav, findHeader("dav")) {
+      kj::Vector<kj::String> extensions;
       for (auto level: split(*dav, ',')) {
         auto trimmed = trim(level);
         if (trimmed == "1") {
@@ -402,6 +403,14 @@ public:
           builder.setDavClass2(true);
         } else if (trimmed == "3") {
           builder.setDavClass3(true);
+        } else {
+          extensions.add(kj::mv(trimmed));
+        }
+      }
+      if (extensions.size() > 0) {
+        auto list = builder.initDavExtensions(extensions.size());
+        for (auto i: kj::indices(extensions)) {
+          list.set(i, extensions[i]);
         }
       }
     }

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -454,6 +454,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
     davClass1 @0 :Bool = false;
     davClass2 @1 :Bool = false;
     davClass3 @2 :Bool = false;
+    davExtensions @3 :List(Text);
   }
 
   enum PropfindDepth {

--- a/tests/tests/apihost.js
+++ b/tests/tests/apihost.js
@@ -1,0 +1,94 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+"use strict";
+
+var utils = require('../utils');
+var actionSelector = utils.actionSelector;
+var appDetailsTitleSelector = utils.appDetailsTitleSelector;
+var very_short_wait = utils.very_short_wait;
+var short_wait = utils.short_wait;
+var medium_wait = utils.medium_wait;
+var very_long_wait = utils.very_long_wait;
+
+module.exports = {
+};
+
+module.exports['Install and launch test app'] = function (browser) {
+  browser
+    .init()
+    .installApp("https://alpha-qkhxczi7kki1x49pfakw.sandstorm.io/apihost-testapp.spk", "e148b304d9642e8c98ef8ea2df2f72ca", "w304h9n5rjx1pzfa8e4guheue5mq3dkwv63aajy1rscupw6e38mh")
+    .assert.containsText('#grainTitle', 'Untitled ApiHost test app instance')
+    .frame('grain-frame')
+      .waitForElementPresent('iframe', medium_wait)
+    .frameParent()
+    .url(undefined, function (response) {
+      var grainUrl = response.value;
+      var expectedGrainPrefix = browser.launch_url + '/grain/';
+      browser.assert.ok(grainUrl.lastIndexOf(expectedGrainPrefix, 0) === 0, "url looks like a grain URL");
+      grainId = grainUrl.slice(expectedGrainPrefix.length);
+    });
+};
+
+var grainId = undefined;
+
+module.exports['Test renderTemplate with static host info'] = function (browser) {
+  browser
+    .frame('grain-frame')
+      .waitForElementVisible('iframe[src]', short_wait)
+      .frame('offer-template')
+        .waitForElementPresent('#text', short_wait)
+        .getText('#text', function (result) {
+          this.assert.equal(typeof result, "object");
+          this.assert.equal(result.status, 0);
+          var renderedTemplate = result.value;
+          var endpoint = renderedTemplate.split("#")[0];
+          
+          // Inject some JS into the browser that does an XHR and returns the body.
+          this
+            .timeouts("script", 5000)
+            .executeAsync(function(endpoint, done) {
+            var xhr = new XMLHttpRequest();
+            xhr.onreadystatechange = function () {
+              if (xhr.readyState == 4) {
+                if (xhr.status === 200) {
+                  console.log("ok!")
+                  console.log(xhr.responseText);
+                  done({
+                    type: xhr.getResponseHeader("Content-Type"),
+                    content: xhr.responseText
+                  });
+                } else {
+                  console.log("failed");
+                  done(null);
+                }
+              }
+            };
+            xhr.open("GET", endpoint + "/test-static", true);
+            xhr.send();
+          }, [endpoint], function (result) {
+            this.assert.equal(typeof result, "object");
+            console.log(result);
+            this.assert.equal(result.status, 0);
+            this.assert.equal(typeof result.value, "object")
+            this.assert.equal(result.value.type, "text/plain");
+            this.assert.equal(result.value.content, "test static resource");
+          });
+        })
+      .frameParent()
+    .frameParent()
+    .end();
+}


### PR DESCRIPTION
This supports both:
* Setting the `DAV` header to return for unauthenticated OPTIONS requests.
* Defining small static resources which can be `GET`ed unauthenticated, e.g. `/status.php`.

Example app code: https://github.com/kentonv/apihost-testapp/blob/master/client/index.html

Also in this PR, I extended web-session.capnp to pass through DAV extension identifiers in OPTIONS requests.

I would like to get this out in this weekend's build so that we can fix up Radicale next week. If @zarvox can't review in time, I'll probably just merge as-is.

@mnutt @synchrone