### PR TITLE
Ignore child tokens in 'requestingAccess' publish.

### DIFF
--- a/shell/shared/grain.js
+++ b/shell/shared/grain.js
@@ -170,8 +170,9 @@ if (Meteor.isServer) {
 
     const _this = this;
     const query = ApiTokens.find({ grainId: grainId, accountId: grain.userId,
+                                   parentToken: { $exists: false },
                                    "owner.user.identityId": { $in: identityIds },
-                                  revoked: { $ne: true }, });
+                                   revoked: { $ne: true }, });
     const handle = query.observe({
       added(apiToken) {
         _this.added("grantedAccessRequests",


### PR DESCRIPTION
Currently, if a user receives access to a grain through a sharing link, that link gets revoked, and then the user tries to visit the grain from their grain list, the client goes into an infinite retry loop.

This fixes the problem.