### PR TITLE
docs: use `vagrant-spk vm *` for up, halt, ssh, destroy

### DIFF
--- a/docs/administering/guide.md
+++ b/docs/administering/guide.md
@@ -22,7 +22,7 @@ By default, Sandstorm installs within **/opt/sandstorm**.
 - Now is a good time to `cd /opt/sandstorm` and use `ls` take a look around!
 
 **Note:** If you are having trouble finding `/opt/sandstorm`, it could be because you need to `vagrant
-ssh` into the virtual machine that runs Sandstorm for you.
+vm ssh` into the virtual machine that runs Sandstorm for you.
 
 The [install script](https://github.com/sandstorm-io/sandstorm/tree/master/install.sh) creates a system
 service to run Sandstorm, by default.

--- a/docs/administering/guide.md
+++ b/docs/administering/guide.md
@@ -22,7 +22,7 @@ By default, Sandstorm installs within **/opt/sandstorm**.
 - Now is a good time to `cd /opt/sandstorm` and use `ls` take a look around!
 
 **Note:** If you are having trouble finding `/opt/sandstorm`, it could be because you need to `vagrant
-vm ssh` into the virtual machine that runs Sandstorm for you.
+ssh` into the virtual machine that runs Sandstorm for you.
 
 The [install script](https://github.com/sandstorm-io/sandstorm/tree/master/install.sh) creates a system
 service to run Sandstorm, by default.

--- a/docs/developing/publishing-apps.md
+++ b/docs/developing/publishing-apps.md
@@ -37,7 +37,7 @@ change it.
 To find out if you have the key material, you can run:
 
 ```bash
-$ vagrant-spk ssh
+$ vagrant-spk vm ssh
 $ spk listkeys -k ~/.sandstorm/sandstorm-keyring
 ```
 
@@ -47,7 +47,7 @@ If you want to change the app ID before publishing the app, you
 can run:
 
 ```bash
-$ vagrant-spk ssh
+$ vagrant-spk vm ssh
 $ spk keygen -k ~/.sandstorm/sandstorm-keyring
 ```
 

--- a/docs/vagrant-spk/customizing.md
+++ b/docs/vagrant-spk/customizing.md
@@ -15,7 +15,7 @@ You should not need to change this script.
 ### setup.sh
 
 This script controls stack-specific setup, like tools to download and install. It runs **once when
-you run `vagrant-spk up`**. When you modify this file, you must **manually re-execute it**. See
+you run `vagrant-spk vm up`**. When you modify this file, you must **manually re-execute it**. See
 below for details.
 
 Each platform stack in `vagrant-spk` provides a reasonable default for `setup.sh`, but if you need
@@ -38,7 +38,7 @@ cd ..
 This is because `vagrant-spk` currently has no way to auto-detect that the `setup.sh` script needs
 to be re-executed.
 
-To verify your `setup.sh` for reproducibility, run `vagrant-spk destroy` then `vagrant-spk up` and
+To verify your `setup.sh` for reproducibility, run `vagrant-spk vm destroy` then `vagrant-spk vm up` and
 manually test your package.
 
 As a performance optimization, you can use `apt-cacher-ng` to speed up package downloads. This can

--- a/docs/vagrant-spk/packaging-tutorial-meteor.md
+++ b/docs/vagrant-spk/packaging-tutorial-meteor.md
@@ -144,7 +144,7 @@ connection.
 
 ```bash
 cd ~/projects/sandstorm-packaging-tutorial/clock
-vagrant-spk up
+vagrant-spk vm up
 ```
 
 You will see a _lot_ of messages printed out. Some of them are not
@@ -154,7 +154,7 @@ noise.
 Eventually, you will get your shell back. At this point, you can
 continue to the next step.
 
-**Troubleshooting note**: If the `vagrant-spk up` command fails, it
+**Troubleshooting note**: If the `vagrant-spk vm up` command fails, it
 could be because you already have Sandstorm installed on your
 laptop. You can recognize this error via the following red text:
 
@@ -396,7 +396,7 @@ it's safe to stop it. Run this command:
 
 ```bash
 cd ~/projects/sandstorm-packaging-tutorial/clock
-vagrant-spk halt
+vagrant-spk vm halt
 ```
 
 This shuts down the whole virtual machine used for developing your
@@ -409,7 +409,7 @@ it online by running:
 
 ```bash
 cd ~/projects/sandstorm-packaging-tutorial/clock
-vagrant-spk up
+vagrant-spk vm up
 ```
 
 If you ever are confused about which Vagrant virtual machines are

--- a/docs/vagrant-spk/packaging-tutorial.md
+++ b/docs/vagrant-spk/packaging-tutorial.md
@@ -108,7 +108,7 @@ Sandstorm, that you will develop the package with. To do that, run the following
 command:
 
 ```bash
-vagrant-spk up
+vagrant-spk vm up
 ```
 
 (You should be running it from the `~/projects/php-app-to-package-for-sandstorm` directory.)
@@ -300,7 +300,7 @@ In our case, we're done using the virtual machine running this app, so
 it's safe to stop it. Run this command:
 
 ```bash
-vagrant-spk halt
+vagrant-spk vm halt
 ```
 
 (You should be running it from the `~/projects/php-app-to-package-for-sandstorm` directory.)
@@ -309,7 +309,7 @@ Now port 6080 is available for other app packaging projects. If you ever want to
 this app's packaging again, you can bring it up by running:
 
 ```bash
-vagrant-spk up
+vagrant-spk vm up
 ```
 
 If you ever are confused about which Vagrant virtual machines are

--- a/docs/vagrant-spk/platform-stacks.md
+++ b/docs/vagrant-spk/platform-stacks.md
@@ -48,7 +48,7 @@ For a Meteor app, keep the following in mind:
 * Get a copy of the app code wherever you like. Alternatively, run `meteor create --example todos`
 * `cd` into that directory.
 * Run `vagrant-spk setupvm meteor`
-* Run `vagrant-spk up`. Note this will print _lots_ of red text; sorry about that, then abruptly end.
+* Run `vagrant-spk vm up`. Note this will print _lots_ of red text; sorry about that, then abruptly end.
 * Run `vagrant-spk init` and edit `.sandstorm/sandstorm-pkgdef.capnp`
 * Run `vagrant-spk dev` and make sure the app works OK at http://local.sandstorm.io:6080/
 * Run `vagrant-spk pack ~/projects/meteor-package.spk` and you have a package file!


### PR DESCRIPTION
Adjusts docs to recommend the canonical commands as amended by sandstorm-io/vagrant-spk#145