### PR TITLE
Add trivial route and template for styleguide

### DIFF
--- a/shell/client/styleguide.html
+++ b/shell/client/styleguide.html
@@ -1,0 +1,6 @@
+<template name="styleguide">
+{{!-- Insert whatever HTML you want to demonstrate here. --}}
+<h1>Sandstorm Style Guide</h1>
+
+<p>Work in progress.</p>
+</template>

--- a/shell/client/styleguide.js
+++ b/shell/client/styleguide.js
@@ -1,0 +1,5 @@
+Router.map(function () {
+  this.route("styleguide", {
+    path: "/styleguide",
+  });
+});


### PR DESCRIPTION
cc @neynah Feel free to add arbitrary HTML to `shell/client/styleguide.html` to demonstrate whatever widgets you find appropriate. :)

If you have a Sandstorm development environment up and running, you'll be able to see this page at http://local.sandstorm.io:6080/styleguide ; if not, happy to help you set one up tomorrow/whenever.