### PR TITLE
Whoops, shouldn't use globalDb from inside db.js

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1216,12 +1216,12 @@ _.extend(SandstormDb.prototype, {
 
   isFeatureKeyValid: function () {
     if (Meteor.settings.public.isFeatureKeyValid) return true;
-    const featureKey = globalDb.currentFeatureKey();
+    const featureKey = this.currentFeatureKey();
     return !!featureKey;
   },
 
   isFeatureKeyValidAndNotExpired: function () {
-    const featureKey = globalDb.currentFeatureKey();
+    const featureKey = this.currentFeatureKey();
     return featureKey && (parseInt(featureKey.expires) > (Date.now() / 1000));
   },
 


### PR DESCRIPTION
Happily, the old code coincidentally did the right thing at runtime, but this is the more reliably correct thing to do.