### PR TITLE
Create command-line tool for generating feature keys.

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1253,7 +1253,6 @@ _.extend(SandstormDb.prototype, {
   },
 
   isFeatureKeyValid: function () {
-    if (Meteor.settings.public.isFeatureKeyValid) return true;
     const featureKey = this.currentFeatureKey();
     return !!featureKey;
   },

--- a/shell/run-dev.sh
+++ b/shell/run-dev.sh
@@ -82,8 +82,7 @@ cat > $SETTINGS << __EOF__
     "isTesting": true,
     "wildcardHost": "$WILDCARD_HOST",
     "quotaEnabled": ${QUOTA_ENABLED:-false},
-    "stripePublicKey": "${STRIPE_PUBLIC_KEY:-}",
-    "isFeatureKeyValid": true
+    "stripePublicKey": "${STRIPE_PUBLIC_KEY:-}"
   },
   "home": "$SANDSTORM_HOME",
   "stripeKey": "${STRIPE_KEY:-}",

--- a/shell/server/admin.js
+++ b/shell/server/admin.js
@@ -133,9 +133,9 @@ Meteor.methods({
       throw new Meteor.Error(401, "Invalid feature key");
     }
 
-    // verifyFeatureKeySignature is provided in feature-key.js
-    const verifiedFeatureKeyBlob = verifyFeatureKeySignature(buf);
-    if (!verifiedFeatureKeyBlob) {
+    // loadSignedFeatureKey is provided in feature-key.js
+    const featureKey = loadSignedFeatureKey(buf);
+    if (!featureKey) {
       throw new Meteor.Error(401, "Invalid feature key");
     }
 

--- a/shell/server/feature-key.js
+++ b/shell/server/feature-key.js
@@ -34,7 +34,6 @@ const signingKey = bits0
 const isTesting = Meteor.settings && Meteor.settings.public &&
                   Meteor.settings.public.isTesting;
 
-// Export for use in Meteor method in admin.js
 function verifyFeatureKeySignature(buf) {
   // buf is a Buffer containing an feature key with attached signature.
   // This function returns the signed data if the signature is valid,

--- a/shell/server/feature-key.js
+++ b/shell/server/feature-key.js
@@ -17,20 +17,25 @@
 const Capnp = Npm.require("capnp");
 const FeatureKey = Capnp.importSystem("sandstorm/feature-key.capnp").FeatureKey;
 
-// These byte-packing tricks that are so convenient in non-memory-safe languages are a
-// bit of a pain in memory-safe languages.  Argh.  At least I have bignums on the server.
+// We don't currently have a way of reading the raw bytes of a capnp struct in Javascript the
+// way we do in C++. Awkwardly, what we end up with is four 64-bit ints that have been stringified
+// since JS can't actually deal with 64-bit ints. We have to laboriously reconstruct the underlying
+// bytes using Bignum. Don't forget that everything is little-endian, as DJBeesus intended.
 const bits0 = Bignum(FeatureKey.signingKey.key0);
 const bits1 = Bignum(FeatureKey.signingKey.key1);
 const bits2 = Bignum(FeatureKey.signingKey.key2);
 const bits3 = Bignum(FeatureKey.signingKey.key3);
-const signingKey = bits0.shiftLeft(64 * 3)
-    .add(bits1.shiftLeft(64 * 2))
-    .add(bits2.shiftLeft(64))
-    .add(bits3)
-    .toBuffer();
+const signingKey = bits0
+    .add(bits1.shiftLeft(64 * 1))
+    .add(bits2.shiftLeft(64 * 2))
+    .add(bits3.shiftLeft(64 * 3))
+    .toBuffer({ endian: "little", size: 32 });
+
+const isTesting = Meteor.settings && Meteor.settings.public &&
+                  Meteor.settings.public.isTesting;
 
 // Export for use in Meteor method in admin.js
-verifyFeatureKeySignature = function (buf) {
+function verifyFeatureKeySignature(buf) {
   // buf is a Buffer containing an feature key with attached signature.
   // This function returns the signed data if the signature is valid,
   // or undefined if the signature is invalid.
@@ -41,6 +46,7 @@ verifyFeatureKeySignature = function (buf) {
   const signedData = buf.slice(64);
 
   if (!Ed25519.Verify(signedData, signature, signingKey)) {
+    console.error("feature key failed signature check", bits0, bits1, bits2, bits3);
     return undefined;
   } else {
     return signedData;
@@ -55,6 +61,12 @@ loadSignedFeatureKey = function (buf) {
   const verifiedFeatureKeyBlob = verifyFeatureKeySignature(buf);
   if (verifiedFeatureKeyBlob) {
     const featureKey = Capnp.parsePacked(FeatureKey, verifiedFeatureKeyBlob);
+    if (featureKey.isForTesting && !isTesting) {
+      // This key is for testing only, but the server is not running in testing mode. Note that
+      // enabling testing mode forfeits up all security.
+      return undefined;
+    }
+
     return featureKey;
   } else {
     return undefined;

--- a/src/sandstorm/feature-key-tool.c++
+++ b/src/sandstorm/feature-key-tool.c++
@@ -120,7 +120,7 @@ public:
     auto unsign = kj::heapArray<byte>(sign.size());
     unsigned long long length;
 
-    auto pk = structToBytes(*FeatureKey::SIGNING_KEY, crypto_sign_ed25519_PUBLICKEYBYTES);
+    auto pk = getUnderlyingBytes(*FeatureKey::SIGNING_KEY, crypto_sign_ed25519_PUBLICKEYBYTES);
 
     if (crypto_sign_ed25519_open(unsign.begin(), &length, sign.begin(), sign.size(), pk) != 0) {
       return "signature check failed";
@@ -158,7 +158,7 @@ public:
     capnp::MallocMessageBuilder builder;
     auto pk = builder.getRoot<PublicSigningKey>();
 
-    memcpy(structToBytes(kj::cp(pk), crypto_sign_ed25519_PUBLICKEYBYTES), publicKey,
+    memcpy(getUnderlyingBytes(kj::cp(pk), crypto_sign_ed25519_PUBLICKEYBYTES), publicKey,
            crypto_sign_ed25519_PUBLICKEYBYTES);
     auto msg = kj::str(
         "(key0 = 0x", kj::hex(pk.getKey0()), ","
@@ -178,13 +178,13 @@ private:
   byte key[crypto_sign_ed25519_SECRETKEYBYTES];
   byte publicKey[crypto_sign_ed25519_PUBLICKEYBYTES];
 
-  const byte* structToBytes(capnp::AnyStruct::Reader reader, size_t size) {
+  const byte* getUnderlyingBytes(capnp::AnyStruct::Reader reader, size_t size) {
     auto data = reader.getDataSection();
     KJ_REQUIRE(data.size() == size);
     return data.begin();
   }
 
-  byte* structToBytes(capnp::AnyStruct::Builder builder, size_t size) {
+  byte* getUnderlyingBytes(capnp::AnyStruct::Builder builder, size_t size) {
     auto data = builder.getDataSection();
     KJ_REQUIRE(data.size() == size);
     return data.begin();

--- a/src/sandstorm/feature-key-tool.c++
+++ b/src/sandstorm/feature-key-tool.c++
@@ -1,0 +1,196 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2015 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <kj/main.h>
+#include <sandstorm/feature-key.capnp.h>
+#include "version.h"
+#include "util.h"
+#include <capnp/serialize.h>
+#include <capnp/serialize-packed.h>
+#include <capnp/schema-parser.h>
+#include <capnp/pretty-print.h>
+#include <sodium/crypto_sign_ed25519.h>
+#include <sodium/randombytes.h>
+
+namespace sandstorm {
+
+class FeatureKeyTool {
+  // Main class for the feature key generation tool.
+
+public:
+  FeatureKeyTool(kj::ProcessContext& context): context(context) {
+    schemaParser.loadCompiledTypeAndDependencies<FeatureKey>();
+  }
+
+  kj::MainFunc getMain() {
+    return kj::MainBuilder(context, "Sandstorm version " SANDSTORM_VERSION,
+                           "Tool used to create feature keys.")
+        .addSubCommand("sign", KJ_BIND_METHOD(*this, getSignMain), "sign a feature key")
+        .addSubCommand("verify", KJ_BIND_METHOD(*this, getVerifyMain), "verify a feature key")
+        .addSubCommand("keygen", KJ_BIND_METHOD(*this, getKeygenMain), "create a new signing key")
+        .addSubCommand("readkey", KJ_BIND_METHOD(*this, getReadkeyMain), "show public key")
+        .build();
+  }
+
+  kj::MainFunc getSignMain() {
+    return kj::MainBuilder(context, "Sandstorm version " SANDSTORM_VERSION,
+                           "Sign a feature key. <file> is a capnp file containing a constant "
+                           "named <name> which is of type FeatureKey. The signed key is written "
+                           "to stdout.")
+        .addOptionWithArg({'I', "import-path"}, KJ_BIND_METHOD(*this, addImportPath),
+                          "<dir>", "search for capnp imports in <dir>")
+        .expectArg("<signing-key>", KJ_BIND_METHOD(*this, loadKey))
+        .expectArg("<file>", KJ_BIND_METHOD(*this, parseSourceFile))
+        .expectOneOrMoreArgs("<name>", KJ_BIND_METHOD(*this, doSign))
+        .build();
+  }
+
+  kj::MainBuilder::Validity addImportPath(kj::StringPtr arg) {
+    importPath.add(arg);
+    return true;
+  }
+
+  kj::MainBuilder::Validity loadKey(kj::StringPtr arg) {
+    auto seed = readAllBytes(raiiOpen(arg, O_RDONLY));
+    if (seed.size() != crypto_sign_ed25519_SEEDBYTES) {
+      return "invalid key file";
+    }
+
+    KJ_ASSERT(crypto_sign_ed25519_seed_keypair(publicKey, key, seed.begin()) == 0);
+    return true;
+  }
+
+  kj::MainBuilder::Validity parseSourceFile(kj::StringPtr arg) {
+    schema = schemaParser.parseDiskFile(arg, arg, importPath);
+    return true;
+  }
+
+  kj::MainBuilder::Validity doSign(kj::StringPtr arg) {
+    capnp::MallocMessageBuilder builder;
+    builder.setRoot(schema.getNested(arg).asConst().as<FeatureKey>());
+
+    kj::VectorOutputStream output;
+    capnp::writePackedMessage(output, builder);
+
+    auto unsign = output.getArray();
+    auto sign = kj::heapArray<byte>(unsign.size() + crypto_sign_ed25519_BYTES);
+    unsigned long long length;
+
+    KJ_ASSERT(crypto_sign_ed25519(sign.begin(), &length, unsign.begin(), unsign.size(), key) == 0);
+
+    auto msg = kj::str(
+        "--------------------- BEGIN SANDSTORM FEATURE KEY ----------------------\n",
+        base64Encode(sign.slice(0, length), true),
+        "---------------------- END SANDSTORM FEATURE KEY -----------------------\n");
+    kj::FdOutputStream(STDOUT_FILENO).write(msg.begin(), msg.size());
+    return true;
+  }
+
+  kj::MainFunc getVerifyMain() {
+    return kj::MainBuilder(context, "Sandstorm version " SANDSTORM_VERSION,
+                           "Read a feature key on standard input, verify the signature, and "
+                           "print the details.")
+        .callAfterParsing(KJ_BIND_METHOD(*this, doVerify))
+        .build();
+  }
+
+  kj::MainBuilder::Validity doVerify() {
+    kj::Vector<kj::String> text;
+    for (auto& line: splitLines(readAll(STDIN_FILENO))) {
+      auto trimmed = trim(line);
+      if (trimmed.size() > 0 && trimmed[0] != '-') {
+        text.add(kj::mv(trimmed));
+      }
+    }
+
+    auto sign = base64Decode(kj::strArray(text, ""));
+    auto unsign = kj::heapArray<byte>(sign.size());
+    unsigned long long length;
+
+    auto pk = structToBytes(*FeatureKey::SIGNING_KEY, crypto_sign_ed25519_PUBLICKEYBYTES);
+
+    if (crypto_sign_ed25519_open(unsign.begin(), &length, sign.begin(), sign.size(), pk) != 0) {
+      return "signature check failed";
+    }
+
+    kj::ArrayInputStream input(unsign.slice(0, length));
+    capnp::PackedMessageReader reader(input);
+    context.exitInfo(capnp::prettyPrint(reader.getRoot<FeatureKey>()).flatten());
+  }
+
+  kj::MainFunc getKeygenMain() {
+    return kj::MainBuilder(context, "Sandstorm version " SANDSTORM_VERSION,
+                           "Generates a new key and writes it to stdout in binary.")
+        .callAfterParsing(KJ_BIND_METHOD(*this, doKeygen))
+        .build();
+  }
+
+  kj::MainBuilder::Validity doKeygen() {
+    byte random[crypto_sign_ed25519_SEEDBYTES];
+    randombytes(random, sizeof(random));
+    kj::FdOutputStream(STDOUT_FILENO)
+        .write(random, sizeof(random));
+    context.exit();
+  }
+
+  kj::MainFunc getReadkeyMain() {
+    return kj::MainBuilder(context, "Sandstorm version " SANDSTORM_VERSION,
+                           "Reads a key file and writes the public key as capnp text.")
+        .expectArg("<keyfile>", KJ_BIND_METHOD(*this, loadKey))
+        .callAfterParsing(KJ_BIND_METHOD(*this, doReadkey))
+        .build();
+  }
+
+  kj::MainBuilder::Validity doReadkey() {
+    capnp::MallocMessageBuilder builder;
+    auto pk = builder.getRoot<PublicSigningKey>();
+
+    memcpy(structToBytes(kj::cp(pk), crypto_sign_ed25519_PUBLICKEYBYTES), publicKey,
+           crypto_sign_ed25519_PUBLICKEYBYTES);
+    auto msg = kj::str(
+        "(key0 = 0x", kj::hex(pk.getKey0()), ","
+        " key1 = 0x", kj::hex(pk.getKey1()), ","
+        " key2 = 0x", kj::hex(pk.getKey2()), ","
+        " key3 = 0x", kj::hex(pk.getKey3()), ")\n");
+    kj::FdOutputStream(STDOUT_FILENO).write(msg.begin(), msg.size());
+    context.exit();
+  }
+
+private:
+  kj::ProcessContext& context;
+  kj::Vector<kj::StringPtr> importPath;
+  capnp::SchemaParser schemaParser;
+  capnp::ParsedSchema schema;
+
+  byte key[crypto_sign_ed25519_SECRETKEYBYTES];
+  byte publicKey[crypto_sign_ed25519_PUBLICKEYBYTES];
+
+  const byte* structToBytes(capnp::AnyStruct::Reader reader, size_t size) {
+    auto data = reader.getDataSection();
+    KJ_REQUIRE(data.size() == size);
+    return data.begin();
+  }
+
+  byte* structToBytes(capnp::AnyStruct::Builder builder, size_t size) {
+    auto data = builder.getDataSection();
+    KJ_REQUIRE(data.size() == size);
+    return data.begin();
+  }
+};
+
+} // namespace sandstorm
+
+KJ_MAIN(sandstorm::FeatureKeyTool)

--- a/src/sandstorm/feature-key.capnp
+++ b/src/sandstorm/feature-key.capnp
@@ -68,6 +68,11 @@ struct FeatureKey {
   isTrial @6 :Bool;
   # Is this a trial key? For display purposes only.
 
+  isForTesting @10 :Bool = false;
+  # Is this key meant for use by Sandstorm core developers for testing purposes? Test keys will
+  # only work when the server is in testing mode. Testing mode forfeits security, so you don't want
+  # to run a real server in this mode.
+
   features :group {
     # Individual features enabled.
 
@@ -77,7 +82,7 @@ struct FeatureKey {
   }
 
   const signingKey :PublicSigningKey =
-      (key0 = 0xa87bfaf12af68423, key1 = 0xc42d2e56f009d882,
-       key2 = 0x62298178d76d746b, key3 = 0xfe7ee882ec3d945a);
+      (key0 = 0x86ada8b5d9f65036, key1 = 0x183909ba08aac323,
+       key2 = 0x6d778da453c9560d, key3 = 0xdf94f532f33a7ea8);
   # The Ed25519 public key used to verify FeatureKeys.
 }


### PR DESCRIPTION
Also:
- Removed isFeatureKeyValid Meteor setting. Instead, feature keys with "isForTesting = true" will work only when the server is running in testing mode (another Meteor setting). I will generate such testing certificates for everyone to use.
- Fixed key reassembly in feature-key.js to be little-endian.