### PR TITLE
Fix position of popup close button on mobile

### DIFF
--- a/shell/client/_topbar.scss
+++ b/shell/client/_topbar.scss
@@ -784,7 +784,7 @@ body>.popup {
     }
 
     @media #{$mobile} {
-      position: static;
+      position: relative;
       margin: 64px auto 32px;
       font-size: 20px;
       width: 90%;


### PR DESCRIPTION
The popup frame should be `position: relative`, so that children (like the close
button) will be placed relative to that frame.