### PR TITLE
Tweak Sandstorm for Work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ IMAGES= \
     shell/public/email-m.svg \
     shell/public/github-m.svg \
     shell/public/key-m.svg \
+    shell/public/ldap-m.svg \
     shell/public/keybase-m.svg \
     shell/public/link-m.svg \
     shell/public/notification-m.svg \

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -25,6 +25,7 @@ globalSubs = [
   Meteor.subscribe("devPackages"),
   Meteor.subscribe("credentials"),
   Meteor.subscribe("accountIdentities"),
+  Meteor.subscribe("featureKey", false),
 ];
 
 Tracker.autorun(function () {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -986,6 +986,10 @@ limitations under the License.
 <template name="adminSettings">
   {{setDocumentTitle}}
   <form id="admin-settings-form">
+    <h4>Basic login providers</h4>
+
+    <p>Choose which services users may use to identify themselves. Anyone can log in, but only users you {{#linkTo route="adminInvites" data=getToken}}invite{{/linkTo}} will be able to install apps or create files.</p>
+
     <p>
       <label><input type="checkbox" class="oauth-checkbox" name="googleLogin"
                     value="value" checked={{googleSetting.value}} data-servicename="google">
@@ -993,16 +997,6 @@ limitations under the License.
         (<a class="configure-oauth" data-servicename="google" href="">configure</a>)
         (<a class="reset-login-tokens" data-servicename="google" href="">log out all users</a>)
       </label><br>
-
-      {{#if isFeatureKeyValid}}
-      <label>
-        Google Organization Domain:
-        <input type="text" name="organizationGoogle" value="{{organizationGoogle}}">
-      </label>
-      {{/if}}
-
-      <span class="details">Users within this Google Apps for Work domain will automatically be upgraded to full accounts upon logging in. Leave blank to disable.</span>
-      <br>
       {{#with googleSetting.automaticallyReset}}
         <p class="alert-danger reset-reason">
           Google login was automatically disabled
@@ -1034,25 +1028,7 @@ limitations under the License.
         </p>
       {{/with}}
       <label><input type="checkbox" name="emailTokenLogin" value="value" checked={{emailTokenEnabled}}> Enable Passwordless Email Login</label><br>
-      {{#if isFeatureKeyValid}}
-        <label>
-          Email Organization Domain:
-          <input type="text" name="organizationEmail" value="{{organizationEmail}}">
-        </label>
-        <span class="details">Users within this email domain will automatically be upgraded to full accounts upon logging in. Leave blank to disable.</span>
-        <br>
-        <hr>
-        <label>
-          <input type="checkbox" name="ldapLogin" value="value" checked={{ldapEnabled}}> Enable LDAP Login
-        </label><br>
-          <label>LDAP Url: <input id="ldapUrl" type="text" name="ldapUrl" value="{{ldapUrl}}"></label>
-          <label>LDAP DN Pattern ($USERNAME will be replaced): <input id="ldapDnPattern" type="text" name="ldapDnPattern" value="{{ldapDnPattern}}"></label>
-          <label>LDAP Base Search Dn: <input id="ldapBase" type="text" name="ldapBase" value="{{ldapBase}}"></label>
-          <label>LDAP Name Field: <input id="ldapNameField" type="text" name="ldapNameField" value="{{ldapNameField}}"></label>
-          <label>Auto-upgrade LDAP accounts: <input type="checkbox" name="organizationLdap" value="value" checked={{organizationLdap}}></label>
-        <hr>
-      {{/if}}
-      <span class="details">Choose which services users may use to identify themselves. Anyone can log in, but only users you {{#linkTo route="adminInvites" data=getToken}}invite{{/linkTo}} will be able to install apps or create files.</span></p>
+    </p>
     <p>SMTP Url: <button id="admin-settings-send-toggle">Test</button><input id="smptUrl" type="text" name="smtpUrl" value="{{smtpUrl}}"><br>
       <span class="details">Address of an SMTP relay server, like <code>smtp://user:pass@host:port</code>, which will be used by email apps and to send {{#linkTo route="adminInvites" data=getToken}}email invites{{/linkTo}}. The SMTP server should be configured to allow sending email from your Sandstorm domain and from email addresses that will be used to send invites. Read the <a href="https://docs.sandstorm.io/en/latest/administering/email/#outgoing-smtp">docs</a> for more details.</span>
     </p>
@@ -1061,6 +1037,37 @@ limitations under the License.
         Send test email to: <input id="email-test-to" type="text">
         <p><button id="admin-settings-send-test">Send</button></p>
       </p>
+    {{/if}}
+    {{#if isFeatureKeyValid}}
+      <h4>LDAP login</h4>
+      <p class="forwork-note">Sandstorm for Work feature</p>
+
+      <p><label>
+        <input type="checkbox" name="ldapLogin" value="value" checked={{ldapEnabled}}> Enable LDAP Login
+      </label><br>
+        <label>LDAP Url: <input id="ldapUrl" type="text" name="ldapUrl" value="{{ldapUrl}}"></label>
+        <label>LDAP DN Pattern ($USERNAME will be replaced): <input id="ldapDnPattern" type="text" name="ldapDnPattern" value="{{ldapDnPattern}}"></label>
+        <label>LDAP Base Search Dn: <input id="ldapBase" type="text" name="ldapBase" value="{{ldapBase}}"></label>
+        <label>LDAP Name Field: <input id="ldapNameField" type="text" name="ldapNameField" value="{{ldapNameField}}"></label></p>
+
+      <h4>SAML login</h4>
+      <p class="forwork-note">Sandstorm for Work feature</p>
+
+      <p>Coming soon!</p>
+
+      <h4>Define oragnization</h4>
+      <p class="forwork-note">Sandstorm for Work feature</p>
+
+      <p>These users will be considered part of your organization. They will automatically be
+        able to log in, install apps, and create grains.</p>
+
+      <p>
+        <label><input type="checkbox" name="isOrganizationLdap" value="value" checked={{isOrganizationLdap}}> Users authenticated via LDAP.</label><br>
+        <label><input type="checkbox" name="isOrganizationGoogle" value="value" checked={{isOrganizationGoogle}}> Users authenticated via Google Apps for Work domain:</label> <input type="text" name="organizationGoogle" value="{{organizationGoogle}}" placeholder="example.com">
+        <label><input type="checkbox" name="isOrganizationEmail" value="value" checked={{isOrganizationEmail}}>Users authenticated via passwordless email login with addresses at domain:</label> <input type="text" name="organizationEmail" value="{{organizationEmail}}" placeholder="example.com"></p>
+    {{else}}
+      <p>To get support for LDAP, SAML, and organization management, enable
+        <a href="{{featuresPath}}">Sandstorm for Work</a>.</p>
     {{/if}}
     <p><button id="admin-settings-save">Save</button></p>
   </form>
@@ -1354,8 +1361,12 @@ limitations under the License.
     {{else}}
       <div class="feature-key-button-row">
         <button class="button-primary feature-key-upload-button">Upload new feature key...</button>
+        <button class="button-secondary feature-key-delete-button">Delete feature key</button>
       </div>
     {{/if}}
+
+    <p><a href="{{settingsPath}}">Go to the settings page to configure Sandstorm for Work features.</a></p>
+
   {{else}}
     <h4>Upload feature key</h4>
     <p>To make use of Sandstorm for Work features like LDAP and SAML login and organization

--- a/shell/client/styles/_admin.scss
+++ b/shell/client/styles/_admin.scss
@@ -22,7 +22,14 @@
       }
     }
   }
+  h4 {
+    margin-bottom: 0;
+  }
   .details {
+    font-size: 70%;
+  }
+  .forwork-note {
+    margin-top: 0;
     font-size: 70%;
   }
   .alert {

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -196,19 +196,19 @@
 
 <template name="ldapLoginForm">
   <form class="ldap">
-    with ldap
+    with LDAP
 
     <label class="username">username
-      <span title="This is your LDAP username. It will be the name that you normally use to login to other internal services at your company." class="info">i</span>
+      <span title="This is your LDAP username. It will be the name that you normally use to log in to other internal services at your company." class="info">i</span>
       <input name="username" type="text">
     </label>
 
     <label class="password">password
-      <span title="This is your LDAP password. It will be the password that you normally use to login to other internal services at your company." class="info">i</span>
+      <span title="This is your LDAP password. It will be the password that you normally use to log in to other internal services at your company." class="info">i</span>
       <input name="password" type="password">
     </label>
     <div class="button-box">
-      <button class="login email">Login</button>
+      <button class="login email">Log in</button>
     </div>
   </form>
 </template>

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -991,14 +991,16 @@ _.extend(SandstormDb.prototype, {
       return false;
     }
 
-    if (identity.services.email && this.getOrganizationEmail()) {
-      let domain = "@" + this.getOrganizationEmail();
-      if (identity.services.email.email.toLowerCase().endsWith(domain)) {
+    const googleDomain = this.getOrganizationGoogle();
+    const emailDomain = this.getOrganizationEmail();
+
+    if (emailDomain && identity.services.email) {
+      if (identity.services.email.email.toLowerCase().split("@").pop() === emailDomain) {
         return true;
       }
-    } else if (identity.services.ldap && this.getOrganizationLdap()) {
+    } else if (this.getOrganizationLdap() && identity.services.ldap) {
       return true;
-    } else if (identity.services.google && this.getOrganizationGoogle()) {
+    } else if (googleDomain && identity.services.google && identity.services.google.hd) {
       let domain = this.getOrganizationGoogle();
       if (identity.services.google.hd.toLowerCase() === domain) {
         return true;


### PR DESCRIPTION
- Group the organizational management (auto-upgrade) settings together rather than putting them next to each provider, because this is an important concept and needs some explanation. New users won't understand the concept of "auto-upgrade" and could easily miss the checkbox otherwise.
- Move LDAP settings into their own section because cramming them between basic login providers created an unnatural split.
- Make auto-upgrade actually work. It din't work previously because the feature key was not subscribed except in admin routes.
- Add a button to delete the feature key, mainly for testing purposes.

![screenshot from 2016-03-10 17-04-18](https://cloud.githubusercontent.com/assets/4001805/13690256/c9d75638-e6e3-11e5-84bf-351c6d73df9b.png)
