### PR TITLE
Tweak ldap settings

### DIFF
--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -186,7 +186,7 @@ Template.adminSettings.events({
     const token = this.token;
     resetResult(state);
     if (globalDb.isFeatureKeyValid()) {
-      state.set("numSettings", 12);
+      state.set("numSettings", 13);
     } else {
       state.set("numSettings", 4);
     }
@@ -208,6 +208,7 @@ Template.adminSettings.events({
       Meteor.call("setSetting", token, "ldapBase", event.target.ldapBase.value, handleErrorBound);
       Meteor.call("setSetting", token, "ldapDnPattern", event.target.ldapDnPattern.value, handleErrorBound);
       Meteor.call("setSetting", token, "ldapNameField", event.target.ldapNameField.value, handleErrorBound);
+      Meteor.call("setSetting", token, "ldapSearchUsername", event.target.ldapSearchUsername.value, handleErrorBound);
 
       if (event.currentTarget.isOrganizationLdap.checked) {
         Meteor.call("setSetting", token, "organizationLdap", true, handleErrorBound);
@@ -331,6 +332,10 @@ Template.adminSettings.helpers({
 
   ldapNameField: function () {
     return globalDb.getLdapNameField() || "cn";
+  },
+
+  ldapSearchUsername: function () {
+    return globalDb.getLdapSearchUsername() || "uid";
   },
 
   smtpUrl: function () {

--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -140,6 +140,10 @@ Template.admin.helpers({
   getToken: getToken,
 });
 
+Template.adminSettings.onCreated(function () {
+  this.explicitDnSelected = new ReactiveVar(globalDb.getLdapExplicitDnSelected());
+});
+
 Template.adminSettings.events({
   "click .oauth-checkbox": function (event) {
     const state = Iron.controller().state;
@@ -181,12 +185,16 @@ Template.adminSettings.events({
     return false; // prevent form from submitting
   },
 
-  "submit #admin-settings-form": function (event) {
+  "submit #admin-settings-form": function (event, template) {
     const state = Iron.controller().state;
     const token = this.token;
     resetResult(state);
     if (globalDb.isFeatureKeyValid()) {
-      state.set("numSettings", 13);
+      if (template.explicitDnSelected.get()) {
+        state.set("numSettings", 12);
+      } else {
+        state.set("numSettings", 13);
+      }
     } else {
       state.set("numSettings", 4);
     }
@@ -205,10 +213,15 @@ Template.adminSettings.events({
     if (globalDb.isFeatureKeyValid()) {
       Meteor.call("setAccountSetting", token, "ldap", event.target.ldapLogin.checked, handleErrorBound);
       Meteor.call("setSetting", token, "ldapUrl", event.target.ldapUrl.value, handleErrorBound);
-      Meteor.call("setSetting", token, "ldapBase", event.target.ldapBase.value, handleErrorBound);
-      Meteor.call("setSetting", token, "ldapDnPattern", event.target.ldapDnPattern.value, handleErrorBound);
+      if (template.explicitDnSelected.get()) {
+        Meteor.call("setSetting", token, "ldapDnPattern", event.target.ldapDnPattern.value, handleErrorBound);
+      } else {
+        Meteor.call("setSetting", token, "ldapBase", event.target.ldapBase.value, handleErrorBound);
+        Meteor.call("setSetting", token, "ldapSearchUsername", event.target.ldapSearchUsername.value, handleErrorBound);
+      }
+
       Meteor.call("setSetting", token, "ldapNameField", event.target.ldapNameField.value, handleErrorBound);
-      Meteor.call("setSetting", token, "ldapSearchUsername", event.target.ldapSearchUsername.value, handleErrorBound);
+      Meteor.call("setSetting", token, "ldapExplicitDnSelected", event.target.ldapExplicitDn.value === "ldapExplicitDn", handleErrorBound);
 
       if (event.currentTarget.isOrganizationLdap.checked) {
         Meteor.call("setSetting", token, "organizationLdap", true, handleErrorBound);
@@ -232,6 +245,10 @@ Template.adminSettings.events({
     }
 
     return false;
+  },
+
+  "change input[name=\"ldapExplicitDn\"]": function (event, template) {
+    template.explicitDnSelected.set(event.target.value === "ldapExplicitDn");
   },
 });
 
@@ -336,6 +353,14 @@ Template.adminSettings.helpers({
 
   ldapSearchUsername: function () {
     return globalDb.getLdapSearchUsername() || "uid";
+  },
+
+  explicitDnSelected: function () {
+    return Template.instance().explicitDnSelected.get();
+  },
+
+  searchDnSelected: function () {
+    return !Template.instance().explicitDnSelected.get();
   },
 
   smtpUrl: function () {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -1048,6 +1048,7 @@ limitations under the License.
         <label>LDAP Url: <input id="ldapUrl" type="text" name="ldapUrl" value="{{ldapUrl}}"></label>
         <label>LDAP DN Pattern ($USERNAME will be replaced): <input id="ldapDnPattern" type="text" name="ldapDnPattern" value="{{ldapDnPattern}}"></label>
         <label>LDAP Base Search Dn: <input id="ldapBase" type="text" name="ldapBase" value="{{ldapBase}}"></label>
+        <label>LDAP Search Username Field: <input id="ldapSearchUsername" type="text" name="ldapNameField" value="{{ldapSearchUsername}}"></label>
         <label>LDAP Name Field: <input id="ldapNameField" type="text" name="ldapNameField" value="{{ldapNameField}}"></label></p>
 
       <h4>SAML login</h4>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -1046,9 +1046,17 @@ limitations under the License.
         <input type="checkbox" name="ldapLogin" value="value" checked={{ldapEnabled}}> Enable LDAP Login
       </label><br>
         <label>LDAP Url: <input id="ldapUrl" type="text" name="ldapUrl" value="{{ldapUrl}}"></label>
+
+        <input type="radio" name="ldapExplicitDn" checked="{{searchDnSelected}}"
+               value="ldapSearchDn"> Specify a Dn search query<br>
+        <input type="radio" name="ldapExplicitDn" checked="{{explicitDnSelected}}"
+               value="ldapExplicitDn"> Specify explicit Dn<br>
+        {{#if explicitDnSelected}}
         <label>LDAP DN Pattern ($USERNAME will be replaced): <input id="ldapDnPattern" type="text" name="ldapDnPattern" value="{{ldapDnPattern}}"></label>
+        {{else}}
         <label>LDAP Base Search Dn: <input id="ldapBase" type="text" name="ldapBase" value="{{ldapBase}}"></label>
         <label>LDAP Search Username Field: <input id="ldapSearchUsername" type="text" name="ldapNameField" value="{{ldapSearchUsername}}"></label>
+        {{/if}}
         <label>LDAP Name Field: <input id="ldapNameField" type="text" name="ldapNameField" value="{{ldapNameField}}"></label></p>
 
       <h4>SAML login</h4>

--- a/shell/packages/accounts-ldap/ldap_server.js
+++ b/shell/packages/accounts-ldap/ldap_server.js
@@ -52,9 +52,8 @@ LDAP.prototype.ldapCheck = function (db, options) {
   if (options.hasOwnProperty("username") && options.hasOwnProperty("ldapPass")) {
     _this.options.base = db.getLdapBase();
     _this.options.dn = db.getLdapDnPattern().replace("$USERNAME", options.username);
-    _this.options.searchBeforeBind = {
-      uid: options.username,
-    };
+    _this.options.searchBeforeBind = {};
+    _this.options.searchBeforeBind[db.getLdapSearchUsername()] = options.username;
 
     let resolved = false;
     let ldapAsyncFut = new Future();

--- a/shell/packages/accounts-ldap/ldap_server.js
+++ b/shell/packages/accounts-ldap/ldap_server.js
@@ -50,10 +50,14 @@ LDAP.prototype.ldapCheck = function (db, options) {
   options = options || {};
 
   if (options.hasOwnProperty("username") && options.hasOwnProperty("ldapPass")) {
-    _this.options.base = db.getLdapBase();
-    _this.options.dn = db.getLdapDnPattern().replace("$USERNAME", options.username);
-    _this.options.searchBeforeBind = {};
-    _this.options.searchBeforeBind[db.getLdapSearchUsername()] = options.username;
+    let explicitDnSelected = db.getLdapExplicitDnSelected();
+    if (explicitDnSelected) {
+      _this.options.dn = db.getLdapDnPattern().replace("$USERNAME", options.username);
+    } else {
+      _this.options.base = db.getLdapBase();
+      _this.options.searchBeforeBind = {};
+      _this.options.searchBeforeBind[db.getLdapSearchUsername()] = options.username;
+    }
 
     let resolved = false;
     let ldapAsyncFut = new Future();
@@ -103,7 +107,7 @@ LDAP.prototype.ldapCheck = function (db, options) {
     }
 
     // If DN is provided, use it to bind
-    if (!_this.options.base) {
+    if (explicitDnSelected) {
       // Attempt to bind to ldap server with provided info
       client.bind(_this.options.searchDN || _this.options.dn, _this.options.searchCredentials ||
           options.ldapPass,

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1289,6 +1289,11 @@ _.extend(SandstormDb.prototype, {
     return setting ? setting.value : "";  // empty if subscription is not ready.
   },
 
+  getLdapExplicitDnSelected: function () {
+    const setting = Settings.findOne({ _id: "ldapExplicitDnSelected" });
+    return setting && setting.value;
+  },
+
   getOrganizationEmail: function () {
     const setting = Settings.findOne({ _id: "organizationEmail" });
     return setting && setting.value;

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1279,6 +1279,11 @@ _.extend(SandstormDb.prototype, {
     return setting ? setting.value : "";  // empty if subscription is not ready.
   },
 
+  getLdapSearchUsername: function () {
+    const setting = Settings.findOne({ _id: "ldapSearchUsername" });
+    return setting ? setting.value : "";  // empty if subscription is not ready.
+  },
+
   getLdapNameField: function () {
     const setting = Settings.findOne({ _id: "ldapNameField" });
     return setting ? setting.value : "";  // empty if subscription is not ready.


### PR DESCRIPTION
Split ldap settings into two branches. It's now more clear that you either need to specify an explicit Dn, or provide a base DN to search on. Also added the ability to specify the username field when searching.