### PR TITLE
Restore last-opened grains on load.

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -93,6 +93,7 @@ const mapGrainStateToTemplateData = function (grainState) {
     interstitial: grainState.shouldShowInterstitial(),
     token: grainState.token(),
     viewInfo: grainState.viewInfo(),
+    grainView: grainState,
   };
   return templateData;
 };
@@ -532,7 +533,7 @@ Template.grainSharePopup.helpers({
 
 Template.requestAccess.onCreated(function () {
   this._status = new ReactiveVar({ showButton: true });
-  this._grain = getActiveGrain(globalGrains.get());
+  this._grain = this.data.grainView;
 
   this.autorun(() => {
     Meteor.userId(); // Read this value so that we resubscribe on login.

--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -63,7 +63,7 @@ GrainView = class GrainView {
     // reconstruct the same view later. However, the parentElement and initialPopup arguments
     // can't be included since they are live objects, not data.
 
-    return [ this._grainId, this._path, this._tokenInfo ];
+    return [this._grainId, this._path, this._tokenInfo];
   }
 
   reset(identityId) {
@@ -782,13 +782,13 @@ window.addEventListener("unload", () => {
       // other tab. Rather than arbitrarily clobber one tab's grains list with the other -- which
       // will likely confuse the user, opening grains in multiple places that weren't previously --
       // we will have to give up and not restore anything. :(
-      Meteor._localStorage.setItem(JSON.stringify({time: Date.now(), grains: []}));
+      Meteor._localStorage.setItem(JSON.stringify({ time: Date.now(), grains: [] }));
       return;
     }
   }
 
   Meteor._localStorage.setItem(key,
-      JSON.stringify({time: Date.now(), grains: grains.map(grain => grain.save())}));
+      JSON.stringify({ time: Date.now(), grains: grains.map(grain => grain.save()) }));
 });
 
 function restoreOpenGrains(old) {
@@ -832,6 +832,7 @@ function restoreOpenGrains(old) {
           alreadyOpenGrain = undefined;
           return result;
         }
+
         const view = new GrainView(args[0], args[1], args[2], mainContentElement);
         view.openSession();
         return view;

--- a/shell/client/grainview.js
+++ b/shell/client/grainview.js
@@ -770,7 +770,7 @@ window.addEventListener("unload", () => {
   if (!Meteor.userId()) return;
 
   const grains = globalGrains.get();
-  const key = "openGrains-" + SHA256(window.location);
+  const key = "openGrains-" + SHA256(window.location.toString());
 
   const old = Meteor._localStorage.getItem(key);
   if (old) {
@@ -782,7 +782,7 @@ window.addEventListener("unload", () => {
       // other tab. Rather than arbitrarily clobber one tab's grains list with the other -- which
       // will likely confuse the user, opening grains in multiple places that weren't previously --
       // we will have to give up and not restore anything. :(
-      Meteor._localStorage.setItem(JSON.stringify({ time: Date.now(), grains: [] }));
+      Meteor._localStorage.setItem(key, JSON.stringify({ time: Date.now(), grains: [] }));
       return;
     }
   }
@@ -831,11 +831,11 @@ function restoreOpenGrains(old) {
           const result = alreadyOpenGrain;
           alreadyOpenGrain = undefined;
           return result;
+        } else {
+          const view = new GrainView(args[0], args[1], args[2], mainContentElement);
+          view.openSession();
+          return view;
         }
-
-        const view = new GrainView(args[0], args[1], args[2], mainContentElement);
-        view.openSession();
-        return view;
       });
       if (alreadyOpenGrain) newGrains.push(alreadyOpenGrain);
       globalGrains.set(newGrains);
@@ -871,7 +871,7 @@ try {
   // Meteor has a nice package for detecting if localStorage is available, but it's internal.
   // We use it anyway. If it goes away, this will throw an exception at startup which will should
   // be really obvious and well fix it.
-  const key = "openGrains-" + SHA256(window.location);
+  const key = "openGrains-" + SHA256(window.location.toString());
   const old = Meteor._localStorage.getItem(key);
   if (old) {
     Meteor.startup(() => restoreOpenGrains(JSON.parse(old)));

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -246,6 +246,8 @@ makeDateString = function (date) {
 
 // export: used in sandstorm-ui-grainlist
 prettySize = function (size) {
+  if (!size) return "";
+
   let suffix = "B";
   if (size >= 1000000000) {
     size = size / 1000000000;

--- a/shell/lib/db-deprecated.js
+++ b/shell/lib/db-deprecated.js
@@ -76,7 +76,9 @@ if (Meteor.isServer) {
 if (Meteor.isClient) {
   Session.setDefault("shrink-navbar", false);
   globalGrains = new ReactiveVar([]);
-  Session.set("shrink-navbar", window.localStorage.getItem("shrink-navbar") === "true");
+  // If Meteor._localStorage disappears, we'll have to write our own localStorage wrapper, I guess.
+  // Using window.localStorage is dangerous because it throws an exception if cookies are disabled.
+  Session.set("shrink-navbar", Meteor._localStorage.getItem("shrink-navbar") === "true");
   globalTopbar = new SandstormTopbar(globalDb,
     {
       get() {
@@ -94,7 +96,7 @@ if (Meteor.isClient) {
       },
 
       set(value) {
-        window.localStorage.setItem("shrink-navbar", value);
+        Meteor._localStorage.setItem("shrink-navbar", value);
         Session.set("shrink-navbar", value);
       },
     });


### PR DESCRIPTION
We store the list of open grains in localStorage at shutdown and restore it at startup. We also clear the saved list at startup so that if you open a second window it doesn't open the same grains again. Additionally, we do *not* store anything when closing a window that only has one grain open (or none), as probably in this case the user is relying on browser tabs rather than our sidebar tabs and restoring the last-opened grain would be surprising.

(Also fixed a random exception I've been seeing and fixes #1578.)