### PR TITLE
Update docs to reflect the fact the we no longer depend on ImageMagick.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -115,7 +115,6 @@ Please install the following:
 * `unzip`
 * `strace`
 * `curl`
-* ImageMagick
 * discount (markdown parser)
 * [Clang compiler](http://clang.llvm.org/) version 3.4 or better
 * [Meteor](http://meteor.com)
@@ -123,7 +122,7 @@ Please install the following:
 On Debian or Ubuntu, you should be able to get all these with:
 
     sudo apt-get install build-essential libcap-dev xz-utils zip \
-        unzip imagemagick strace curl clang-3.4 discount git
+        unzip strace curl clang-3.4 discount git
     curl https://install.meteor.com/ | sh
 
 ### Get the source code


### PR DESCRIPTION
See https://github.com/sandstorm-io/sandstorm/commit/f9e5db8a488502bcf10a7d0b5cba7bcab75c6307.