### PR TITLE
Implement `tabId` to correlate sessions in a grain tab.

### DIFF
--- a/docs/developing/auth.md
+++ b/docs/developing/auth.md
@@ -40,6 +40,13 @@ related to user identity and permissions:
   SHA-256. For example: `0ba26e59c64ec75dedbc11679f267a40`.  This
   header is **not sent at all for anonymous users**.
 
+* `X-Sandstorm-Tab-Id`: Unique identifier for the grain tab in which
+  this request is taking place. This can be used to correlate multiple
+  requests being performed in the same tab even when the user is
+  anonymous. Also, for HTTP APIs, requests using the same API token
+  will have the same tab ID, to allow you to correlate requests from
+  the same client.
+
 * `X-Sandstorm-Permissions`: This contains a list of the permissions
   held by the current user, joined with a comma such as `edit,read` or
   `read`. Permissions are defined in the package's

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1357,6 +1357,8 @@ Meteor.startup(function () {
         );
 
         // Send message to event.source with URL containing id2
+        // TODO(someday): Send back the tabId that requests to this token will use? Could be
+        //   useful.
         templateLink = window.location.origin + "/offer-template.html#" + id2;
         event.source.postMessage({ rpcId: rpcId, uri: templateLink }, event.origin);
       }, (error) => {

--- a/shell/packages/sandstorm-backend/sandstorm-backend.js
+++ b/shell/packages/sandstorm-backend/sandstorm-backend.js
@@ -266,16 +266,21 @@ SandstormBackend.prototype.openSessionInternal = function (grainId, userId, iden
                  title: title,
                  grainId: grainId,
                  hostId: session.hostId,
+                 tabId: session.tabId,
                  salt: cachedSalt,
                },
              };
     }
   }
 
+  // TODO(someday): Allow caller to specify the parent session from which to inherit the tab ID, or
+  //   something.
+
   session = {
     _id: sessionId,
     grainId: grainId,
     hostId: Crypto.createHash("sha256").update(sessionId).digest("hex").slice(0, 32),
+    tabId: Crypto.createHash("sha256").update("tab:").update(sessionId).digest("hex").slice(0, 32),
     timestamp: new Date().getTime(),
     hasLoaded: false,
   };
@@ -297,6 +302,7 @@ SandstormBackend.prototype.openSessionInternal = function (grainId, userId, iden
              title: title,
              grainId: grainId,
              hostId: session.hostId,
+             tabId: session.tabId,
              salt: cachedSalt,
            },
          };

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -249,6 +249,9 @@ Sessions = new Mongo.Collection("sessions");
 //   grainId:  _id of the grain to which this session is connected.
 //   hostId: ID part of the hostname from which this grain is being served. I.e. this replaces the
 //       '*' in WILDCARD_HOST.
+//   tabId: Random value unique to the grain tab in which this session is displayed. Typically
+//       every session has a different `tabId`, but embedded sessions (including in the powerbox)
+//       have the same `tabId` as the outer session.
 //   timestamp:  Time of last keep-alive message to this session.  Sessions time out after some
 //       period.
 //   userId:  User ID of the user who owns this session.

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -37,10 +37,11 @@ ROOT_URL = Url.parse(process.env.ROOT_URL);
 HOSTNAME = ROOT_URL.hostname;
 
 SessionContextImpl = class SessionContextImpl {
-  constructor(grainId, sessionId, identityId) {
+  constructor(grainId, sessionId, identityId, tabId) {
     this.grainId = grainId;
     this.sessionId = sessionId;
     this.identityId = identityId;
+    this.tabId = tabId;
   }
 
   offer(cap, requiredPermissions, descriptor, displayInfo) {
@@ -184,8 +185,8 @@ Meteor.methods({
 });
 
 HackSessionContextImpl = class HackSessionContextImpl extends SessionContextImpl {
-  constructor(grainId, sessionId, identityId) {
-    super(grainId, sessionId, identityId);
+  constructor(grainId, sessionId, identityId, tabId) {
+    super(grainId, sessionId, identityId, tabId);
   }
 
   _getPublicId() {
@@ -386,8 +387,8 @@ HackSessionContextImpl = class HackSessionContextImpl extends SessionContextImpl
   }
 };
 
-makeHackSessionContext = (grainId, sessionId, identityId) => {
-  return new Capnp.Capability(new HackSessionContextImpl(grainId, sessionId, identityId),
+makeHackSessionContext = (grainId, sessionId, identityId, tabId) => {
+  return new Capnp.Capability(new HackSessionContextImpl(grainId, sessionId, identityId, tabId),
                               HackSessionContext);
 };
 


### PR DESCRIPTION
In the future, a grain tab may in fact be displaying multiple grains at once, and thus multiple sessions. This can happen when the Picker Powerbox is displaying an embedded picker, or when a grain embeds other grains (e.g. the "Tabbify" proposal). It may also be useful for a single grain to recognize server-side when multiple sequential back-end sessions actually come from the same tab, as occurs e.g. when the user suspends their laptop and then comes back later without refreshing their browser.

In some cases it may be helpful if these grains can recognize that they live in the same tab. Hence we generate a `tabId` which is passed to `newSession()` and uniquely identifies the tab.

The current motivating use case is one where the Powerbox is being used in an authentication interaction: The app wishes the user to "verify" their email address via a powerbox query. The user chooses which address to verify, and a verification capability is returned. We need to make sure the app cannot take this verification capability and pass it off to other users who can then "authenticate" as the address to other apps. To do that, each app needs to be able to check that the verification was actually created by this session's user. We could do this by attaching verification to user IDs, but that would not work in the case that the user is anonymous. Tab IDs are assigned even to anonymous users.