### PR TITLE
Make sure to fill in profile defaults for the 'added by' column.

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -958,6 +958,7 @@ Template.whoHasAccessPopup.helpers({
     let identity = ContactProfiles.findOne({ _id: identityId });
     if (!identity) {
       identity = Meteor.users.findOne({ _id: identityId });
+      SandstormDb.fillInProfileDefaults(identity);
     }
 
     if (identity) {


### PR DESCRIPTION
Fixes https://github.com/sandstorm-io/sandstorm/issues/679. Note that when you link a new identity, you are not required to fill in profile information for it, so `profile.name` being empty needs to be handled. Note also that the `ContactsProfiles` pseudocollection already fills in the defaults in the non-self case.