### PR TITLE
GrainViewList

### DIFF
--- a/shell/.meteor/packages
+++ b/shell/.meteor/packages
@@ -47,6 +47,7 @@ sandstorm-ui-applist
 sandstorm-ui-app-details
 sandstorm-ui-app-install
 sandstorm-ui-grainlist
+sandstorm-ui-grainview
 sandstorm-ui-autocomplete-input
 sandstorm-ui-powerbox
 meteor-node-forge

--- a/shell/.meteor/versions
+++ b/shell/.meteor/versions
@@ -96,6 +96,7 @@ sandstorm-ui-app-install@0.1.0
 sandstorm-ui-applist@0.1.0
 sandstorm-ui-autocomplete-input@0.1.0
 sandstorm-ui-grainlist@0.1.0
+sandstorm-ui-grainview@0.1.0
 sandstorm-ui-powerbox@0.1.0
 sandstorm-ui-topbar@0.1.0
 service-configuration@1.0.5

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1431,9 +1431,8 @@ Router.map(function () {
         const openView = function openView() {
           const mainContentElement = document.querySelector("body>.main-content");
           if (mainContentElement) {
-            const grainToOpen = new GrainView(globalGrains, grainId, path, undefined,
-                                              mainContentElement, initialPopup);
-            globalGrains.add(grainToOpen);
+            const grainToOpen = globalGrains.addNewGrainView(grainId, path, undefined,
+                                                             mainContentElement, initialPopup);
             grainToOpen.openSession();
             globalGrains.setActive(grainId);
           } else {
@@ -1493,10 +1492,9 @@ Router.map(function () {
           const openView = function openView() {
             const mainContentElement = document.querySelector("body>.main-content");
             if (mainContentElement) {
-              const grainToOpen = new GrainView(globalGrains, grainId, path, tokenInfo,
-                                                mainContentElement);
+              const grainToOpen = globalGrains.addNewGrainView(grainId, path, tokenInfo,
+                                                               mainContentElement);
               grainToOpen.openSession();
-              globalGrains.add(grainToOpen);
               globalGrains.setActive(grainId);
             } else {
               Meteor.defer(openView);

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -55,12 +55,7 @@ logoutSandstorm = function () {
     sessionStorage.removeItem("linkingIdentityLoginToken");
     Accounts._loginButtonsSession.closeDropdown();
     globalTopbar.closePopup();
-    const openGrains = globalGrains.get();
-    openGrains.forEach(function (grain) {
-      grain.destroy();
-    });
-
-    globalGrains.set([]);
+    globalGrains.clear();
     Router.go("root");
   });
 };
@@ -550,7 +545,7 @@ Template.layout.helpers({
     const route = Router.current().route.getName();
     if (route === "shared") return;
     if (route === "grain") {
-      if (_.some(globalGrains.get(), function (grain) {
+      if (_.some(globalGrains.getAll(), function (grain) {
         return grain.isActive() && !grain.isOwner();
       })) {
 

--- a/shell/lib/db-deprecated.js
+++ b/shell/lib/db-deprecated.js
@@ -75,7 +75,8 @@ if (Meteor.isServer) {
 
 if (Meteor.isClient) {
   Session.setDefault("shrink-navbar", false);
-  globalGrains = new ReactiveVar([]);
+  globalGrains = new GrainViewList();
+
   // If Meteor._localStorage disappears, we'll have to write our own localStorage wrapper, I guess.
   // Using window.localStorage is dangerous because it throws an exception if cookies are disabled.
   Session.set("shrink-navbar", Meteor._localStorage.getItem("shrink-navbar") === "true");

--- a/shell/packages/accounts-identity/accounts-identity-client.js
+++ b/shell/packages/accounts-identity/accounts-identity-client.js
@@ -259,11 +259,9 @@ const CURRENT_IDENTITY_KEY = "Accounts.CurrentIdentityId";
 Accounts.getCurrentIdentityId = function () {
   // TODO(cleanup): `globalGrains` is only in scope here because of a Meteor bug. We should figure
   //   out a better way to track a reference to it.
-  const grainList = globalGrains.get();
-  for (let i = 0; i < grainList.length; i++) {
-    if (grainList[i].isActive()) {
-      return grainList[i].identityId();
-    }
+  const activeGrain = globalGrains.getActive();
+  if (activeGrain) {
+    return activeGrain.identityId();
   }
 
   const identityId = Session.get(CURRENT_IDENTITY_KEY);
@@ -280,11 +278,9 @@ Accounts.setCurrentIdentityId = function (identityId) {
 
   // TODO(cleanup): `globalGrains` is only in scope here because of a Meteor bug. We should figure
   //   out a better way to track a reference to it.
-  const grainList = globalGrains.get();
-  for (let i = 0; i < grainList.length; i++) {
-    if (grainList[i].isActive()) {
-      return grainList[i].switchIdentity(identityId);
-    }
+  const activeGrain = globalGrains.getActive();
+  if (activeGrain) {
+    return activeGrain.switchIdentity(identityId);
   }
 
   Session.set(CURRENT_IDENTITY_KEY, identityId);

--- a/shell/packages/accounts-identity/package.js
+++ b/shell/packages/accounts-identity/package.js
@@ -21,7 +21,7 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.use("ecmascript");
-  api.use(["underscore", "random", "sandstorm-db", "sandstorm-backend", "mongo"]);
+  api.use(["underscore", "random", "reactive-var", "sandstorm-db", "sandstorm-backend", "mongo"]);
   api.use("accounts-base", ["client", "server"]);
   api.use(["session", "templating"], ["client"]);
   api.imply("accounts-base", ["client", "server"]);

--- a/shell/packages/sandstorm-ui-grainview/grainview-list.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview-list.js
@@ -1,0 +1,247 @@
+GrainViewList = class GrainViewList {
+  constructor() {
+    this._grains = new ReactiveVar([]);
+
+    // Restore last-open grain list for the same URL.
+
+    // Meteor has a nice package for detecting if localStorage is available, but it's internal.
+    // We use it anyway. If it goes away, this will throw an exception at startup which will should
+    // be really obvious and well fix it.
+    const key = "openGrains-" + SHA256(window.location.toString());
+    const old = Meteor._localStorage.getItem(key);
+    if (old) {
+      Meteor.startup(() => this.restoreOpenGrains(JSON.parse(old)));
+      Meteor._localStorage.removeItem(key);
+    }
+
+    window.addEventListener("unload", () => {
+      // If more than one grain is open, save a list to restore later. We don't save if just one grain
+      // because people who like to open grains in separate browser tabs probably don't want this
+      // feature. Also, anonymous users who can only open one grain at a time (because they have no
+      // sidebar) would probably be surprised to find the grain re-open if they return to Sandstorm
+      // later.
+
+      // Don't save anything if the user isn't logged in, because users who aren't logged in can't
+      // see the sidebar and probably would be surprised that Sandstorm remembers what they had
+      // opened.
+      if (!Meteor.userId()) return;
+
+      const grains = this._grains.get();
+      const key = "openGrains-" + SHA256(window.location.toString());
+
+      const old = Meteor._localStorage.getItem(key);
+      if (old) {
+        const oldParsed = JSON.parse(old);
+
+        if (oldParsed.time > Date.now() - 5000) {
+          // Crap. It seems that some other tab was closed in the last 5 seconds that had the same
+          // URL (perhaps a common one like "/apps"). We have no way to distinguish our tab from this
+          // other tab. Rather than arbitrarily clobber one tab's grains list with the other --
+          // which will likely confuse the user, opening grains in multiple places that weren't
+          // previously -- we will have to give up and not restore anything. :(
+          Meteor._localStorage.setItem(key, JSON.stringify({ time: Date.now(), grains: [] }));
+          return;
+        }
+      }
+
+      Meteor._localStorage.setItem(key,
+          JSON.stringify({ time: Date.now(), grains: grains.map(grain => grain.save()) }));
+    });
+
+    let lastUserId = Meteor.userId();
+    Tracker.autorun(() => {
+      const currentUserId = Meteor.userId();
+      if (currentUserId !== lastUserId) {
+        const current = Router.current();
+        if (current.route.getName() === "grain" || current.route.getName() === "shared") {
+          current.state.set("beforeActionHookRan", false);
+        }
+
+        this.clear();
+        lastUserId = currentUserId;
+      }
+    });
+  }
+
+  clear() {
+    const grains = this._grains.get();
+    grains.forEach(function (grain) {
+      grain.destroy();
+    });
+
+    this._grains.set([]);
+  }
+
+  getAll() {
+    return this._grains.get();
+  }
+
+  getById(grainId) {
+    check(grainId, String);
+
+    const grains = this._grains.get();
+    for (let i = 0; i < grains.length; i++) {
+      const grain = grains[i];
+      if (grains[i].grainId() === grainId) {
+        return grains[i];
+      }
+    }
+
+    return null;
+  }
+
+  getByOrigin(origin) {
+    check(origin, String);
+
+    const grains = this._grains.get();
+    for (let i = 0; i < grains.length; i++) {
+      if (grains[i].origin() === origin) {
+        return grains[i];
+      }
+    }
+
+    return null;
+  }
+
+  add(grainview) {
+    const grains = this._grains.get();
+    grains.push(grainview);
+    this._grains.set(grains);
+  }
+
+  remove(grainId, updateActive) {
+    check(grainId, String);
+    const grains = this._grains.get();
+    let newActiveIdx;
+    for (let idx = 0; idx < grains.length; idx++) {
+      const grain = grains[idx];
+      if (grain.grainId() === grainId) {
+        const wasActive = grain.isActive();
+        grain.destroy();
+        grains.splice(idx, 1);
+        if (updateActive && grains.length == 0) {
+          Router.go("grains");
+        } else if (updateActive && wasActive) {
+          const newActiveIdx = (idx == grains.length ? idx - 1 : idx);
+          grains[newActiveIdx].setActive(true);
+          Router.go(grains[newActiveIdx].route());
+        }
+
+        this._grains.set(grains);
+        return;
+      }
+    }
+  }
+
+  setActive(grainId) {
+    check(grainId, String);
+    const grains = this._grains.get();
+    for (let i = 0; i < grains.length; i++) {
+      const grain = grains[i];
+      if (grain.grainId() === grainId) {
+        if (!grain.isActive()) {
+          grain.setActive(true);
+        }
+      } else {
+        if (grain.isActive()) {
+          grain.setActive(false);
+        }
+      }
+    }
+  }
+
+  setAllInactive() {
+    this._grains.get().forEach(function (grain) {
+      if (grain.isActive()) {
+        grain.setActive(false);
+      }
+    });
+  }
+
+  getActive() {
+    const grains = this._grains.get();
+    for (let i = 0; i < grains.length; i++) {
+      if (grains[i].isActive()) {
+        return grains[i];
+      }
+    }
+
+    return null;
+  }
+
+  restoreOpenGrains(old) {
+    // Load last-opened grain list, if any.
+
+    if (old.grains.length === 0) return;
+
+    const mainContentElement = document.querySelector("body>.main-content");
+    if (!mainContentElement) {
+      // Main content doesn't exist yet. Defer.
+      Meteor.defer(() => this.restoreOpenGrains(old));
+      return;
+    }
+
+    const ready = () => {
+      if (Meteor.loggingIn()) return false;
+
+      for (const i in globalSubs) {
+        if (!globalSubs[i].ready()) return false;
+      }
+
+      return true;
+    };
+
+    // Open all view sessions as soon as we're fully loaded.
+    onceConditionIsTrue(ready, () => this.restore(old, mainContentElement));
+  }
+
+  restore(old, mainContentElement) {
+    const alreadyOpen = this._grains.get();
+
+    if (alreadyOpen.length > 1) {
+      // It would be bad to overwrite the grain list if something is open already. This should
+      // never happen, though, because the /grain and /shared routes won't begin to render until
+      // all subscriptions are ready.
+      console.error("Couldn't restore grain list because multiple grains are already open.");
+    } else {
+      let alreadyOpenGrain = alreadyOpen[0];  // maybe undefined
+
+      const newGrains = old.grains.map(args => {
+        if (alreadyOpenGrain && alreadyOpenGrain.grainId() === args[0]) {
+          // Inject the already-open grain into the grain list here to maintain ordering.
+          const result = alreadyOpenGrain;
+          alreadyOpenGrain = undefined;
+          return result;
+        } else {
+          const view = new GrainView(this, args[0], args[1], args[2], mainContentElement);
+          view.openSession();
+          return view;
+        }
+      });
+      if (alreadyOpenGrain) newGrains.push(alreadyOpenGrain);
+      this._grains.set(newGrains);
+    }
+  }
+};
+
+try {
+  // We want to clear "openGrains" entries more than a week old since those windows are
+  // probably never going to be restored. We can't use Meteor._localStorage for this because
+  // it doesn't provide a way to iterate over all keys. So we use window.localStorage in a
+  // try/catch.
+  const keys = new Array(window.localStorage.length);
+  for (let i = 0; i < keys.length; i++) {
+    keys[i] = window.localStorage.key(i);
+  }
+
+  keys.forEach(key => {
+    if (key.startsWith("openGrains-")) {
+      if (JSON.parse(window.localStorage.getItem(key)).time < Date.now() - 86400000 * 7) {
+        // This is more than a week old. Delete.
+        delete window.localStorage[key];
+      }
+    }
+  });
+} catch (e) {
+  console.error(e);
+}

--- a/shell/packages/sandstorm-ui-grainview/grainview-list.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview-list.js
@@ -107,10 +107,12 @@ GrainViewList = class GrainViewList {
     return null;
   }
 
-  add(grainview) {
+  addNewGrainView(grainId, path, tokenInfo, parentElement, initialPopup) {
     const grains = this._grains.get();
+    const grainview = new GrainView(this, grainId, path, tokenInfo, parentElement, initialPopup);
     grains.push(grainview);
     this._grains.set(grains);
+    return grainview;
   }
 
   remove(grainId, updateActive) {
@@ -200,10 +202,7 @@ GrainViewList = class GrainViewList {
     };
 
     // Open all view sessions as soon as we're fully loaded.
-    onceConditionIsTrue(ready, () => {
-      console.log("is ready: " + JSON.stringify(old));
-      this.restore(old, mainContentElement);
-    });
+    onceConditionIsTrue(ready, () => this.restore(old, mainContentElement));
   }
 
   restore(old, mainContentElement) {

--- a/shell/packages/sandstorm-ui-grainview/grainview-list.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview-list.js
@@ -49,7 +49,11 @@ GrainViewList = class GrainViewList {
     });
 
     this._grainsUserId = new ReactiveVar(Meteor.userId());
-    Tracker.autorun(() => {
+
+    // Although only ever construct a single global GrainViewList, and therefore we never need to
+    // stop() the below autorun(), it's probably a good idea keep a reference to the handle, just in
+    // case we need it someday.
+    this._autoclearHandle = Tracker.autorun(() => {
       const currentUserId = Meteor.userId();
       if (currentUserId !== this._grainsUserId.get()) {
         const current = Router.current();
@@ -61,7 +65,7 @@ GrainViewList = class GrainViewList {
         this._grainsUserId.set(currentUserId);
       }
     });
-  }
+  };
 
   clear() {
     const grains = this._grains.get();

--- a/shell/packages/sandstorm-ui-grainview/grainview.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview.js
@@ -1,7 +1,7 @@
 let counter = 0;
 
 GrainView = class GrainView {
-  constructor(grainId, path, tokenInfo, parentElement, initialPopup) {
+  constructor(grains, grainId, path, tokenInfo, parentElement, initialPopup) {
     // `path` starts with a slash and includes the query and fragment.
     //
     // Owned grains:
@@ -19,6 +19,9 @@ GrainView = class GrainView {
     //   callback sets error, openingSession on failure
     //                 grainId, sessionId, title, and session Sub on success
 
+    check(grains, GrainViewList);
+
+    this._grains = grains;
     this._grainId = grainId;
     this._originalPath = path;
     this._path = path;
@@ -433,21 +436,13 @@ GrainView = class GrainView {
   }
 
   _redirectFromShareLink() {
-
     // We should remove this tab from the tab list, since the /grain/<grainId> route
     // will set up its own tab for this grain.  There could even already be a tab open, if the
     // user reuses a /shared/ link.
-    this.destroy();
-    const allGrains = globalGrains.get();
-    for (let i = 0; i < allGrains.length; i++) {
-      if (allGrains[i] === this) {
-        allGrains.splice(i, 1);
-        globalGrains.set(allGrains);
-      }
-    }
 
-    return Router.go("/grain/" + this._tokenInfo.grainId + this._path, {},
-                     { replaceState: true });
+    this._grains.remove(this._grainId, false);
+    Router.go("/grain/" + this._tokenInfo.grainId + this._path, {},
+              { replaceState: true });
   }
 
   _addSessionObserver(sessionId) {
@@ -744,7 +739,7 @@ GrainView = class GrainView {
   }
 };
 
-const onceConditionIsTrue = (condition, continuation) => {
+onceConditionIsTrue = (condition, continuation) => {
   Tracker.nonreactive(() => {
     Tracker.autorun((handle) => {
       if (!condition()) {
@@ -757,124 +752,3 @@ const onceConditionIsTrue = (condition, continuation) => {
   });
 };
 
-window.addEventListener("unload", () => {
-  // If more than one grain is open, save a list to restore later. We don't save if just one grain
-  // because people who like to open grains in separate browser tabs probably don't want this
-  // feature. Also, anonymous users who can only open one grain at a time (because they have no
-  // sidebar) would probably be surprised to find the grain re-open if they return to Sandstorm
-  // later.
-
-  // Don't save anything if the user isn't logged in, because users who aren't logged in can't
-  // see the sidebar and probably would be surprised that Sandstorm remembers what they had
-  // opened.
-  if (!Meteor.userId()) return;
-
-  const grains = globalGrains.get();
-  const key = "openGrains-" + SHA256(window.location.toString());
-
-  const old = Meteor._localStorage.getItem(key);
-  if (old) {
-    const oldParsed = JSON.parse(old);
-
-    if (oldParsed.time > Date.now() - 5000) {
-      // Crap. It seems that some other tab was closed in the last 5 seconds that had the same
-      // URL (perhaps a common one like "/apps"). We have no way to distinguish our tab from this
-      // other tab. Rather than arbitrarily clobber one tab's grains list with the other -- which
-      // will likely confuse the user, opening grains in multiple places that weren't previously --
-      // we will have to give up and not restore anything. :(
-      Meteor._localStorage.setItem(key, JSON.stringify({ time: Date.now(), grains: [] }));
-      return;
-    }
-  }
-
-  Meteor._localStorage.setItem(key,
-      JSON.stringify({ time: Date.now(), grains: grains.map(grain => grain.save()) }));
-});
-
-function restoreOpenGrains(old) {
-  // Load last-opened grain list, if any.
-
-  if (old.grains.length === 0) return;
-
-  const mainContentElement = document.querySelector("body>.main-content");
-  if (!mainContentElement) {
-    // Main content doesn't exist yet. Defer.
-    Meteor.defer(() => restoreOpenGrains(old));
-    return;
-  }
-
-  const ready = () => {
-    if (Meteor.loggingIn()) return false;
-
-    for (const i in globalSubs) {
-      if (!globalSubs[i].ready()) return false;
-    }
-
-    return true;
-  };
-
-  // Open all view sessions as soon as we're fully loaded.
-  onceConditionIsTrue(ready, () => {
-    const alreadyOpen = globalGrains.get();
-
-    if (alreadyOpen.length > 1) {
-      // It would be bad to overwrite the grain list if something is open already. This should
-      // never happen, though, because the /grain and /shared routes won't begin to render until
-      // all subscriptions are ready.
-      console.error("Couldn't restore grain list because multiple grains are already open.");
-    } else {
-      let alreadyOpenGrain = alreadyOpen[0];  // maybe undefined
-
-      const newGrains = old.grains.map(args => {
-        if (alreadyOpenGrain && alreadyOpenGrain.grainId() === args[0]) {
-          // Inject the already-open grain into the grain list here to maintain ordering.
-          const result = alreadyOpenGrain;
-          alreadyOpenGrain = undefined;
-          return result;
-        } else {
-          const view = new GrainView(args[0], args[1], args[2], mainContentElement);
-          view.openSession();
-          return view;
-        }
-      });
-      if (alreadyOpenGrain) newGrains.push(alreadyOpenGrain);
-      globalGrains.set(newGrains);
-    }
-  });
-}
-
-try {
-  // We want to clear "openGrains" entries more than a week old since those windows are
-  // probably never going to be restored. We can't use Meteor._localStorage for this because
-  // it doesn't provide a way to iterate over all keys. So we use window.localStorage in a
-  // try/catch.
-  const keys = new Array(window.localStorage.length);
-  for (let i = 0; i < keys.length; i++) {
-    keys[i] = window.localStorage.key(i);
-  }
-
-  keys.forEach(key => {
-    if (key.startsWith("openGrains-")) {
-      if (JSON.parse(window.localStorage.getItem(key)).time < Date.now() - 86400000 * 7) {
-        // This is more than a week old. Delete.
-        delete window.localStorage[key];
-      }
-    }
-  });
-} catch (e) {
-  console.error(e);
-}
-
-{
-  // Restore last-open grain list for the same URL.
-
-  // Meteor has a nice package for detecting if localStorage is available, but it's internal.
-  // We use it anyway. If it goes away, this will throw an exception at startup which will should
-  // be really obvious and well fix it.
-  const key = "openGrains-" + SHA256(window.location.toString());
-  const old = Meteor._localStorage.getItem(key);
-  if (old) {
-    Meteor.startup(() => restoreOpenGrains(JSON.parse(old)));
-    Meteor._localStorage.removeItem(key);
-  }
-}

--- a/shell/packages/sandstorm-ui-grainview/package.js
+++ b/shell/packages/sandstorm-ui-grainview/package.js
@@ -1,0 +1,29 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Package.describe({
+  summary: "Sandstorm package containing GrainView and GrainViewList classes.",
+  version: "0.1.0",
+});
+
+Package.onUse(function (api) {
+  api.use(["ecmascript"]);
+  api.use(["check", "underscore", "tracker", "accounts-base", "sha", "iron:router"], ["client"]);
+  api.addFiles(["grainview.js", "grainview-list.js"], "client");
+  api.export("GrainView");
+  api.export("GrainViewList");
+});
+

--- a/shell/packages/sandstorm-ui-grainview/package.js
+++ b/shell/packages/sandstorm-ui-grainview/package.js
@@ -21,7 +21,8 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.use(["ecmascript"]);
-  api.use(["check", "underscore", "tracker", "accounts-base", "sha", "iron:router"], ["client"]);
+  api.use(["check", "underscore", "tracker", "accounts-base", "sha",
+           "reactive-var", "iron:router", "accounts-identity",], ["client"]);
   api.addFiles(["grainview.js", "grainview-list.js"], "client");
   api.export("GrainView");
   api.export("GrainViewList");

--- a/shell/packages/sandstorm-ui-grainview/package.js
+++ b/shell/packages/sandstorm-ui-grainview/package.js
@@ -22,7 +22,8 @@ Package.describe({
 Package.onUse(function (api) {
   api.use(["ecmascript"]);
   api.use(["check", "underscore", "tracker", "accounts-base", "sha",
-           "reactive-var", "iron:router", "accounts-identity",], ["client"]);
+           "reactive-var", "iron:router", "accounts-identity",
+          ], ["client"]);
   api.addFiles(["grainview.js", "grainview-list.js"], "client");
   api.export("GrainView");
   api.export("GrainViewList");

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -80,7 +80,7 @@ Template.sandstormTopbar.helpers({
 
   grains: function () {
     const topbar = Template.instance().data;
-    const grains = topbar._grains.get();
+    const grains = topbar._grains.getAll();
     const data = grains.map(function (grain) {
       grain.depend();
       return {
@@ -98,7 +98,7 @@ Template.sandstormTopbar.helpers({
 
   grainCount: function () {
     const topbar = Template.instance().data;
-    const grains = topbar._grains.get();
+    const grains = topbar._grains.getAll();
     return grains.length;
   },
 
@@ -255,43 +255,7 @@ Template.sandstormTopbar.events({
   "click .navbar .close-button": function (event) {
     const grainId = event.currentTarget.parentNode.getAttribute("data-grainid");
     const topbar = Template.instance().data;
-    const grains = topbar._grains.get();
-
-    let activeIndex = -1;
-    let closeIndex = -1;
-    grains.forEach(function (grain, i) {
-      if (grain.isActive()) {
-        activeIndex = i;
-      }
-
-      if (grain.grainId() == grainId) {
-        closeIndex = i;
-        grain.destroy();
-      }
-    });
-
-    if (grains.length == 1) {
-      // Redirect to /grain/ after closing the last grain, if it was the active view.
-      topbar._grains.set([]);
-      if (activeIndex == 0) {
-        Router.go("grains");
-      }
-
-      return;
-    }
-
-    if (activeIndex == closeIndex) {
-      // If the user closed the active grain, redirect to the next one after closing this one.
-      const newActiveIndex = (activeIndex == grains.length - 1) ? activeIndex - 1 : activeIndex;
-      // Unless the active grain was the last one, in which case redirect to the previous one.
-      grains.splice(closeIndex, 1);
-      grains[newActiveIndex].setActive(true);
-      topbar._grains.set(grains);
-      Router.go(grains[newActiveIndex].route());
-    } else {
-      grains.splice(closeIndex, 1);
-      topbar._grains.set(grains);
-    }
+    topbar._grains.remove(grainId, true);
   },
 
   "click .demo-notice .sign-in": function (event) {

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -241,6 +241,17 @@ module.exports["Sign in at grain URL"] = function (browser) {
     });
 }
 
+module.exports["Logging out closes grain"] = function (browser) {
+  browser
+    .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
+    .waitForElementVisible("#grainTitle", medium_wait)
+    .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
+    .execute("window.Meteor.logout()")
+    .waitForElementVisible(".request-access", medium_wait)
+    .assert.containsText(".request-access", "Please sign in to request access.")
+    .end()
+}
+
 module.exports["Test grain anonymous user"] = function (browser) {
   browser
     // Upload app as normal user

--- a/tests/tests/restore-open-grains.js
+++ b/tests/tests/restore-open-grains.js
@@ -89,5 +89,5 @@ module.exports["Test restore open grains"] = function (browser) {
               });
           });
       });
-    })
+    });
 }

--- a/tests/tests/restore-open-grains.js
+++ b/tests/tests/restore-open-grains.js
@@ -1,0 +1,93 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var utils = require('../utils'),
+    appDetailsTitleSelector = utils.appDetailsTitleSelector,
+    appSelector = utils.appSelector,
+    actionSelector = utils.actionSelector,
+    short_wait = utils.short_wait,
+    medium_wait = utils.medium_wait,
+    long_wait = utils.long_wait,
+    very_long_wait = utils.very_long_wait;
+var path = require('path');
+var assetsPath = path.resolve(__dirname, '../assets');
+var expectedHackerCMSButtonText = 'New Hacker CMS site';
+var expectedHackerCMSGrainTitle = 'Untitled Hacker CMS site';
+var expectedGitWebGrainTitle = 'Untitled GitWeb repository';
+var hackerCmsAppId = "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh";
+
+
+module.exports["Test restore open grains"] = function (browser) {
+  browser
+    // Create three Hacker CMS grains.
+    .installApp("http://sandstorm.io/apps/ssjekyll8.spk",
+                "ca690ad886bf920026f8b876c19539c1",
+                hackerCmsAppId)
+    .waitForElementVisible("#grainTitle", medium_wait)
+    .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
+
+    .click(".navitem-create-grain>a")
+    .waitForElementVisible(".app-list", medium_wait)
+    .click(appSelector(hackerCmsAppId))
+    .waitForElementVisible(actionSelector, short_wait)
+    .click(actionSelector)
+    .waitForElementVisible("#grainTitle", medium_wait)
+    .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
+
+    .click(".navitem-create-grain>a")
+    .waitForElementVisible(".app-list", medium_wait)
+    .click(appSelector(hackerCmsAppId))
+    .waitForElementVisible(actionSelector, short_wait)
+    .click(actionSelector)
+    .waitForElementVisible("#grainTitle", medium_wait)
+    .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
+
+    .execute(function () {
+      var result = [];
+      var tabs = document.querySelectorAll(".navbar-grains>li");
+      for (var ii = 0; ii < tabs.length; ++ii) {
+        result.push(tabs[ii].getAttribute("data-grainid"))
+      }
+      return result;
+    }, [], function (response) {
+      var grainIds = response.value;
+      browser.assert.equal(grainIds.length, 3);
+      browser.url(function (restoreUrl) {
+        browser
+          .url(restoreUrl.value) // Triggers a page reload.
+          .waitForElementVisible(".navbar-grains>li[data-grainid='" + grainIds[0] + "']", medium_wait)
+          .waitForElementVisible(".navbar-grains>li[data-grainid='" + grainIds[1] + "']", medium_wait)
+          .waitForElementVisible(".navbar-grains>li[data-grainid='" + grainIds[2] + "']", medium_wait)
+          .execute(function (){
+            return document.querySelectorAll(".navbar-grains>li").length;
+          }, [], function (response) {
+            browser.assert.equal(response.value, 3);
+            browser
+              .click(".navbar-grains>li[data-grainid='" + grainIds[0] + "']>button.close-button")
+              .click(".navbar-grains>li[data-grainid='" + grainIds[1] + "']>button.close-button")
+              .click(".navbar-grains>li[data-grainid='" + grainIds[2] + "']>button.close-button")
+              .execute(function (){
+                return document.querySelectorAll(".navbar-grains>li").length;
+              }, [], function (response) {
+                browser.assert.equal(response.value, 0);
+                browser.end();
+              });
+          });
+      });
+    })
+}


### PR DESCRIPTION
This defines a new class `GrainViewList` for the value held by `globalGrains`. The list is automatically cleared whenever `Meteor.userId()` is detected to have changed. When an oauth identity is linked, the grain restoration logic is postponed until the linking is complete, so that the automatic clearing does not destroy any open grains.

Fixes #1625. (@kentonv: I don't fully understand your comment about membranes there. I think it suffices to remove the grain iframe from the DOM, because that should cause any javascript associated with the grain to stop executing.)