### PR TITLE
mailConfig.port is a string

### DIFF
--- a/shell/packages/sandstorm-email/email.js
+++ b/shell/packages/sandstorm-email/email.js
@@ -19,7 +19,7 @@ const makePool = function (mailConfig) {
   const pool = simplesmtp.createClientPool(
     mailConfig.port,
     mailConfig.hostname,
-    { secureConnection: (mailConfig.port === 465),
+    { secureConnection: (mailConfig.port === "465"),
       // XXX allow maxConnections to be configured?
       auth, });
 


### PR DESCRIPTION
After https://github.com/sandstorm-io/sandstorm/pull/1644, I noticed that I could no longer send email. This fixes the problem.