### PR TITLE
Check that immediately after demo upgrade, the current identity is the non-demo identity.

### DIFF
--- a/tests/tests/account.js
+++ b/tests/tests/account.js
@@ -32,6 +32,7 @@ module.exports["Test link identities"] = function (browser) {
   var devName1 = "A" + crypto.randomBytes(10).toString("hex");
   var devName2 = "A" + crypto.randomBytes(10).toString("hex");
   var devName3 = "A" + crypto.randomBytes(10).toString("hex");
+  var devIdentityId1 = crypto.createHash("sha256").update("dev:" + devName1).digest("hex");
   var devIdentityId3 = crypto.createHash("sha256").update("dev:" + devName3).digest("hex");
   browser
     .init()
@@ -49,6 +50,9 @@ module.exports["Test link identities"] = function (browser) {
     .submitForm(".login-buttons-list form.dev")
     .waitForElementVisible("form.account-profile-editor", short_wait) // confirm profile
     .submitForm("form.account-profile-editor")
+    .execute(function () { return Accounts.getCurrentIdentityId(); }, [], function (response) {
+      browser.assert.equal(response.value, devIdentityId1)
+    })
     .execute("window.Meteor.logout()")
 
     // Linking the first identity to a new account should fail.


### PR DESCRIPTION
A logged-in user has a "current identity" for each open grain, as well as one for the Sandstorm shell in general. Currently we make sure that after a demo user upgrades, their shell current identity is equal to their non-demo identity.

We do not switch the identity on any other grains. User testing has suggested that it would maybe be less confusing if we did switch those identities, including for any open grain views. However, I'm not entirely convinced that's the correct behavior, as there may be some apps that present a completely different view for different identities, so automatically switching identities for them could make it seem like data has been lost. In any case, switching the identities would not be a completely trivial change. If we decide that's the way to go, we should open an issue for it.

