### PR TITLE
Refactor Picker Powerbox so that query matching happens on the server side.

### DIFF
--- a/shell/.jscsrc
+++ b/shell/.jscsrc
@@ -8,5 +8,6 @@
   "maximumLineLength": 10000,
   "requirePaddingNewLinesBeforeLineComments": false,
   "requireShorthandArrowFunctions": false,
+  "disallowQuotedKeysInObjects": false,  # https://github.com/jscs-dev/node-jscs/issues/2183
   "excludeFiles": ['.meteor', '**/node_modules', 'public/*']
 }

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1308,8 +1308,8 @@ Meteor.startup(function () {
       check(powerboxRequest, {
         // TODO: be more strict, and check more fields, once the test apps are more conformant
         rpcId: Match.Any,
-        query: Match.Optional([Object]), // TODO: be more precise, and also make non-optional once tests are updated to provide a query
-        saveLabel: Match.Optional(String),
+        query: Match.Optional([String]),
+        saveLabel: Match.Optional(Match.ObjectIncluding({ defaultText: String })),
       });
 
       const powerboxRequestInfo = {

--- a/shell/packages/sandstorm-ui-powerbox/package.js
+++ b/shell/packages/sandstorm-ui-powerbox/package.js
@@ -20,7 +20,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use(["ecmascript", "check", "reactive-var", "templating", "tracker", "underscore", "sandstorm-db", "sandstorm-ui-topbar"], "client");
+  api.use(["ecmascript", "check", "reactive-var", "templating", "tracker", "underscore", "sandstorm-db", "sandstorm-ui-topbar", "mongo"], "client");
   api.use(["ecmascript", "check"], "server");
   api.addFiles(["powerbox.html", "powerbox-client.js"], "client");
   api.addFiles(["powerbox-server.js"], "server");

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -92,6 +92,7 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
             this._requestInfo.source.postMessage({
               rpcId: this._requestInfo.rpcId,
               token: apiToken,
+              // encoded/packed/base64url of (tags = [(id = 15831515641881813735)])
               descriptor: "EAZQAQEAABEBF1EEAQH_5-Jn6pjXtNsAAAA",
             }, this._requestInfo.origin);
             // Completion event closes popup.

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -134,6 +134,20 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
   }
 
   filteredCardData() {
+    // Returns an array of "cards" (options from which the user can pick), sorted in the order in
+    // which they should appear. Each has the fields described in the comments for
+    // Meteor.publish("powerboxOptions") in powerbox-server.js as well as the following fields
+    // added client-side:
+    //
+    // _id: Unique identifier for this card among the results.
+    // title: Human-readable title string.
+    // appTitle (optional): Human-readable title of the app serving this option.
+    // iconSrc (optional): URL of an icon.
+    // lastUsed (optional): Date when this item was last accessed.
+    // callback: Function returning a function to call if this card is chosen. (The double-function
+    //     is necessary because when a function value is named in a Blaze template, Blaze calls
+    //     the function, thinking it is a helper.)
+
     const cards = PowerboxOptions.find({ requestId: this._requestId }).map(cardData => {
       // Use ID as title if we don't find anything better.
       cardData.title = cardData._id;

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -316,11 +316,6 @@ Template.powerboxRequest.helpers({
     return ref && ref._selectedProvider && ref._selectedProvider.get().templateData();
   },
 
-  requestedInterfaceIsImplementedByFrontendRef: function () {
-    const ref = Template.instance().data.get();
-    return true;
-  },
-
   showWebkeyInput: function () {
     // Transitional feature: treat requests that specified no query patterns to match, not even the
     // empty list, as requests for webkeys.  Later, we"ll want to transition the test apps to

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -1,3 +1,21 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const PowerboxOptions = new Mongo.Collection("powerboxOptions");
+
 SandstormPowerboxRequest = class SandstormPowerboxRequest {
   constructor(db, requestInfo) {
     check(requestInfo, Match.ObjectIncluding({
@@ -5,7 +23,7 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
       origin: Match.Any,
       rpcId: Match.Any,
       // For reasons I don't understand, Match.Optional does not work here.
-      query: Match.OneOf(undefined, [Object]),
+      query: Match.OneOf(undefined, [String]),
       saveLabel: Match.Optional(Match.Any),
       sessionId: String,
       grainId: String,
@@ -21,6 +39,14 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
     // State to track UI status.
     this._filter = new ReactiveVar("");
     this._selectedProvider = new ReactiveVar(undefined);
+
+    this._requestId = Random.id();
+  }
+
+  subscribe(tmpl) {
+    if (this._requestInfo.query) {
+      tmpl.subscribe("powerboxOptions", this._requestId, this._requestInfo.query);
+    }
   }
 
   finalize() {
@@ -33,95 +59,10 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
     }
   }
 
-  hex64ToDecimal(n) {
-    if (typeof n != "string") {
-      throw new Error("Expected string.");
-    }
-
-    if (n.length != 18 || !n.match(/0x[0-9a-fA-F]{16}/)) {
-      throw new Error("Expected '0x' followed by 16 hexadecimal digits");
-    }
-
-    let upper32 = parseInt(n.substring(0, 10));
-    let lower32 = parseInt("0x" + n.substring(10, 18));
-
-    let result = "";
-    for (let exponent = 0; exponent < 22; exponent += 1) {
-      const w = Math.floor(upper32 / 10);
-      const x = upper32 % 10;
-
-      const lowerPlusRemainder = (x * Math.pow(2, 32)) + lower32;
-      const y = Math.floor(lowerPlusRemainder / 10);
-      const z = lowerPlusRemainder % 10;
-
-      result = z.toString() + result;
-
-      upper32 = w;
-      lower32 = y;
-
-      if (upper32 == 0 && lower32 == 0) {
-        break;
-      }
-    }
-
-    return result;
-  }
-
-  decimalify(interfaceId) {
-    if (interfaceId.lastIndexOf("0x", 0) === 0 && interfaceId.length === 18) {
-      try {
-        return this.hex64ToDecimal(interfaceId);
-      } catch (e) {
-        return interfaceId;
-      }
-    }
-
-    return interfaceId;
-  }
-
-  interfaceIdsMatch(a, b) {
-    // Compares two interface IDs which may be either decimal strings or 0x-prefixed hexadecimal
-    // strings.  Strictly speaking, node-capnp would also accept octal strings, but there's not
-    // a great reason for wanting anything besides hex or decimal here.
-    return this.decimalify(a) === this.decimalify(b);
-  }
-
-  requestedInterfaceMatchesTag(target) {
-    // This whole function should probably be migrated to use the powerbox interface matching code,
-    // once that exists.
-
-    // target is (the JS equivalent of) a PowerboxDescriptor.Tag struct.
-    check(target, {
-      id: String,
-      value: Match.Optional(Match.Any),
-    });
-    if (!this._requestInfo.query) return false;
-    for (let i = 0; i < this._requestInfo.query.length; i++) {
-      const powerboxDescriptor = this._requestInfo.query[i];
-      const tags = powerboxDescriptor.tags;
-      const quality = powerboxDescriptor.quality || "acceptable";
-      if (quality === "acceptable" || quality === "preferred") {
-        for (let j = 0; j < tags.length; j++) {
-          const tag = tags[j];
-          // TODO: implement the more precise request matching algorithm in grain.capnp
-          // which also considers tag values
-          if (tag.id) {
-            if (this.interfaceIdsMatch(tag.id, target.id)) {
-              return true;
-            }
-          }
-        }
-      }
-    }
-
-    return false;
-  }
-
   completeUiView(roleAssignment) {
     const fulfillingProvider = this._selectedProvider.get();
     if (fulfillingProvider.type === "frontendref-uiview") {
       const fulfillingGrainId = fulfillingProvider.grainId;
-      const fulfillingApiToken = fulfillingProvider.apiToken; // Possibly irrelevant?
       const fulfillingGrainTitle = fulfillingProvider.title;
 
       const saveLabel = this._requestInfo.saveLabel || { defaultText: fulfillingGrainTitle };
@@ -151,12 +92,7 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
             this._requestInfo.source.postMessage({
               rpcId: this._requestInfo.rpcId,
               token: apiToken,
-              descriptor: {
-                tags: [
-                  { id: "15831515641881813735" }, // UiView
-                ],
-                quality: "acceptable",
-              },
+              descriptor: "EAZQAQEAABEBF1EEAQH_5-Jn6pjXtNsAAAA",
             }, this._requestInfo.origin);
             // Completion event closes popup.
             this._requestInfo.onCompleted();
@@ -168,18 +104,22 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
     }
   }
 
-  selectGrain(grainCard) {
+  selectGrain(grainCard, viewInfo) {
+    if (viewInfo.permissions) indexElements(viewInfo.permissions);
+    // It's essential that we index the roles *before* hiding obsolete roles,
+    // or else we'll produce the incorrect roleAssignment for roles that are
+    // described after obsolete roles in the pkgdef.
+    if (viewInfo.roles) indexElements(viewInfo.roles);
+    viewInfo.roles = removeObsolete(viewInfo.roles);
+
     this._selectedProvider.set({
       type: "frontendref-uiview",
       grainId: grainCard.grainId,
       title: grainCard.title,
       templateName: "powerboxProviderUiView",
       templateData: () => {
-        const grain = this._db.collections.grains.findOne(grainCard.grainId);
-        const viewInfo = grain.cachedViewInfo;
-        this.annotateViewInfo(viewInfo);
         return {
-          _id: grainCard.grainId,
+          _id: grainCard._id,
           title: grainCard.title,
           appTitle: grainCard.appTitle,
           iconSrc: grainCard.iconSrc,
@@ -193,252 +133,119 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
     });
   }
 
-  selectApiToken(apiTokenCard) {
-    Meteor.call("getViewInfoForApiToken", apiTokenCard._id, (err, result) => {
-      if (err) {
-        console.log(err);
-        this._error.set(err.toString());
-      } else {
-        const viewInfo = result;
-        this.annotateViewInfo(viewInfo);
-        this._selectedProvider.set({
-          type: "frontendref-uiview",
-          grainId: apiTokenCard.grainId,
-          apiToken: apiTokenCard._id,
-          title: apiTokenCard.title,
-          templateName: "powerboxProviderUiView",
-          templateData: () => {
-            return {
-              _id: apiTokenCard._id,
-              title: apiTokenCard.title,
-              appTitle: apiTokenCard.appTitle,
-              iconSrc: apiTokenCard.iconSrc,
-              lastUsed: apiTokenCard.lastUsed,
-              viewInfo: viewInfo,
-              onComplete: (roleAssignment) => {
-                this.completeUiView(roleAssignment);
-              },
-            };
-          },
-        });
-      }
-    });
-  }
-
-  annotateViewInfo(viewInfo) {
-    if (viewInfo.permissions) indexElements(viewInfo.permissions);
-    // It's essential that we index the roles *before* hiding obsolete roles,
-    // or else we'll produce the incorrect roleAssignment for roles that are
-    // described after obsolete roles in the pkgdef.
-    if (viewInfo.roles) indexElements(viewInfo.roles);
-    viewInfo.roles = removeObsolete(viewInfo.roles);
-  }
-
   filteredCardData() {
-    // TODO(soon): also pull in card data from grains that purport to implement the interface requested.
+    const cards = PowerboxOptions.find({ requestId: this._requestId }).map(cardData => {
+      // Use ID as title if we don't find anything better.
+      cardData.title = cardData._id;
 
-    if (this.requestedInterfaceMatchesTag({ id: "15831515641881813735" })) { // UiView
-      return this.uiViewCardData();
-    } else if (this.requestedInterfaceMatchesTag({ id: "12214421258504904768" })) {
-      return this.ipNetworkCardData();
-    } else if (this.requestedInterfaceMatchesTag({ id: "16369547182874744570" })) {
-      return this.ipInterfaceCardData();
-    } else {
-      return [];
-    }
-  }
-
-  ipNetworkCardData() {
-    const cards = [];
-    if (this._db.isAdmin()) {
-      cards.push({
-        _id: "frontendref-ipnetwork",
-        title: "Admin: grant all outgoing network access",
-        iconSrc: "/settings.svg",
-        callback: () => {
-          // Because Blaze always invokes functions when referenced as values from the data context, we
-          // need to double-wrap this callback.
-          return () => {
-            this.completeNewIpNetwork();
-          };
-        },
-      });
-    }
-
-    return cards;
-  }
-
-  completeNewIpNetwork() {
-    Meteor.call("newFrontendRef",
-      this._requestInfo.sessionId,
-      { ipNetwork: true },
-      (err, token) => {
-        if (err) {
-          console.log(err);
-          this._error.set(err.toString());
-        } else {
-          this._completed = true;
-          this._requestInfo.source.postMessage({
-            rpcId: this._requestInfo.rpcId,
-            token: token,
-            descriptor: {
-              tags: [
-                { id: "12214421258504904768" }, // IpNetwork
-              ],
-              quality: "acceptable",
-            },
-          }, this._requestInfo.origin);
-          // Completion event closes popup.
-          this._requestInfo.onCompleted();
+      if (cardData.grainId) {
+        this.extendWithGrainInfo(cardData);
+      } else if (cardData.frontendRef) {
+        // TODO(cleanup): English text probably desn't belong in source files.
+        if (cardData.frontendRef.ipNetwork) {
+          cardData.title = "Admin: grant all outgoing network access";
+        } else if (cardData.frontendRef.ipInterface) {
+          cardData.title = "Admin: grant all incoming network access";
         }
+
+        cardData.callback = () => () => {
+          return this.completeNewFrontendRef(cardData.frontendRef, cardData.title);
+        };
       }
-    );
-  }
 
-  ipInterfaceCardData() {
-    const cards = [];
-    if (this._db.isAdmin()) {
-      cards.push({
-        _id: "frontendref-ipinterface",
-        title: "Admin: grant all incoming network access",
-        iconSrc: "/settings.svg",
-        callback: () => {
-          // Because Blaze always invokes functions when referenced as values from the data context, we
-          // need to double-wrap this callback.
-          return () => {
-            this.completeNewIpInterface();
-          };
-        },
-      });
-    }
-
-    return cards;
-  }
-
-  completeNewIpInterface() {
-    Meteor.call("newFrontendRef",
-      this._requestInfo.sessionId,
-      { ipInterface: true },
-      (err, token) => {
-        if (err) {
-          console.log(err);
-          this._error.set(err.toString());
-        } else {
-          this._completed = true;
-          this._requestInfo.source.postMessage({
-            rpcId: this._requestInfo.rpcId,
-            token: token,
-            descriptor: {
-              tags: [
-                { id: "16369547182874744570" }, // IpInterface
-              ],
-              quality: "acceptable",
-            },
-          }, this._requestInfo.origin);
-          // Completion event closes popup.
-          this._requestInfo.onCompleted();
-        }
-      }
-    );
-  }
-
-  uiViewCardData() {
-    // Map user grains into card data
-    const ownedGrains = this._db.currentUserGrains().fetch();
-    const ownedGrainIds = _.pluck(ownedGrains, "_id");
-    const ownedGrainCardData = mapGrainsToGrainCardData(ownedGrains, this._db, this.selectGrain.bind(this));
-
-    // Also map API tokens.  Be careful to only include tokens for grains that aren't in the grain
-    // list, and only include one token for each grain.
-    const apiTokens = this._db.currentUserApiTokens().fetch();
-    const tokensForGrain = _.groupBy(apiTokens, "grainId");
-    const grainIdsForApiTokens = Object.keys(tokensForGrain);
-    const grainIdsForApiTokensForNonOwnedGrains = _.filter(grainIdsForApiTokens, (grainId) => {
-      return !_.contains(ownedGrainIds, grainId);
+      return cardData;
     });
-    const tokensToList = grainIdsForApiTokensForNonOwnedGrains.map((grainId) => {
-      return _.sortBy(tokensForGrain[grainId], function (t) {
-        if (t.owner && t.owner.user && t.owner.user.lastUsed) {
-          return -t.owner.user.lastUsed;
-        } else {
-          return 0;
-        }
-      })[0];
-    });
-    const apiTokenCardData = mapApiTokensToGrainCardData(tokensToList, this._db, this.selectApiToken.bind(this));
 
-    // Filter cards to match search, then sort cards by recency of usage
-    const sortedFilteredCardData = _.chain([ownedGrainCardData, apiTokenCardData])
-        .flatten()
+    const now = new Date();
+    return _.chain(cards)
         .filter(compileMatchFilter(this._filter.get()))
-        .sortBy((card) => card.lastUsed)
-        .reverse()
+        .sortBy(card => -(card.lastUsed || now).getTime())
         .value();
+  }
 
-    return sortedFilteredCardData;
-  };
-};
+  extendWithGrainInfo(cardData) {
+    // Extend a grain card with display info.
 
-const mapApiTokensToGrainCardData = function (apiTokens, db, selectApiToken) {
-  const staticAssetHost = db.makeWildcardHost("static");
-  return apiTokens.map((apiToken) => {
-    const ownerData = apiToken.owner.user;
-    const grainInfo = ownerData.denormalizedGrainMetadata;
-    const appTitle = (grainInfo && grainInfo.appTitle && grainInfo.appTitle.defaultText) || "";
-    const iconSrc = (grainInfo && grainInfo.icon && grainInfo.icon.assetId) ?
-        (window.location.protocol + "//" + staticAssetHost + "/" + grainInfo.icon.assetId) :
-        Identicon.identiconForApp((grainInfo && grainInfo.appId) || "00000000000000000000000000000000");
-    const grainCard = {
-      type: "apiToken",
-      _id: apiToken._id,
-      grainId: apiToken.grainId,
-      title: ownerData.title,
-      appTitle: appTitle,
-      iconSrc: iconSrc,
-      lastUsed: ownerData.lastUsed,
-    };
-    grainCard.callback = function () {
+    // Look for an owned grain.
+    const grain = this._db.collections.grains.findOne(cardData.grainId);
+    if (grain && grain.userId === Meteor.userId()) {
+      cardData.title = grain.title;
+      const pkg = this._db.collections.packages.findOne(grain.packageId);
+      cardData.appTitle = pkg ? SandstormDb.appNameFromPackage(pkg) : "";
+      cardData.iconSrc = pkg ? this._db.iconSrcForPackage(pkg, "grain") : "";
+      cardData.lastUsed = grain.lastUsed;
+
       // Because Blaze always invokes functions when referenced as values from the data context, we
       // need to double-wrap this callback.
-      return function () {
-        selectApiToken(grainCard);
+      cardData.callback = () => () => {
+        return this.selectGrain(cardData, grain.cachedViewInfo || {});
       };
-    };
 
-    return grainCard;
-  });
-};
+      return;
+    }
 
-const mapGrainsToGrainCardData = function (grains, db, selectGrain) {
-  const packageIds = _.chain(grains)
-      .pluck("packageId")
-      .uniq()
-      .value();
-  const packages = db.collections.packages.find({ _id: { $in: packageIds } }).fetch();
-  const packagesById = _.indexBy(packages, "_id");
-  return grains.map(function (grain) {
-    const pkg = packagesById[grain.packageId];
-    const iconSrc = pkg ? db.iconSrcForPackage(pkg, "grain") : "";
-    const appTitle = pkg ? SandstormDb.appNameFromPackage(pkg) : "";
-    const cardData = {
-      type: "grain",
-      _id: grain._id,
-      grainId: grain._id,
-      title: grain.title,
-      appTitle: appTitle,
-      iconSrc: iconSrc,
-      lastUsed: grain.lastUsed,
-    };
-    cardData.callback = function () {
-      // Because Blaze always invokes functions when referenced as values from the data context, we
-      // need to double-wrap this callback.
-      return function () {
-        selectGrain(cardData);
+    // Look for an ApiToken.
+    const apiToken = this._db.collections.apiTokens.findOne(
+        { grainId: cardData.grainId, "owner.user": { $exists: true } });
+    if (apiToken) {
+      const ownerData = apiToken.owner.user;
+      const grainInfo = ownerData.denormalizedGrainMetadata;
+      const staticAssetHost = this._db.makeWildcardHost("static");
+
+      cardData.title = ownerData.title;
+      cardData.appTitle =
+          (grainInfo && grainInfo.appTitle && grainInfo.appTitle.defaultText) || "";
+      cardData.iconSrc = (grainInfo && grainInfo.icon && grainInfo.icon.assetId) ?
+          (window.location.protocol + "//" + staticAssetHost + "/" + grainInfo.icon.assetId) :
+          Identicon.identiconForApp(
+              (grainInfo && grainInfo.appId) || "00000000000000000000000000000000");
+      cardData.lastUsed = ownerData.lastUsed;
+      cardData.apiTokenId = apiToken._id;
+
+      cardData.callback = () => () => {
+        Meteor.call("getViewInfoForApiToken", grainCard.tokenId, (err, result) => {
+          if (err) {
+            console.log(err);
+            this._error.set(err.toString());
+          } else {
+            this.selectGrain(grainCard, result || {});
+          }
+        });
       };
-    };
 
-    return cardData;
-  });
+      return;
+    }
+
+    // Didn't find either. Don't know why this option was returned but oh well.
+    cardData.callback = () => () => {
+      this.selectGrain(cardData, {});
+    };
+  }
+
+  completeNewFrontendRef(frontendRef, defaultLabel) {
+    const saveLabel = this._requestInfo.saveLabel || { defaultText: defaultLabel };
+
+    Meteor.call("newFrontendRef",
+      this._requestInfo.sessionId,
+      frontendRef,
+      saveLabel,
+      (err, result) => {
+        if (err) {
+          console.log(err);
+          this._error.set(err.toString());
+        } else {
+          this._completed = true;
+          this._requestInfo.source.postMessage({
+            rpcId: this._requestInfo.rpcId,
+            token: result.sturdyRef,
+            descriptor: result.descriptor,
+          }, this._requestInfo.origin);
+          // Completion event closes popup.
+          this._requestInfo.onCompleted();
+        }
+      }
+    );
+  }
 };
 
 const matchesAppOrGrainTitle = function (needle, cardData) {
@@ -476,6 +283,13 @@ const removeObsolete = function (arr) {
   });
 };
 
+Template.powerboxRequest.onCreated(function () {
+  this.autorun(() => {
+    const request = this.data.get();
+    if (request) request.subscribe(this);
+  });
+});
+
 Template.powerboxRequest.onRendered(function () {
   const searchbar = this.findAll(".search-bar")[0];
   if (searchbar) searchbar.focus();
@@ -504,11 +318,7 @@ Template.powerboxRequest.helpers({
 
   requestedInterfaceIsImplementedByFrontendRef: function () {
     const ref = Template.instance().data.get();
-    return (
-      ref.requestedInterfaceMatchesTag({ id: "12214421258504904768" }) || // IpNetwork
-      ref.requestedInterfaceMatchesTag({ id: "16369547182874744570" }) || // IpInterface
-      ref.requestedInterfaceMatchesTag({ id: "15831515641881813735" }) // UiView
-    );
+    return true;
   },
 
   showWebkeyInput: function () {
@@ -585,8 +395,8 @@ Template.powerboxProviderUiView.events({
 });
 
 Template.powerboxCardButton.events({
-  "click .card-button": function (event) {
-    const ref = Template.instance().data;
+  "click .card-button": function (event, tmpl) {
+    const ref = tmpl.data;
     ref && ref.onClick && ref.onClick();
   },
 });

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -135,7 +135,7 @@ class PowerboxOption {
 const specialCaseTypes = {
   // This object maps tag IDs to functions which return lists of matches for that tag.
 
-  15831515641881813735(db, userId, value) {  // UiView
+  "15831515641881813735"(db, userId, value) {  // UiView
     if (!userId) return [];
 
     // TODO(someday): Allow `value` to specify app IDs to filter for.
@@ -152,7 +152,7 @@ const specialCaseTypes = {
     });
   },
 
-  12214421258504904768(db, userId, value) {  // IpNetwork
+  "12214421258504904768"(db, userId, value) {  // IpNetwork
     if (Meteor.users.findOne(userId).isAdmin) {
       return [
         new PowerboxOption({
@@ -165,7 +165,7 @@ const specialCaseTypes = {
     }
   },
 
-  16369547182874744570(db, userId, value) {  // IpInterface
+  "16369547182874744570"(db, userId, value) {  // IpInterface
     if (Meteor.users.findOne(userId).isAdmin) {
       return [
         new PowerboxOption({

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -1,16 +1,53 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const Capnp = Npm.require("capnp");
+const Grain = Capnp.importSystem("sandstorm/grain.capnp");
+
 Meteor.methods({
-  newFrontendRef(sessionId, frontendRefVariety) {
+  newFrontendRef(sessionId, frontendRefVariety, saveLabel) {
     // Checks if the requester is an admin, and if so, provides a new frontendref of the desired
     // variety, provided by the requesting user, owned by the grain for this session.
     check(sessionId, String);
     check(frontendRefVariety, Match.OneOf(
-      { ipNetwork: Boolean },
-      { ipInterface: Boolean },
+      { ipNetwork: true },
+      { ipInterface: true },
     ));
+    check(saveLabel, {
+      defaultText: String,
+      localizations: Match.Optional([{ locale: String, text: String }]),
+    });
 
     const db = this.connection.sandstormDb;
-    if (!db.isAdmin(this.userId)) {
-      throw new Meteor.Error(403, "User must be an admin to powerbox offer frontendrefs");
+
+    let descriptor;
+    if (frontendRefVariety.ipNetwork) {
+      if (!db.isAdmin(this.userId)) {
+        throw new Meteor.Error(403, "User must be an admin to powerbox offer IpNetwork");
+      }
+
+      descriptor = "EAZQAQEAABEBF1EEAQH_QCAqemtXgqkAAAA";
+    } else if (frontendRefVariety.ipInterface) {
+      if (!db.isAdmin(this.userId)) {
+        throw new Meteor.Error(403, "User must be an admin to powerbox offer IpInterface");
+      }
+
+      descriptor = "EAZQAQEAABEBF1EEAQH_-tY-6W5QLOMAAAA";
+    } else {
+      throw new Meteor.Error(500, "Unimplemented frontendRef type");
     }
 
     const session = db.collections.sessions.findOne(sessionId);
@@ -22,7 +59,7 @@ Meteor.methods({
     const apiTokenOwner = {
       grain: {
         grainId: grainId,
-        saveLabel: { defaultText: "Admin-provided raw outgoing network access" },
+        saveLabel: saveLabel,
         introducerIdentity: session.identityId,
       },
     };
@@ -31,8 +68,240 @@ Meteor.methods({
       { userIsAdmin: Meteor.userId() },
     ];
 
-    // TODO: refactor: reaches out into core.js
-    const sturdyRef = waitPromise(saveFrontendRef(frontendRefVariety, apiTokenOwner, requirements)).sturdyRef;
-    return sturdyRef.toString();
+    // TODO(cleanup): refactor: reaches out into core.js
+    const sturdyRef = waitPromise(saveFrontendRef(frontendRefVariety, apiTokenOwner, requirements)).sturdyRef.toString();
+    return { sturdyRef, descriptor };
   },
+});
+
+class PowerboxOption {
+  constructor(fields) {
+    _.extend(this, fields);
+  }
+
+  intersect(other) {
+    // Intersect two options with the same ID. Used when combining matches from multiple tags
+    // in the same descriptor. The tags are a conjunction.
+    //
+    // Returns true if there was any overlap, or false if there was no overlap and therefore the
+    // option should be dropped.
+
+    if (other._id != this._id) {
+      throw new Error("can only merge options with the same ID");
+    }
+
+    if (other.grainId) {
+      if (this.uiView && !other.uiView) delete this.uiView;
+      if (this.hostedObject && !other.hostedObject) delete this.hostedObject;
+      return !!(this.uiView || this.hostedObject);
+    } else {
+      // No intersection logic needed for other types.
+      return true;
+    }
+  }
+
+  union(other) {
+    // Union two options with the same ID. Used when combining matches from multiple descriptors.
+    // The descriptors are a disjunction.
+
+    if (other._id != this._id) {
+      throw new Error("can only merge options with the same ID");
+    }
+
+    if (other.grainId) {
+      if (!this.uiView && other.uiView) this.uiView = other.uiView;
+      if (!this.hostedObject && other.hostedObject) this.hostedObject = other.hostedObject;
+    }
+  }
+
+  subtract(other) {
+    // Remove `other` from this. Used when `other` is a match deemed unacceptable. Returns true
+    // if there's anything left, false otherwise.
+
+    if (other._id != this._id) {
+      throw new Error("can only merge options with the same ID");
+    }
+
+    if (other.grainId) {
+      if (this.uiView && other.uiView) delete this.uiView;
+      if (this.hostedObject && other.hostedObject) delete this.hostedObject;
+      return !!(this.uiView || this.hostedObject);
+    } else {
+      return false;
+    }
+  }
+}
+
+const specialCaseTypes = {
+  // This object maps tag IDs to functions which return lists of matches for that tag.
+
+  15831515641881813735(db, userId, value) {  // UiView
+    if (!userId) return [];
+
+    // TODO(someday): Allow `value` to specify app IDs to filter for.
+
+    const sharedGrainIds = db.userApiTokens(userId).map(token => token.grainId);
+    const ownedGrainIds = Grains.find({ userId: userId }, { fields: { _id: 1 } }).map(grain => grain._id);
+
+    return _.uniq(sharedGrainIds.concat(ownedGrainIds)).map(grainId => {
+      return new PowerboxOption({
+        _id: "grain-" + grainId,
+        grainId: grainId,
+        uiView: {},
+      });
+    });
+  },
+
+  12214421258504904768(db, userId, value) {  // IpNetwork
+    if (Meteor.users.findOne(userId).isAdmin) {
+      return [
+        new PowerboxOption({
+          _id: "frontendref-ipnetwork",
+          frontendRef: { ipNetwork: true },
+        }),
+      ];
+    } else {
+      return [];
+    }
+  },
+
+  16369547182874744570(db, userId, value) {  // IpInterface
+    if (Meteor.users.findOne(userId).isAdmin) {
+      return [
+        new PowerboxOption({
+          _id: "frontendref-ipinterface",
+          frontendRef: { ipInterface: true },
+        }),
+      ];
+    } else {
+      return [];
+    }
+  },
+};
+
+Meteor.publish("powerboxOptions", function (requestId, descriptorList) {
+  // Performs a powerbox query, returning options to present to the user in the powerbox.
+  // `descriptorList` is an array of `PowerboxDescriptor`s, each individually serialized in
+  // packed format and base64-encoded. The publish populates a pseudo-collection called
+  // `powerboxOptions`. Each item has the following fields:
+  //
+  //   _id: Object with two fields: `requestId` (as passed when subscribing) and `optionId` (a
+  //       unique identifier for the option).
+  //   matchQuality: "preferred" or "acceptable" ("unacceptable" options aren't returned).
+  //   frontendRef: If present, selecting this option means creating a simple frontendRef. The
+  //       field value should be passed back to the method `newFrontendRef` verbatim. The fromat
+  //       of the field is the same as ApiTokens.frontendRef.
+  //   grainId: If present, this option selects a grain to satisfy the request. One or both of
+  //       `uiView` and `hostedObject` will be present. Mutually exclusive with `frontendRef`.
+  //   uiView: If present, this option creates a UiView for a grain. The UI should allow the user
+  //       to choose a role to grant. Only present when `grainId` is also present. `uiView` is an
+  //       object with the fields:
+  //     TODO(someday): Some sort of indication of what options the powerbox should give the user
+  //         as far as which permissions to grant? Unclear if any app would ever want to specify
+  //         permissions when requesting a plain UiView.
+  //   hostedObject: If present, this grain advertises that it publishes capabilities that might
+  //       match the query. If selected, a request session to the grain embedded should be shown
+  //       embedded in the powerbox and the same request should be passed to it. Only present when
+  //       `grainId` is also present. `hostedObject`, when present, is (for now) an empty object.
+
+  const results = {};
+  const db = this.connection.sandstormDb;
+
+  if (descriptorList.length > 0) {
+    const descriptorMatches = descriptorList.map(packedDescriptor => {
+      // Decode the descriptor.
+      // TODO(now): Also single-segment? Canonical?
+
+      // Use URL-safe base64.
+      unUrlsafe = packedDescriptor.replace("-", "+").replace("_", "/");
+
+      const descriptor = Capnp.parsePacked(
+          Grain.PowerboxDescriptor, new Buffer(unUrlsafe, "base64"));
+
+      if (!descriptor.tags || descriptor.tags.length === 0) return {};
+
+      // Expand each tag into a match map.
+      const tagMatches = descriptor.tags.map(tag => {
+        const type = specialCaseTypes[tag.id];
+        const result = {};
+
+        if (type) {
+          type(db, this.userId, tag.value).forEach(option => {
+            result[option._id] = option;
+          });
+        }
+
+        return result;
+      });
+
+      // Intersect two tags' matches.
+      const matches = tagMatches.reduce((a, b) => {
+        for (const id in a) {
+          if (id in b) {
+            if (!a[id].intersect(b[id])) {
+              // Empty intersection.
+              delete a[id];
+            }
+          } else {
+            // This match only exists in a, not b, so delete it.
+            delete a[id];
+          }
+        }
+
+        return a;
+      });
+
+      return { descriptor, matches };
+    });
+
+    // TODO(someday): The implementation of matchQuality here is not quite right. In theory, we're
+    //   supposed to compare descriptors to determine which ones are more specific than which
+    //   others, and prefer the most-specific match. For now, though, I've implemented a heuristic:
+    //   consider each descriptor in order. If it is "unacceptable", have it cancel out any
+    //   matches seen previously. Otherwise, take the maximum match quality. This will usually
+    //   produce the same results as long as "unacceptable" descrtiptors are placed last in the
+    //   list.
+
+    const matches = descriptorMatches.reduce((finalMatches, clause) => {
+      if (clause.matchQuality === "unacceptable") {
+        // Remove b's matches from a.
+        for (const id in clause.matches) {
+          if (id in finalMatches) {
+            if (!finalMatches[id].subtract(clause.matches[id])) {
+              delete finalMatches[id];
+            }
+          }
+        }
+
+        return finalMatches;
+      } else {
+        for (const id in clause.matches) {
+          if (id in finalMatches) {
+            finalMatches[id].union(clause.matches[id]);
+          } else {
+            finalMatches[id] = clause.matches[id];
+          }
+
+          if (clause.matchQuality === "preferred") {
+            finalMatches[id].matchQuality = "preferred";
+          }
+        }
+
+        return finalMatches;
+      }
+    }, {});
+
+    for (const id in matches) {
+      if (!matches[id].matchQuality) {
+        matches[id].matchQuality = "acceptable";
+      }
+
+      matches[id].requestId = requestId;
+      this.added("powerboxOptions", id, matches[id]);
+    }
+  }
+
+  // TODO(someday): Make reactive? Seems annoying.
+
+  this.ready();
 });

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -21,8 +21,8 @@ const Ip = Capnp.importSystem("sandstorm/ip.capnp");
 function encodePowerboxDescriptor(desc) {
   return Capnp.serializePacked(Grain.PowerboxDescriptor, desc)
               .toString("base64")
-              .replace("+", "-")
-              .replace("/", "_");
+              .replace(/\+/g, "-")
+              .replace(/\//g, "_");
 }
 
 Meteor.methods({
@@ -219,11 +219,9 @@ Meteor.publish("powerboxOptions", function (requestId, descriptorList) {
       // Decode the descriptor.
       // TODO(now): Also single-segment? Canonical?
 
-      // Use URL-safe base64.
-      unUrlsafe = packedDescriptor.replace("-", "+").replace("_", "/");
-
+      // Note: Node's base64 decoder also accepts URL-safe base64, so no need to translate.
       const descriptor = Capnp.parsePacked(
-          Grain.PowerboxDescriptor, new Buffer(unUrlsafe, "base64"));
+          Grain.PowerboxDescriptor, new Buffer(packedDescriptor, "base64"));
 
       if (!descriptor.tags || descriptor.tags.length === 0) return {};
 

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -17,6 +17,13 @@
 const Capnp = Npm.require("capnp");
 const Grain = Capnp.importSystem("sandstorm/grain.capnp");
 
+function encodePowerboxDescriptor(desc) {
+  return Capnp.serializePacked(Grain.PowerboxDescriptor, desc)
+              .toString("base64")
+              .replace("+", "-")
+              .replace("/", "_");
+}
+
 Meteor.methods({
   newFrontendRef(sessionId, frontendRefVariety, saveLabel) {
     // Checks if the requester is an admin, and if so, provides a new frontendref of the desired
@@ -39,13 +46,13 @@ Meteor.methods({
         throw new Meteor.Error(403, "User must be an admin to powerbox offer IpNetwork");
       }
 
-      descriptor = "EAZQAQEAABEBF1EEAQH_QCAqemtXgqkAAAA";
+      descriptor = encodePowerboxDescriptor({tags: [{id: "12214421258504904768"}]});
     } else if (frontendRefVariety.ipInterface) {
       if (!db.isAdmin(this.userId)) {
         throw new Meteor.Error(403, "User must be an admin to powerbox offer IpInterface");
       }
 
-      descriptor = "EAZQAQEAABEBF1EEAQH_-tY-6W5QLOMAAAA";
+      descriptor = encodePowerboxDescriptor({tags: [{id: "16369547182874744570"}]});
     } else {
       throw new Meteor.Error(500, "Unimplemented frontendRef type");
     }

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -189,7 +189,7 @@ Meteor.publish("powerboxOptions", function (requestId, descriptorList) {
   //       unique identifier for the option).
   //   matchQuality: "preferred" or "acceptable" ("unacceptable" options aren't returned).
   //   frontendRef: If present, selecting this option means creating a simple frontendRef. The
-  //       field value should be passed back to the method `newFrontendRef` verbatim. The fromat
+  //       field value should be passed back to the method `newFrontendRef` verbatim. The format
   //       of the field is the same as ApiTokens.frontendRef.
   //   grainId: If present, this option selects a grain to satisfy the request. One or both of
   //       `uiView` and `hostedObject` will be present. Mutually exclusive with `frontendRef`.
@@ -259,7 +259,7 @@ Meteor.publish("powerboxOptions", function (requestId, descriptorList) {
     //   others, and prefer the most-specific match. For now, though, I've implemented a heuristic:
     //   consider each descriptor in order. If it is "unacceptable", have it cancel out any
     //   matches seen previously. Otherwise, take the maximum match quality. This will usually
-    //   produce the same results as long as "unacceptable" descrtiptors are placed last in the
+    //   produce the same results as long as "unacceptable" descriptors are placed last in the
     //   list.
 
     const matches = descriptorMatches.reduce((finalMatches, clause) => {

--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -13,8 +13,6 @@
     {{#if selectedProvider }}
       {{> Template.dynamic template=selectedProviderTemplate data=selectedProviderTemplateData }}
     {{else}}
-      {{#if requestedInterfaceIsImplementedByFrontendRef}}
-      {{!-- TODO: switch this to support all interfaces --}}
       <div class="search-row">
         <label>
           <span title="Search" class="search-icon"></span>
@@ -30,9 +28,6 @@
         <p>No grains can provide the requested interface.</p>
       {{/each}}
       </ul>
-      {{else}}
-      <p>Requests for arbitrary interfaces not yet supported.  (Soon!)</p>
-      {{/if}}
     {{/if}}
   {{/if}}
 </template>

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -256,7 +256,7 @@ hashSturdyRef = (sturdyRef) => {
 };
 
 function generateSturdyRef() {
-  return Random.id(22);
+  return Random.secret();
 }
 
 Meteor.methods({


### PR DESCRIPTION
PowerboxDescriptors are now provided in base64url-serialized-packed Cap'n Proto format, not JSON. For example, a UiView can be requested as "EAZQAQEAABEBF1EEAQH_5-Jn6pjXtNsAAAA".

This will be necessary going forward because PowerboxDescriptor.Tag.value is an AnyPointer, the schema of which Sandstorm may not even know. The query-matching algorithm is designed to operate on Cap'n Proto binary format without the need for a schema, but without a schema it is not possible to convert to/from JSON.

I expect most apps won't need to customize their queries very much, so can probably get away with using hard-coded queries copied from documentation. Copying a whole query string seems not much worse than copying a type ID. I also imagine adding an spk sub-command for generating query strings.