### PR TITLE
Fix email invites

### DIFF
--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -272,7 +272,7 @@ Meteor.methods({
           to: email,
           from: from,
           subject: subject,
-          text: message.replace(/\$KEY/g, origin + Router.routes.signup.path({ key: key })),
+          text: message.replace(/\$KEY/g, origin + "/signup/" + key),
         });
         SignupKeys.update(key, { $set: { definitelySent: true } });
       }


### PR DESCRIPTION
In the client/server split, I missed that a server Meteor method relied upon
one of the client-side route definitions.

Considering that we shouldn't ever change that route definition, since it would
break already-sent signup invites, we can manually construct the appropriate
path on the server.