### PR TITLE
Mention https port in reverse proxy docs

### DIFF
--- a/docs/administering/reverse-proxy.md
+++ b/docs/administering/reverse-proxy.md
@@ -49,26 +49,31 @@ Test your nginx configuration:
 
 ### Configure Sandstorm's configuration files
 
-First, **configure Sandstorm to listen on localhost, port 6080, for HTTP requests.** To do that, you
-will need to edit `/opt/sandstorm/sandstorm.conf`. Make sure `HTTPS_PORT=...` line is **not** set,
-as Sandstorm's HTTPS is designed for users of [sandcats.io free SSL](sandcats.md). Your `PORT`
-and `BIND_IP` settings should look like this.
+First, **configure Sandstorm to listen on localhost, port 6080, for HTTP requests.** We use port
+6080 here to match the example nginx configuration. You will need to edit
+`/opt/sandstorm/sandstorm.conf`. Make sure there is no `HTTPS_PORT=...` line, as the
+`HTTPS_PORT=...` configuration option enables Sandstorm's [auto-renewing sandcats.io free
+SSL](sandcats.md). The `PORT` and `BIND_IP` settings should look like this.
 
 ```
 PORT=6080
 BIND_IP=127.0.0.1
 ```
 
-Then, **configure Sandstorm to use your new base URL and wildcard host.** To do that, edit
-`/opt/sandstorm/sandstorm.conf` and adjust those settings. Here is an example for a Sandstorm server
-that would be accessed by visiting `example.com` over HTTPS.
+Then, **configure Sandstorm to use your new base URL and wildcard host.** You might also need to add
+a new DNS record to your domain; read more about [wildcard DNS for Sandstorm.](wildcard.md) Here is
+an example pair of lines from `/opt/sandstorm/sandstorm.conf` for a Sandstorm server that would be
+accessed by visiting `example.com` over HTTPS.
 
 ```
 BASE_URL=https://example.com
 WILDCARD_HOST=*.example.com
 ```
 
-If you need a custom port number, you should place it in both `WILDCARD_HOST` and `BASE_URL`.
+**If you are serving HTTPS or HTTP on non-default port numbers,** then you will need to add a port
+number to both `WILDCARD_HOST` and `BASE_URL`.  In the example configuration, nginx listens for
+HTTPS on port 443 and HTTP on port 80, which are the default ports, so you do not need add a port
+number unless you are doing an unusual Sandstorm install.
 
 ### Run
 
@@ -79,13 +84,15 @@ sudo service nginx restart
 sudo service sandstorm restart
 ```
 
-### Reconfigure login within Sandstorm, if necessary
+### Test your Sandstorm install
 
-Make sure to test your Sandstorm install by visiting it on the web. If this operation
-probably your `BASE_URL`, and if you are using OAuth providers for login, then this
-change will disable them. Make sure to visit **Admin Settings** within your Sandstorm
-install and re-enable them.
+Make sure to test your Sandstorm install by visiting it on the web.
 
-If OAuth providers were your only way to log in, you might need to get a login token via the command
-line. See the answer in the [frequently-asked questions
-page.](faq.md#how-do-i-log-in-if-theres-a-problem-with-logging-in-via-the-web)
+**Make sure login works.** If you changed your `BASE_URL`, Sandstorm will temporarily disable any
+OAuth providers like Google or GitHub so that you can ensure they are configured correctly. Make
+sure to visit **Admin Settings** within your Sandstorm install and re-enable them. If OAuth
+providers were your only way to log in, you might need to get a [login token via the command
+line.](faq.md#how-do-i-log-in-if-theres-a-problem-with-logging-in-via-the-web)
+
+**Make sure grains can start.** Visit a grain, or create a new one, and ensure it loads properly. If
+it does not, you might have an issue with [wildcard DNS.](wildcard.md)

--- a/docs/administering/reverse-proxy.md
+++ b/docs/administering/reverse-proxy.md
@@ -35,16 +35,27 @@ Copy [nginx-example.conf](https://github.com/sandstorm-io/sandstorm/blob/master/
 
 `nginx-example.conf` may be renamed to anything, such as `example.com.conf`. You'll need to make the following changes.
 
-
 - All `server_name` lines should match the DNS hostnames for your Sandstorm install.
+
 - Point `ssl_certificate` and `ssl_certificate_key` to your corresponding TLS certificate and key files.
 
 Test your nginx configuration:
+
 `sudo nginx -t`
 
 ### Configure Sandstorm's configuration files
 
-Specify HTTPS, and remove port numbers from the base URL and wildcard host. To do that, edit
+First, **configure Sandstorm to speak HTTP on port 6080 on localhost.** To do that, you will need to
+edit `/opt/sandstorm/sandstorm.conf`. Make sure `HTTPS_PORT=...` line is **not** set, as Sandstorm's
+HTTPS is designed for users of [sandcats.io free SSL](../sandcats.md), where Sandstorm manages HTTPS
+keys. The `PORT` and `BIND_IP` settings should look like this.
+
+```
+PORT=6080
+BIND_IP=127.0.0.1
+```
+
+Then, **configure Sandstorm to use your new base URL and wildcard host.** To do that, edit
 `/opt/sandstorm/sandstorm.conf` and adjust these lines.
 
 ```
@@ -52,7 +63,7 @@ BASE_URL=https://example.com
 WILDCARD_HOST=*.example.com
 ```
 
-If you need a custom port number, you should place it in `WILDCARD_HOST` as well as `BASE_URL`.
+If you need a custom port number, you should place it in both `WILDCARD_HOST` and `BASE_URL`.
 
 ### Run
 

--- a/docs/administering/reverse-proxy.md
+++ b/docs/administering/reverse-proxy.md
@@ -1,24 +1,28 @@
 This document helps you configure Sandstorm to share port 80 (HTTP) with other services on the same
-machine, or port 443 (HTTPS) with other services.
+machine, or port 443 (HTTPS) with other services. It allows you to use a custom domain name, without
+an ugly port number such as `:6080` in your URLs, and optionally with HTTPS.
 
-If you use this document to set up HTTPS, note that it results in nginx having your HTTPS private
-key. If you want [**free, auto-renewing sandcats.io HTTPS certificates**,](ssl.md) you will need to
-use `sniproxy` instead of `nginx`; see the [note at the bottom of the HTTPS overview page](ssl.md).
-This tutorial works properly with certificates you purchase, or with [self-signed
-SSL.](self-signed.md)
-
-Through this process, you can remove the `:6080` of the URL if your Sandstorm is listening on port
-6080.
+If you use this document to set up HTTPS, note that you are in charge of obtaining and renewing your
+HTTPS certificates.  This tutorial works properly with certificates you purchase, or with
+[self-signed SSL.](self-signed.md) If you want [**free, auto-renewing sandcats.io HTTPS
+certificates**,](ssl.md) you will need to use `sniproxy` instead of `nginx`; see the [note at the
+bottom of the HTTPS overview page](ssl.md).
 
 ## Configuring nginx and Sandstorm for reverse proxying
 
-In this configuration, [nginx](http://nginx.org/en/) will listen on port 80 and redirect all
-Sandstorm traffic to HTTPS (port 443).  nginx will also listen on port 443 and reverse-proxy to
-Sandstorm on port 6080.
+### HTTPS or not: you choose
 
-If you want to use just HTTP (port 80), read the comments in the example configuration file.
+When running Sandstorm behind a reverse proxy such as nginx, you can configure HTTPS in the reverse
+proxy.
 
-### Prerequisites
+This tutorial provides links to sample configuration files where relevant. The example files
+configure nginx to listen on ports 80 (HTTP) and 443 (HTTPS). On port 443, nginx routes the traffic
+to Sandstorm; on port 80, nginx serves a HTTP redirect to upgrade the request to HTTPS.
+
+If you prefer to not use HTTPS, there are comments in the example coniguration file that indicates
+what changes to make.
+
+### Prerequisites for HTTPS
 
 Create DNS entries for `example.com` and `*.example.com`.
 
@@ -27,9 +31,9 @@ subjectAltName. You can do that by [buying a wildcard HTTPS
 certificate](https://google.com/search?q=cheap+wildcard+ssl) or by following our [self-signed
 certificate authority instructions.](self-signed.md)
 
-Install `nginx` with your package manager.
-
 ### Configure nginx
+
+Install `nginx` with your package manager.
 
 Copy [nginx-example.conf](https://github.com/sandstorm-io/sandstorm/blob/master/docs/administering/sample-config/nginx-example.conf) to `/etc/nginx/sites-enabled/`.
 
@@ -45,10 +49,10 @@ Test your nginx configuration:
 
 ### Configure Sandstorm's configuration files
 
-First, **configure Sandstorm to speak HTTP on port 6080 on localhost.** To do that, you will need to
-edit `/opt/sandstorm/sandstorm.conf`. Make sure `HTTPS_PORT=...` line is **not** set, as Sandstorm's
-HTTPS is designed for users of [sandcats.io free SSL](../sandcats.md), where Sandstorm manages HTTPS
-keys. The `PORT` and `BIND_IP` settings should look like this.
+First, **configure Sandstorm to listen on localhost, port 6080, for HTTP requests.** To do that, you
+will need to edit `/opt/sandstorm/sandstorm.conf`. Make sure `HTTPS_PORT=...` line is **not** set,
+as Sandstorm's HTTPS is designed for users of [sandcats.io free SSL](sandcats.md). Your `PORT`
+and `BIND_IP` settings should look like this.
 
 ```
 PORT=6080
@@ -56,7 +60,8 @@ BIND_IP=127.0.0.1
 ```
 
 Then, **configure Sandstorm to use your new base URL and wildcard host.** To do that, edit
-`/opt/sandstorm/sandstorm.conf` and adjust these lines.
+`/opt/sandstorm/sandstorm.conf` and adjust those settings. Here is an example for a Sandstorm server
+that would be accessed by visiting `example.com` over HTTPS.
 
 ```
 BASE_URL=https://example.com

--- a/docs/administering/wildcard.md
+++ b/docs/administering/wildcard.md
@@ -1,13 +1,84 @@
-To run Sandstorm, you must assign it a wildcard host, in which it can
-generate new hostnames as-needed. For instance, you might set up
-Sandstorm to run at `example.com` and assign it the wildcard
-`*.example.com`.
+To run Sandstorm, you must assign it a wildcard host, in which it can generate new hostnames
+as-needed. For instance, you might set up Sandstorm to run at `example.com` and assign it the
+wildcard `*.example.com`.
 
-Setting up wildcard DNS and especially SSL can be difficult and
-costly, which commonly leads to the question: "Why does Sandstorm need
-this?" This page seeks to answer the questions.
+This page explains how to configure this and why it is needed.
 
-## It's all about security.
+## How to configure and test your own wildcard DNS record for Sandstorm
+
+If your Sandstorm server is at `example.com` you might have the following lines in your
+`/opt/sandstorm/sandstorm.conf`.
+
+```
+BASE_URL=https://example.com
+WILDCARD_HOST=*.example.com
+```
+
+In order for Sandstorm grains to load, DNS lookups for domains within the `WILDCARD_HOST` need to
+resolve to your Sandstorm server. You can manually test this on many systems. Open a terminal and
+run this comand.
+
+```
+host arbitrary.example.com
+```
+
+You should see a message like:
+
+```
+arbitrary.example.com has address 93.184.216.34
+```
+
+If you see something like that, then a `WILDCARD_HOST` of `*.example.com` exists. The IP address
+printed by the `host` command should match the IP address for your Sandstorm server. If `host` tells
+you the domain is `not found: 3(NXDOMAIN)`, then you probably need to adjust your DNS zone to create
+a wildcard record. If your system does not have `host`, you can try `dig` or `ping` which serve
+similar functions.
+
+To learn how to add a new wildcard DNS record, consider reading this [tutorial on setting up
+Sandstorm using the DigitalOcean DNS control
+panel](https://www.digitalocean.com/community/tutorials/how-to-install-sandstorm-on-ubuntu-14-04). Your
+domain's DNS configuration tool might look different, but the fundamentals are probably the
+same. Text-based DNS configuration systems might need a record like the following, for a Sandstorm
+server running at 93.184.216.34.
+
+```
+* IN A 93.184.216.34
+```
+
+Once you add a wildcard record, you can re-run the test with `host` to see if your wildcard record
+is working. You can try looking up other subdomains than `arbitrary`, such as `arbitrary2`, to make
+sure that all subdomains resolve to the right IP address.
+
+**Sandstorm can use a BASE_URL within a wildcard DNS record.** If `*.example.com` maps to the right
+IP address, then you can configure Sandstorm to use a BASE_URL that is part of a wildcard DNS
+record. This can be convenient if you already have one wildcard DNS record. Note that the
+`WILDCARD_HOST` and the `BASE_URL` must be within the same domain name because otherwise web
+browsers may prevent Sandstorm from setting a cookie with the wildcard subdomains, as part of a web
+browser privacy protection feature (third-party cookies). One such configuration would look like
+this.
+
+```
+BASE_URL=https://sandstorm.example.com
+WILDCARD_HOST=sandstorm-*.example.com
+```
+
+**Raw IP address users can use xip.io.** If your Sandstorm BASE_URL is a base IP address, consider
+reading about [how to use Sandstorm with an internal IP address and
+xip.io](faq.md#how-do-i-use-sandstorm-with-an-internal-ip-address).
+
+## local.sandstorm.io and sandcats.io provide wildcard DNS
+
+If you are using `vagrant-spk` to develop Sandstorm apps, or are developing Sandstorm itself, you
+will likely use `local.sandstorm.io` as the `BASE_URL` for your Sandstorm server. Sandstorm.io (the
+company behind Sandstorm) maintains `local.sandstorm.io` as a wildcard domain where both
+`local.sandstorm.io` and all of its subdomains (`*.local.sandstorm.io`) point to `127.0.0.1`, the
+same as `localhost`. This allows you to run Sandstorm for development without needing to own a
+domain name or configure wildcard DNS for a subdomain.
+
+Within the `sandcats.io` DNS service, each domain is also a wildcard domain. This allows a
+self-hosted Sandstorm domain to operate correctly.
+
+## Why Sandstorm needs wildcard DNS
 
 Sandstorm is designed to implement strong sandboxing of apps, such
 that users need not worry about the risk that a malicious -- or simply
@@ -18,22 +89,6 @@ we trust Sandstorm to keep things secure."
 
 Using a wildcard host is just one part of [Sandstorm's security
 model](../using/security-practices.md).
-
-## Sandstorm handles this for localhost + sandcats users
-
-Sandstorm runs `local.sandstorm.io` as a wildcard domain where
-both `local.sandstorm.io` and all of its subdomains
-(`*.local.sandstorm.io`) point to `127.0.0.1`, the same as
-`localhost`. This allows you to conveniently run Sandstorm on
-your own computer or a virtual machine for development and
-testing by configuring it to use `local.sandstorm.io` and
-`*.local.sandstorm.io`, without needing to own a domain and
-configure wildcard DNS for a subdomain.
-
-For the `sandcats.io` DNS service, each domain is also a wildcard
-domain. This allows a self-hosted Sandstorm domain to operate
-correctly.
-
 
 ## Frequently-asked questions about wildcards
 


### PR DESCRIPTION
These docs changes adjust a few things:

- Mention how `HTTPS_PORT` relates to other things in the reverse proxy docs.

- Adjust `wildcard.md` to tell people how to set up wildcard DNS, rather than just that we're so cool to use it.

- Adjust reverse proxy docs to clarify that HTTPS behind a reverse proxy is optional.