### PR TITLE
In grain-invite emails, fill in the "from" field with a more appropriate value.

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1009,6 +1009,15 @@ Template.emailInviteTab.helpers({
   preselectedIdentityId: function () {
     return Session.get("share-grain-" + Template.instance().grain.grainId());
   },
+
+  invitationExplanation: function () {
+    const primaryEmail = globalDb.getPrimaryEmail(Meteor.userId(), Accounts.getCurrentIdentityId());
+    if (primaryEmail) {
+      return "Invitation will be sent from " + primaryEmail;
+    } else {
+      return null;
+    }
+  },
 });
 
 Template.emailInviteTab.events({

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1013,7 +1013,7 @@ Template.emailInviteTab.helpers({
   invitationExplanation: function () {
     const primaryEmail = globalDb.getPrimaryEmail(Meteor.userId(), Accounts.getCurrentIdentityId());
     if (primaryEmail) {
-      return "Invitation will be sent from " + primaryEmail;
+      return "Invitation will be from " + primaryEmail;
     } else {
       return null;
     }

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -546,6 +546,11 @@ limitations under the License.
     </div>
     {{#if completionState.clear}}
     <div class="button-container" role="presentation">
+      {{#with invitationExplanation}}
+        {{!-- Display the entire message in the hover text, in case "overflow: ellipsis" causes
+              part of the message to be hidden in the main view. --}}
+        <p class="invitation-explanation" title="{{.}}">{{.}}</p>
+      {{/with}}
       <button>Send</button>
     </div>
     {{/if}}

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -1061,20 +1061,19 @@ body>.popup {
     }
 
     .button-container {
-      position: relative;
-      margin-top: 5px;
-      margin-bottom: 45px;
+      display: flex;
+      justify-content: space-between;
       margin-top: 10px;
     }
     .share-tabs form button {
       @extend %unstyled-button;
+      @extend %button-primary;
       border: 1px solid #ccc;
       border-radius: 4px;
       padding: 5px 16px;
       font-size: 10pt;
-      position: absolute;
-      right: 0;
       text-transform: uppercase;
+      margin-left: auto;
     }
     .share-token-role {
       width: 40%;
@@ -1128,7 +1127,12 @@ body>.popup {
     .personal-message {
       height: 100px;
     }
-    .label-explanation {
+    .invitation-explanation {
+      max-width: 80%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .invitation-explanation, .label-explanation {
       font-size: 8pt;
       font-style: italic;
     }

--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -392,8 +392,8 @@ Meteor.methods({
 
       const accountId = this.userId;
       const outerResult = { successes: [], failures: [] };
-      const envelopeFrom = globalDb.getReturnAddress();
-      const fromEmail = globalDb.getPrimaryEmailWithDisplayName(accountId, identityId);
+      const fromEmail = globalDb.getReturnAddressWithDisplayName(identityId);
+      const replyTo = globalDb.getPrimaryEmail(accountId, identityId);
       contacts.forEach(function (contact) {
         if (contact.isDefault && contact.profile.service === "email") {
           const emailAddress = contact.profile.intrinsicName;
@@ -411,7 +411,7 @@ Meteor.methods({
             SandstormEmail.send({
               to: emailAddress,
               from: fromEmail,
-              envelopeFrom: envelopeFrom,
+              replyTo: replyTo,
               subject: title + " - Invitation to collaborate",
               text: message.text + "\n\nFollow this link to open the shared grain:\n\n" + url +
                 "\n\nNote: If you forward this email to other people, they will be able to " +
@@ -452,7 +452,7 @@ Meteor.methods({
               SandstormEmail.send({
                 to: email.email,
                 from: fromEmail,
-                envelopeFrom: envelopeFrom,
+                replyTo: replyTo,
                 subject: title + " - Invitation to collaborate",
                 text: message.text + "\n\nFollow this link to open the shared grain:\n\n" + url +
                   "\n\nNote: You will need to log in with your " + loginNote +
@@ -505,8 +505,8 @@ Meteor.methods({
       const identity = globalDb.getIdentity(identityId);
       globalDb.addContact(grainOwner._id, identityId);
 
-      const envelopeFrom = globalDb.getReturnAddress();
-      const fromEmail = globalDb.getPrimaryEmailWithDisplayName(Meteor.userId(), identityId);
+      const fromEmail = globalDb.getReturnAddressWithDisplayName(identityId);
+      const replyTo = globalDb.getPrimaryEmail(Meteor.userId(), identityId);
 
       // TODO(soon): In the HTML version, we should display an identity card.
       let identityNote = "";
@@ -551,8 +551,8 @@ Meteor.methods({
 
       SandstormEmail.send({
         to: emailAddress,
-        envelopeFrom: envelopeFrom,
         from: fromEmail,
+        replyTo: replyTo,
         subject: grain.title + " - Request for access",
         text: message + "\n\nFollow this link to share access:\n\n" + url,
         html: html,

--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -391,9 +391,9 @@ Meteor.methods({
       }
 
       const accountId = this.userId;
-      const identity = globalDb.getIdentity(identityId);
-      const sharerDisplayName = identity.profile.name;
       const outerResult = { successes: [], failures: [] };
+      const envelopeFrom = globalDb.getReturnAddress();
+      const fromEmail = globalDb.getPrimaryEmailWithDisplayName(accountId, identityId);
       contacts.forEach(function (contact) {
         if (contact.isDefault && contact.profile.service === "email") {
           const emailAddress = contact.profile.intrinsicName;
@@ -410,8 +410,9 @@ Meteor.methods({
           try {
             SandstormEmail.send({
               to: emailAddress,
-              from: "Sandstorm server <no-reply@" + HOSTNAME + ">",
-              subject: sharerDisplayName + " has invited you to join a grain: " + title,
+              from: fromEmail,
+              envelopeFrom: envelopeFrom,
+              subject: title + " - Invitation to collaborate",
               text: message.text + "\n\nFollow this link to open the shared grain:\n\n" + url +
                 "\n\nNote: If you forward this email to other people, they will be able to " +
                 "access the share as well. To prevent this, remove the link before forwarding.",
@@ -450,8 +451,9 @@ Meteor.methods({
                   " to access this grain.";
               SandstormEmail.send({
                 to: email.email,
-                from: "Sandstorm server <no-reply@" + HOSTNAME + ">",
-                subject: sharerDisplayName + " has invited you to join a grain: " + title,
+                from: fromEmail,
+                envelopeFrom: envelopeFrom,
+                subject: title + " - Invitation to collaborate",
                 text: message.text + "\n\nFollow this link to open the shared grain:\n\n" + url +
                   "\n\nNote: You will need to log in with your " + loginNote +
                   " to access this grain.",
@@ -504,15 +506,7 @@ Meteor.methods({
       globalDb.addContact(grainOwner._id, identityId);
 
       const envelopeFrom = globalDb.getReturnAddress();
-      let fromEmail = globalDb.getServerTitle() + " <" + globalDb.getReturnAddress() + ">";
-      const senderEmails = SandstormDb.getVerifiedEmails(identity);
-      const senderPrimaryEmail = _.findWhere(senderEmails, { primary: true });
-      const accountPrimaryEmailAddress = Meteor.user().primaryEmail;
-      if (_.findWhere(senderEmails, { email: accountPrimaryEmailAddress })) {
-        fromEmail = accountPrimaryEmailAddress;
-      } else if (senderPrimaryEmail) {
-        fromEmail = senderPrimaryEmail.email;
-      }
+      const fromEmail = globalDb.getPrimaryEmailWithDisplayName(Meteor.userId(), identityId);
 
       // TODO(soon): In the HTML version, we should display an identity card.
       let identityNote = "";


### PR DESCRIPTION
This uses `SandstormDb.getReturnAddress()` for the envelope sender and something like "Alice \<alice@example.com\>" for the inner "from" field. It also fills the subject line with "grain title - Invitation to collaborate".

I tested this out with some display names containing non-ASCII characters and it seems to work; at least, when gmail received the messaged the headers were properly encoded as per [RFC 2047](https://tools.ietf.org/html/rfc2047).

One snag is that SimpleSmtp (or something that it depends on) does not like to see certain characters such as "<" in the display name, and encoding or escaping them does not seem to help. (Whereas according to my reading of [RFC 2822](https://tools.ietf.org/html/rfc2822), "<" ought to be allowed.) So I drop such characters.