### PR TITLE
Fix typo in troubleshooting guide

### DIFF
--- a/docs/developing/troubleshooting.md
+++ b/docs/developing/troubleshooting.md
@@ -1,8 +1,13 @@
 This page lists common problems and work-arounds.
 
-This page needs expansion! If you encounter a new problem and solve it, feel free to add it here. If you encounter a problem you don't know how to solve, try asking on Stack Overflow, and be sure to add the "sandstorm.io" tag to your question. Or, talk to us on IRC (#sandstorm on freenode) or [sandstorm-dev](https://groups.google.com/group/sandstorm-dev).
+This page needs expansion! If you encounter a new problem and solve it, feel
+free to add it here. If you encounter a problem you don't know how to solve,
+try asking on Stack Overflow, and be sure to add the "sandstorm.io" tag to your
+question. Or, talk to us on IRC (#sandstorm on freenode) or
+[sandstorm-dev](https://groups.google.com/group/sandstorm-dev).
 
-Note that language-specific issues should be documented in the language-specific guide pages, namely:
+Note that language-specific issues should be documented in the
+language-specific guide pages, namely:
 
 * [Python](raw-python.md)
 * [Ruby on Rails](raw-ruby-on-rails.md)
@@ -35,16 +40,20 @@ very likely you are seeing this error.
 If possible, configure the app to use a base URL of `''`, literally
 the empty string. Then it will send HTTP redirects without
 specifying a base URL. If that isn't possible, Sandstorm apps should
-look at the
+look at the `Host:` header for a base URL.
 
-Sandstorm apps should look at the `Host:` header for a base URL if
-they need one.
 ## KeyError: 'getpwuid(): uid not found: 1000'
 
-This is a Python bug. See [the Python packaging guide](raw-python.md#keyerror-getpwuid-uid-not-found-1000) for a work-around.
+This is a Python bug. See
+[the Python packaging guide](raw-python.md#keyerror-getpwuid-uid-not-found-1000)
+for a work-around.
 
 ## `EROFS` or "Read-only filesystem"
 
-Only the `/var` directory is writable; the rest of the filesystem (which contains the contents of your app package) is read-only.
+Only the `/var` directory is writable; the rest of the filesystem (which
+contains the contents of your app package) is read-only.
 
-If your app wants to write to locations other than `/var`, and it's not easy to change the app's code, one work-around is to create a symlink from the location you app wants to modify to a location under `/var`.  This won't work for all applications however.
+If your app wants to write to locations other than `/var`, and it's not easy to
+change the app's code, one work-around is to create a symlink from the location
+you app wants to modify to a location under `/var`.  This won't work for all
+applications however.


### PR DESCRIPTION
Fixes a typo.

Before

> If possible, configure the app to use a base URL of '', literally the empty string. Then it will send HTTP redirects without specifying a base URL. If that isn't possible, Sandstorm apps should look at the
> 
> Sandstorm apps should look at the Host: header for a base URL if they need one.

After

> If possible, configure the app to use a base URL of '', literally the empty string. Then it will send HTTP redirects without specifying a base URL. If that isn't possible, Sandstorm apps should look at the `Host:` header for a base URL.

Also made the word-wrapping in this file consistent; let me know if you'd rather I not touch this, and I'll put it back.