### PR TITLE
Added icon preview graphic to docs

### DIFF
--- a/docs/developing/publishing-apps.md
+++ b/docs/developing/publishing-apps.md
@@ -131,6 +131,8 @@ Your app's manifest, or package definition file, (`sandstorm-pkgdef.capnp`) cont
 
 You can embed both SVGs or PNGs, and Sandstorm will use the best version provided for the use in question. Using PNGs requires a slightly different structure, which you can find an example of [here](https://github.com/dwrensha/sharelatex/blob/sandstorm-app/sandstorm-pkgdef.capnp#L26).
 
+<img src="https://inozs8hbcttx5fdveukc.oasis.sandstorm.io/docs/docs-package-icons.png"></img>
+
 * The `appGrid` icon represents your app on the "New" screen on Sandstorm. It should be 128 x 128 pixels, and no larger than 64 KB.
 * The `grain` icon represents individual grains on both the navbar and the grain list. It should be 24 x 24 pixels, and no larger than 4 KB. If you omit this, the appGrid icon will be used.
 * The `market` icon is used in the app market. It should be 150 x 150 pixels, and no larger than 256 KB. If you omit this, the appGrid icon will be used.


### PR DESCRIPTION
This partially fixes #1564. @paulproteus is going to re-host the image.

![image](https://cloud.githubusercontent.com/assets/855341/14057035/e69184a4-f2b1-11e5-93ef-8714ff5651ba.png)

