### PR TITLE
Don't show identity chooser interstitial if the opener is the grain owner or the token creator.

### DIFF
--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -94,6 +94,7 @@ Meteor.publish("tokenInfo", function (token) {
   }, {
     fields: {
       grainId: 1,
+      identityId: 1,
       owner: 1,
       revoked: 1,
     },
@@ -110,6 +111,7 @@ Meteor.publish("tokenInfo", function (token) {
       fields: {
         packageId: 1,
         appId: 1,
+        userId: 1,
       },
     });
     if (!grain) {
@@ -132,7 +134,8 @@ Meteor.publish("tokenInfo", function (token) {
           const identityIds = SandstormDb.getUserIdentityIds(user);
           const childToken = ApiTokens.findOne({ "owner.user.identityId": { $in: identityIds },
                                                  parentToken: apiToken._id, });
-          if (childToken) {
+          if (childToken || this.userId === grain.userId ||
+              identityIds.indexOf(apiToken.identityId) >= 0) {
             this.added("tokenInfo", token, { alreadyRedeemed: true, grainId: apiToken.grainId, });
             this.ready();
             return;

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -437,9 +437,19 @@ module.exports["Test grain identity chooser interstitial"] = function (browser) 
     .waitForElementVisible(".new-share-token", short_wait)
     .submitForm('.new-share-token')
     .waitForElementVisible('#share-token-text', medium_wait)
-    // Navigate to the url with an anonymous user
     .getText('#share-token-text', function(shareLink) {
       browser
+        .url(shareLink.value)
+         // Identity picker should not come up on visiting our own link.
+        .url(shareLink.value)
+        .waitForElementVisible('.grain-frame', medium_wait)
+        .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
+        .frame('grain-frame')
+        .waitForElementPresent('#publish', medium_wait)
+        .assert.containsText('#publish', 'Publish')
+        .frame(null)
+
+        // Navigate to the url with an anonymous user
         .loginDevAccount()
         .pause(short_wait)
         // Try incognito
@@ -480,6 +490,25 @@ module.exports["Test grain identity chooser interstitial"] = function (browser) 
         .waitForElementPresent('#publish', medium_wait)
         .assert.containsText('#publish', 'Publish')
         .frame(null)
-        .end();
+
+        .click('.topbar .share > .show-popup')
+        .waitForElementVisible("#shareable-link-tab-header", short_wait)
+        .click("#shareable-link-tab-header")
+        .waitForElementVisible(".new-share-token", short_wait)
+        .submitForm('.new-share-token')
+        .waitForElementVisible('#share-token-text', medium_wait)
+        .getText('#share-token-text', function(shareLink) {
+          browser
+            .url(shareLink.value)
+             // Identity picker should not come up on visiting our own link.
+            .url(shareLink.value)
+            .waitForElementVisible('.grain-frame', medium_wait)
+            .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
+            .frame('grain-frame')
+            .waitForElementPresent('#publish', medium_wait)
+            .assert.containsText('#publish', 'Publish')
+            .frame(null)
+            .end()
+        });
     });
 }

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -351,8 +351,6 @@ module.exports["Test roleless sharing"] = function (browser) {
 
             .loginDevAccount(firstUserName)
             .url(response.value)
-            .waitForElementVisible("button.pick-identity", short_wait)
-            .click("button.pick-identity")
             .waitForElementVisible('.grain-frame', medium_wait)
             .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
             .click('.topbar .share > .show-popup')


### PR DESCRIPTION
Fixes #1716.