### PR TITLE
In grain-invite emails, fill in the "from" header with the server's configured Return Address.

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1331,6 +1331,17 @@ _.extend(SandstormDb.prototype, {
     const setting = Settings.findOne({ _id: "organizationLdap" });
     return setting ? setting.value : false;
   },
+
+  getReturnAddressWithDisplayName: function (identityId) {
+    check(identityId, String);
+    const identity = this.getIdentity(identityId);
+
+    // First remove any instances of characters that cause trouble for SimpleSmtp. Ideally,
+    // we could escape such characters with a backslash, but that does not seem to help here.
+    const sanitized = identity.profile.name.replace(/"|<|>|\\|\r/g, "");
+    const displayName = sanitized + " (via " + this.getServerTitle() + ")";
+    return "\"" + displayName + "\" <" + this.getReturnAddress() + ">";
+  },
 });
 
 SandstormDb.escapeMongoKey = (key) => {

--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -388,9 +388,8 @@ Meteor.methods({
       }
 
       const accountId = this.userId;
-      const identity = globalDb.getIdentity(identityId);
-      const sharerDisplayName = identity.profile.name;
       const outerResult = { successes: [], failures: [] };
+      const fromEmail = globalDb.getReturnAddressWithDisplayName(identityId);
       contacts.forEach(function (contact) {
         if (contact.isDefault && contact.profile.service === "email") {
           const emailAddress = contact.profile.intrinsicName;
@@ -407,8 +406,8 @@ Meteor.methods({
           try {
             SandstormEmail.send({
               to: emailAddress,
-              from: "Sandstorm server <no-reply@" + HOSTNAME + ">",
-              subject: sharerDisplayName + " has invited you to join a grain: " + title,
+              from: fromEmail,
+              subject: title + " - Invitation to collaborate",
               text: message.text + "\n\nFollow this link to open the shared grain:\n\n" + url +
                 "\n\nNote: If you forward this email to other people, they will be able to " +
                 "access the share as well. To prevent this, remove the link before forwarding.",
@@ -447,8 +446,8 @@ Meteor.methods({
                   " to access this grain.";
               SandstormEmail.send({
                 to: email.email,
-                from: "Sandstorm server <no-reply@" + HOSTNAME + ">",
-                subject: sharerDisplayName + " has invited you to join a grain: " + title,
+                from: fromEmail,
+                subject: title + " - Invitation to collaborate",
                 text: message.text + "\n\nFollow this link to open the shared grain:\n\n" + url +
                   "\n\nNote: You will need to log in with your " + loginNote +
                   " to access this grain.",
@@ -500,16 +499,7 @@ Meteor.methods({
       const identity = globalDb.getIdentity(identityId);
       globalDb.addContact(grainOwner._id, identityId);
 
-      const envelopeFrom = globalDb.getReturnAddress();
-      let fromEmail = globalDb.getServerTitle() + " <" + globalDb.getReturnAddress() + ">";
-      const senderEmails = SandstormDb.getVerifiedEmails(identity);
-      const senderPrimaryEmail = _.findWhere(senderEmails, { primary: true });
-      const accountPrimaryEmailAddress = Meteor.user().primaryEmail;
-      if (_.findWhere(senderEmails, { email: accountPrimaryEmailAddress })) {
-        fromEmail = accountPrimaryEmailAddress;
-      } else if (senderPrimaryEmail) {
-        fromEmail = senderPrimaryEmail.email;
-      }
+      const fromEmail = globalDb.getReturnAddressWithDisplayName(identityId);
 
       // TODO(soon): In the HTML version, we should display an identity card.
       let identityNote = "";
@@ -554,7 +544,6 @@ Meteor.methods({
 
       SandstormEmail.send({
         to: emailAddress,
-        envelopeFrom: envelopeFrom,
         from: fromEmail,
         subject: grain.title + " - Request for access",
         text: message + "\n\nFollow this link to share access:\n\n" + url,


### PR DESCRIPTION
An alternative to #1696. Fixes #1717. See [this sandstorm-dev thread](https://groups.google.com/forum/#!topic/sandstorm-dev/qSDba86W7xI) for another user who ran into similar issues.

This sends all "request access" and "grain invitation" emails from the server's configured value for "Return Address". Our original plan was to use the server's Return Address for the bounce address and then to use the sending user's actual verified email address for the inner "from" header. There are two problems with that plan:

  1. Some people want to use existing SMTP setups that refuse to send things with arbitrary values in the "from" header.

  2. Writing arbitrary values in the "from" header will probably make the emails likely to end up in a spam folder. My understanding is that the reason that Google Docs can get away with sending invites that come from the inviter's gmail address (rather than `invitations@googledocs.com` or something) is that Google controls both pieces, and therefore can do whatever DKIM signing is necessary. Once Sandstorm has a more complete email setup, we should be capable of something similar, but until then I don't see how the recipients of these emails are supposed to verify that we're not just spoofing the "from" header. I mean, we basically would be spoofing it, albeit with informal permission from the inviter.

It possible that I'm missing something important in my analysis. Maybe someone with a better understanding of DKIM and such can explain what I'm getting wrong?