### PR TITLE
Fix mobile popup positioning

### DIFF
--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -1,4 +1,4 @@
-body>.popup.login>.frame {
+body>.popup.login>.frame-container>.frame {
   width: 200px;
   border: none;
   min-width: 200px;
@@ -15,7 +15,7 @@ body>.popup.login>.frame {
   }
 }
 
-body>.popup.account>.frame {
+body>.popup.account>.frame-container>.frame {
   width: 250px;
   border: none;
 
@@ -1093,7 +1093,7 @@ body>.popup,
   }
 }
 
-body>.popup.billing-prompt>.frame {
+body>.popup.billing-prompt>.frame-container>.frame {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 
@@ -1117,7 +1117,7 @@ body>.popup.billing-prompt>.frame {
   overflow: hidden;
 }
 
-body>.popup.billing-prompt>.frame, .first-time-billing-prompt {
+body>.popup.billing-prompt>.frame-container>.frame, .first-time-billing-prompt {
   text-align: center;
 
   >h2 {

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -732,7 +732,7 @@ body>.topbar {
 
 // =======================================================================================
 
-body>.popup.who-has-access>.frame {
+body>.popup.who-has-access>.frame-container {
   width: 500px;
 }
 
@@ -751,11 +751,7 @@ body>.popup {
     background-color: rgba(0, 0, 0, 0.5);
   }
 
-  >.frame {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-begin;
-    justify-content: flex-begin;
+  >.frame-container {
     max-height: calc(100vh - 64px);
     min-width: 250px;
     line-height: normal;
@@ -763,16 +759,68 @@ body>.popup {
     background-color: white;
     font-weight: normal;
     color: black;
-    width: 400px;
     box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.2);
     border-left: 1px solid #E0E0E0;
     border-right: 1px solid #E0E0E0;
     border-bottom: 1px solid #E0E0E0;
 
+    >.frame {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-begin;
+      justify-content: flex-begin;
+      >.close-popup {
+        display: block;
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: 32px;
+        height: 32px;
+        color: transparent;
+        overflow: hidden;
+        background-image: url("/close-m.svg");
+        background-size: 20px 20px;
+        background-repeat: no-repeat;
+        background-position: center;
+        border: none;
+        border-radius: 16px;
+        background-color: transparent;
+        margin: 0;
+      }
+
+      >.close-popup:hover {
+        background-color: #eee;
+        cursor: pointer;
+      }
+
+      >h4 {
+        margin: 0px;
+        font-size: 14px;
+        padding-left: $topbar-popup-padding;
+        line-height: 32px;
+        border-bottom: 1px solid #ccc;
+        margin-bottom: 16px;
+
+        @media #{$mobile} {
+          font-size: 14pt;
+        }
+      }
+
+      >* {
+        margin-left: $topbar-popup-padding;
+        margin-right: $topbar-popup-padding;
+      }
+
+      >*:last-child {
+        margin-bottom: $topbar-popup-padding;
+      }
+    }
+
     @media #{$desktop} {
+      // Adds a small white arrow pointing at the element this popup "descends" from.
       position: fixed;
       top: 32px;
-      max-width: 50%;
 
       &::before {
         content: " ";
@@ -796,58 +844,12 @@ body>.popup {
     }
 
     @media #{$mobile} {
-      position: relative;
+      position: static;
       margin: 64px auto 32px;
       font-size: 20px;
       width: 90%;
       border: 1px solid #ccc;
       overflow-y: auto;
-    }
-
-    >.close-popup {
-      display: block;
-      position: absolute;
-      top: 0;
-      right: 0;
-      width: 32px;
-      height: 32px;
-      color: transparent;
-      overflow: hidden;
-      background-image: url("/close-m.svg");
-      background-size: 20px 20px;
-      background-repeat: no-repeat;
-      background-position: center;
-      border: none;
-      border-radius: 16px;
-      background-color: transparent;
-      margin: 0;
-    }
-
-    >.close-popup:hover {
-      background-color: #eee;
-      cursor: pointer;
-    }
-
-    >h4 {
-      margin: 0px;
-      font-size: 14px;
-      padding-left: $topbar-popup-padding;
-      line-height: 32px;
-      border-bottom: 1px solid #ccc;
-      margin-bottom: 16px;
-
-      @media #{$mobile} {
-        font-size: 14pt;
-      }
-    }
-
-    >* {
-      margin-left: $topbar-popup-padding;
-      margin-right: $topbar-popup-padding;
-    }
-
-    >*:last-child {
-      margin-bottom: $topbar-popup-padding;
     }
 
     &.centered {
@@ -958,7 +960,7 @@ body>.popup {
     }
   }
 
-  &.share>.frame, &.who-has-access>.frame {
+  &.share>.frame-container>.frame, &.who-has-access>.frame-container>.frame {
     $popup-background-color: #ededed;
 
     >h4 {

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -74,15 +74,19 @@ limitations under the License.
   {{#with currentPopup}}
     <div class="popup {{name}}">
       {{#if onlyPopup}}
-        <div class="frame centered">
-          <button class="close-popup">Close</button>
-          {{>popupTemplate data.get}}
+        <div class="frame-container centered">
+          <div class="frame">
+            <button class="close-popup">Close</button>
+            {{>popupTemplate data.get}}
+          </div>
         </div>
       {{else}}
         {{#with position}}
-          <div class="frame align-{{align}}" style="{{align}}: {{px}}px">
-            <button class="close-popup">Close</button>
-            {{>popupTemplateNested ../data.get}}
+          <div class="frame-container align-{{align}}" style="{{align}}: {{px}}px">
+            <div class="frame">
+              <button class="close-popup">Close</button>
+              {{>popupTemplateNested ../data.get}}
+            </div>
           </div>
         {{/with}}
       {{/if}}

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -232,7 +232,7 @@ Template.sandstormTopbar.events({
     }
   },
 
-  "click .popup>.frame>.close-popup": function (event) {
+  "click .popup>.frame-container>.frame>.close-popup": function (event) {
     event.stopPropagation();
     Template.instance().data.closePopup();
   },


### PR DESCRIPTION
We rely on `position: static` on mobile to ignore the `left: $41px` or `right:
0px` inline styles which we compute to place the popup near its controlling
element for desktop.

Since we benefit from using `position: relative` for the contents of the frame,
split this into two nested divs:

`div.frame-container` is responsible for the placement and size of the popup as
well as border and drop-shadow.

`div.frame` is responsible for including all of the interesting content of that
popup, which can be `position: relative` to allow for absolutely-positioned
items within the frame.

Fixes #1725.