### PR TITLE
Fix up more popup styling

### DIFF
--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -1,33 +1,39 @@
-body>.popup.login>.frame-container>.frame {
-  width: 200px;
-  border: none;
-  min-width: 200px;
+body>.popup.login>.frame-container {
+  width: 202px; // 2px of border
+  >.frame {
+    width: 200px;
+    border: none;
+    min-width: 200px;
 
-  >p.demo-note {
-    border-bottom: 1px solid #c1c1c1;
-    font-size: 80%;
-    color: #444;
-    padding: 4px 16px;
-  }
+    >p.demo-note {
+      border-bottom: 1px solid #c1c1c1;
+      font-size: 80%;
+      color: #444;
+      padding: 4px 16px;
+    }
 
-  >* {
-    margin: 0;
+    >* {
+      margin: 0;
+    }
   }
 }
 
-body>.popup.account>.frame-container>.frame {
-  width: 250px;
-  border: none;
+body>.popup.account>.frame-container {
+  width: 252px; // includes 2px of border
+  >.frame {
+    width: 250px;
+    border: none;
 
-  >p.demo-note {
-    border-bottom: 1px solid #c1c1c1;
-    font-size: 80%;
-    color: #444;
-    padding: 4px 16px;
-  }
+    >p.demo-note {
+      border-bottom: 1px solid #c1c1c1;
+      font-size: 80%;
+      color: #444;
+      padding: 4px 16px;
+    }
 
-  >* {
-    margin: 0;
+    >* {
+      margin: 0;
+    }
   }
 }
 

--- a/shell/client/styles/_powerbox.scss
+++ b/shell/client/styles/_powerbox.scss
@@ -1,8 +1,9 @@
 body>.popup.request>.frame-container>.frame {
   display: flex;
   flex-direction: column;
-  align-items: flex-begin;
-  justify-content: flex-begin;
+  align-items: flex-start;
+  justify-content: flex-start;
+  max-height: inherit;
 
   >h4 {
     flex: none;
@@ -49,6 +50,7 @@ body>.popup.request>.frame-container>.frame {
     padding: 0px;
     margin: 10px;
     margin-top: 10px;
+    width: calc(100% - 20px);
     >li.powerbox-card {
       @extend %powerbox-card;
     }

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -753,7 +753,6 @@ body>.popup {
 
   >.frame-container {
     max-height: calc(100vh - 64px);
-    min-width: 250px;
     line-height: normal;
     white-space: normal;
     background-color: white;
@@ -768,8 +767,8 @@ body>.popup {
       position: relative;
       display: flex;
       flex-direction: column;
-      align-items: flex-begin;
-      justify-content: flex-begin;
+      align-items: flex-start;
+      justify-content: flex-start;
       >.close-popup {
         display: block;
         position: absolute;
@@ -795,6 +794,7 @@ body>.popup {
       }
 
       >h4 {
+        width: 100%;
         margin: 0px;
         font-size: 14px;
         padding-left: $topbar-popup-padding;
@@ -847,7 +847,7 @@ body>.popup {
       position: static;
       margin: 64px auto 32px;
       font-size: 20px;
-      width: 90%;
+      max-width: 90%;
       border: 1px solid #ccc;
       overflow-y: auto;
     }
@@ -988,6 +988,7 @@ body>.popup {
     }
 
     .share-tabs {
+      width: 100%;
       padding: $topbar-popup-padding;
       border-top: 1px solid #ccc;
       position: relative;
@@ -1138,6 +1139,7 @@ body>.popup {
     }
 
     >.footer {
+      width: 100%;
       background-color: $popup-background-color;
       border-top: 1px solid #ccc;
       margin: 0px;


### PR DESCRIPTION
This also fixes a bug in the powerbox popup where at small screen heights
content would overflow the .frame-container by using `max-height: inherit`.

This also fixes an issue where I wrote `flex-begin` rather than `flex-start` in
four places.  It would be nice if we had a CSS/SCSS linter.