### PR TITLE
Consolidate organization membership settings

### DIFF
--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -223,7 +223,7 @@ Template.adminSettings.events({
     const token = this.token;
     resetResult(state);
     if (globalDb.isFeatureKeyValid()) {
-      state.set("numSettings", 20);
+      state.set("numSettings", 17);
     } else {
       state.set("numSettings", 4);
     }
@@ -259,23 +259,29 @@ Template.adminSettings.events({
       Meteor.call("setSetting", token, "samlEntryPoint", event.target.samlEntryPoint.value, handleErrorBound);
       Meteor.call("setSetting", token, "samlPublicCert", event.target.samlPublicCert.value, handleErrorBound);
 
-      Meteor.call("setSetting", token, "organizationLdap", event.currentTarget.isOrganizationLdap.checked, handleErrorBound);
-
-      Meteor.call("setSetting", token, "organizationSaml", event.currentTarget.isOrganizationSaml.checked, handleErrorBound);
-
-      if (event.currentTarget.isOrganizationGoogle.checked) {
-        Meteor.call("setSetting", token, "organizationGoogle",
-            event.currentTarget.organizationGoogle.value.toLowerCase(), handleErrorBound);
-      } else {
-        Meteor.call("setSetting", token, "organizationGoogle", null, handleErrorBound);
-      }
-
-      if (event.currentTarget.isOrganizationEmail.checked) {
-        Meteor.call("setSetting", token, "organizationEmail",
-            event.currentTarget.organizationEmail.value.toLowerCase(), handleErrorBound);
-      } else {
-        Meteor.call("setSetting", token, "organizationEmail", null, handleErrorBound);
-      }
+      const orgSettings = {
+        membership: {
+          emailToken: {
+            enabled: event.currentTarget.isOrganizationEmail.checked,
+            domain: event.currentTarget.organizationEmail.value.toLowerCase(),
+          },
+          google: {
+            enabled: event.currentTarget.isOrganizationGoogle.checked,
+            domain: event.currentTarget.organizationGoogle.value.toLowerCase(),
+          },
+          ldap: {
+            enabled: event.currentTarget.isOrganizationLdap.checked,
+          },
+          saml: {
+            enabled: event.currentTarget.isOrganizationSaml.checked,
+          },
+        },
+        // Disabled until we've actually implemented the feature.
+        //settings: {
+        //  publishContacts: Boolean,
+        //},
+      };
+      Meteor.call("saveOrganizationSettings", token, orgSettings, handleErrorBound);
     }
 
     return false;
@@ -305,11 +311,11 @@ Template.adminSettings.helpers({
   },
 
   isOrganizationGoogle: function () {
-    return !!globalDb.getOrganizationGoogle();
+    return globalDb.getOrganizationGoogleEnabled();
   },
 
   organizationGoogle: function () {
-    const val = globalDb.getOrganizationGoogle();
+    const val = globalDb.getOrganizationGoogleDomain();
     if (!val) {
       // Setting has never been set before. Show a reasonable default
       const user = Meteor.user();
@@ -329,11 +335,11 @@ Template.adminSettings.helpers({
   },
 
   isOrganizationEmail: function () {
-    return !!globalDb.getOrganizationEmail();
+    return globalDb.getOrganizationEmailEnabled();
   },
 
   organizationEmail: function () {
-    const val = globalDb.getOrganizationEmail();
+    const val = globalDb.getOrganizationEmailDomain();
     if (!val) {
       // Setting has never been set before. Show a reasonable default
       const user = Meteor.user();
@@ -353,11 +359,11 @@ Template.adminSettings.helpers({
   },
 
   isOrganizationLdap: function () {
-    return globalDb.getOrganizationLdap();
+    return globalDb.getOrganizationLdapEnabled();
   },
 
   isOrganizationSaml: function () {
-    return globalDb.getOrganizationSam();
+    return globalDb.getOrganizationSamlEnabled();
   },
 
   ldapEnabled: function () {

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1011,18 +1011,19 @@ _.extend(SandstormDb.prototype, {
     }
 
     const orgMembership = this.getOrganizationMembership();
-    const googleEnabled = orgMembership.google.enabled;
-    const googleDomain = orgMembership.google.domain;
-    const emailEnabled = orgMembership.emailToken.enabled;
-    const emailDomain = orgMembership.emailToken.domain;
-
+    const googleEnabled = orgMembership && orgMembership.google && orgMembership.google.enabled;
+    const googleDomain = orgMembership && orgMembership.google && orgMembership.google.domain;
+    const emailEnabled = orgMembership && orgMembership.emailToken && orgMembership.emailToken.enabled;
+    const emailDomain = orgMembership && orgMembership.emailToken && orgMembership.emailToken.domain;
+    const ldapEnabled = orgMembership && orgMembership.ldap && orgMembership.ldap.enabled;
+    const samlEnabled = orgMembership && orgMembership.saml && orgMembership.saml.enabled;
     if (emailEnabled && emailDomain && identity.services.email) {
       if (identity.services.email.email.toLowerCase().split("@").pop() === emailDomain) {
         return true;
       }
-    } else if (orgMembership.ldap.enabled && identity.services.ldap) {
+    } else if (ldapEnabled && identity.services.ldap) {
       return true;
-    } else if (orgMembership.saml.enabled && identity.services.saml) {
+    } else if (samlEnabled && identity.services.saml) {
       return true;
     } else if (googleEnabled && googleDomain && identity.services.google && identity.services.google.hd) {
       if (identity.services.google.hd.toLowerCase() === googleDomain) {

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1010,20 +1010,22 @@ _.extend(SandstormDb.prototype, {
       return false;
     }
 
-    const googleDomain = this.getOrganizationGoogle();
-    const emailDomain = this.getOrganizationEmail();
+    const orgMembership = this.getOrganizationMembership();
+    const googleEnabled = orgMembership.google.enabled;
+    const googleDomain = orgMembership.google.domain;
+    const emailEnabled = orgMembership.emailToken.enabled;
+    const emailDomain = orgMembership.emailToken.domain;
 
-    if (emailDomain && identity.services.email) {
+    if (emailEnabled && emailDomain && identity.services.email) {
       if (identity.services.email.email.toLowerCase().split("@").pop() === emailDomain) {
         return true;
       }
-    } else if (this.getOrganizationLdap() && identity.services.ldap) {
+    } else if (orgMembership.ldap.enabled && identity.services.ldap) {
       return true;
-    } else if (this.getOrganizationSaml() && identity.services.saml) {
+    } else if (orgMembership.saml.enabled && identity.services.saml) {
       return true;
-    } else if (googleDomain && identity.services.google && identity.services.google.hd) {
-      let domain = this.getOrganizationGoogle();
-      if (identity.services.google.hd.toLowerCase() === domain) {
+    } else if (googleEnabled && googleDomain && identity.services.google && identity.services.google.hd) {
+      if (identity.services.google.hd.toLowerCase() === googleDomain) {
         return true;
       }
     }
@@ -1346,24 +1348,39 @@ _.extend(SandstormDb.prototype, {
     return setting ? setting.value : "";  // empty if subscription is not ready.
   },
 
-  getOrganizationEmail: function () {
-    const setting = Settings.findOne({ _id: "organizationEmail" });
+  getOrganizationMembership: function () {
+    const setting = Settings.findOne({ _id: "organizationMembership" });
     return setting && setting.value;
   },
 
-  getOrganizationGoogle: function () {
-    const setting = Settings.findOne({ _id: "organizationGoogle" });
-    return setting && setting.value;
+  getOrganizationEmailEnabled: function () {
+    const membership = this.getOrganizationMembership();
+    return membership && membership.emailToken && membership.emailToken.enabled;
   },
 
-  getOrganizationLdap: function () {
-    const setting = Settings.findOne({ _id: "organizationLdap" });
-    return setting ? setting.value : false;
+  getOrganizationEmailDomain: function () {
+    const membership = this.getOrganizationMembership();
+    return membership && membership.emailToken && membership.emailToken.domain;
   },
 
-  getOrganizationSaml: function () {
-    const setting = Settings.findOne({ _id: "organizationSaml" });
-    return setting ? setting.value : false;
+  getOrganizationGoogleEnabled: function () {
+    const membership = this.getOrganizationMembership();
+    return membership && membership.google && membership.google.enabled;
+  },
+
+  getOrganizationGoogleDomain: function () {
+    const membership = this.getOrganizationMembership();
+    return membership && membership.google && membership.google.domain;
+  },
+
+  getOrganizationLdapEnabled: function () {
+    const membership = this.getOrganizationMembership();
+    return membership && membership.ldap && membership.ldap.enabled;
+  },
+
+  getOrganizationSamlEnabled: function () {
+    const membership = this.getOrganizationMembership();
+    return membership && membership.ldap && membership.saml.enabled;
   },
 
   getSamlEntryPoint: function () {

--- a/shell/packages/sandstorm-db/migrations.js
+++ b/shell/packages/sandstorm-db/migrations.js
@@ -496,6 +496,36 @@ function smtpPortShouldBeNumber() {
   }
 }
 
+function consolidateOrgSettings() {
+  const orgGoogleDomain = Settings.findOne({ _id: "organizationGoogle" });
+  const orgEmailDomain = Settings.findOne({ _id: "organizationEmail" });
+  const orgLdap = Settings.findOne({ _id: "organizationLdap" });
+  const orgSaml = Settings.findOne({ _id: "organizationSaml" });
+
+  const orgMembership = {
+    google: {
+      enabled: orgGoogleDomain ? !!orgGoogleDomain.value : false,
+      domain: orgGoogleDomain ? orgGoogleDomain.value : "",
+    },
+    email: {
+      enabled: orgEmailDomain ? !!orgEmailDomain.value : false,
+      domain: orgEmailDomain ? orgEmailDomain.value : "",
+    },
+    ldap: {
+      enabled: orgLdap ? orgLdap.value : false,
+    },
+    saml: {
+      enabled: orgSaml ? orgSaml.value : false,
+    },
+  };
+
+  Settings.upsert({ _id: "organizationMembership" }, { value: orgMembership });
+  Settings.remove({ _id: "organizationGoogle" });
+  Settings.remove({ _id: "organizationEmail" });
+  Settings.remove({ _id: "organizationLdap" });
+  Settings.remove({ _id: "organizationSaml" });
+}
+
 // This must come after all the functions named within are defined.
 // Only append to this list!  Do not modify or remove list entries;
 // doing so is likely change the meaning and semantics of user databases.
@@ -522,6 +552,7 @@ const MIGRATIONS = [
   assignBonuses,
   splitSmtpUrl,
   smtpPortShouldBeNumber,
+  consolidateOrgSettings,
 ];
 
 function migrateToLatest() {

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -19,8 +19,7 @@ const publicAdminSettings = [
   "google", "github", "ldap", "saml", "emailToken", "splashUrl", "signupDialog",
   "adminAlert", "adminAlertTime", "adminAlertUrl", "termsUrl",
   "privacyUrl", "appMarketUrl", "appIndexUrl", "appUpdatesEnabled",
-  "serverTitle", "returnAddress", "ldapNameField", "organizationEmail", "organizationLdap",
-  "organizationGoogle", "organizationSaml",
+  "serverTitle", "returnAddress", "ldapNameField", "organizationMembership",
 ];
 
 const FEATURE_KEY_FIELDS_PUBLISHED_TO_ADMINS = [
@@ -158,6 +157,34 @@ Meteor.methods({
         value: buf,
       }
     );
+  },
+
+  saveOrganizationSettings(token, params) {
+    checkAuth(token);
+    check(params, {
+      membership: {
+        emailToken: {
+          enabled: Boolean,
+          domain: String,
+        },
+        google: {
+          enabled: Boolean,
+          domain: String,
+        },
+        ldap: {
+          enabled: Boolean,
+        },
+        saml: {
+          enabled: Boolean,
+        },
+      },
+      // Disabled until we've actually implemented the feature.
+      //settings: {
+      //  publishContacts: Boolean,
+      //},
+    });
+
+    this.connection.sandstormDb.collections.settings.upsert({ _id: "organizationMembership" }, { value: params.membership });
   },
 
   adminConfigureLoginService: function (token, options) {


### PR DESCRIPTION
Reduces client-server/DB roundtrips when checking org membership and makes for more straightforward settings code.  The setup wizard uses this merged settings layout.

@jparyani I'd appreciate a sanity check on this.