### PR TITLE
Make install succeed when /usr/local/bin is unwritable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1360,9 +1360,24 @@ install_sandstorm_symlinks() {
     return
   fi
 
+  local FAILED_TO_WRITE_SYMLINK="no"
+
   # Install tools.
-  ln -sfT $PWD/sandstorm /usr/local/bin/sandstorm
-  ln -sfT $PWD/sandstorm /usr/local/bin/spk
+  ln -sfT $PWD/sandstorm /usr/local/bin/sandstorm || FAILED_TO_WRITE_SYMLINK=yes
+  ln -sfT $PWD/sandstorm /usr/local/bin/spk || FAILED_TO_WRITE_SYMLINK=yes
+
+  # If /usr/local/bin is not actually writeable, even though we are root, then bail on this for now.
+  # That can happen on e.g. CoreOS; see https://github.com/sandstorm-io/sandstorm/issues/1660
+  # the bash "-w" does not detect read-only mounts, so we use a behavior check above.
+  if [ "${FAILED_TO_WRITE_SYMLINK}" = "yes" ] ; then
+    echo ""
+    echo "*** WARNING: /usr/local/bin was not writeable. To run sandstorm or spk manually, use:"
+    echo " - $PWD/sandstorm"
+    echo " - $PWD/spk"
+    echo ""
+    return
+  fi
+
 }
 
 ask_about_starting_at_boot() {

--- a/installer-tests/full-server-install-with-unwritable-usr-local.t
+++ b/installer-tests/full-server-install-with-unwritable-usr-local.t
@@ -5,6 +5,8 @@ Cleanup: uninstall_sandstorm
 
 $[run]sudo cat /proc/sys/kernel/unprivileged_userns_clone
 $[slow]0
+$[run]sudo chattr +i /usr/local/bin && echo now-unwritable
+now-unwritable
 $[run]CURL_USER_AGENT=testing OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh -i
 $[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
 
@@ -34,13 +36,12 @@ $[slow]Congratulations! We have registered your
 Your credentials to use it are in /opt/sandstorm/var/sandcats; consider making a backup.
 $[veryslow]Downloading: https://dl.sandstorm.io
 $[veryslow]GPG signature is valid.
+$[slow]*** WARNING: /usr/local/bin was not writeable.
 $[veryslow]Sandstorm started. PID =
 $[veryslow]Visit this link to configure it:
   http://
 To learn how to control the server, run:
   sandstorm help
 $[exitcode]0
-$[run]which sandstorm
-/usr/local/bin/sandstorm
 $[run]for i in `seq 0 20`; do nc -z localhost 6080 && { echo yay; break; } || sleep 1 ; done
 $[slow]yay


### PR DESCRIPTION
Close #1660

Note that this prints an ugly warning when this occurs. If we want smarter handling, someone can file a new bug. I think this addresses @ndarilek's need that `install.sh` should succeed on CoreOS.