### PR TITLE
Fix a copy-o.

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1410,7 +1410,7 @@ _.extend(SandstormDb.prototype, {
 
   getOrganizationSamlEnabled: function () {
     const membership = this.getOrganizationMembership();
-    return membership && membership.ldap && membership.saml.enabled;
+    return membership && membership.saml && membership.saml.enabled;
   },
 
   getSamlEntryPoint: function () {


### PR DESCRIPTION
I don't think this would actually break under any actual circumstances (the
migration guarantees all the things being null-guarded all exist), but it's
clearly not what was intended.