### PR TITLE
Remove ip_tables red herring warning

### DIFF
--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1164,8 +1164,7 @@ void SupervisorMain::unshareNetwork() {
 
   // Check if iptables module is available, skip the rest if not.
   if (!isIpTablesAvailable) {
-    KJ_LOG(WARNING,
-        "ip_tables kernel module not loaded; cannot set up transparent network forwarding.");
+    // TODO(soon): Put a runtime warning here, so that people can notice if this code won't work.
     return;
   }
 


### PR DESCRIPTION
Note that this does not remove the underlying code. I can do that if we
really want, but for what it is worth, the warning causes much more heartache
than the unused code.