### PR TITLE
Rearrange some symlinks and add version.h to get libsodium to build.

### DIFF
--- a/src/sodium/crypto_core_hchacha20.h
+++ b/src/sodium/crypto_core_hchacha20.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_core_hchacha20.h

--- a/src/sodium/crypto_generichash
+++ b/src/sodium/crypto_generichash
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/crypto_generichash

--- a/src/sodium/crypto_generichash_blake2b
+++ b/src/sodium/crypto_generichash_blake2b
@@ -1,1 +1,0 @@
-../../deps/libsodium/src/libsodium/crypto_generichash/blake2

--- a/src/sodium/crypto_hash
+++ b/src/sodium/crypto_hash
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/crypto_hash

--- a/src/sodium/crypto_hash_sha256
+++ b/src/sodium/crypto_hash_sha256
@@ -1,1 +1,0 @@
-../../deps/libsodium/src/libsodium/crypto_hash/sha256

--- a/src/sodium/crypto_hash_sha512
+++ b/src/sodium/crypto_hash_sha512
@@ -1,1 +1,0 @@
-../../deps/libsodium/src/libsodium/crypto_hash/sha512

--- a/src/sodium/crypto_onetimeauth
+++ b/src/sodium/crypto_onetimeauth
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/crypto_onetimeauth

--- a/src/sodium/crypto_onetimeauth_poly1305
+++ b/src/sodium/crypto_onetimeauth_poly1305
@@ -1,1 +1,0 @@
-../../deps/libsodium/src/libsodium/crypto_onetimeauth/poly1305

--- a/src/sodium/crypto_pwhash_argon2i.h
+++ b/src/sodium/crypto_pwhash_argon2i.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_pwhash_argon2i.h

--- a/src/sodium/crypto_stream
+++ b/src/sodium/crypto_stream
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/crypto_stream

--- a/src/sodium/crypto_stream.h
+++ b/src/sodium/crypto_stream.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_stream.h

--- a/src/sodium/crypto_stream_aes128ctr.h
+++ b/src/sodium/crypto_stream_aes128ctr.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_stream_aes128ctr.h

--- a/src/sodium/crypto_stream_chacha20
+++ b/src/sodium/crypto_stream_chacha20
@@ -1,1 +1,0 @@
-../../deps/libsodium/src/libsodium/crypto_stream/chacha20

--- a/src/sodium/crypto_stream_salsa20.h
+++ b/src/sodium/crypto_stream_salsa20.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_stream_salsa20.h

--- a/src/sodium/crypto_stream_salsa2012.h
+++ b/src/sodium/crypto_stream_salsa2012.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_stream_salsa2012.h

--- a/src/sodium/crypto_stream_salsa208.h
+++ b/src/sodium/crypto_stream_salsa208.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_stream_salsa208.h

--- a/src/sodium/crypto_stream_xsalsa20.h
+++ b/src/sodium/crypto_stream_xsalsa20.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_stream_xsalsa20.h

--- a/src/sodium/sodium
+++ b/src/sodium/sodium
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/sodium/

--- a/src/sodium/version.h
+++ b/src/sodium/version.h
@@ -1,0 +1,29 @@
+
+#ifndef sodium_version_H
+#define sodium_version_H
+
+#include "export.h"
+
+#define SODIUM_VERSION_STRING "X.X.XX"
+
+#define SODIUM_LIBRARY_VERSION_MAJOR 0
+#define SODIUM_LIBRARY_VERSION_MINOR 0
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+SODIUM_EXPORT
+const char *sodium_version_string(void);
+
+SODIUM_EXPORT
+int         sodium_library_version_major(void);
+
+SODIUM_EXPORT
+int         sodium_library_version_minor(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This makes the directory struct more closely match the source libsodium repo, so that [these relative includes](https://github.com/jedisct1/libsodium/commit/c3b68c12d60b92d7344f75936c00c928db815f5c) have a chance of working.

The new symlink to the `sodium/` directory requires that we have provide a `version.h`, which is usually generated at configure-time from `version.h.in`.