### PR TITLE
Get libsodium to build with the new include/sodium/private directory.

### DIFF
--- a/src/sodium/crypto_core_hchacha20.h
+++ b/src/sodium/crypto_core_hchacha20.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_core_hchacha20.h

--- a/src/sodium/crypto_pwhash_argon2i.h
+++ b/src/sodium/crypto_pwhash_argon2i.h
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/crypto_pwhash_argon2i.h

--- a/src/sodium/private
+++ b/src/sodium/private
@@ -1,0 +1,1 @@
+../../deps/libsodium/src/libsodium/include/sodium/private


### PR DESCRIPTION
This should fix the build once https://github.com/jedisct1/libsodium/commit/3927cad829156038a6baa9821d041b76b2f8f0f8 gets pushed to the libsodium stable branch.