### PR TITLE
Setup wizard

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1526,7 +1526,7 @@ print_success() {
     echo "Visit this link to configure it:"
   fi
   echo ""
-  echo "  ${BASE_URL:-(unknown; bad config)}/admin/settings/$ADMIN_TOKEN"
+  echo "  ${BASE_URL:-(unknown; bad config)}/setup/token/$ADMIN_TOKEN"
   if [ "${SANDCATS_HTTPS_SUCCESSFUL}" = "yes" ] ; then
     echo ""
     echo "(If your browser shows you an OCSP error, wait 10 minutes for it to auto-resolve"

--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -27,7 +27,8 @@ const resetResult = function (state) {
   state.set("powerboxOfferUrl", null);
 };
 
-const getToken = function () {
+// Export for use in other admin/ routes
+getToken = function () {
   const state = Iron.controller().state;
   const token = state.get("token");
   if (!token) {
@@ -125,7 +126,7 @@ Template.admin.helpers({
   },
 
   featureKeyActive: function () {
-    return Router.current().route.getName() == "adminFeatureKey";
+    return Router.current().route.getName() == "adminFeatureKeyPage";
   },
 
   wildcardHostSeemsBroken: function () {
@@ -987,7 +988,8 @@ Template.featureKeyUploadForm.events({
       if (err) {
         instance.error.set(err.message);
       } else {
-        instance.data.successCb && instance.data.successCb();
+        instance.error.set(undefined);
+        instance.data && instance.data.successCb && instance.data.successCb();
       }
     });
   },
@@ -1005,7 +1007,7 @@ Template.featureKeyUploadForm.events({
           if (err) {
             instance.error.set(err.message);
           } else {
-            instance.data.successCb && instance.data.successCb();
+            instance.data && instance.data.successCb && instance.data.successCb();
           }
         });
       });
@@ -1038,11 +1040,23 @@ Template.adminFeatureKey.events({
   },
 });
 
-Template.adminFeatureKey.helpers({
+Template.adminFeatureKeyPage.helpers({
   setDocumentTitle: function () {
-    document.title = "Features · Admin · " + globalDb.getServerTitle();
+    document.title = "Feature Key · Admin · " + globalDb.getServerTitle();
   },
 
+  settingsPath: function () {
+    const state = Iron.controller().state;
+    const token = state.get("token");
+    return "/admin/settings" + (token ? "/" + token : "");
+  },
+
+  hasFeatureKey: function () {
+    return !!globalDb.collections.featureKey.findOne();
+  },
+});
+
+Template.adminFeatureKey.helpers({
   currentFeatureKey: function () {
     return globalDb.collections.featureKey.findOne();
   },
@@ -1094,12 +1108,6 @@ Template.adminFeatureKey.helpers({
     d.setTime(parseInt(stringSecondsSinceEpoch) * 1000);
 
     return MONTHS[d.getMonth()] + " " + d.getDate() + ", " + d.getFullYear();
-  },
-
-  settingsPath: function () {
-    const state = Iron.controller().state;
-    const token = state.get("token");
-    return "/admin/settings" + (token ? "/" + token : "");
   },
 });
 
@@ -1202,7 +1210,7 @@ Router.map(function () {
     path: "/admin/advanced/:_token?",
     controller: adminRoute,
   });
-  this.route("adminFeatureKey", {
+  this.route("adminFeatureKeyPage", {
     path: "/admin/features/:_token?",
     controller: adminRoute,
   });
@@ -1211,5 +1219,118 @@ Router.map(function () {
     action: function () {
       this.redirect("adminSettings", this.params);
     },
+  });
+});
+
+const newAdminRoute = RouteController.extend({
+  template: "newAdmin",
+  waitOn: function () {
+    const subs = [
+      Meteor.subscribe("admin", this.params._token),
+      Meteor.subscribe("adminServiceConfiguration", this.params._token),
+      Meteor.subscribe("featureKey", true, this.params._token),
+    ];
+    if (this.params._token) {
+      subs.push(Meteor.subscribe("adminToken", this.params._token));
+    }
+
+    return subs;
+  },
+
+  data: function () {
+    const adminToken = AdminToken.findOne();
+    return {
+      settings: Settings.find(),
+      token: this.params._token,
+      isUserPermitted: isAdmin() || (adminToken && adminToken.tokenIsValid),
+    };
+  },
+
+  action: function () {
+    // Test the WILDCARD_HOST for sanity.
+    Tracker.nonreactive(() => {
+      if (Session.get("alreadyTestedWildcardHost")) {
+        return;
+      }
+
+      HTTP.call("GET", "//" + makeWildcardHost("selftest-" + Random.hexString(20)),
+                { timeout: 2000 }, (error, response) => {
+                  Session.set("alreadyTestedWildcardHost", true);
+                  let looksGood;
+                  if (error) {
+                    looksGood = false;
+                  } else {
+                    if (response.statusCode === 200) {
+                      looksGood = true;
+                    } else {
+                      console.log("Surpring status code from self test domain", response.statusCode);
+                      looksGood = false;
+                    }
+                  }
+
+                  Session.set("wildcardHostWorks", looksGood);
+                });
+    });
+
+    const state = this.state;
+    Meteor.call("getSmtpUrl", this.params._token, function (error, result) {
+      state.set("smtpUrl", result);
+    });
+
+    const user = Meteor.user();
+    if (user && user.loginIdentities) {
+      if (this.params._token) {
+        if (!user.signupKey || !user.isAdmin) {
+          Meteor.call("signUpAsAdmin", this.params._token);
+        } else if (user.isAdmin) {
+          // We don't need the token. Redirect to the current route, minus the token parameter.
+          Router.go(this.route.getName(), {}, _.pick(this.params, "query", "hash"));
+        }
+      }
+    }
+
+    resetResult(state);
+    state.set("configurationServiceName", null);
+    state.set("token", this.params._token);
+    this.render();
+  },
+});
+
+Router.map(function () {
+  this.route("newAdminIdentity", {
+    path: "/admin-new/identity/:_token?",
+    controller: newAdminRoute,
+  });
+  this.route("newAdminEmailConfig", {
+    path: "/admin-new/email/:_token?",
+    controller: newAdminRoute,
+  });
+  this.route("newAdminUsers", {
+    path: "/admin-new/users/:_token?",
+    controller: newAdminRoute,
+  });
+  this.route("newAdminAppConfig", {
+    path: "/admin-new/app-config/:_token?",
+    controller: newAdminRoute,
+  });
+  this.route("newAdminAlerts", {
+    path: "/admin-new/alerts/:_token?",
+    controller: newAdminRoute,
+  });
+  this.route("newAdminStatus", {
+    path: "/admin-new/status/:_token?",
+    controller: newAdminRoute,
+  });
+  this.route("newAdminNetworkCapabilities", {
+    path: "/admin-new/network-capabilities/:_token?",
+    controller: newAdminRoute,
+  });
+  this.route("newAdminStats", {
+    path: "/admin-new/stats/:_token?",
+    controller: newAdminRoute,
+  });
+  this.route("newAdminFeatureKey", {
+    path: "/admin-new/feature-key/:_token?",
+    controller: newAdminRoute,
   });
 });

--- a/shell/client/admin/admin-new-client.js
+++ b/shell/client/admin/admin-new-client.js
@@ -1,0 +1,15 @@
+Template.adminNavPill.helpers({
+  currentRouteNameIs(name) {
+    return Router.current().route.getName() === name;
+  },
+});
+
+Template.newAdmin.helpers({
+  adminTab() {
+    return Router.current().route.getName();
+  },
+
+  wildcardHostSeemsBroken() {
+    return Session.get("alreadyTestedWildcardHost") && !Session.get("wildcardHostWorks");
+  },
+});

--- a/shell/client/admin/admin.html
+++ b/shell/client/admin/admin.html
@@ -1,0 +1,74 @@
+<template name="adminNavPill">
+{{!--
+  Takes as arguments:
+
+  routeName: String
+       data: String
+--}}
+<li class="nav-pill {{#if currentRouteNameIs routeName}}active{{/if}}">
+  {{#linkTo route=routeName data=data}}{{> Template.contentBlock}}{{/linkTo}}
+</li>
+</template>
+
+<template name="newAdmin">
+  {{>title "(new) Admin Settings"}}
+  {{#if wildcardHostSeemsBroken}}
+  <div class="wildcard-host-warning">
+    WARNING: This server seems to have its WILDCARD_HOST misconfigured.  Until you fix it, you will
+    not be able to use any apps.
+    <a target="_blank"
+       href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
+      Learn more.</a>  You'll need to adjust DNS, SSL/TLS certificates, or edit the sandstorm.conf
+    file. Once you have addressed the issue, reload this page. If you're still having problems,
+    email us at support@sandstorm.io.
+  </div>
+  {{/if}}
+
+  {{> _adminConfigureLoginServiceDialog}}
+  <div class="admin-settings">
+    {{#if isUserPermitted}}
+      <ul class="nav-pills">
+        {{#adminNavPill routeName="newAdminIdentity" data=getToken}}Identity Providers{{/adminNavPill}}
+        {{#adminNavPill routeName="newAdminEmailConfig" data=getToken}}Email Configuration{{/adminNavPill}}
+        {{#adminNavPill routeName="newAdminUsers" data=getToken}}User Accounts{{/adminNavPill}}
+        {{#adminNavPill routeName="newAdminAppConfig" data=getToken}}App Configuration{{/adminNavPill}}
+        {{#adminNavPill routeName="newAdminAlerts" data=getToken}}Admin Alerts{{/adminNavPill}}
+        {{#adminNavPill routeName="newAdminStatus" data=getToken}}System Status{{/adminNavPill}}
+        {{#adminNavPill routeName="newAdminNetworkCapabilities" data=getToken}}Network Capabilities{{/adminNavPill}}
+        {{#adminNavPill routeName="newAdminStats" data=getToken}}Stats{{/adminNavPill}}
+        {{#adminNavPill routeName="newAdminFeatureKey" data=getToken}}For Work{{/adminNavPill}}
+      </ul>
+      {{> Template.dynamic template=adminTab}}
+    {{else}}
+      <p>
+        You are not logged in as admin and there isn't a valid token specified. You should
+        either log in as an admin user or generate a token from the command line by doing
+        `sandstorm admin-token` in order to access the admin settings page.
+      </p>
+    {{/if}}
+  </div>
+</template>
+
+<template name="newAdminUsers">
+  <h1>User Accounts</h1>
+</template>
+
+<template name="newAdminAppConfig">
+  <h1>App Configuration</h1>
+</template>
+
+<template name="newAdminAlerts">
+  <h1>Admin Alerts</h1>
+</template>
+
+<template name="newAdminNetworkCapabilities">
+  <h1>Network Capabilities</h1>
+</template>
+
+<template name="newAdminStats">
+  <h1>Stats</h1>
+</template>
+
+<template name="newAdminFeatureKey">
+  <h1>Sandstorm for Work</h1>
+</template>

--- a/shell/client/admin/email-config-client.js
+++ b/shell/client/admin/email-config-client.js
@@ -1,0 +1,96 @@
+/* globals getToken, globalDb */
+
+Template.newAdminEmailConfig.onCreated(function () {
+  const c = globalDb.getSmtpConfig();
+  this.hostname = new ReactiveVar(c && c.hostname || "");
+  this.port = new ReactiveVar(c && c.port || "25");
+  this.username = new ReactiveVar(c && c.auth && c.auth.user || "");
+  this.password = new ReactiveVar(c && c.auth && c.auth.pass || "");
+  this.returnAddress = new ReactiveVar(c && c.returnAddress || ("support@" + window.location.hostname));
+  this.state = new ReactiveVar("default");
+  this.errorMessage = new ReactiveVar("");
+});
+
+Template.newAdminEmailConfig.helpers({
+  hostname() {
+    const instance = Template.instance();
+    return instance.hostname.get();
+  },
+
+  port() {
+    const instance = Template.instance();
+    return instance.port.get();
+  },
+
+  username() {
+    const instance = Template.instance();
+    return instance.username.get();
+  },
+
+  password() {
+    const instance = Template.instance();
+    return instance.password.get();
+  },
+
+  returnAddress() {
+    const instance = Template.instance();
+    return instance.returnAddress.get();
+  },
+
+  isFormSubmitting() {
+    const instance = Template.instance();
+    return instance.state.get() === "submitting";
+  },
+
+  hasError() {
+    const instance = Template.instance();
+    return instance.state.get() === "error";
+  },
+
+  hasSuccess() {
+    const instance = Template.instance();
+    return instance.state.get() === "success";
+  },
+
+  errorMessage() {
+    const instance = Template.instance();
+    return instance.errorMessage.get();
+  },
+});
+
+const extractDataFromForm = (instance) => {
+  const hostname = instance.hostname.get();
+  const port = parseInt(instance.port.get());
+  const user = instance.username.get();
+  const pass = instance.password.get();
+  const returnAddress = instance.returnAddress.get();
+  const formData = {
+    hostname,
+    port,
+    auth: {
+      user,
+      pass,
+    },
+    returnAddress,
+  };
+  return formData;
+};
+
+Template.newAdminEmailConfig.events({
+  "submit .email-form"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    const token = getToken();
+    const formData = extractDataFromForm(instance);
+    Meteor.call("setSmtpConfig", token && token._token, formData, (err) => {
+      if (err) {
+        instance.errorMessage.set(err.toString());
+        instance.state.set("error");
+      } else {
+        instance.state.set("success");
+      }
+    });
+    instance.state.set("submitting");
+  },
+});

--- a/shell/client/admin/email-config.html
+++ b/shell/client/admin/email-config.html
@@ -1,0 +1,54 @@
+<template name="newAdminEmailConfig">
+  <h1>Email Configuration</h1>
+
+  <h2>Email relay</h2>
+
+  <p>This is the server that Sandstorm will use to send email.</p>
+
+  {{#if hasSuccess}}<p class="flash-message success-message">Saved changes.</p>{{/if}}
+  {{#if hasError}}<p class="flash-message error-message">Failed to save changes: {{errorMessage}}</p>{{/if}}
+
+  <form class="email-form">
+
+    <div class="input-group host-port">
+      <label>
+        SMTP host
+        <input class="hostname" type="text" value="{{hostname}}" required />
+      </label>
+      <label>
+        Port
+        <input class="port" type="number" value="{{port}}" required />
+      </label>
+    </div>
+
+    <div class="input-group">
+      <label>
+        Username
+        <input class="username" type="text" value="{{username}}" />
+      </label>
+    </div>
+
+    <div class="input-group">
+      <label>
+        Password
+        <input class="password" type="password" value="{{password}}" />
+      </label>
+    </div>
+
+    <div class="input-group">
+      <label>
+        Support email address
+        <input class="from-address" type="text" value="{{returnAddress}}" required />
+      </label>
+      <span class="form-subtext">
+        Enter a single email address.  Email sent by this Sandstorm
+        instance will appear to come from this address.
+      </span>
+    </div>
+
+    <div class="form-buttons">
+      <button class="form-submit" type="submit">Save Configuration</button>
+    </div>
+
+  </form>
+</template>

--- a/shell/client/admin/identity-providers.html
+++ b/shell/client/admin/identity-providers.html
@@ -1,0 +1,332 @@
+<template name="newAdminIdentity">
+  <h1>Identity Providers</h1>
+  <p>Choose which services users may use to identify themselves.  Anyone can log in, but only users you invite will be able to install apps or create grains.</p>
+  {{>adminIdentityProviderTable idpData=idpData}}
+</template>
+
+<template name="modalDialogWithBackdrop">
+{{!-- expects some arguments:
+   onDismiss: Function.  A callback to trigger when the user requests that this modal be dismissed,
+                         by clicking on a close button or outside the boundary of the modal.
+   A content block of what to put inside the modal.
+--}}
+<div class="modal" role="dialog">
+  {{!-- TODO: animate --}}
+  <div class="modal-backdrop"></div>
+  <div class="fade in modal" role="dialog">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <button class="modal-close-button"></button>
+        {{> Template.contentBlock }}
+      </div>
+    </div>
+  </div>
+</div>
+</template>
+
+<template name="adminIdentityProviderConfigureEmail">
+{{#modalDialogWithBackdrop onDismiss=onDismiss}}
+  <h2>Email Login Configuration</h2>
+
+  {{#if errorMessage}}
+    {{#focusingErrorBox}}
+      Failed to save changes: {{errorMessage}}
+    {{/focusingErrorBox}}
+  {{/if}}
+
+  <form class="setup-idp-form">
+    <div class="form-group">
+      <label><input type="checkbox" name="enableEmail" checked="{{emailChecked}}"/>Enable login with email</label>
+      <span class="form-subtext">
+        To use email login, you'll also need to configure an email relay.
+      </span>
+    </div>
+  </form>
+
+  <div class="idp-modal-button-row">
+    <button class="idp-modal-save">
+      Save
+    </button>
+    <button class="idp-modal-cancel">
+      Cancel
+    </button>
+  </div>
+{{/modalDialogWithBackdrop}}
+</template>
+
+<template name="adminIdentityProviderConfigureGoogle">
+{{#modalDialogWithBackdrop onDismiss=onDismiss}}
+  <h2>Google Login Configuration</h2>
+
+  {{#if errorMessage}}
+    {{#focusingErrorBox}}
+      Failed to save changes: {{errorMessage}}
+    {{/focusingErrorBox}}
+  {{/if}}
+
+  <form class="setup-idp-form">
+    <div class="form-group">
+      <label>
+        <input type="checkbox" name="enableGoogle" checked="{{googleChecked}}"/>Enable login with Google
+      </label>
+    </div>
+
+    {{!-- TODO: replace these instructions with our own, which we can keep more up-to-date. --}}
+    {{> configureLoginServiceDialogForGoogle}}
+
+    <p>Now, copy over some details:</p>
+    <div class="form-group">
+      <label>
+        Client ID:
+        <input type="text" name="clientId" value="{{clientId}}"/>
+      </label>
+    </div>
+    <div class="form-group">
+      <label>
+        Client Secret:
+        <input type="text" name="clientSecret" value="{{clientSecret}}"/>
+      </label>
+    </div>
+  </form>
+
+  <div class="idp-modal-button-row">
+    <button class="idp-modal-save" {{saveHtmlDisabled}}>
+      Save
+    </button>
+    <button class="idp-modal-cancel">
+      Cancel
+    </button>
+  </div>
+{{/modalDialogWithBackdrop}}
+</template>
+
+<template name="adminIdentityProviderConfigureGitHub">
+{{#modalDialogWithBackdrop onDismiss=onDismiss}}
+  <h2>GitHub Configuration</h2>
+
+  <form class="setup-idp-form">
+    <div class="form-group">
+      <label>
+        <input type="checkbox" name="enableGithub" checked="{{githubChecked}}"/>Enable login with GitHub
+      </label>
+    </div>
+
+    {{!-- TODO: replace these instructions with our own, which we can keep more up-to-date. --}}
+    {{> configureLoginServiceDialogForGithub}}
+
+    <p>Now, copy over some details:</p>
+    <div class="form-group">
+      <label>
+        Client ID:
+        <input type="text" name="clientId" value="{{clientId}}"/>
+      </label>
+    </div>
+    <div class="form-group">
+      <label>
+        Client Secret:
+        <input type="text" name="clientSecret" value="{{clientSecret}}"/>
+      </label>
+    </div>
+  </form>
+
+  <div class="idp-modal-button-row">
+    <button class="idp-modal-save" {{saveHtmlDisabled}}>
+      Save
+    </button>
+    <button class="idp-modal-cancel">
+      Cancel
+    </button>
+  </div>
+{{/modalDialogWithBackdrop}}
+</template>
+
+<template name="adminIdentityProviderConfigureLdap">
+{{#modalDialogWithBackdrop onDismiss=onDismiss}}
+  <h2>LDAP Configuration</h2>
+
+  {{#if errorMessage}}
+    {{#focusingErrorBox}}
+      Failed to save changes: {{errorMessage}}
+    {{/focusingErrorBox}}
+  {{/if}}
+
+  <form class="setup-idp-form">
+    <div class="form-group">
+      <label><input type="checkbox" name="enableLdap" checked="{{ldapChecked}}"/>Enable login with LDAP</label>
+    </div>
+
+    <div class="form-group">
+      <label>LDAP server URL:
+        <input type="text" name="ldapUrl" value="{{ldapUrl}}" />
+      </label>
+      <span class="form-subtext">
+        e.g. <code>ldap://ldap.example.com:389</code>.  Use port 636 for SSL.
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label>Bind user DN
+        <input type="text" name="ldapSearchBindDn" value="{{ldapSearchBindDn}}"/>
+      </label>
+      <span class="form-subtext">
+        The DN to bind as when searching for a user in the tree, e.g.
+        <code>cn=admin,ou=users,dc=example,dc=com</code>.  Optional,
+        but needed if your server doesn't allow unauthenticated searches.
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label>Bind user password
+        <input type="text" name="ldapSearchBindPassword" value="{{ldapSearchBindPassword}}"/>
+      </label>
+      <span class="form-subtext">
+        Optional, needed if specifying bind DN above.
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label>Base DN
+        <input type="text" name="ldapBase" value="{{ldapBase}}"/>
+      </label>
+      <span class="form-subtext">
+        The root object under which to search for user account nodes, e.g.
+        <code>ou=users,dc=example,dc=com</code>
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label>LDAP username attribute
+        <input type="text" name="ldapSearchUsername" value="{{ldapSearchUsername}}"/>
+      </label>
+      <span class="form-subtext">
+        The LDAP attribute on a user object which represents the user's
+        username (what they will enter in the username field when signing in).
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label>LDAP given name attribute
+        <input type="text" name="ldapNameField" value="{{ldapNameField}}"/>
+      </label>
+      <span class="form-subtext">
+        The LDAP attribute on a user object which represents the user's full display name.
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label>LDAP email attribute
+        <input type="text" name="ldapEmailField" value="{{ldapEmailField}}"/>
+      </label>
+      <span class="form-subtext">
+        The LDAP attribute on a user object which represents the user's email address.
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label>Additional LDAP filter criteria
+        <input type="text" name="ldapFilter" value="{{ldapFilter}}"/>
+      </label>
+      <span class="form-subtext">
+        An optional LDAP query fragment that will be included in the user
+        search. This is not commonly used. See <a target="_blank" href="http://www.ietf.org/rfc/rfc2254.txt">RFC2254</a>.
+      </span>
+    </div>
+
+  </form>
+
+  <div class="idp-modal-button-row">
+    <button class="idp-modal-save" {{saveHtmlDisabled}}>
+      Save
+    </button>
+    <button class="idp-modal-cancel">
+      Cancel
+    </button>
+  </div>
+{{/modalDialogWithBackdrop}}
+</template>
+
+<template name="adminIdentityProviderConfigureSaml">
+{{#modalDialogWithBackdrop onDismiss=onDismiss}}
+  <h2>SAML Login Configuration</h2>
+
+  <p>
+    Your SAML IDP should be configured to return a persistent nameID. In addition you <strong>must</strong>
+    configure your IDP to provide two extra attributes, <code>email</code> and <code>displayName</code>.
+  </p>
+
+  {{#if errorMessage}}
+    {{#focusingErrorBox}}
+      Failed to save changes: {{errorMessage}}
+    {{/focusingErrorBox}}
+  {{/if}}
+
+  <form class="setup-idp-form">
+    <div class="form-group">
+      <label><input type="checkbox" name="enableSaml" checked="{{samlChecked}}"/>Enable login with SAML</label>
+    </div>
+
+    <div class="form-group">
+      <label>SAML provider entry point URL:
+        <input type="text" name="entryPoint" value="{{samlEntryPoint}}" placeholder="https://YOUR_SAML_PROVIDER.com/sso/saml" />
+      </label>
+    </div>
+
+    <div class="form-group">
+      <label>SAML cert for above provider:
+        <textarea type="text" name="publicCert" value="{{samlPublicCert}}" placeholder="base64 encoded cert (e.g. MIID...8F==)"></textarea>
+      </label>
+    </div>
+  </form>
+
+  <div class="idp-modal-button-row">
+    <button class="idp-modal-save" {{saveHtmlDisabled}}>
+      Save
+    </button>
+    <button class="idp-modal-cancel">
+      Cancel
+    </button>
+  </div>
+{{/modalDialogWithBackdrop}}
+</template>
+
+<template name="adminIdentityProviderTable">
+<div class="identity-provider-table" role="grid">
+  <div class="idp-table-header" role="rowgroup">
+    <div class="idp-header-row" role="row">
+      <span class="idp" role="rowheader">Identity Provider</span>
+      <span class="idp-status" role="rowheader">Status</span>
+    </div>
+  </div>
+  <div class="idp-table-rows" role="rowgroup">
+  {{#each idp in idpData}}
+    {{> adminIdentityRow idp=idp}}
+  {{/each}}
+  {{#each idp in idpData}}
+    {{#if currentPopupIs idp.id}}
+      <div >
+        {{> Template.dynamic template=idp.popupTemplate data=popupData}}
+      </div>
+    {{/if}}
+  {{/each}}
+  </div>
+</div>
+</template>
+
+<template name="adminIdentityRow">
+<div class="idp-table-row" role="row">
+  <span class="idp" role="gridcell">{{idp.label}}</span>
+  <span class="idp-status" role="gridcell">
+    {{#if idp.enabled}}
+      <span class="idp-enabled">Enabled</span>
+    {{else}}
+      <span class="idp-disabled">Not Enabled</span>
+    {{/if}}
+
+    {{#if needsFeatureKey}}
+      <button class="get-feature-key" title="Get feature key to configure {{idp.label}} login">Get feature key to configure</button>
+    {{else}}
+      <button class="configure-idp" title="Configure {{idp.label}} login">Configure</button>
+    {{/if}}
+  </span>
+</div>
+</template>

--- a/shell/client/admin/identity-providers.js
+++ b/shell/client/admin/identity-providers.js
@@ -1,0 +1,716 @@
+/* global Settings */
+
+const idpData = function (configureCallback) {
+  const emailTokenEnabled = globalDb.getSettingWithFallback("emailToken", false);
+  const googleEnabled = globalDb.getSettingWithFallback("google", false);
+  const githubEnabled = globalDb.getSettingWithFallback("github", false);
+  const ldapEnabled = globalDb.getSettingWithFallback("ldap", false);
+  const samlEnabled = globalDb.getSettingWithFallback("saml", false);
+  return [
+    {
+      id: "email-token",
+      label: "E-mail (passwordless)",
+      icon: "/email.svg", // Or use identicons
+      enabled: emailTokenEnabled,
+      popupTemplate: "adminIdentityProviderConfigureEmail",
+      onConfigure() {
+        configureCallback("email-token");
+      },
+    },
+    {
+      id: "google",
+      label: "Google",
+      icon: "/google.svg", // Or use identicons
+      enabled: googleEnabled,
+      popupTemplate: "adminIdentityProviderConfigureGoogle",
+      onConfigure() {
+        configureCallback("google");
+      },
+    },
+    {
+      id: "github",
+      label: "GitHub",
+      icon: "/github.svg", // Or use identicons
+      enabled: githubEnabled,
+      popupTemplate: "adminIdentityProviderConfigureGitHub",
+      onConfigure() {
+        configureCallback("github");
+      },
+    },
+    {
+      id: "ldap",
+      label: "LDAP",
+      icon: "/ldap.svg", // Or use identicons
+      enabled: ldapEnabled,
+      restricted: true,
+      popupTemplate: "adminIdentityProviderConfigureLdap",
+      onConfigure() {
+        configureCallback("ldap");
+      },
+    },
+    {
+      id: "saml",
+      label: "SAML",
+      icon: "/ldap.svg", // Or use identicons
+      enabled: samlEnabled,
+      restricted: true,
+      popupTemplate: "adminIdentityProviderConfigureSaml",
+      onConfigure() {
+        configureCallback("saml");
+      },
+    },
+  ];
+};
+
+Template.adminIdentityProviderTable.onCreated(function () {
+  this.currentPopup = new ReactiveVar(undefined);
+});
+
+Template.adminIdentityProviderTable.helpers({
+  idpData() {
+    const instance = Template.instance();
+    return idpData((idp) => {
+      instance.currentPopup.set(idp);
+    });
+  },
+
+  currentPopupIs(arg) {
+    const instance = Template.instance();
+    return instance.currentPopup.get() === arg;
+  },
+
+  popupData() {
+    const instance = Template.instance();
+    // The data context passed in to the popupTemplate instance, as specified in the idpData above.
+    return {
+      onDismiss() {
+        return () => {
+          instance.currentPopup.set(undefined);
+        };
+      },
+    };
+  },
+});
+
+Template.adminIdentityRow.events({
+  "click button.configure-idp"() {
+    const instance = Template.instance();
+    instance.data.idp.onConfigure();
+  },
+
+  "click button.get-feature-key"() {
+    // TODO: non-setup-UI probably shouldn't do this.  Pass in a callback instead?
+    Router.go("setupWizardFeatureKey");
+  },
+});
+
+Template.adminIdentityRow.helpers({
+  needsFeatureKey() {
+    const instance = Template.instance();
+    const featureKeyValid = globalDb.isFeatureKeyValid();
+    return instance.data.idp.restricted && !featureKeyValid;
+  },
+});
+
+Template.modalDialogWithBackdrop.onCreated(function () {
+  // This keypress event listener which closes the dialog when Escape is pressed should be scoped to
+  // the browser window, not this template.
+  this.keypressListener = (evt) => {
+    if (evt.keyCode === 27) {
+      this.data.onDismiss && this.data.onDismiss();
+    }
+  };
+
+  window.addEventListener("keydown", this.keypressListener);
+  document.getElementsByTagName("body")[0].classList.add("modal-shown");
+});
+
+Template.modalDialogWithBackdrop.onDestroyed(function () {
+  window.removeEventListener("keydown", this.keypressListener);
+  document.getElementsByTagName("body")[0].classList.remove("modal-shown");
+});
+
+Template.modalDialogWithBackdrop.events({
+  "click .modal"(evt) {
+    if (evt.currentTarget === evt.target) {
+      // Only dismiss if the click was on the backdrop, not the main form.
+      const instance = Template.instance();
+      instance.data.onDismiss && instance.data.onDismiss();
+    }
+  },
+
+  "click .modal-close-button"(evt) {
+    const instance = Template.instance();
+    instance.data.onDismiss && instance.data.onDismiss();
+  },
+});
+
+// Email form.
+Template.adminIdentityProviderConfigureEmail.onCreated(function () {
+  const emailEnabled = globalDb.getSettingWithFallback("emailToken", false);
+  this.emailChecked = new ReactiveVar(emailEnabled);
+  this.errorMessage = new ReactiveVar(undefined);
+});
+
+Template.adminIdentityProviderConfigureEmail.onRendered(function () {
+  // Focus the first input when the form is shown.
+  this.find("input").focus();
+});
+
+Template.adminIdentityProviderConfigureEmail.events({
+  "click input[name=enableEmail]"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    instance.emailChecked.set(!instance.emailChecked.get());
+  },
+
+  "click .idp-modal-save"(evt) {
+    const instance = Template.instance();
+    const enableEmail = instance.emailChecked.get();
+    const token = Iron.controller().state.get("token");
+    Meteor.call("setAccountSetting", token, "emailToken", enableEmail, (err) => {
+      if (err) {
+        instance.errorMessage.set(err.message);
+      } else {
+        instance.data.onDismiss()();
+      }
+    });
+  },
+
+  "click .idp-modal-cancel"(evt) {
+    const instance = Template.instance();
+    // double invocation because there's no way to pass a callback function around in Blaze without
+    // invoking it, and we need to pass it to modalDialogWithBackdrop
+    instance.data.onDismiss()();
+  },
+});
+
+Template.adminIdentityProviderConfigureEmail.helpers({
+  emailChecked() {
+    const instance = Template.instance();
+    return instance.emailChecked.get();
+  },
+
+  errorMessage() {
+    const instance = Template.instance();
+    return instance.errorMessage.get();
+  },
+});
+
+// Google form.
+Template.adminIdentityProviderConfigureGoogle.onCreated(function () {
+  const googleChecked = globalDb.getSettingWithFallback("google", false);
+
+  const configurations = Package["service-configuration"].ServiceConfiguration.configurations;
+  const googleConfiguration = configurations.findOne({ service: "google" });
+  const clientId = googleConfiguration && googleConfiguration.clientId;
+  const clientSecret = googleConfiguration && googleConfiguration.secret;
+
+  this.googleChecked = new ReactiveVar(googleChecked);
+  this.clientId = new ReactiveVar(clientId);
+  this.clientSecret = new ReactiveVar(clientSecret);
+  this.errorMessage = new ReactiveVar(undefined);
+});
+
+Template.adminIdentityProviderConfigureGoogle.onRendered(function () {
+  // Focus the first input when the form is shown.
+  this.find("input").focus();
+});
+
+Template.adminIdentityProviderConfigureGoogle.helpers({
+  googleChecked() {
+    const instance = Template.instance();
+    return instance.googleChecked.get();
+  },
+
+  clientId() {
+    const instance = Template.instance();
+    return instance.clientId.get();
+  },
+
+  clientSecret() {
+    const instance = Template.instance();
+    return instance.clientSecret.get();
+  },
+
+  saveHtmlDisabled() {
+    const instance = Template.instance();
+    if (instance.googleChecked.get() && (!instance.clientId.get() || !instance.clientSecret.get())) {
+      return "disabled";
+    }
+
+    return "";
+  },
+
+  errorMessage() {
+    const instance = Template.instance();
+    return instance.errorMessage.get();
+  },
+});
+
+Template.adminIdentityProviderConfigureGoogle.events({
+  "click input[name=enableGoogle]"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    instance.googleChecked.set(!instance.googleChecked.get());
+  },
+
+  "input input[name=clientId]"(evt) {
+    const instance = Template.instance();
+    instance.clientId.set(evt.currentTarget.value);
+  },
+
+  "input input[name=clientSecret]"(evt) {
+    const instance = Template.instance();
+    instance.clientSecret.set(evt.currentTarget.value);
+  },
+
+  "click .idp-modal-save"(evt) {
+    const instance = Template.instance();
+    const enableGoogle = instance.googleChecked.get();
+    const token = Iron.controller().state.get("token");
+    const configuration = {
+      service: "google",
+      clientId: instance.clientId.get(),
+      secret: instance.clientSecret.get(),
+      loginStyle: "redirect",
+    };
+    // TODO: rework this into a single Meteor method call.
+    Meteor.call("adminConfigureLoginService", token, configuration, (err) => {
+      if (err) {
+        instance.errorMessage.set(err.message);
+      } else {
+        Meteor.call("setAccountSetting", token, "google", enableGoogle, (err) => {
+          if (err) {
+            instance.errorMessage.set(err.message);
+          } else {
+            instance.data.onDismiss()();
+          }
+        });
+      }
+    });
+  },
+
+  "click .idp-modal-cancel"(evt) {
+    const instance = Template.instance();
+    // double invocation because there's no way to pass a callback function around in Blaze without
+    // invoking it, and we need to pass it to modalDialogWithBackdrop
+    instance.data.onDismiss()();
+  },
+});
+
+// GitHub form.
+Template.adminIdentityProviderConfigureGitHub.onCreated(function () {
+  const githubChecked = globalDb.getSettingWithFallback("github", false);
+
+  const configurations = Package["service-configuration"].ServiceConfiguration.configurations;
+  const githubConfiguration = configurations.findOne({ service: "github" });
+  const clientId = githubConfiguration && githubConfiguration.clientId;
+  const clientSecret = githubConfiguration && githubConfiguration.secret;
+
+  this.githubChecked = new ReactiveVar(githubChecked);
+  this.clientId = new ReactiveVar(clientId);
+  this.clientSecret = new ReactiveVar(clientSecret);
+  this.errorMessage = new ReactiveVar(undefined);
+});
+
+Template.adminIdentityProviderConfigureGitHub.onRendered(function () {
+  // Focus the first input when the form is shown.
+  this.find("input").focus();
+});
+
+Template.adminIdentityProviderConfigureGitHub.helpers({
+  githubChecked() {
+    const instance = Template.instance();
+    return instance.githubChecked.get();
+  },
+
+  clientId() {
+    const instance = Template.instance();
+    return instance.clientId.get();
+  },
+
+  clientSecret() {
+    const instance = Template.instance();
+    return instance.clientSecret.get();
+  },
+
+  saveHtmlDisabled() {
+    const instance = Template.instance();
+    if (instance.githubChecked.get() && (!instance.clientId.get() || !instance.clientSecret.get())) {
+      return "disabled";
+    }
+
+    return "";
+  },
+
+  errorMessage() {
+    const instance = Template.instance();
+    return instance.errorMessage.get();
+  },
+});
+
+Template.adminIdentityProviderConfigureGitHub.events({
+  "click input[name=enableGithub]"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    instance.githubChecked.set(!instance.githubChecked.get());
+  },
+
+  "input input[name=clientId]"(evt) {
+    const instance = Template.instance();
+    instance.clientId.set(evt.currentTarget.value);
+  },
+
+  "input input[name=clientSecret]"(evt) {
+    const instance = Template.instance();
+    instance.clientSecret.set(evt.currentTarget.value);
+  },
+
+  "click .idp-modal-save"(evt) {
+    const instance = Template.instance();
+    const enableGithub = instance.githubChecked.get();
+    const token = Iron.controller().state.get("token");
+    const configuration = {
+      service: "github",
+      clientId: instance.clientId.get(),
+      secret: instance.clientSecret.get(),
+      loginStyle: "redirect",
+    };
+    // TODO: rework this into a single Meteor method call.
+    Meteor.call("adminConfigureLoginService", token, configuration, (err) => {
+      if (err) {
+        instance.errorMessage.set(err.message);
+      } else {
+        Meteor.call("setAccountSetting", token, "github", enableGithub, (err) => {
+          if (err) {
+            instance.errorMessage.set(err.message);
+          } else {
+            instance.data.onDismiss()();
+          }
+        });
+      }
+    });
+  },
+
+  "click .idp-modal-cancel"(evt) {
+    const instance = Template.instance();
+    // double invocation because there's no way to pass a callback function around in Blaze without
+    // invoking it, and we need to pass it to modalDialogWithBackdrop
+    instance.data.onDismiss()();
+  },
+});
+
+// LDAP form.
+Template.adminIdentityProviderConfigureLdap.onCreated(function () {
+  const ldapChecked = globalDb.getSettingWithFallback("ldap", false);
+  const url = globalDb.getLdapUrl();
+  const searchBindDn = globalDb.getLdapSearchBindDn();
+  const searchBindPassword = globalDb.getLdapSearchBindPassword();
+  const base = globalDb.getLdapBase(); //"ou=users,dc=example,dc=com"
+  const searchUsername = globalDb.getLdapSearchUsername() || "uid";
+  const nameField = globalDb.getLdapNameField() || "cn";
+  const emailField = globalDb.getLdapEmailField() || "mail";
+  const filter = globalDb.getLdapFilter();
+
+  this.ldapChecked = new ReactiveVar(ldapChecked);
+  this.ldapUrl = new ReactiveVar(url);
+  this.ldapSearchBindDn = new ReactiveVar(searchBindDn);
+  this.ldapSearchBindPassword = new ReactiveVar(searchBindPassword);
+  this.ldapBase = new ReactiveVar(base);
+  this.ldapSearchUsername = new ReactiveVar(searchUsername);
+  this.ldapNameField = new ReactiveVar(nameField);
+  this.ldapEmailField = new ReactiveVar(emailField);
+  this.ldapFilter = new ReactiveVar(filter);
+  this.errorMessage = new ReactiveVar(undefined);
+});
+
+Template.adminIdentityProviderConfigureLdap.onRendered(function () {
+  // Focus the first input when the form is shown.
+  this.find("input").focus();
+});
+
+Template.adminIdentityProviderConfigureLdap.helpers({
+  ldapChecked() {
+    const instance = Template.instance();
+    return instance.ldapChecked.get();
+  },
+
+  ldapUrl() {
+    const instance = Template.instance();
+    return instance.ldapUrl.get();
+  },
+
+  ldapBase() {
+    const instance = Template.instance();
+    return instance.ldapBase.get();
+  },
+
+  ldapSearchUsername() {
+    const instance = Template.instance();
+    return instance.ldapSearchUsername.get();
+  },
+
+  ldapFilter() {
+    const instance = Template.instance();
+    return instance.ldapFilter.get();
+  },
+
+  ldapSearchBindDn() {
+    const instance = Template.instance();
+    return instance.ldapSearchBindDn.get();
+  },
+
+  ldapSearchBindPassword() {
+    const instance = Template.instance();
+    return instance.ldapSearchBindPassword.get();
+  },
+
+  ldapNameField() {
+    const instance = Template.instance();
+    return instance.ldapNameField.get();
+  },
+
+  ldapEmailField() {
+    const instance = Template.instance();
+    return instance.ldapEmailField.get();
+  },
+
+  saveHtmlDisabled() {
+    const instance = Template.instance();
+    // Anything goes if the provider is disabled.
+    if (!instance.ldapChecked.get()) {
+      return "";
+    }
+
+    // If the provider is enabled, then you must provide:
+    // * a nonempty URL
+    // * a nonempty username attribute
+    // * a nonempty given name attribute
+    // * a nonempty email attribute
+    if (!instance.ldapUrl.get() ||
+        !instance.ldapSearchUsername.get() ||
+        !instance.ldapNameField.get() ||
+        !instance.ldapEmailField.get()) {
+      return "disabled";
+    }
+
+    return "";
+  },
+
+  errorMessage() {
+    const instance = Template.instance();
+    return instance.errorMessage.get();
+  },
+});
+
+Template.adminIdentityProviderConfigureLdap.events({
+  "click input[name=enableLdap]"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    instance.ldapChecked.set(!instance.ldapChecked.get());
+  },
+
+  "input input[name=ldapUrl]"(evt) {
+    const instance = Template.instance();
+    instance.ldapUrl.set(evt.currentTarget.value);
+  },
+
+  "input input[name=ldapSearchBindDn]"(evt) {
+    const instance = Template.instance();
+    instance.ldapSearchBindDn.set(evt.currentTarget.value);
+  },
+
+  "input input[name=ldapSearchBindPassword]"(evt) {
+    const instance = Template.instance();
+    instance.ldapSearchBindPassword.set(evt.currentTarget.value);
+  },
+
+  "input input[name=ldapBase]"(evt) {
+    const instance = Template.instance();
+    instance.ldapBase.set(evt.currentTarget.value);
+  },
+
+  "input input[name=ldapSearchUsername]"(evt) {
+    const instance = Template.instance();
+    instance.ldapSearchUsername.set(evt.currentTarget.value);
+  },
+
+  "input input[name=ldapNameField]"(evt) {
+    const instance = Template.instance();
+    instance.ldapNameField.set(evt.currentTarget.value);
+  },
+
+  "input input[name=ldapEmailField]"(evt) {
+    const instance = Template.instance();
+    instance.ldapEmailField.set(evt.currentTarget.value);
+  },
+
+  "input input[name=ldapFilter]"(evt) {
+    const instance = Template.instance();
+    instance.ldapFilter.set(evt.currentTarget.value);
+  },
+
+  "click .idp-modal-save"(evt) {
+    // TODO(soon): refactor the backend to make this a single Meteor call, and an atomic DB write.
+    const instance = Template.instance();
+    const token = Iron.controller().state.get("token");
+
+    // A list of settings to save with the setSetting method, in order.
+    const settingsToSave = [
+      { name: "ldapUrl",                value: instance.ldapUrl.get() },
+      { name: "ldapSearchBindDn",       value: instance.ldapSearchBindDn.get() },
+      { name: "ldapSearchBindPassword", value: instance.ldapSearchBindPassword.get() },
+      { name: "ldapBase",               value: instance.ldapBase.get() },
+      { name: "ldapSearchUsername",     value: instance.ldapSearchUsername.get() },
+      { name: "ldapNameField",          value: instance.ldapNameField.get() },
+      { name: "ldapEmailField",         value: instance.ldapEmailField.get() },
+      { name: "ldapFilter",             value: instance.ldapFilter.get() },
+    ];
+
+    const saveSettings = function (settingList, errback, callback) {
+      const setting = settingList[0];
+      Meteor.call("setSetting", token, setting.name, setting.value, (err) => {
+        if (err) {
+          errback(err);
+        } else {
+          settingList.shift();
+          if (settingList.length === 0) {
+            callback();
+          } else {
+            saveSettings(settingList, errback, callback);
+          }
+        }
+      });
+    };
+
+    saveSettings(settingsToSave,
+      (err) => { instance.errorMessage.set(err.message); },
+
+      () => {
+        // ldap requires the "setAccountSetting" method, so it's separated out here.
+        Meteor.call("setAccountSetting", token, "ldap", instance.ldapChecked.get(), (err) => {
+          if (err) {
+            instance.errorMessage.set(err.message);
+          } else {
+            instance.data.onDismiss()();
+          }
+        });
+      }
+    );
+  },
+
+  "click .idp-modal-cancel"(evt) {
+    const instance = Template.instance();
+    // double invocation because there's no way to pass a callback function around in Blaze without
+    // invoking it, and we need to pass it to modalDialogWithBackdrop
+    instance.data.onDismiss()();
+  },
+});
+
+// SAML form.
+Template.adminIdentityProviderConfigureSaml.onCreated(function () {
+  const samlChecked = globalDb.getSettingWithFallback("saml", false);
+  const samlEntryPoint = globalDb.getSamlEntryPoint();
+  const samlPublicCert = globalDb.getSamlPublicCert();
+
+  this.samlChecked = new ReactiveVar(samlChecked);
+  this.samlEntryPoint = new ReactiveVar(samlEntryPoint);
+  this.samlPublicCert = new ReactiveVar(samlPublicCert);
+  this.errorMessage = new ReactiveVar(undefined);
+});
+
+Template.adminIdentityProviderConfigureSaml.onRendered(function () {
+  // Focus the first input when the form is shown.
+  this.find("input").focus();
+});
+
+Template.adminIdentityProviderConfigureSaml.helpers({
+  samlChecked() {
+    const instance = Template.instance();
+    return instance.samlChecked.get();
+  },
+
+  samlEntryPoint() {
+    const instance = Template.instance();
+    return instance.samlEntryPoint.get();
+  },
+
+  samlPublicCert() {
+    const instance = Template.instance();
+    return instance.samlPublicCert.get();
+  },
+
+  saveHtmlDisabled() {
+    const instance = Template.instance();
+    if (instance.samlChecked.get() &&
+            (!instance.samlEntryPoint.get() || !instance.samlPublicCert.get())) {
+      return "disabled";
+    }
+
+    return "";
+  },
+
+  errorMessage() {
+    const instance = Template.instance();
+    return instance.errorMessage.get();
+  },
+});
+
+Template.adminIdentityProviderConfigureSaml.events({
+  "click input[name=enableSaml]"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    instance.samlChecked.set(!instance.samlChecked.get());
+  },
+
+  "input input[name=entryPoint]"(evt) {
+    const instance = Template.instance();
+    instance.samlEntryPoint.set(evt.currentTarget.value);
+  },
+
+  "input textarea[name=publicCert]"(evt) {
+    const instance = Template.instance();
+    instance.samlPublicCert.set(evt.currentTarget.value);
+  },
+
+  "click .idp-modal-save"(evt) {
+    const instance = Template.instance();
+    const enableSaml = instance.samlChecked.get();
+    const samlEntryPoint = instance.samlEntryPoint.get();
+    const samlPublicCert = instance.samlPublicCert.get();
+    const token = Iron.controller().state.get("token");
+    // TODO: rework this into a single Meteor method call.
+    Meteor.call("setSetting", token, "samlEntryPoint", samlEntryPoint, (err) => {
+      if (err) {
+        instance.errorMessage.set(err.message);
+      } else {
+        Meteor.call("setSetting", token, "samlPublicCert", samlPublicCert, (err) => {
+          if (err) {
+            instance.errorMessage.set(err.message);
+          } else {
+            Meteor.call("setAccountSetting", token, "saml", enableSaml, (err) => {
+              if (err) {
+                instance.errorMessage.set(err.message);
+              } else {
+                instance.data.onDismiss()();
+              }
+            });
+          }
+        });
+      }
+    });
+  },
+
+  "click .idp-modal-cancel"(evt) {
+    const instance = Template.instance();
+    // double invocation because there's no way to pass a callback function around in Blaze without
+    // invoking it, and we need to pass it to modalDialogWithBackdrop
+    instance.data.onDismiss()();
+  },
+});

--- a/shell/client/admin/system-status-client.js
+++ b/shell/client/admin/system-status-client.js
@@ -16,12 +16,14 @@ Template.newAdminStatus.helpers({
   },
 
   logHtml() {
+    // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
     return AnsiUp.ansi_to_html(
       AdminLog.find({}, { $sort: { _id: 1 } })
           .map(entry => entry.text)
           .join(""),
       { use_classes: true }
     );
+    // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
   },
 });
 

--- a/shell/client/admin/system-status-client.js
+++ b/shell/client/admin/system-status-client.js
@@ -1,0 +1,31 @@
+const systemStatus = new Mongo.Collection("systemStatus");
+
+Template.newAdminStatus.helpers({
+  grainsActive() {
+    const data = systemStatus.findOne("globalStatus");
+    return data && data.activeGrains || 0;
+  },
+
+  usersActive() {
+    const data = systemStatus.findOne("globalStatus");
+    return data && data.activeUsers || 0;
+  },
+
+  sandstormVersion() {
+    return "0.147";
+  },
+
+  logHtml() {
+    return AnsiUp.ansi_to_html(
+      AdminLog.find({}, { $sort: { _id: 1 } })
+          .map(entry => entry.text)
+          .join(""),
+      { use_classes: true }
+    );
+  },
+});
+
+Template.newAdminStatus.onCreated(function () {
+  this.subscribe("adminLog");
+  this.subscribe("systemStatus");
+});

--- a/shell/client/admin/system-status.html
+++ b/shell/client/admin/system-status.html
@@ -1,0 +1,12 @@
+<template name="newAdminStatus">
+  <h1>System Status</h1>
+
+  <h2>Current Usage</h2>
+  <p>{{grainsActive}} open grains</p>
+  <p>{{usersActive}} users with grains open</p>
+
+  <h2>System Log</h2>
+  <div class="admin-log-box" aria-live="polite">
+    <pre>...{{{logHtml}}}</pre>
+  </div>
+</template>

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -496,7 +496,7 @@
       {{/unless}}
     {{else}}
       {{#if currentUserIsAdmin}}
-        <p>You are an admin on this server.  Excellent.</p>
+        <p>Great! Your account has admin privileges.</p>
       {{else}}
         {{#if serverHasAdmin}}
           <p>

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -513,7 +513,7 @@
       {{/if}}
     {{/if}}
   {{else}}
-    <p>You can now create the first account on this Sandstorm server.</p>
+    <p>You can now create an admin account on this Sandstorm server.</p>
     <div class="center">
       <p>Log in to create your admin account</p>
 

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -183,7 +183,7 @@
         <ul class="setup-features">
           <li>Login with Google, GitHub, or email address</li>
           <li>Each user gets their own workspace</li>
-          <li>Share grains with everyone</li>
+          <li>Share grains with anyone</li>
         </ul>
         <div class="setup-pricing-block">
           <p class="setup-price">Free</p>

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -155,9 +155,13 @@
           {{#linkTo route="adminSettings" class="admin-settings-button"}}Proceed to Admin Panel{{/linkTo}}
         </p>
       {{else}}
-        <p class="center">
-          <button class="make-self-admin">Give yourself admin privileges</button>
-        </p>
+        {{#if identityUser}}
+          {{> identityLoginInterstitial }}
+        {{else}}
+          <p class="center">
+            <button class="make-self-admin">Give yourself admin privileges</button>
+          </p>
+        {{/if}}
       {{/if}}
     {{else}}
       <p>
@@ -165,7 +169,13 @@
       </p>
       <p>
         <div class="center">
+          {{#if showSignInPanel}}
+            {{#with linkingNewIdentity=notLinkingNewIdentity}}
+              {{> loginButtonsDialog freshAccountsUi}}
+            {{/with}}
+          {{else}}
           <button class="sign-in-button">Sign in to become admin</button>
+          {{/if}}
         </div>
       </p>
     {{/if}}

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -1,0 +1,601 @@
+<template name="focusingErrorBox">
+{{!-- An error message which focuses itself and scrolls itself on screen each
+      time it is rendered, for accessibility. --}}
+<p class="flash-message error-message" tabindex="-1">
+  {{> Template.contentBlock}}
+</p>
+</template>
+
+<template name="focusingSuccessBox">
+{{!-- A success message which focuses itself and scrolls itself on screen each
+      time it is rendered, for accessibility. --}}
+<p class="flash-message success-message" tabindex="-1">
+  {{> Template.contentBlock}}
+</p>
+</template>
+
+<template name="setupWizardButtonRow">
+<div class="setup-button-row">
+  {{>Template.contentBlock }}
+</div>
+</template>
+
+<template name="setupWizardProgressBarItem">
+{{!-- pure template, takes args:
+        stepName: String   lowercase name of this step, to be used in class names an
+   isCurrentStep: Boolean  Is stepName the current step?
+       mayJumpTo: Boolean  Should this be linked, or just text?
+           route: String   Name of the route to link to, if this is rendered as a link.
+       className: String   Additional classes to place on the rendered li element.
+
+    and a content block, which should be safe to place inside a <span>.
+--}}
+<li class="setup-progress-step step-{{stepName}} {{className}}">
+  {{#if isCurrentStep}}
+    <span>
+      {{> Template.contentBlock}}
+    </span>
+  {{else}}
+    {{#if mayJumpTo}}
+      {{#linkTo route=route class=linkClassName}}
+        {{> Template.contentBlock}}
+      {{/linkTo}}
+    {{else}}
+      <span>
+        {{> Template.contentBlock}}
+      </span>
+    {{/if}}
+  {{/if}}
+</li>
+</template>
+
+<template name="setupWizardProgressBar">
+{{!-- expected arguments:
+   currentStep: String, should be one of ["intro", "identity", "organization", "email", "user", "success"]
+--}}
+<div class="setup-progress">
+  <ol class="setup-progress-labels">
+    {{#setupWizardProgressBarItem stepName="identity"
+                                   isCurrentStep=(currentStepIs "identity")
+                                   mayJumpTo=(mayJumpTo "identity")
+                                   route="setupWizardIdentity"
+                                   className=itemClassName}}
+      Login provider(s)
+    {{/setupWizardProgressBarItem}}
+
+    {{#if hasFeatureKey}}
+      {{#setupWizardProgressBarItem stepName="organization"
+                                     isCurrentStep=(currentStepIs "organization")
+                                     mayJumpTo=(mayJumpTo "organization")
+                                     route="setupWizardOrganization"
+                                     className=itemClassName}}
+        Organization
+      {{/setupWizardProgressBarItem}}
+    {{/if}}
+
+    {{#setupWizardProgressBarItem stepName="email"
+                                   isCurrentStep=(currentStepIs "email")
+                                   mayJumpTo=(mayJumpTo "email")
+                                   route="setupWizardEmailConfig"
+                                   className=itemClassName
+                                   }}
+      Set up email
+    {{/setupWizardProgressBarItem}}
+
+    {{#setupWizardProgressBarItem stepName="user"
+                                   isCurrentStep=(currentStepIs "user")
+                                   mayJumpTo=(mayJumpTo "user")
+                                   route="setupWizardLoginUser"
+                                   className=itemClassName
+                                   }}
+      Create admin account
+    {{/setupWizardProgressBarItem}}
+  </ol>
+  <div class="setup-progress-bar">
+    <div class="{{#if currentStepAtOrPast "identity"    }}complete{{else}}incomplete{{/if}}"></div>
+    {{#if hasFeatureKey}}
+    <div class="{{#if currentStepAtOrPast "organization"}}complete{{else}}incomplete{{/if}}"></div>
+    {{/if}}
+    <div class="{{#if currentStepAtOrPast "email"       }}complete{{else}}incomplete{{/if}}"></div>
+    <div class="{{#if currentStepAtOrPast "user"        }}complete{{else}}incomplete{{/if}}"></div>
+    <div class="{{#if currentStepAtOrPast "success"     }}complete{{else}}incomplete{{/if}}"></div>
+  </div>
+</div>
+</template>
+
+<template name="setupWizardHelpFooter">
+<div class="setup-help-row">
+  <span class="setup-help-label">Need help?</span>
+  <a class="setup-help-link" target="_blank" href="https://docs.sandstorm.io/en/latest/administering/">Documentation</a>
+  <a class="setup-help-link" href="mailto:support@sandstorm.io">Email support</a>
+  {{!-- TODO(someday): Live Chat link --}}
+</div>
+</template>
+
+<template name="setupWizardLayout">
+<div class="setup-root">
+  {{> yield}}
+  {{> setupWizardHelpFooter }}
+  <div class="sandstorm-logo-row">
+    <div class="sandstorm-logo"></div>
+  </div>
+</div>
+</template>
+
+<template name="setupWizardIntro">
+<div class="setup-page-content">
+  <h1 class="setup-page-title">Welcome to Sandstorm!</h1>
+
+  {{#if initialSetupComplete}}
+    <p>
+      This Sandstorm server is ready to roll.
+      You can adjust server settings, including which providers are
+      enabled and how Sandstorm sends email.
+
+      {{#unless currentUserIsAdmin}}
+      You can also turn an existing user into an administrator.
+      {{/unless}}
+    </p>
+
+    {{#if errorMessage}}
+      {{#focusingErrorBox}}
+        {{errorMessage}}
+      {{/focusingErrorBox}}
+    {{/if}}
+
+    {{#if successMessage}}
+      {{#focusingSuccessBox}}
+        {{successMessage}}
+      {{/focusingSuccessBox}}
+    {{/if}}
+
+    {{#if currentUser}}
+      {{#if currentUserIsAdmin}}
+        <p class="center">
+          {{#linkTo route="adminSettings" class="admin-settings-button"}}Proceed to Admin Panel{{/linkTo}}
+        </p>
+      {{else}}
+        <p class="center">
+          <button class="make-self-admin">Give yourself admin privileges</button>
+        </p>
+      {{/if}}
+    {{else}}
+      <p>
+        To make an account into an admin account, please sign in:
+      </p>
+      <p>
+        <div class="center">
+          <button class="sign-in-button">Sign in to become admin</button>
+        </div>
+      </p>
+    {{/if}}
+
+    <p class="center">
+      {{#linkTo route="setupWizardIdentity" class="rerun-wizard-button"}}Revisit setup wizard{{/linkTo}}
+    </p>
+
+  {{else}}
+    <p>Choose what type of Sandstorm server to set up:</p>
+
+    <div class="setup-type-selection">
+      <div class="setup-type">
+        <h3>Standard</h3>
+        <ul class="setup-features">
+          <li>Login with Google, GitHub, or email address</li>
+          <li>Each user gets their own workspace</li>
+          <li>Share grains with everyone</li>
+        </ul>
+        <div class="setup-pricing-block">
+          <p class="setup-price">$0/user/month</p>
+          <p class="subheader">Free</p>
+          <p class="subheader">Open source</p>
+        </div>
+        <button class="setup-sandstorm-standard">Begin Standard Setup</button>
+      </div>
+      <div class="setup-type">
+        <h3>Sandstorm for Work</h3>
+        <ul class="setup-features">
+          <li>Includes everything in Standard</li>
+          <li class="setup-additional-feature">+ Single sign-on: email/LDAP/SAML</li>
+          <li class="setup-additional-feature">+ Automatic user provisioning</li>
+        </ul>
+        <div class="setup-pricing-block">
+          <p class="setup-price">$15/user/month</p>
+          <p class="subheader">Free trial for every organization</p>
+          <p class="subheader">Special pricing/discounts for non-profits</p>
+        </div>
+        <button class="setup-sandstorm-for-work">Begin Sandstorm for Work Setup</button>
+      </div>
+    </div>
+  {{/if}}
+</div>
+</template>
+
+<template name="setupWizardFeatureKey">
+<div class="setup-page-content">
+  <h1 class="setup-page-title">Sandstorm for Work feature key</h1>
+
+  {{!-- feature key form --}}
+  {{> adminFeatureKey }}
+
+  {{#setupWizardButtonRow}}
+    <button class="setup-next-button" {{nextButtonClass}}>
+      Next
+    </button>
+    <button class="setup-back-button">
+      Back
+    </button>
+  {{/setupWizardButtonRow}}
+</div>
+</template>
+
+<template name="setupWizardIdentity">
+<div class="setup-page-content">
+  <h1 class="setup-page-title">Configure Identity Provider(s)</h1>
+  {{> setupWizardProgressBar currentStep="identity"}}
+
+  <p>
+    To use Sandstorm, you need to create a user account.  Every user account on
+    Sandstorm is backed by an identity provider.  You'll use this identity provider
+    to authenticate as the first administrator of this Sandstorm install.
+  </p>
+
+  <p>
+    Configure the identity provider(s) you wish to enable.
+  </p>
+
+  {{> adminIdentityProviderTable idpData=idpData}}
+
+  {{#setupWizardButtonRow}}
+    <button class="setup-next-button" {{nextHtmlDisabled}}>
+      Next
+    </button>
+    <button class="setup-back-button">
+      Back
+    </button>
+  {{/setupWizardButtonRow}}
+</div>
+</template>
+
+<template name="setupWizardOrganization">
+<div class="setup-page-content">
+  <h1 class="setup-page-title">Configure Organization</h1>
+
+{{#if hasFeatureKey}}
+  {{> setupWizardProgressBar currentStep="organization"}}
+
+  <p>
+    Sandstorm for Work allows you to define an organization.
+    You can automatically apply some settings to all members of your organization.
+    Users within the organization will automatically be able to log in, install apps, and create grains.
+  </p>
+
+  {{#if errorMessage}}
+    {{#focusingErrorBox}}
+      Failed to save changes: {{errorMessage}}
+    {{/focusingErrorBox}}
+  {{/if}}
+
+  <form class="setup-organization-management-form">
+  <h4>Organization membership</h4>
+  <div class="org-membership">
+    <div class="org-options-group">
+        <label><input type="checkbox" name="email-toggle" checked="{{emailChecked}}" {{emailHtmlDisabled}}>Users authenticated via email address</label>
+      {{#if emailDisabled }}
+      <span class="form-subtext">Note: disabled because email login is not configured.</span>
+      {{/if}}
+      <div class="form-group">
+        <label>Domain:
+          <input type="text" name="email-domain" value="{{emailDomain}}" {{emailHtmlDisabled}}>
+        </label>
+        <span class="form-subtext">
+          Users with an email address at this domain will be members of this server's organization.
+        </span>
+      </div>
+    </div>
+
+    <div class="org-options-group">
+        <label><input type="checkbox" name="gapps-toggle" checked="{{gappsChecked}}" {{gappsHtmlDisabled}}>Users authenticated via Google Apps for Work</label>
+      {{#if gappsDisabled }}
+      <span class="form-subtext">Note: disabled because Google login is not configured.</span>
+      {{/if}}
+      <div class="form-group">
+        <label>Domain:
+          <input type="text" name="gapps-domain" value="{{gappsDomain}}" {{gappsHtmlDisabled}}>
+        </label>
+        <span class="form-subtext">
+          Users with a Google Apps for Work account under this domain will be members of this server's organization.
+        </span>
+      </div>
+    </div>
+
+    <div class="org-options-group">
+        <label><input type="checkbox" name="ldap-toggle" checked="{{ldapChecked}}" {{ldapHtmlDisabled}}>Users authenticated via LDAP</label>
+      {{#if ldapDisabled }}
+      <span class="form-subtext">Note: disabled because LDAP login is not configured.</span>
+      {{/if}}
+    </div>
+
+    <div class="org-options-group">
+        <label><input type="checkbox" name="saml-toggle" checked="{{samlChecked}}" {{samlHtmlDisabled}}>Users authenticated via SAML</label>
+      {{#if samlDisabled }}
+      <span class="form-subtext">Note: disabled because SAML login is not configured.</span>
+      {{/if}}
+    </div>
+  </div>
+
+  {{!-- Disabled until the feature is implemented.
+  <h4>Organization-wide settings (coming soon!)</h4>
+  <div class="org-options-group">
+    <label>
+      <input type="checkbox" name="share-contacts" checked="{{shareContacts}}" disabled>Make all organization users visible to each other
+    </label>
+    <span class="form-subtext">
+      This setting automatically adds users within the organization to each
+      other's contact list so that they can share grains with each other.  Disable
+      this if you have some users whose identity should stay hidden from other users.
+    </span>
+  </div>
+  --}}
+
+  </form>
+  {{#setupWizardButtonRow}}
+    <button class="setup-next-button">
+      Save and continue
+    </button>
+    <button class="setup-back-button">
+      Back
+    </button>
+  {{/setupWizardButtonRow}}
+{{else}}
+  <p>Sandstorm for Work allows you to define an organization.  To use Sandstorm for Work, please
+  {{#linkTo route="setupWizardFeatureKey"}}
+    provide a feature key
+  {{/linkTo}}.</p>
+{{/if}}
+</div>
+</template>
+
+<template name="setupWizardEmailTestPopup">
+{{!-- Expects a single String argument "token" to be passed in via the data context. --}}
+<h2>Send a test email</h2>
+{{#if hasError}}
+  {{#focusingErrorBox}}
+    {{message}}
+  {{/focusingErrorBox}}
+{{/if}}
+{{#if hasSuccess}}
+  {{#focusingSuccessBox}}
+    {{message}}
+  {{/focusingSuccessBox}}
+{{/if}}
+<form class="email-test-form">
+  <div class="form-group">
+    <label>
+      Send test mail to:
+      <input class="test-address" type="email" name="test-address" value="{{testAddress}}" required />
+    </label>
+  </div>
+  <button class="send-test-email" {{htmlDisabled}}>Send test email</button>
+</form>
+</template>
+
+<template name="setupWizardEmailConfig">
+<div class="setup-page-content">
+  <h1 class="setup-page-title">Outbound Email Setup</h1>
+  {{> setupWizardProgressBar currentStep="email"}}
+
+  <p>
+    Sandstorm needs a way to send email.  You can skip this step (unless you're using email login),
+    but email-related features will be unavailable until you configure email in the future.
+  </p>
+
+  <p>
+    <strong>How Sandstorm uses email:</strong>
+    Sandstorm sends email notifications, and Sandstorm apps can send email notifications, too.
+    Every app receives a unique email address, so Sandstorm needs to send email from a variety of "From:" addresses.
+    Therefore, Gmail SMTP won't work, but there are other free services.
+    See more info in <a target="_blank" href="https://docs.sandstorm.io/en/latest/administering/email/#outgoing-smtp">the docs</a>.
+  </p>
+
+  {{#if errorMessage}}
+    {{#focusingErrorBox}}
+      Failed to save changes: {{errorMessage}}
+    {{/focusingErrorBox}}
+  {{/if}}
+
+  <form class="email-form">
+    <div class="input-group">
+      <div class="host-port">
+        <label>
+          SMTP host
+          <input class="hostname" type="text" name="smtp-hostname" value="{{smtpHostname}}" required />
+        </label>
+        <label>
+          Port
+          <input class="port" type="number" name="smtp-port" value="{{smtpPort}}" required />
+        </label>
+      </div>
+      <div class="form-subtext">Use port 25 for SMTP (unencrypted or with StartTLS), port 465 for TLS-encrypted SMTPS.</div>
+    </div>
+
+    <div class="input-group">
+      <label>
+        Username (optional)
+        <input class="username" type="text" name="smtp-username" value="{{smtpUsername}}" />
+      </label>
+    </div>
+
+    <div class="input-group">
+      <label>
+        Password (optional)
+        <input class="password" type="password" name="smtp-password" value="{{smtpPassword}}" />
+      </label>
+    </div>
+
+    <div class="input-group">
+      <label>
+        Sandstorm server's own email address
+        <input class="from-address" type="email" name="smtp-return-address" value="{{smtpReturnAddress}}" required />
+      </label>
+      <div class="form-subtext">
+        Sandstorm will send login emails, notifications of granted access requests, and other emails from this address.
+        It will also use this address in the SMTP envelope.
+      </div>
+    </div>
+  </form>
+
+  {{#if showTestSendEmailPopup}}
+    {{#modalDialogWithBackdrop onDismiss=closePopupCallback}}
+      {{> setupWizardEmailTestPopup token=token smtpConfig=getSmtpConfig }}
+    {{/modalDialogWithBackdrop}}
+  {{/if}}
+
+  {{#setupWizardButtonRow}}
+    <button class="setup-next-button" {{nextHtmlDisabled}}>
+      Save and continue
+    </button>
+    <button class="setup-skip-email" {{skipHtmlDisabled}}>
+      Skip for now
+    </button>
+    <button class="setup-test-email-button" {{testHtmlDisabled}}>
+      Test
+    </button>
+    <button class="setup-back-button">
+      Back
+    </button>
+  {{/setupWizardButtonRow}}
+</div>
+</template>
+
+<template name="setupWizardLoginUser">
+<div class="setup-page-content">
+  <h1 class="setup-page-title">Create admin account</h1>
+  {{> setupWizardProgressBar currentStep="user"}}
+
+  {{#if errorMessage}}
+    {{#focusingErrorBox}}
+      {{errorMessage}}
+    {{/focusingErrorBox}}
+  {{/if}}
+
+  {{#if successMessage}}
+    {{#focusingSuccessBox}}
+      {{successMessage}}
+    {{/focusingSuccessBox}}
+  {{/if}}
+
+{{#if identityUser}}
+  {{> identityLoginInterstitial }}
+{{else}}
+  {{#if currentUser}}
+    {{#if currentUserFirstLogin}}
+      {{> sandstormAccountsFirstSignIn accountSettingsUi}}
+      {{#unless serverHasAdmin}}
+        {{redeemSessionForAdmin}}
+      {{/unless}}
+    {{else}}
+      {{#if currentUserIsAdmin}}
+        <p>You are an admin on this server.  Excellent.</p>
+      {{else}}
+        {{#if serverHasAdmin}}
+          <p>
+            This Sandstorm server already has an admin user, but if you want, you can also make
+            yourself an admin.
+          </p>
+          <div class="center">
+            <button class="make-self-admin">Become an admin</button>
+          </div>
+        {{else}}
+          <p>Making you an admin on this server...</p>
+          {{redeemSessionForAdmin}}
+        {{/if}}
+      {{/if}}
+    {{/if}}
+  {{else}}
+    <p>You can now create the first account on this Sandstorm server.</p>
+    <div class="center">
+      <p>Log in to create your admin account</p>
+
+      {{!-- The loginButtonsDialog apparently requires this in the parent data context, which seems
+            wrong.  It should probably be passed in explicitly instead.  --}}
+      {{#with linkingNewIdentity=notLinkingNewIdentity}}
+        {{> loginButtonsDialog globalAccountsUi}}
+      {{/with}}
+    </div>
+  {{/if}}
+{{/if}}
+
+  {{#setupWizardButtonRow}}
+    <button class="setup-next-button" {{nextHtmlDisabled}}>
+      Finish
+    </button>
+    <button class="setup-back-button">
+      Back
+    </button>
+  {{/setupWizardButtonRow}}
+</div>
+</template>
+
+<template name="setupWizardSuccess">
+<div class="setup-page-content">
+  <h1 class="setup-page-title">Ready to roll!</h1>
+  <p>Your Sandstorm server is now ready to use.</p>
+  <p>What would you like to do next?</p>
+
+  <div class="setup-next-steps">
+    {{#linkTo route="adminInvites" class="setup-button-secondary"}}
+      Add users
+    {{/linkTo}}
+    {{#linkTo route="adminSettings" class="setup-button-secondary"}}
+      Edit other settings
+    {{/linkTo}}
+    {{#linkTo route="apps" class="setup-button-primary"}}
+      Start using Sandstorm
+    {{/linkTo}}
+  </div>
+
+  {{#setupWizardButtonRow}}
+    <button class="setup-back-button">
+      Back
+    </button>
+  {{/setupWizardButtonRow}}
+</div>
+</template>
+
+<template name="setupWizardVerifyToken">
+<div class="setup-page-content">
+  <h1 class="setup-page-title">Verifying token...</h1>
+  {{#if rejected}}
+  <p>
+    Sorry, it looks like your setup token has expired.
+  </p>
+
+  <p>
+    Generate a new one now from the command line by running <code>sandstorm admin-token</code> to
+    access the setup wizard.
+  </p>
+  {{/if}}
+</div>
+</template>
+
+<template name="setupWizardTokenExpired">
+<div class="setup-page-content">
+  <h1 class="setup-page-title">Setup token required</h1>
+  {{#if hasUsers}}
+  <p>
+  This server is already set up, so we recommend administering it via the main
+  {{#linkTo route="adminSettings"}}administration panel{{/linkTo}}.
+  </p>
+  {{/if}}
+
+  <p>
+    To use this server's setup page, you need a valid setup token.
+  </p>
+
+  <p>
+    Generate a new one now from the command line by running <code>sandstorm admin-token</code> and
+    following the link it outputs.
+  </p>
+</div>
+</template>

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -496,7 +496,13 @@
 {{else}}
   {{#if currentUser}}
     {{#if currentUserFirstLogin}}
-      {{> sandstormAccountsFirstSignIn accountSettingsUi}}
+      <h1>Confirm your profile</h1>
+      <div class="single-identity-editor">
+        {{#with accountProfileEditorData}}
+          {{> _accountProfileEditor}}
+        {{/with}}
+      </div>
+
       {{#unless serverHasAdmin}}
         {{redeemSessionForAdmin}}
       {{/unless}}
@@ -526,7 +532,7 @@
       {{!-- The loginButtonsDialog apparently requires this in the parent data context, which seems
             wrong.  It should probably be passed in explicitly instead.  --}}
       {{#with linkingNewIdentity=notLinkingNewIdentity}}
-        {{> loginButtonsDialog globalAccountsUi}}
+        {{> loginButtonsDialog freshAccountsUi}}
       {{/with}}
     </div>
   {{/if}}

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -550,9 +550,11 @@
   <p>What would you like to do next?</p>
 
   <div class="setup-next-steps">
-    {{#linkTo route="adminInvites" class="setup-button-secondary"}}
-      Add users
-    {{/linkTo}}
+    {{#unless someOrgMembershipEnabled}}
+      {{#linkTo route="adminInvites" class="setup-button-secondary"}}
+        Add users
+      {{/linkTo}}
+    {{/unless}}
     {{#linkTo route="adminSettings" class="setup-button-secondary"}}
       Edit other settings
     {{/linkTo}}

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -376,7 +376,13 @@
       <input class="test-address" type="email" name="test-address" value="{{testAddress}}" required />
     </label>
   </div>
-  <button class="send-test-email" {{htmlDisabled}}>Send test email</button>
+  <button class="send-test-email" {{htmlDisabled}}>
+    {{#if isSubmitting}}
+    Sending...
+    {{else}}
+    Send test email
+    {{/if}}
+  </button>
 </form>
 </template>
 

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -186,9 +186,9 @@
           <li>Share grains with everyone</li>
         </ul>
         <div class="setup-pricing-block">
-          <p class="setup-price">$0/user/month</p>
-          <p class="subheader">Free</p>
+          <p class="setup-price">Free</p>
           <p class="subheader">Open source</p>
+          <p class="subheader">&nbsp;</p>
         </div>
         <button class="setup-sandstorm-standard">Begin Standard Setup</button>
       </div>

--- a/shell/client/setup-wizard/wizard.js
+++ b/shell/client/setup-wizard/wizard.js
@@ -154,6 +154,7 @@ Template.setupWizardVerifyToken.helpers({
 Template.setupWizardIntro.onCreated(function () {
   this.errorMessage = new ReactiveVar(undefined);
   this.successMessage = new ReactiveVar(undefined);
+  this.showSignInPanel = new ReactiveVar(false);
 });
 
 Template.setupWizardIntro.helpers({
@@ -168,6 +169,16 @@ Template.setupWizardIntro.helpers({
     return isAdmin();
   },
 
+  showSignInPanel() {
+    const instance = Template.instance();
+    return instance.showSignInPanel.get();
+  },
+
+  identityUser: function () {
+    const user = Meteor.user();
+    return user && user.profile;
+  },
+
   errorMessage() {
     const instance = Template.instance();
     return instance.errorMessage.get();
@@ -176,6 +187,14 @@ Template.setupWizardIntro.helpers({
   successMessage() {
     const instance = Template.instance();
     return instance.successMessage.get();
+  },
+
+  notLinkingNewIdentity() {
+    return undefined;
+  },
+
+  freshAccountsUi() {
+    return new AccountsUi(globalDb);
   },
 });
 
@@ -199,6 +218,11 @@ Template.setupWizardIntro.events({
         instance.successMessage.set("You are now an admin.");
       }
     });
+  },
+
+  "click .sign-in-button"() {
+    const instance = Template.instance();
+    instance.showSignInPanel.set(true);
   },
 });
 

--- a/shell/client/setup-wizard/wizard.js
+++ b/shell/client/setup-wizard/wizard.js
@@ -1,0 +1,876 @@
+// Pseudocollection telling the client if there's an admin user yet.
+HasAdmin = new Mongo.Collection("hasAdmin");
+
+const setupSteps = ["intro", "identity", "email", "user", "success"];
+const setupStepsForWork = ["intro", "identity", "organization", "email", "user", "success"];
+
+// Combined with the list of steps above to DRY up the ordering.
+const setupStepRouteMap = {
+  intro: "setupWizardIntro",
+  identity: "setupWizardIdentity",
+  organization: "setupWizardOrganization",
+  email: "setupWizardEmailConfig",
+  user: "setupWizardLoginUser",
+  success: "setupWizardSuccess",
+};
+
+const providerEnabled = function (providerString) {
+  const setting = globalDb.collections.settings.findOne({ _id: providerString });
+  if (setting) {
+    return setting.value;
+  } else {
+    return false;
+  }
+};
+
+const setupIsStepCompleted = {
+  intro() {
+    return true;
+  },
+
+  identity() {
+    return (
+      providerEnabled("emailToken") ||
+      providerEnabled("google") ||
+      providerEnabled("github") ||
+      providerEnabled("ldap") ||
+      providerEnabled("saml")
+    );
+  },
+
+  organization() {
+    // all states are valid here
+    return true;
+  },
+
+  email() {
+    // We allow skipping email unless you have emailToken login configured, in which case we don't.
+    if (providerEnabled("emailToken")) {
+      const smtpConfig = globalDb.getSmtpConfig();
+      return !!(smtpConfig && smtpConfig.hostname && smtpConfig.port && smtpConfig.returnAddress);
+    } else {
+      return true;
+    }
+  },
+
+  user() {
+    return true;
+  },
+
+  success() {
+    return true;
+  },
+};
+
+const getRouteAfter = (currentStep) => {
+  const steps = globalDb.isFeatureKeyValid() ? setupStepsForWork : setupSteps;
+  const currentIdx = steps.indexOf(currentStep);
+  const nextIdx = currentIdx + 1;
+  return setupStepRouteMap[steps[nextIdx]];
+};
+
+const getRouteBefore = (currentStep) => {
+  const steps = globalDb.isFeatureKeyValid() ? setupStepsForWork : setupSteps;
+  const currentIdx = steps.indexOf(currentStep);
+  const prevIdx = currentIdx - 1;
+  return setupStepRouteMap[steps[prevIdx]];
+};
+
+Template.setupWizardProgressBar.helpers({
+  currentStep() {
+    return Template.instance().data.currentStep;
+  },
+
+  currentStepIs(step) {
+    return Template.instance().data.currentStep === step;
+  },
+
+  currentStepAtOrPast(otherStep) {
+    const steps = globalDb.isFeatureKeyValid() ? setupStepsForWork : setupSteps;
+    const currentStep = Template.instance().data.currentStep;
+    const currentIdx = steps.indexOf(currentStep);
+    const otherIdx = steps.indexOf(otherStep);
+    if (otherIdx === -1) {
+      console.error("Invalid step '" + otherStep + "' - acceptable steps are " + steps);
+    }
+
+    return currentIdx >= otherIdx;
+  },
+
+  itemClassName() {
+    return globalDb.isFeatureKeyValid() ? "of-five" : "of-four";
+  },
+
+  mayJumpTo(step) {
+    // You may jump to a step if all the previous steps are considered completed.
+    const steps = globalDb.isFeatureKeyValid() ? setupStepsForWork : setupSteps;
+    for (let i = 0; i < steps.length; i++) {
+      const stepName = steps[i];
+      if (stepName === step) {
+        return true;
+      }
+
+      if (!setupIsStepCompleted[stepName]()) {
+        return false;
+      }
+    }
+
+    return true;
+  },
+
+  hasFeatureKey() {
+    return globalDb.isFeatureKeyValid();
+  },
+});
+
+Template.setupWizardProgressBarItem.helpers({
+  linkClassName() {
+    const instance = Template.instance();
+    return instance.data.isCurrentStep ? "setup-current-step" : "";
+  },
+});
+
+const focusAndScrollIntoView = function () {
+  // When an error or success message appears on the page or is updated, we generally want to focus
+  // it (for screenreader users) and scroll it into the view (for visual users), lest they miss the
+  // message entirely.
+  this.firstNode.focus && this.firstNode.focus();
+  this.firstNode.scrollIntoView && this.firstNode.scrollIntoView();
+};
+
+Template.focusingErrorBox.onRendered(focusAndScrollIntoView);
+Template.focusingSuccessBox.onRendered(focusAndScrollIntoView);
+
+Template.setupWizardVerifyToken.helpers({
+  verifyState() {
+    return Iron.controller().state.get("redeemStatus");
+  },
+
+  rejected() {
+    return Iron.controller().state.get("redeemStatus") === "rejected";
+  },
+});
+
+Template.setupWizardIntro.onCreated(function () {
+  this.errorMessage = new ReactiveVar(undefined);
+  this.successMessage = new ReactiveVar(undefined);
+});
+
+Template.setupWizardIntro.helpers({
+  initialSetupComplete() {
+    // We use the existence of any user as the heuristic for determining
+    // if setup is complete, since creating the admin user is the final step.
+    const hasUsersEntry = HasUsers.findOne("hasUsers");
+    return hasUsersEntry && hasUsersEntry.hasUsers;
+  },
+
+  currentUserIsAdmin() {
+    return isAdmin();
+  },
+
+  errorMessage() {
+    const instance = Template.instance();
+    return instance.errorMessage.get();
+  },
+
+  successMessage() {
+    const instance = Template.instance();
+    return instance.successMessage.get();
+  },
+});
+
+Template.setupWizardIntro.events({
+  "click .setup-sandstorm-standard"() {
+    Router.go("setupWizardIdentity");
+  },
+
+  "click .setup-sandstorm-for-work"() {
+    Router.go("setupWizardFeatureKey");
+  },
+
+  "click .make-self-admin"() {
+    const instance = Template.instance();
+    const token = Iron.controller().state.get("token");
+    Meteor.call("signUpAsAdmin", token, (err) => {
+      if (err) {
+        instance.errorMessage.set(err.message);
+      } else {
+        sessionStorage.removeItem("setup-token");
+        instance.successMessage.set("You are now an admin.");
+      }
+    });
+  },
+});
+
+Template.setupWizardFeatureKey.helpers({
+  featureKey() {
+    return globalDb.currentFeatureKey();
+  },
+
+  nextButtonClass() {
+    return globalDb.isFeatureKeyValid() ? "" : "disabled";
+  },
+});
+
+Template.setupWizardFeatureKey.events({
+  "click .setup-next-button"() {
+    if (globalDb.isFeatureKeyValid()) {
+      Router.go(getRouteAfter("intro"));
+    }
+  },
+
+  "click .setup-back-button"() {
+    Router.go("setupWizardIntro");
+  },
+});
+
+Template.setupWizardIdentity.helpers({
+  nextHtmlDisabled() {
+    const allowProgress = setupIsStepCompleted.identity();
+    return allowProgress ? "" : "disabled";
+  },
+});
+
+Template.setupWizardIdentity.events({
+  "click .setup-next-button"() {
+    Router.go(getRouteAfter("identity"));
+  },
+
+  "click .setup-back-button"() {
+    Router.go(getRouteBefore("identity"));
+  },
+});
+
+Template.setupWizardOrganization.onCreated(function () {
+  const ldapChecked = globalDb.getOrganizationLdapEnabled();
+  const samlChecked = globalDb.getOrganizationSamlEnabled();
+  const gappsChecked = globalDb.getOrganizationGoogleEnabled();
+  const emailChecked = globalDb.getOrganizationEmailEnabled();
+  const gappsDomain = globalDb.getOrganizationGoogleDomain();
+  const emailDomain = globalDb.getOrganizationEmailDomain();
+
+  this.ldapChecked = new ReactiveVar(ldapChecked);
+  this.samlChecked = new ReactiveVar(samlChecked);
+  this.gappsChecked = new ReactiveVar(gappsChecked);
+  this.emailChecked = new ReactiveVar(emailChecked);
+  this.gappsDomain = new ReactiveVar(gappsDomain);
+  this.emailDomain = new ReactiveVar(emailDomain);
+  this.shareContacts = new ReactiveVar(true);
+  this.errorMessage = new ReactiveVar(undefined);
+});
+
+Template.setupWizardOrganization.helpers({
+  hasFeatureKey() {
+    return globalDb.isFeatureKeyValid();
+  },
+
+  emailChecked() {
+    const instance = Template.instance();
+    return instance.emailChecked.get();
+  },
+
+  gappsChecked() {
+    const instance = Template.instance();
+    return instance.gappsChecked.get();
+  },
+
+  ldapChecked() {
+    const instance = Template.instance();
+    return instance.ldapChecked.get();
+  },
+
+  samlChecked() {
+    const instance = Template.instance();
+    return instance.samlChecked.get();
+  },
+
+  emailDisabled() {
+    return !providerEnabled("emailToken");
+  },
+
+  gappsDisabled() {
+    return !providerEnabled("google");
+  },
+
+  ldapDisabled() {
+    return !providerEnabled("ldap");
+  },
+
+  samlDisabled() {
+    return !providerEnabled("saml");
+  },
+
+  emailHtmlDisabled() {
+    return providerEnabled("emailToken") ? "" : "disabled";
+  },
+
+  gappsHtmlDisabled() {
+    return providerEnabled("google") ? "" : "disabled";
+  },
+
+  ldapHtmlDisabled() {
+    return providerEnabled("ldap") ? "" : "disabled";
+  },
+
+  samlHtmlDisabled() {
+    return providerEnabled("saml") ? "" : "disabled";
+  },
+
+  emailDomain() {
+    const instance = Template.instance();
+    return instance.emailDomain.get();
+  },
+
+  gappsDomain() {
+    const instance = Template.instance();
+    return instance.gappsDomain.get();
+  },
+
+  shareContacts() {
+    const instance = Template.instance();
+    return instance.shareContacts.get();
+  },
+
+  errorMessage() {
+    const instance = Template.instance();
+    return instance.errorMessage.get();
+  },
+});
+
+Template.setupWizardOrganization.events({
+  "click input[name=email-toggle]"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    instance.emailChecked.set(!instance.emailChecked.get());
+  },
+
+  "click input[name=gapps-toggle]"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    instance.gappsChecked.set(!instance.gappsChecked.get());
+  },
+
+  "click input[name=ldap-toggle]"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    instance.ldapChecked.set(!instance.ldapChecked.get());
+  },
+
+  "click input[name=saml-toggle]"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    instance.samlChecked.set(!instance.samlChecked.get());
+  },
+
+  "input input[name=email-domain]"(evt) {
+    const instance = Template.instance();
+    instance.emailDomain.set(evt.currentTarget.value);
+  },
+
+  "input input[name=gapps-domain]"(evt) {
+    const instance = Template.instance();
+    instance.gappsDomain.set(evt.currentTarget.value);
+  },
+
+  "click .setup-next-button"() {
+    const instance = Template.instance();
+    const params = {
+      membership: {
+        emailToken: {
+          enabled: instance.emailChecked.get(),
+          domain: instance.emailDomain.get(),
+        },
+        google: {
+          enabled: instance.gappsChecked.get(),
+          domain: instance.gappsDomain.get(),
+        },
+        ldap: {
+          enabled: instance.ldapChecked.get(),
+        },
+        saml: {
+          enabled: instance.samlChecked.get(),
+        },
+      },
+      // Disabled until we've actually implemented the feature.
+      //settings: {
+      //  publishContacts: instance.shareContacts.get(),
+      //},
+    };
+    const token = Iron.controller().state.get("token");
+    Meteor.call("saveOrganizationSettings", token, params, (err) => {
+      if (err) {
+        // Force repaint of focusingErrorBox to cause the error to be focused/scrolled on-screen,
+        // even if err.message is the same as the previous value.
+        instance.errorMessage.set(undefined);
+        Tracker.flush();
+        instance.errorMessage.set(err.message);
+      } else {
+        Router.go(getRouteAfter("organization"));
+      }
+    });
+  },
+
+  "click .setup-back-button"() {
+    Router.go(getRouteBefore("organization"));
+  },
+});
+
+Template.setupWizardEmailConfig.onCreated(function () {
+  const smtpConfig = globalDb.getSmtpConfig();
+  this.errorMessage = new ReactiveVar(undefined);
+  this.smtpHostname = new ReactiveVar(smtpConfig && smtpConfig.hostname);
+  this.smtpPort = new ReactiveVar(smtpConfig && smtpConfig.port);
+  this.smtpUsername = new ReactiveVar(smtpConfig && smtpConfig.auth && smtpConfig.auth.user || "");
+  this.smtpPassword = new ReactiveVar(smtpConfig && smtpConfig.auth && smtpConfig.auth.pass || "");
+  this.smtpReturnAddress = new ReactiveVar(smtpConfig && smtpConfig.returnAddress);
+  this.showTestSendEmailPopup = new ReactiveVar(false);
+  this.getSmtpConfig = () => {
+    const portValue = parseInt(this.smtpPort.get());
+    const smtpConfig = {
+      hostname: this.smtpHostname.get(),
+      port: _.isNaN(portValue) ? 25 : portValue,
+      auth: {
+        user: this.smtpUsername.get(),
+        pass: this.smtpPassword.get(),
+      },
+      returnAddress: this.smtpReturnAddress.get(),
+    };
+    return smtpConfig;
+  };
+});
+
+Template.setupWizardEmailConfig.events({
+  "input input[name=smtp-hostname]"(evt) {
+    const instance = Template.instance();
+    instance.smtpHostname.set(evt.currentTarget.value);
+  },
+
+  "input input[name=smtp-port]"(evt) {
+    const instance = Template.instance();
+    instance.smtpPort.set(evt.currentTarget.value);
+  },
+
+  "input input[name=smtp-username]"(evt) {
+    const instance = Template.instance();
+    instance.smtpUsername.set(evt.currentTarget.value);
+  },
+
+  "input input[name=smtp-password]"(evt) {
+    const instance = Template.instance();
+    instance.smtpPassword.set(evt.currentTarget.value);
+  },
+
+  "input input[name=smtp-return-address]"(evt) {
+    const instance = Template.instance();
+    instance.smtpReturnAddress.set(evt.currentTarget.value);
+  },
+
+  "click .setup-test-email-button"() {
+    const instance = Template.instance();
+    instance.showTestSendEmailPopup.set(true);
+  },
+
+  "click .setup-next-button"() {
+    const instance = Template.instance();
+    const smtpConfig = instance.getSmtpConfig();
+    const token = Iron.controller().state.get("token");
+    Meteor.call("setSmtpConfig", token, smtpConfig, (err) => {
+      if (err) {
+        // Force repaint of focusingErrorBox to cause the error to be focused/scrolled on-screen,
+        // even if err.message is the same as the previous value.
+        instance.errorMessage.set(undefined);
+        Tracker.flush();
+        instance.errorMessage.set(err.message);
+      } else {
+        Router.go(getRouteAfter("email"));
+      }
+    });
+  },
+
+  "click .setup-back-button"() {
+    Router.go(getRouteBefore("email"));
+  },
+
+  "click .setup-skip-email"() {
+    Router.go(getRouteAfter("email"));
+  },
+});
+
+Template.setupWizardEmailTestPopup.onCreated(function () {
+  this.testAddress = new ReactiveVar("");
+  this.feedbackMessage = new ReactiveVar(undefined);
+});
+
+Template.setupWizardEmailTestPopup.onRendered(function () {
+  this.find("input").focus();
+});
+
+Template.setupWizardEmailTestPopup.helpers({
+  testAddress() {
+    const instance = Template.instance();
+    return instance.testAddress.get();
+  },
+
+  hasError() {
+    const instance = Template.instance();
+    const message = instance.feedbackMessage.get();
+    if (message && message.type === "error") {
+      return true;
+    }
+
+    return false;
+  },
+
+  hasSuccess() {
+    const instance = Template.instance();
+    const message = instance.feedbackMessage.get();
+    if (message && message.type === "success") {
+      return true;
+    }
+
+    return false;
+  },
+
+  message() {
+    const instance = Template.instance();
+    const message = instance.feedbackMessage.get();
+    return message && message.text;
+  },
+
+  htmlDisabled() {
+    const instance = Template.instance();
+    return instance.testAddress.get() ? "" : "disabled";
+  },
+});
+
+Template.setupWizardEmailTestPopup.events({
+  "input input.test-address"(evt) {
+    const instance = Template.instance();
+    instance.testAddress.set(evt.currentTarget.value);
+  },
+
+  "submit form.email-test-form"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    Meteor.call("testSend", instance.data.token, instance.data.smtpConfig, instance.testAddress.get(), (err) => {
+      if (err) {
+        instance.feedbackMessage.set({
+          type: "error",
+          text: err.message,
+        });
+      } else {
+        instance.feedbackMessage.set({
+          type: "success",
+          text: "Sent a test email to " + instance.testAddress.get() + ".  It should arrive shortly.",
+        });
+      }
+    });
+  },
+});
+
+Template.setupWizardEmailConfig.helpers({
+  smtpHostname() {
+    const instance = Template.instance();
+    return instance.smtpHostname.get();
+  },
+
+  smtpPort() {
+    const instance = Template.instance();
+    return instance.smtpPort.get();
+  },
+
+  smtpUsername() {
+    const instance = Template.instance();
+    return instance.smtpUsername.get();
+  },
+
+  smtpPassword() {
+    const instance = Template.instance();
+    return instance.smtpPassword.get();
+  },
+
+  smtpReturnAddress() {
+    const instance = Template.instance();
+    return instance.smtpReturnAddress.get();
+  },
+
+  showTestSendEmailPopup() {
+    const instance = Template.instance();
+    return instance.showTestSendEmailPopup.get();
+  },
+
+  closePopupCallback() {
+    const instance = Template.instance();
+    return () => {
+      instance.showTestSendEmailPopup.set(false);
+    };
+  },
+
+  nextHtmlDisabled() {
+    const instance = Template.instance();
+    // If email login is enabled, require a valid hostname, port, and return address.
+    const forbidProgress = providerEnabled("emailToken") && (
+        !instance.smtpHostname.get() ||
+        !instance.smtpPort.get() ||
+        !instance.smtpReturnAddress.get()
+        );
+    return forbidProgress ? "disabled" : "";
+  },
+
+  skipHtmlDisabled() {
+    const smtpConfig = globalDb.getSmtpConfig();
+    const forbidProgress = providerEnabled("emailToken") && (
+        !(smtpConfig && smtpConfig.hostname && smtpConfig.port && smtpConfig.returnAddress)
+    );
+    return forbidProgress ? "disabled" : "";
+  },
+
+  testHtmlDisabled() {
+    const instance = Template.instance();
+    const missingRequiredSetting = (
+        !instance.smtpHostname.get() ||
+        !instance.smtpPort.get() ||
+        !instance.smtpReturnAddress.get()
+        );
+    return missingRequiredSetting ? "disabled" : "";
+  },
+
+  errorMessage() {
+    const instance = Template.instance();
+    return instance.errorMessage.get();
+  },
+
+  token() {
+    return Iron.controller().state.get("token");
+  },
+
+  getSmtpConfig() {
+    const instance = Template.instance();
+    return instance.getSmtpConfig();
+  },
+});
+
+Template.setupWizardLoginUser.onCreated(function () {
+  this.triedRedeemingToken = false;
+  this.errorMessage = new ReactiveVar(undefined);
+  this.successMessage = new ReactiveVar(undefined);
+});
+
+Template.setupWizardLoginUser.helpers({
+  globalAccountsUi() {
+    return globalAccountsUi;
+  },
+
+  currentUserIsAdmin() {
+    return isAdmin();
+  },
+
+  serverHasAdmin() {
+    return HasAdmin.findOne();
+  },
+
+  currentUserFirstLogin() {
+    return !Meteor.loggingIn() && Meteor.user() && !Meteor.user().hasCompletedSignup;
+  },
+
+  identityUser: function () {
+    const user = Meteor.user();
+    return user && user.profile;
+  },
+
+  redeemSessionForAdmin() {
+    const instance = Template.instance();
+    if (!instance.triedRedeemingToken && !isAdmin()) {
+      instance.triedRedeemingToken = true;
+      const token = Iron.controller().state.get("token");
+      Meteor.call("signUpAsAdmin", token, (err) => {
+        if (err) {
+          instance.errorMessage.set(err.message);
+        } else {
+          // We were made into an admin.  Delete our token.
+          sessionStorage.removeItem("setup-token");
+          instance.successMessage.set("You are now an admin.");
+        }
+      });
+    }
+
+    return;
+  },
+
+  accountSettingsUi() {
+    return new SandstormAccountSettingsUi(globalTopbar, globalDb,
+        window.location.protocol + "//" + makeWildcardHost("static"));
+  },
+
+  errorMessage() {
+    const instance = Template.instance();
+    return instance.errorMessage.get();
+  },
+
+  successMessage() {
+    const instance = Template.instance();
+    return instance.successMessage.get();
+  },
+
+  nextHtmlDisabled() {
+    const hasAdmin = HasAdmin.findOne();
+    return hasAdmin ? "" : "disabled";
+  },
+
+  notLinkingNewIdentity() {
+    // This apparently has to exist as a key in the parent data context.
+    return undefined;
+  },
+});
+
+Template.setupWizardLoginUser.events({
+  "click .make-self-admin"() {
+    const instance = Template.instance();
+    const token = Iron.controller().state.get("token");
+    Meteor.call("signUpAsAdmin", token, (err) => {
+      if (err) {
+        instance.errorMessage.set(err.message);
+      } else {
+        // We were made into an admin.  Delete our token.
+        sessionStorage.removeItem("setup-token");
+        instance.successMessage.set("You are now an admin.");
+      }
+    });
+  },
+
+  "click .setup-back-button"() {
+    Router.go(getRouteBefore("user"));
+  },
+
+  "click .setup-next-button"() {
+    Router.go(getRouteAfter("user"));
+  },
+});
+
+Template.setupWizardSuccess.events({
+  "click .setup-back-button"() {
+    Router.go(getRouteBefore("success"));
+  },
+});
+
+const setupRoute = RouteController.extend({
+  waitOn: function () {
+    const token = sessionStorage.getItem("setup-token");
+    const subs = [
+      Meteor.subscribe("admin", token),
+      Meteor.subscribe("adminServiceConfiguration", token),
+      Meteor.subscribe("credentials"),
+      Meteor.subscribe("featureKey", true, token),
+      Meteor.subscribe("hasUsers"),
+      Meteor.subscribe("hasAdmin", token),
+    ];
+    if (token) {
+      subs.push(Meteor.subscribe("adminToken", token));
+    }
+
+    return subs;
+  },
+
+  action: function () {
+    const token = sessionStorage.getItem("setup-token");
+    const state = this.state;
+    state.set("token", token);
+    // Using AdminToken pseudocollection from admin-client.js
+    let tokenStatus = undefined;
+    if (token) {
+      tokenStatus = AdminToken.findOne();
+    }
+
+    const isUserPermitted = isAdmin() || (tokenStatus && tokenStatus.tokenIsValid);
+    if (!isUserPermitted) {
+      Router.go("setupWizardTokenExpired");
+    }
+
+    this.render();
+  },
+
+  onAfterAction: function () {
+    // Scroll to the top of the page each time you navigate to a setup wizard page.
+    document.getElementsByTagName("body")[0].scrollTop = 0;
+  },
+});
+
+Template.setupWizardTokenExpired.helpers({
+  hasUsers() {
+    const hasUsersEntry = HasUsers.findOne("hasUsers");
+    return hasUsersEntry && hasUsersEntry.hasUsers;
+  },
+});
+
+Router.map(function () {
+  this.route("setupWizardIntro", {
+    path: "/setup",
+    layoutTemplate: "setupWizardLayout",
+    controller: setupRoute,
+  });
+  this.route("setupWizardFeatureKey", {
+    path: "/setup/feature-key",
+    layoutTemplate: "setupWizardLayout",
+    controller: setupRoute,
+  });
+  this.route("setupWizardIdentity", {
+    path: "/setup/identity",
+    layoutTemplate: "setupWizardLayout",
+    controller: setupRoute,
+  });
+  this.route("setupWizardOrganization", {
+    path: "/setup/organization",
+    layoutTemplate: "setupWizardLayout",
+    controller: setupRoute,
+  });
+  this.route("setupWizardEmailConfig", {
+    path: "/setup/email",
+    layoutTemplate: "setupWizardLayout",
+    controller: setupRoute,
+  });
+  this.route("setupWizardLoginUser", {
+    path: "/setup/user",
+    layoutTemplate: "setupWizardLayout",
+    controller: setupRoute,
+  });
+  this.route("setupWizardSuccess", {
+    path: "/setup/success",
+    layoutTemplate: "setupWizardLayout",
+    controller: setupRoute,
+  });
+  this.route("setupWizardVerifyToken", {
+    path: "/setup/token/:_token",
+    layoutTemplate: "setupWizardLayout",
+    onBeforeAction: function () {
+      this.state.set("redeemStatus", "in-progress");
+      // For whatever reason, the RouteController is no longer available in the async callback
+      // below, so we save a handle to the state object.
+      const state = this.state;
+      Meteor.call("redeemSetupToken", this.params._token, (err, result) => {
+        if (err) {
+          console.log("token was rejected");
+          console.log(err);
+          state.set("redeemStatus", "rejected");
+        } else {
+          sessionStorage.setItem("setup-token", result);
+          Router.go("setupWizardIntro");
+        }
+      });
+      this.next();
+    },
+  });
+  this.route("setupWizardTokenExpired", {
+    path: "/setup/expired",
+    layoutTemplate: "setupWizardLayout",
+    waitOn() {
+      return [
+        Meteor.subscribe("hasUsers"),
+      ];
+    },
+  });
+});

--- a/shell/client/setup-wizard/wizard.js
+++ b/shell/client/setup-wizard/wizard.js
@@ -242,12 +242,17 @@ Template.setupWizardIdentity.events({
 });
 
 Template.setupWizardOrganization.onCreated(function () {
-  const ldapChecked = globalDb.getOrganizationLdapEnabled();
-  const samlChecked = globalDb.getOrganizationSamlEnabled();
-  const gappsChecked = globalDb.getOrganizationGoogleEnabled();
-  const emailChecked = globalDb.getOrganizationEmailEnabled();
-  const gappsDomain = globalDb.getOrganizationGoogleDomain();
-  const emailDomain = globalDb.getOrganizationEmailDomain();
+  const ldapChecked = globalDb.getOrganizationLdapEnabled() || false;
+  const samlChecked = globalDb.getOrganizationSamlEnabled() || false;
+  const gappsChecked = globalDb.getOrganizationGoogleEnabled() || false;
+  const emailChecked = globalDb.getOrganizationEmailEnabled() || false;
+
+  const featureKey = globalDb.collections.featureKey.findOne();
+  const featureKeyContactAddress = featureKey && featureKey.customer && featureKey.customer.contactEmail;
+  const inferredDomain = featureKeyContactAddress && featureKeyContactAddress.split("@")[1] || "";
+
+  const gappsDomain = globalDb.getOrganizationGoogleDomain() || inferredDomain;
+  const emailDomain = globalDb.getOrganizationEmailDomain() || inferredDomain;
 
   this.ldapChecked = new ReactiveVar(ldapChecked);
   this.samlChecked = new ReactiveVar(samlChecked);

--- a/shell/client/setup-wizard/wizard.js
+++ b/shell/client/setup-wizard/wizard.js
@@ -767,6 +767,17 @@ Template.setupWizardLoginUser.events({
   },
 });
 
+Template.setupWizardSuccess.helpers({
+  someOrgMembershipEnabled() {
+    return (
+      globalDb.getOrganizationLdapEnabled() ||
+      globalDb.getOrganizationSamlEnabled() ||
+      globalDb.getOrganizationGoogleEnabled() ||
+      globalDb.getOrganizationEmailEnabled()
+    );
+  },
+});
+
 Template.setupWizardSuccess.events({
   "click .setup-back-button"() {
     Router.go(getRouteBefore("success"));

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -981,7 +981,7 @@ limitations under the License.
           {{#linkTo route="adminAdvanced" data=getToken}}Advanced{{/linkTo}}
         </li>
         <li id="featurekey-tab" class="{{#if featureKeyActive}}active{{/if}}">
-          {{#linkTo route="adminFeatureKey" data=getToken}}For Work{{/linkTo}}
+          {{#linkTo route="adminFeatureKeyPage" data=getToken}}For Work{{/linkTo}}
         </li>
       </ul>
       {{> Template.dynamic template=adminTab}}
@@ -1387,9 +1387,17 @@ limitations under the License.
   </form>
 </template>
 
-<template name="adminFeatureKey">
+<template name="adminFeatureKeyPage">
   {{setDocumentTitle}}
 
+  {{> adminFeatureKey . }}
+
+  {{#if hasFeatureKey }}
+    <p><a href="{{settingsPath}}">Go to the settings page to configure Sandstorm for Work features.</a></p>
+  {{/if}}
+</template>
+
+<template name="adminFeatureKey">
   {{#if currentFeatureKey}}
     <h4>Current feature key</h4>
     {{#with featureKey=currentFeatureKey}}
@@ -1439,9 +1447,6 @@ limitations under the License.
         <button class="button-secondary feature-key-delete-button">Delete feature key</button>
       </div>
     {{/if}}
-
-    <p><a href="{{settingsPath}}">Go to the settings page to configure Sandstorm for Work features.</a></p>
-
   {{else}}
     <h4>Upload feature key</h4>
     <p>To make use of Sandstorm for Work features like LDAP and SAML login and organization

--- a/shell/client/styles/_admin-email.scss
+++ b/shell/client/styles/_admin-email.scss
@@ -1,0 +1,91 @@
+.email-form {
+  .input-group {
+    margin-bottom: 16px;
+  }
+
+  .host-port {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-begin;
+    justify-content: flex-begin;
+    >* {
+      margin-right: 16px;
+    }
+  }
+
+  .port {
+    max-width: 5em;
+  }
+
+  label {
+    display: block;
+    font-weight: normal;
+    font-size: 20px;
+  }
+
+  input[type="text"], input[type="email"], input[type="number"], input[type="password"] {
+    display: block;
+    color: #222;
+    background-color: white;
+    padding: 4px;
+    font-size: 16px;
+    border-radius: 2px;
+    border: 1px solid #d3d3d3;
+  }
+
+  .form-subtext {
+    font-size: 14px;
+    color: #666;
+  }
+
+  button {
+    margin-left: 8px;
+  }
+
+  button.form-cancel {
+    @extend %button-base;
+    @extend %button-secondary;
+  }
+
+  button.form-submit {
+    @extend %button-base;
+    @extend %button-primary;
+  }
+
+  .form-buttons {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+    margin-top: 16px;
+  }
+}
+
+.email-test-form {
+
+  .form-group {
+    margin-bottom: 10px;
+  }
+
+  label {
+    display: block;
+    font-weight: normal;
+    font-size: 20px;
+  }
+
+  input {
+    display: block;
+    color: #222;
+    background-color: white;
+    padding: 4px;
+    font-size: 16px;
+    border-radius: 2px;
+    border: 1px solid #d3d3d3;
+  }
+
+  button {
+    @extend %button-base;
+    @extend %button-primary;
+  }
+}

--- a/shell/client/styles/_admin-identity.scss
+++ b/shell/client/styles/_admin-identity.scss
@@ -1,0 +1,145 @@
+%idp-status {
+  display: inline-block;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  height: 28px;
+}
+
+%idp-table-row {
+  min-height: 32px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: 1px;
+}
+
+.identity-provider-table {
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-begin;
+
+  margin-bottom: 32px;
+
+  .idp-table-header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .idp-header-row {
+    width: 100%;
+    @extend %idp-table-row;
+    span {
+      min-height: 32px;
+      color: black;
+      background-color: #d3d3d3;
+      margin-right: 1px;
+    }
+  }
+  .idp-table-row {
+    @extend %idp-table-row;
+    color: #5b5b5b;
+    background-color: white;
+    button {
+      @extend %button-base;
+      @extend %button-secondary;
+      height: 26px;
+    }
+  }
+  .idp {
+    padding-left: 16px;
+    width: 200px;
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+  .idp-status {
+    padding-left: 16px;
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .idp-enabled {
+    @extend %idp-status;
+    color: #366456;
+    background-color: #d9ebcd;
+  }
+  .idp-disabled {
+    @extend %idp-status;
+    color: #656565;
+    background-color: #e9e9e9;
+  }
+}
+
+.setup-idp-form {
+  margin-bottom: 10px;
+
+  .idp-options-group {
+    display: block;
+    position: relative;
+    padding-left: 24px;
+    margin-bottom: 20px;
+    input[type=checkbox] {
+      position: absolute;
+      margin-left: -24px;
+    }
+    &::after {
+      border-bottom: 1px solid #ddd;
+    }
+  }
+
+  .form-group {
+    margin-bottom: 10px;
+  }
+
+  label {
+    display: block;
+    font-weight: normal;
+    font-size: 20px;
+  }
+
+  input[type="text"], textarea {
+    display: block;
+    width: 100%;
+    background-color: white;
+    padding: 4px;
+    font-size: 16px;
+    border-radius: 2px;
+    border: 1px solid #d3d3d3;
+  }
+
+  textarea {
+    min-height: 200px;
+  }
+
+  .form-subtext {
+    font-size: 14px;
+    color: #666;
+  }
+}
+
+.idp-modal-button-row {
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: flex-start;
+  justify-content: flex-start;
+  .idp-modal-save {
+    @extend %button-base;
+    @extend %button-primary;
+    margin-left: 10px;
+  }
+  .idp-modal-cancel {
+    @extend %button-base;
+    @extend %button-secondary;
+    margin-left: 10px;
+  }
+}
+
+

--- a/shell/client/styles/_admin-status.scss
+++ b/shell/client/styles/_admin-status.scss
@@ -1,0 +1,6 @@
+.admin-log-box {
+  max-height: 60vh;
+  overflow: scroll;
+  background-color: white;
+  border: 1px solid #ccc;
+}

--- a/shell/client/styles/_new-admin.scss
+++ b/shell/client/styles/_new-admin.scss
@@ -1,0 +1,48 @@
+// The purple used for the new design's nav pills.
+$darker-purple-color: #65468e;
+
+.admin-settings {
+  padding: 32px;
+
+  h1 {
+    font-weight: normal;
+    padding-top: 12px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #a2a2a2;
+  }
+
+  h2 {
+    font-size: 24px;
+    font-weight: normal;
+  }
+}
+
+.nav-pills {
+  margin: 0;
+  padding: 0;
+  >li {
+    display: inline-block;
+    list-style-type: none;
+    height: 32px;
+    margin: 2px;
+    a {
+      display: inline-block;
+      height: 32px;
+      border: 1px solid #dddddd;
+      border-radius: 4px;
+      padding: 4px 8px;
+      font-weight: normal;
+      color: black;
+      background-color: white;
+    }
+
+    &.active a {
+      color: white;
+      background-color: $darker-purple-color;
+    }
+  }
+}
+
+@import "_admin-identity.scss";
+@import "_admin-email.scss";
+@import "_admin-status.scss";

--- a/shell/client/styles/_partials.scss
+++ b/shell/client/styles/_partials.scss
@@ -50,18 +50,30 @@
   min-height: 26px;
   font-size: 13px;
   text-align: center;
+  text-decoration: none;
+}
+
+%button-disabled {
+  color: #777777;
+  background-color: #efefef;
+  border: 1px solid lighten(#afafaf, 10%);
+  &:hover {
+    color: #777777;
+    background-color: #efefef;
+    border: 1px solid lighten(#afafaf, 10%);
+  }
 }
 
 %button-primary {
   // A button coloring for the primary action of a form.
-  background-color: $sandstorm-purple-color;
+  background-color: #65468e;
   color: white;
   border: 1px solid darken($sandstorm-purple-color, 10%);
-  &:disabled {
-    background-color: #333333;
-  }
   &:hover {
-    background-color: darken($sandstorm-purple-color, 10%);
+    background-color: #714daa;
+  }
+  &:disabled {
+    @extend %button-disabled;
   }
 }
 
@@ -72,5 +84,18 @@
   border: 1px solid darken(white, 30%);
   &:hover {
     background-color: darken(white, 10%);
+  }
+  &:disabled {
+    @extend %button-disabled;
+  }
+}
+
+%button-dark {
+  background-color: #303030;
+  color: #ffffff;
+  border: 1px solid #4e4e4e;
+  transition: background-color .35s;
+  &:hover {
+    background-color: #4e4e4e;
   }
 }

--- a/shell/client/styles/_setup-wizard.scss
+++ b/shell/client/styles/_setup-wizard.scss
@@ -1,0 +1,382 @@
+.setup-root {
+  display: block;
+  width: 100%;
+  min-height: 100%; // An explicit height: 100% loses the background color behind the logo when scrolling.
+  position: relative;
+  padding-left: 64px;
+  padding-right: 64px;
+  padding-top: 32px;
+  padding-bottom: 32px;
+  background-color: #303030;
+}
+
+.setup-page-content {
+  background-color: #efefef;
+  padding: 32px;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 900px;
+}
+
+.setup-page-title {
+  margin-top: 0;
+  margin-bottom: 32px;
+  font-weight: normal;
+  text-align: center;
+}
+
+.setup-help-row {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 900px;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-begin;
+
+  background-color: #303030;
+  color: #ffffff;
+
+  .setup-help-label {
+    display: inline-block;
+    margin-right: 1em;
+    font-size: 13px;
+  }
+
+  .setup-help-link {
+    display: inline-block;
+    @extend %button-base;
+    @extend %button-dark;
+    font-weight: normal; // overriding default bold links
+    margin: 4px;
+    text-decoration: none;
+  }
+}
+
+.setup-progress {
+  margin-bottom: 32px;
+}
+
+.setup-progress-labels {
+  margin-top: 0;
+  margin-bottom: 8px;
+  padding: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-begin;
+  justify-content: center;
+}
+
+.setup-progress-step {
+  // base percent to flex: should be 100%/(num_steps + 1) to make the steps' labels line up with
+  // the endpoints of the progress bars below, but the number of steps varies, so we need to set
+  // the size depending on how many there are.
+  &.of-four {
+    flex: 0 1 25%;
+  }
+  &.of-five {
+    flex: 0 1 20%;
+  }
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-begin;
+  /* border: 1px solid #000; */
+}
+
+.setup-progress-bar {
+  display: flex;
+  >* {
+    flex: 1;
+    height: 12px;
+    border-left: 1px solid #9A94A0;
+  }
+  :last-child {
+    border-right: 1px solid #9A94A0;
+  }
+
+  .complete {
+    background-color: #6e3c8e;
+  }
+  .incomplete {
+    background-color: #e9e4ef;
+  }
+}
+
+.setup-welcome {
+  text-align: center;
+}
+
+.setup-type-selection {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-begin;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.setup-type {
+  flex: 1 1 auto;
+  min-width: 300px;
+  background-color: #fff;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px;
+  margin: 10px;
+
+  h3 {
+    text-align: center;
+    font-size: 20px;
+    font-weight: 600;
+    margin-left: 0px;
+    margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 8px;
+  }
+
+  .setup-features {
+    width: 100%;
+    flex: 1 1 auto;
+    list-style-type: none;
+    padding-left: 12px;
+    margin-top: 0;
+    margin-bottom: 16px;
+
+    .setup-additional-feature {
+      color: #888;
+    }
+    >li {
+      margin-bottom: 8px;
+    }
+
+    border-bottom: 1px solid #aaa
+  }
+
+  .setup-pricing-block {
+    text-align: center;
+    margin-bottom: 8px;
+    .setup-price {
+      font-size: 24px;
+      margin-top: 0px;
+      margin-bottom: 2px;
+    }
+    .subheader {
+      color: #444;
+      font-size: 12px;
+      margin-top: 2px;
+      margin-bottom: 2px;
+    }
+  }
+
+  button {
+    text-align: center;
+    width: 100%;
+    @extend %button-base;
+    @extend %button-primary;
+    height: 32px;
+    font-size: 16px;
+  }
+}
+
+.setup-organization-management-form {
+  h4 {
+    font-size: 20px;
+  }
+  .org-options-group {
+    display: block;
+    position: relative;
+    padding-left: 24px;
+    margin-bottom: 20px;
+    input[type=checkbox] {
+      position: absolute;
+      margin-left: -24px;
+      font-size: 16px;
+    }
+    &::after {
+      border-bottom: 1px solid #ddd;
+    }
+  }
+  .form-group {
+    margin-bottom: 10px;
+  }
+  label {
+    display: block;
+    font-weight: normal;
+    font-size: 20px;
+  }
+  input[type=text] {
+    display: block;
+    background-color: white;
+    padding: 4px;
+    font-size: 16px;
+    border-radius: 2px;
+    border: 1px solid #d3d3d3;
+  }
+  .form-subtext {
+    font-size: 14px;
+    color: #666;
+  }
+}
+
+.setup-next-steps {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-begin;
+  justify-content: center;
+  >* {
+    margin-left: 10px;
+  }
+}
+
+.setup-button-row {
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+  justify-content: flex-begin;
+}
+
+.setup-next-button {
+  @extend %button-base;
+  @extend %button-primary;
+  margin-left: 10px;
+  margin-bottom: 15px;
+}
+
+.setup-back-button {
+  @extend %button-base;
+  @extend %button-secondary;
+  margin-bottom: 15px;
+  margin-right: auto;
+}
+
+.setup-test-email-button, .setup-skip-email {
+  @extend %button-base;
+  @extend %button-secondary;
+  margin-bottom: 15px;
+  margin-left: 10px;
+}
+
+.setup-get-feature-key {
+  @extend %button-base;
+  @extend %button-secondary;
+}
+
+.setup-button-primary {
+  @extend %button-base;
+  @extend %button-primary;
+}
+
+.setup-button-secondary {
+  @extend %button-base;
+  @extend %button-secondary;
+}
+
+.center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.make-self-admin, .sign-in-button, .admin-settings-button, .rerun-wizard-button {
+  @extend %button-base;
+  display: block;
+  width: 200px;
+}
+
+.make-self-admin, .sign-in-button, .admin-settings-button {
+  @extend %button-primary;
+}
+
+.rerun-wizard-button {
+  @extend %button-secondary;
+}
+
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1000;
+  background-color: #000;
+  opacity: .5;
+}
+
+.modal {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  opacity: 1;
+  z-index: 1010;
+  display: block;
+  overflow-y: auto;
+}
+
+.modal-dialog {
+  position: relative;
+  width: 600px;
+  margin-top: 36px;
+  margin-bottom: auto;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.modal-close-button {
+  display: block;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 32px;
+  height: 32px;
+  color: transparent;
+  overflow: hidden;
+  background-image: url("/close-m.svg");
+  background-size: 20px 20px;
+  background-repeat: no-repeat;
+  background-position: center;
+  border: none;
+  border-radius: 16px;
+  background-color: transparent;
+  margin: 0;
+  &:hover {
+    background-color: #eee;
+    cursor: pointer;
+  }
+}
+
+.modal-content {
+  min-height: 32px;
+  background-color: #fff;
+  opacity: 1;
+  padding: 24px;
+  >h2 {
+    font-weight: normal;
+    margin: 0;
+    margin-bottom: 24px;
+    border-bottom: 1px solid #ddd;
+  }
+}
+
+.sandstorm-logo-row {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-begin;
+  align-items: center;
+}
+
+.sandstorm-logo {
+  display: block;
+  flex: none;
+  width: 200px;
+  height: 200px;
+  @extend %pseudo-img-tag;
+  background-image: url('/sandstorm-gradient-logo.svg')
+}

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -32,10 +32,12 @@
     position: fixed;
     left: 0;
     top: 0;
-    z-index: 1000;
-  }
-  body>.menu-button:hover {
-    background-color: $topbar-background-color-hover;
+    &:hover {
+      background-color: $topbar-background-color-hover;
+    }
+    &.expanded {
+      z-index: 101;
+    }
   }
 }
 
@@ -67,7 +69,6 @@ body>.topbar {
   padding: 0;
   width: 100%;
   text-align: left;
-  z-index: 100;
 
   line-height: 32px;
   height: 32px;
@@ -86,6 +87,9 @@ body>.topbar {
     &.expanded {
       height: 100%;
       box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.2);
+      // We avoid placing a z-index on the topbar when not expanded, lest modal dialogs
+      // that don't live at the same depth in the DOM be made unable to cover the topbar.
+      z-index: 100;
     }
   }
 
@@ -616,7 +620,6 @@ body>.topbar {
     }
     margin: 0;
     padding: 0;
-    z-index: 100;
     >ul.navbar-grains {
       margin: 0;
       padding: 0;

--- a/shell/client/styles/_widgets.scss
+++ b/shell/client/styles/_widgets.scss
@@ -9,6 +9,17 @@
   @extend %button-secondary;
 }
 
+.button-link {
+  background: none;
+  border: none;
+  display: inline;
+  font-weight: normal;
+  font-size: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
 .flash-message {
   border-radius: 5px;
   padding: 16px;

--- a/shell/client/styles/shell.scss
+++ b/shell/client/styles/shell.scss
@@ -41,6 +41,10 @@ body {
   font-family: "Source Sans Pro", sans-serif;
   font-weight: normal;
   background-color: white;
+  &.modal-shown {
+    // When a modal is being shown, make it so only the modal scrolls.
+    overflow-y: hidden;
+  }
 }
 
 *, *:before, *:after {
@@ -432,6 +436,10 @@ div.popup h2 {
 
 // Admin settings styles
 @import "_admin.scss";
+@import "_new-admin.scss";
+
+// Setup wizard styles
+@import "_setup-wizard.scss";
 
 body>.popup.admin-alert>.frame>p {
   display: block;

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -122,6 +122,14 @@ limitations under the License.
 </template>
 
 <template name="_accountProfileEditor">
+{{!-- Expected arguments to data context:
+          identity: Object.  Should contain the usual Meteor.user fields (_id, profile, etc.)
+setActionCompleted: (optional) Function.  Callback triggered on profile saved or picture updated.
+   termsAndPrivacy: (optional) Object containing Strings termsUrl and/or privacyUrl.
+        staticHost: String.  Used to generate avatar URL.
+                db: instance of SandstormDb (optional, but needed for sandstormAccountsFirstSignIn?)
+       hideButtons: Boolean (optional, default value is false)
+--}}
   <div class="identity-editor">
     <form class="account-profile-editor" data-identity-id="{{identity._id}}">
       <div class="editor">
@@ -202,6 +210,7 @@ limitations under the License.
             {{> billingOptins}}
           {{/if}}
           {{/unless}}
+          {{#unless hideButtons}}
           <li class="save">
             <button disabled="{{profileSaved}}">
               {{#if hasCompletedSignup}}Save{{else}}Continue{{/if}}
@@ -210,6 +219,7 @@ limitations under the License.
             <button class="logout">Cancel</button>
             {{/unless}}
           </li>
+          {{/unless}}
         </ul>
       </div>
     </form>

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -317,9 +317,9 @@ const submitProfileForm = function (form, cb) {
 };
 
 Template._accountProfileEditor.onCreated(function () {
+  this.submitProfileForm = submitProfileForm; // Stored on the object so setup wizard can call it directly.
   this._profileSaved = new ReactiveVar(true);
   this._setActionCompleted = this.data.setActionCompleted || function () {};
-  this.submitProfileForm = submitProfileForm; // Stored on the object so setup wizard can call it directly.
 });
 
 Template._accountProfileEditor.events({

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -271,10 +271,7 @@ Template.sandstormAccountsFirstSignIn.helpers({
   },
 });
 
-const submitProfileForm = function (event, cb) {
-  event.preventDefault();
-  const form = Template.instance().find("form");
-
+const submitProfileForm = function (form, cb) {
   if (form.agreedToTerms && !form.agreedToTerms.checked) {
     alert("You must agree to the terms to continue.");
     return;
@@ -319,9 +316,17 @@ const submitProfileForm = function (event, cb) {
   BlackrockPayments.processOptins(form);
 };
 
+Template._accountProfileEditor.onCreated(function () {
+  this._profileSaved = new ReactiveVar(true);
+  this._setActionCompleted = this.data.setActionCompleted || function () {};
+  this.submitProfileForm = submitProfileForm; // Stored on the object so setup wizard can call it directly.
+});
+
 Template._accountProfileEditor.events({
   "submit form.account-profile-editor": function (event, instance) {
-    submitProfileForm(event, function () {
+    event.preventDefault();
+    const form = Template.instance().find("form");
+    submitProfileForm(form, function () {
       instance._profileSaved.set(true);
       instance._setActionCompleted({ success: "profile saved" });
     });
@@ -345,14 +350,7 @@ Template._accountProfileEditor.events({
     event.preventDefault();
     Meteor.logout();
   },
-});
 
-Template._accountProfileEditor.onCreated(function () {
-  this._profileSaved = new ReactiveVar(true);
-  this._setActionCompleted = this.data.setActionCompleted || function () {};
-});
-
-Template._accountProfileEditor.events({
   "click .picture button": function (event, instance) {
     event.preventDefault();
 

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -623,6 +623,14 @@ FeatureKey = new Mongo.Collection("featureKey");
 //
 // This is only intended to be visible on the server.
 
+SetupSession = new Mongo.Collection("setupSession");
+// Responsible for storing information about setup sessions.  Contains a single document with three
+// keys:
+//
+//   _id: "current-session"
+//   creationDate: Date object indicating when this session was created.
+//   hashedSessionId: the sha256 of the secret session id that was returned to the client
+
 if (Meteor.isServer) {
   Meteor.publish("credentials", function () {
     // Data needed for isSignedUp() and isAdmin() to work.
@@ -928,6 +936,7 @@ SandstormDb = function () {
     appIndex: AppIndex,
     keybaseProfiles: KeybaseProfiles,
     featureKey: FeatureKey,
+    setupSession: SetupSession,
 
     // Intentionally omitted:
     // - Migrations, since it's used only within this package.
@@ -1216,6 +1225,15 @@ _.extend(SandstormDb.prototype, {
   getSetting: function (name) {
     const setting = Settings.findOne(name);
     return setting && setting.value;
+  },
+
+  getSettingWithFallback: function (name, fallbackValue) {
+    const value = this.getSetting(name);
+    if (value === undefined) {
+      return fallbackValue;
+    }
+
+    return value;
   },
 
   addUserActions: function (packageId) {

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -22,8 +22,6 @@ limitations under the License.
       Sandstorm has been updated &mdash; Click here to reload
     </div>
   {{/if}}
-  {{!-- Becomes hamburger menu button in mobile view. --}}
-  <div class="menu-button"></div>
   <ul class="topbar {{#if _menuExpanded.get}}expanded{{/if}}">
     <ul class="menubar {{#if shrinkNavbar}}shrink-desktop{{/if}}">
       {{#each items}}
@@ -66,6 +64,10 @@ limitations under the License.
       </ul>
     </ul>
   </ul>
+  {{!-- Becomes hamburger menu button in mobile view.  Placed after the topbar so it stacks above
+        the other topbar items without needing z-index, which would make it impossible to have
+        modals cover this button. --}}
+  <div class="menu-button {{#if _menuExpanded.get}}expanded{{/if}}"></div>
   {{!-- We wish to block reload if there are *any* grains open, regardless of the current route --}}
   {{#if grainCount }}
     {{>sandstormTopbarBlockReload}}

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -55,7 +55,7 @@ const tokenIsSetupSession = function (token) {
       const hash = Crypto.createHash("sha256").update(token).digest("base64");
       const now = new Date();
       const sessionLifetime = 24 * 60 * 60 * 1000; // length of setup session validity, in milliseconds: 1 day
-      if (setupSession.hashedSessionId === hash && (now - setupSession.creationDate < sessionLifetime)) {
+      if (setupSession.hashedSessionId === hash && ((now - setupSession.creationDate) < sessionLifetime)) {
         return true;
       }
     }

--- a/shell/server/admin/system-status-server.js
+++ b/shell/server/admin/system-status-server.js
@@ -1,0 +1,93 @@
+const Crypto = Npm.require("crypto");
+
+const hashSessionId = function (sessionId) {
+  return Crypto.createHash("sha256").update(sessionId).digest("base64");
+};
+
+Meteor.publish("systemStatus", function () {
+  // A pseudocollection containing the number of active grain sessions and unique
+  // userIds associated with these sessions
+  const db = this.connection.sandstormDb;
+  if (!db.isAdminById(this.userId)) {
+    throw new Meteor.Error(403, "User must be admin to view system status.");
+  }
+
+  const _this = this;
+  const userIdToSessionHashes = {}; // Maps userId => list of (sha256(sessionId))
+  const grainIdToSessionHashes = {}; // Maps grainId => list of (sha256(sessionId))
+
+  let userIdCount = 0;
+  let grainIdCount = 0;
+
+  this.added("systemStatus", "globalStatus", {
+    activeUsers: userIdCount,
+    activeGrains: grainIdCount,
+  });
+
+  const query = db.collections.sessions.find();
+  const handle = query.observe({
+    added(session) {
+      const hashedSessionId = hashSessionId(session._id);
+      const changed = {};
+
+      // Update userId cache.
+      if (session.userId) {
+        if (userIdToSessionHashes[session.userId] === undefined) {
+          userIdToSessionHashes[session.userId] = [];
+          userIdCount = userIdCount + 1;
+          changed.activeUsers = userIdCount;
+        }
+
+        userIdToSessionHashes[session.userId] =
+            _.union(userIdToSessionHashes[session.userId], [hashedSessionId]);
+      }
+
+      // Update grainId cache.
+      if (grainIdToSessionHashes[session.grainId] === undefined) {
+        grainIdToSessionHashes[session.grainId] = [];
+        grainIdCount = grainIdCount + 1;
+        changed.activeGrains = grainIdCount;
+      }
+
+      grainIdToSessionHashes[session.grainId] =
+          _.union(grainIdToSessionHashes[session.grainId], [hashedSessionId]);
+
+      if (!_.isEmpty(changed)) {
+        _this.changed("systemStatus", "globalStatus", changed);
+      }
+    },
+
+    removed(session) {
+      const hashedSessionId = hashSessionId(session._id);
+      const changed = {};
+
+      if (session.userId) {
+        userIdToSessionHashes[session.userId] =
+            _.without(userIdToSessionHashes[session.userId], hashedSessionId);
+
+        if (userIdToSessionHashes[session.userId].length === 0) {
+          userIdToSessionHashes[session.userId] = undefined;
+          userIdCount = userIdCount - 1;
+          changed.activeUsers = userIdCount;
+        }
+      }
+
+      grainIdToSessionHashes[session.grainId] =
+          _.without(grainIdToSessionHashes[session.grainId], hashedSessionId);
+
+      if (grainIdToSessionHashes[session.grainId].length === 0) {
+        grainIdToSessionHashes[session.grainId] = undefined;
+        grainIdCount = grainIdCount - 1;
+        changed.activeGrains = grainIdCount;
+      }
+
+      if (!_.isEmpty(changed)) {
+        _this.changed("systemStatus", "globalStatus", changed);
+      }
+    },
+  });
+  this.onStop(() => {
+    handle.stop();
+  });
+  this.ready();
+});

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -31,6 +31,7 @@ Accounts.identityServices.github = {
       method: "loginWithGithub",
       name: "github",
       displayName: "GitHub",
+      linkingNewIdentity: false,
     },
   },
 };
@@ -47,6 +48,7 @@ Accounts.identityServices.google = {
       method: "loginWithGoogle",
       name: "google",
       displayName: "Google",
+      linkingNewIdentity: false,
     },
   },
 };

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -845,9 +845,10 @@ public:
       context.exitInfo(hexString);
     } else {
       context.exitInfo(kj::str("Generated new admin token.\n\nPlease proceed to ", config.rootUrl,
-        "/setup/token/", hexString, " in order to access the admin settings page and configure ",
-        "your login system. This token will expire in 15 min, and if you take too long, you will ",
-        "have to regenerate a new token with `sandstorm admin-token`."));
+        "/setup/token/", hexString, " in order to access the admin settings page and configure "
+        "your login system. You must visit the link within 15 minutes, after which you will have "
+        "24 hours to complete the setup process.  If you need more time, you can always generate "
+        "a new token with `sandstorm admin-token`."));
     }
   }
 

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -845,7 +845,7 @@ public:
       context.exitInfo(hexString);
     } else {
       context.exitInfo(kj::str("Generated new admin token.\n\nPlease proceed to ", config.rootUrl,
-        "/admin/settings/", hexString, " in order to access the admin settings page and configure ",
+        "/setup/token/", hexString, " in order to access the admin settings page and configure ",
         "your login system. This token will expire in 15 min, and if you take too long, you will ",
         "have to regenerate a new token with `sandstorm admin-token`."));
     }


### PR DESCRIPTION
To explain some of the unusual code and layout: this changeset started out as an attempt to build the new admin UI, and switched to being the setup wizard partway through.  A significant amount of code for the former was reusable for the latter; rather than try to separate out the two changes, I include some unrelated unlinked routes (`/admin-new/*`) and supporting code (`shell/client/admin/*`).  There are some things that will need to be reworked depending on context (setup wizard vs admin settings).

We're going to need the new admin panel code and layouts in the not-so-distant future anyway, and I didn't really want to deal with figuring out exactly what depends on what, pulling the pieces apart, only to merge them back together later.

Since there are a bunch of UI states that we didn't fully consider in the design phase, I had to wing some of the copy, which I am happy to replace with better text.

I need sleep now, but I'll post screenshots in the morning.