### PR TITLE
Switch the button in sharing emails from blue to purple.

### DIFF
--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -19,7 +19,7 @@ const Crypto = Npm.require("crypto");
 const emailLinkWithInlineStyle = function (url, text) {
   return "<a href='" + url + "' style='display:inline-block;text-decoration:none;" +
    "font-family:sans-serif;width:200px;min-height:30px;line-height:30px;" +
-   "border-radius:4px;text-align:center;background:#428bca;color:white'>" +
+   "border-radius:4px;text-align:center;background:#762F87;color:white'>" +
    text + "</a>";
 };
 


### PR DESCRIPTION
This is [`$sandstorm-purple-color`](https://github.com/sandstorm-io/sandstorm/blob/0ba3e06c246217c81f46a641e8e1a9c4561d49ba/shell/client/styles/_colors.scss#L4).

Looks like:
<img width="936" alt="email" src="https://cloud.githubusercontent.com/assets/495768/14303411/733d6818-fb78-11e5-953f-1e033ab68d75.png">

