### PR TITLE
Allow muting the app dev message with a particular key in localStorage

### DIFF
--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -726,20 +726,22 @@ Template.notificationItem.events({
 
 Meteor.startup(function () {
   // Tell app authors how to run JS in the context of the grain-frame.
-  console.log(
-      "%cApp authors: To understand the grain-frame in Sandstorm and how to find " +
-      "logs and perform troubleshooting, see: " +
-      "\n- https://docs.sandstorm.io/en/latest/developing/path/ " +
-      "\n- https://docs.sandstorm.io/en/latest/using/top-bar/ " +
-      "\n- https://docs.sandstorm.io/en/latest/developing/troubleshooting/ " +
-      "\n" +
-      "\nWhen debugging, make sure you execute Javascript " +
-      "in the context of the 'grain-frame' IFRAME. References: " +
-      "\n- https://stackoverflow.com/questions/3275816/debugging-iframes-with-chrome-developer-tools " +
-      "\n- https://developer.mozilla.org/en-US/docs/Tools/Working_with_iframes " +
-      "\n" +
-      "\nWe can also provide personal assistance! Get in touch: https://sandstorm.io/community",
-    "font-size: large; background-color: yellow;");
+  if (!Meteor._localStorage.getItem("muteDevNote")) {
+    console.log(
+        "%cApp authors: To understand the grain-frame in Sandstorm and how to find " +
+        "logs and perform troubleshooting, see: " +
+        "\n- https://docs.sandstorm.io/en/latest/developing/path/ " +
+        "\n- https://docs.sandstorm.io/en/latest/using/top-bar/ " +
+        "\n- https://docs.sandstorm.io/en/latest/developing/troubleshooting/ " +
+        "\n" +
+        "\nWhen debugging, make sure you execute Javascript " +
+        "in the context of the 'grain-frame' IFRAME. References: " +
+        "\n- https://stackoverflow.com/questions/3275816/debugging-iframes-with-chrome-developer-tools " +
+        "\n- https://developer.mozilla.org/en-US/docs/Tools/Working_with_iframes " +
+        "\n" +
+        "\nWe can also provide personal assistance! Get in touch: https://sandstorm.io/community",
+      "font-size: large; background-color: yellow;");
+  }
 
   Meteor.subscribe("notifications");
 


### PR DESCRIPTION
I'm tired of seeing this every time the page refreshes and I care about what's
being logged but instead see mostly this giant note with yellow background and
larger type than console.log() and links that are large click targets that make
it harder to focus the JS console input.

Disable the note from the JS console:

    localStorage.setItem("muteDevNote", true)