### PR TITLE
Feature key form: don't allow submitting an empty feature key text

### DIFF
--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -978,15 +978,18 @@ Template.adminAdvanced.helpers({
 
 Template.featureKeyUploadForm.onCreated(function () {
   this.error = new ReactiveVar(undefined);
+  this.text = new ReactiveVar("");
 });
 
 Template.featureKeyUploadForm.events({
   "submit form": function (evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
     const state = Iron.controller().state;
     const token = state.get("token");
-    evt.preventDefault();
+
     const instance = Template.instance();
-    const text = instance.find("textarea").value;
+    const text = instance.text.get();
     Meteor.call("submitFeatureKey", token, text, (err) => {
       if (err) {
         instance.error.set(err.message);
@@ -1017,11 +1020,24 @@ Template.featureKeyUploadForm.events({
       reader.readAsText(file);
     }
   },
+
+  "input textarea"(evt) {
+    const instance = Template.instance();
+    instance.text.set(evt.currentTarget.value);
+  },
 });
 
 Template.featureKeyUploadForm.helpers({
   currentError: function () {
     return Template.instance().error.get();
+  },
+
+  text() {
+    return Template.instance().text.get();
+  },
+
+  htmlDisabled() {
+    return Template.instance().text.get() ? "" : "disabled";
   },
 });
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -1477,10 +1477,10 @@ limitations under the License.
       {{/if}}
     {{/with}}
     <label>Feature key:
-    <textarea class="feature-key" placeholder="Paste feature key here..."></textarea>
+      <textarea class="feature-key" placeholder="Paste feature key here..." value="{{text}}"></textarea>
     </label>
     <div class="feature-key-button-row">
-      <button class="check-key">Verify</button>
+      <button class="check-key" {{htmlDisabled}}>Verify</button>
     </div>
     <label>Or select a file to upload: <input name="feature-key" type="file" /></label>
   </form>


### PR DESCRIPTION
Due to a hilarious dual-purposing, the default empty string value is
considered by the backend to mean "please delete the current feature key".

We have a button for that, with an appropriate warning.  We should not let you
accidentally remove your feature key in this manner.

Fixes #1766.