### PR TITLE
Add webfont icon to LDAP and SAML identity cards and switch to webfont for other providers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,10 +48,6 @@ shell/public/google-color.svg
 shell/public/google.svg
 shell/public/troubleshoot.svg
 shell/public/email-494949.svg
-shell/public/debug-9E9E9E.svg
-shell/public/email-9E9E9E.svg
-shell/public/github-9E9E9E.svg
-shell/public/google-9E9E9E.svg
 shell/public/*-m.svg
 shell/public/sandstorm-icons
 shell/public/icons/icons-*.eot

--- a/Makefile
+++ b/Makefile
@@ -108,11 +108,6 @@ IMAGES= \
     shell/public/email-494949.svg \
     shell/public/close-FFFFFF.svg \
                                   \
-    shell/public/debug-9E9E9E.svg \
-    shell/public/email-9E9E9E.svg \
-    shell/public/github-9E9E9E.svg \
-    shell/public/google-9E9E9E.svg \
-                                  \
     shell/public/install-6A237C.svg \
     shell/public/install-9E40B5.svg \
     shell/public/plus-6A237C.svg \
@@ -315,10 +310,6 @@ shell/public/google-color.svg: icons/google.svg
 shell/public/github-color.svg: icons/github.svg
 	@$(call color,custom color $<)
 	@sed -e 's/#111111/#191919/g' < $< > $@
-
-shell/public/%-9E9E9E.svg: icons/%.svg
-	@$(call color,custom color $<)
-	@sed -e 's/#111111/#9E9E9E/g' < $< > $@
 
 shell/public/email-494949.svg: icons/email.svg
 	@$(call color,custom color $<)

--- a/icons/ldap.svg
+++ b/icons/ldap.svg
@@ -3,17 +3,9 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 25 25" style="enable-background:new 0 0 25 25;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:none;}
 	.st1{fill:#111111;}
 </style>
 <g>
-	<polygon class="st0" points="21.7,12 18.1,12 18.1,14.9 21.7,14.9 21.7,12 	"/>
-	<polygon class="st0" points="14.9,16.1 13.3,16.1 13.3,19 16.8,19 16.8,16.1 14.9,16.1 	"/>
-	<polygon class="st0" points="16.1,21.2 15.8,21.2 15.8,25 19.3,25 19.3,21.2 16.1,21.2 	"/>
-	<polygon class="st0" points="21.7,16.1 18.1,16.1 18.1,19 21.7,19 21.7,16.1 	"/>
-	<path class="st0" d="M12,23.8V10.7h2.9V1.4H4.1V25H12V23.8L12,23.8z M10.2,2.6h3.6v2.9h-3.6V2.6L10.2,2.6z M9,9.6H5.4V6.7H9V9.6
-		L9,9.6z M9,5.5H5.4V2.6H9V5.5L9,5.5z M10.2,6.7h3.6v2.9h-3.6V6.7L10.2,6.7z"/>
-	<polygon class="st0" points="13.3,12 13.3,14.9 16.8,14.9 16.8,12 13.3,12 	"/>
 	<polygon class="st1" points="5.4,5.5 9,5.5 9,2.6 5.4,2.6 5.4,5.5 	"/>
 	<polygon class="st1" points="13.8,2.6 10.2,2.6 10.2,5.5 13.8,5.5 13.8,2.6 	"/>
 	<polygon class="st1" points="5.4,9.6 9,9.6 9,6.7 5.4,6.7 5.4,9.6 	"/>

--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -1609,24 +1609,38 @@ ul.identity-card-list {
   color: black;
   font-family: "Source Sans Pro", sans-serif;
   background-color: white;
-  background-repeat: no-repeat;
-  background-position: 50px 30px;
-  background-size: 16px 16px;
+
+  &::before {
+    color: #9E9E9E;
+    position: absolute;
+    left: 50px;
+    top: 30px;
+    font-size: 16px;
+    @extend .icon;
+  }
 
   &[data-service-name=github] {
-    background-image: url("/github-9E9E9E.svg");
+    @extend .icon-github;
   }
 
   &[data-service-name=google] {
-    background-image: url("/google-9E9E9E.svg");
+    @extend .icon-google;
   }
 
   &[data-service-name=dev] {
-    background-image: url("/debug-9E9E9E.svg");
+    @extend .icon-debug;
   }
 
   &[data-service-name=email] {
-    background-image: url("/email-9E9E9E.svg");
+    @extend .icon-email;
+  }
+
+  &[data-service-name=ldap] {
+    @extend .icon-ldap;
+  }
+
+  &[data-service-name=saml] {
+    @extend .icon-ldap;
   }
 
   .picture {


### PR DESCRIPTION
Turns out that `ldap.svg` currently has some invisible cruft in it that causes it to render poorly in the webfont. So part of my change here is to delete that cruft.