### PR TITLE
Send a new SandstormCore capability on Supervisor.keepAlive().

### DIFF
--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -30,9 +30,16 @@ interface Supervisor {
   getMainView @0 () -> (view :Grain.UiView);
   # Get the grain's main UiView.
 
-  keepAlive @1 ();
+  keepAlive @1 (core :SandstormCore);
   # Must call periodically to prevent supervisor from killing itself off.  Call at least once
   # per minute.
+  #
+  # `core` may be null. If not null, then it is a new copy of the SandstormCore capability which
+  # should replace the old one. This allows the grain to recover if the original SandstormCore
+  # becomes disconnected.
+  #
+  # TODO(reliability): Passing `core` here is an ugly hack. The supervisor really needs a way to
+  #   proactively reconnect.
 
   syncStorage @8 ();
   # Calls syncfs() on /var.


### PR DESCRIPTION
This is important if the front-end has independently shut down and started up again; any existing capability will be disconnected.

As part of this, I had to refactor the CapabilityRedirector stuff a bit. Previously, were actually creating two levels of redirectors, one of which was never being redirected.

While I was there, I also made CapabilityRedirector directly detect disconnects in case the caller can't (as is the case after keepAlive()).

(This problem has been causing the feature key vendor to fail a lot.)