### PR TITLE
Attempt to make the 'grain identity chooser interstitial' test more robust.

### DIFF
--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -474,6 +474,10 @@ module.exports["Test grain identity chooser interstitial"] = function (browser) 
         .click("button.pick-identity")
         .waitForElementVisible('.grain-frame', medium_wait)
         .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
+        .frame('grain-frame')
+        .waitForElementPresent('#publish', medium_wait)
+        .assert.containsText('#publish', 'Publish')
+        .frame(null)
 
          // Identity picker should not come up on reloading the page.
         .url(shareLink.value)


### PR DESCRIPTION
Lately we've been seeing a bunch of failures like https://build.sandstorm.io/job/Sandstorm/1099/. My current hypothesis is that [our `unload` listener](https://github.com/sandstorm-io/sandstorm/blob/480bf3fde24796c169d4b196da6b5f0deab51660/shell/packages/sandstorm-ui-grainview/grainview-list.js#L35-L67) somehow interacts poorly with our grain loading logic, particularly in the case when a share link is being redeemed. It would be good to actually track down the root cause, but in the meantime let's make our tests less flaky.
