### PR TITLE
Offer templates should avoid extra newlines on the clipboard in Firefox

### DIFF
--- a/shell/public/offer-template.html
+++ b/shell/public/offer-template.html
@@ -64,9 +64,10 @@ body {
     </style>
   </head>
   <body>
-    <div id="container">
-      <pre id="text"></pre>
-    </div>
+    <!-- Since <pre> doesn't bound selection, this needs to all be on the same line,
+         or copying by triple-click or the clipboard button will capture additional
+         newlines in Firefox. -->
+    <div id="container"><pre id="text"></pre></div>
     <button id="clipboard" aria-label="Copy" data-clipboard-target="#text"></button>
     <div id="clipboardSuccess">copied</div>
 


### PR DESCRIPTION
There appears to be a Selection edge case in Firefox that inserts spurious
newlines into the value copied onto the clipboard if you attempt to select
everything contained by a `<pre>` within a `<div>` if the `<div>` contains newlines,
but the `<pre>` does not.

Removing the contained newlines makes Firefox do the right thing.

Fixes #1795.