### PR TITLE
Don't default to dev server when using install.sh -u.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -638,7 +638,6 @@ choose_install_mode() {
     echo ""
     echo "NOTE: Showing you all options, including development options, but omitting "
     echo "      init script automation, because you chose to install without using root."
-    CHOSEN_INSTALL_MODE="${CHOSEN_INSTALL_MODE:-2}"  # dev server mode by default
   fi
 
   if [ -z "${CHOSEN_INSTALL_MODE:-}" ]; then


### PR DESCRIPTION
There is no reason to expect that non-root installs want a dev server. In fact, dev servers mostly don't work with non-root installs (although I'd prefer not to default to live either because I often use this flow for testing).