### PR TITLE
Mail integration tests: faster and cleaner closing of simplesmtp stub client and server.

### DIFF
--- a/tests/commands/assertReceiveEmail.js
+++ b/tests/commands/assertReceiveEmail.js
@@ -34,10 +34,12 @@ ReceiveEmail.prototype.command = function(selector, expectedMessage, timeout, cb
     self.emit("complete");
   }, timeout);
 
-  server = simplesmtp.createSimpleServer({SMTPBanner:"Sandstorm Testing Mail Server"}, function (req) {
+  var options = { SMTPBanner:"Sandstorm Testing Mail Server", timeout: 10000 };
+  server = simplesmtp.createSimpleServer(options, function (req) {
     var mailparser = new MailParser();
 
     req.pipe(mailparser);
+    req.accept();
     mailparser.on("end", function (mail) {
       clearTimeout(timeoutHandle);
       server.server.end(function () {});

--- a/tests/commands/sendEmail.js
+++ b/tests/commands/sendEmail.js
@@ -27,6 +27,7 @@ SendEmail.prototype.command = function(message, timeout, cb) {
       cb.call(self.client.api, new Error("Timed out while trying to send email"));
     }
 
+    pool.close();
     self.emit("complete");
   }, timeout);
 
@@ -38,6 +39,7 @@ SendEmail.prototype.command = function(message, timeout, cb) {
       cb.call(self.client.api, err);
     }
 
+    pool.close();
     self.emit("complete");
   });
 


### PR DESCRIPTION
The SMTP server in `assertReceiveEmail` currently has the default connection timeout of 60 seconds. This implies that if you just run the roundcube tests, you end up waiting for a minute after the tests are complete until they actually shut down. 10 seconds, as specified by the `timeout` option in this pull request, is more reasonable. (As far as I could determine, there is no easy way to immediately close the connection.)

The `req.accept()` call makes sure that the client knows that the message was accepted. Without it, Sandstorm throws a "DeliveryError: Message delivery failed" exception that gets logged in `sandstorm.log`.

The `pool.close()` calls in `sendEmail` shut down the client right away. (Currently this connection stays open until a timeout, as in the server.)


These changes should help fix our current problem where the tests finish and display `OK. 517 total assertions passed. (7m 25s)` but don't actually shut down right away.

I hope that these changes might also lower the frequency of the `EADDRINUSE` errors we have been seeing intermittently in the tests. I still don't understand how those errors are happening, but it seems plausible that they could be related to the problems fixed here.