### PR TITLE
Undo: Don't default to dev server when using install.sh -u.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -638,6 +638,7 @@ choose_install_mode() {
     echo ""
     echo "NOTE: Showing you all options, including development options, but omitting "
     echo "      init script automation, because you chose to install without using root."
+    CHOSEN_INSTALL_MODE="${CHOSEN_INSTALL_MODE:-2}"  # dev server mode by default
   fi
 
   if [ -z "${CHOSEN_INSTALL_MODE:-}" ]; then


### PR DESCRIPTION
Reverts sandstorm-io/sandstorm#1800

I'm stupid. See discussion on #1800.