### PR TITLE
Make sure that the fibers package targets the correct v8 version.

### DIFF
--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -87,8 +87,12 @@ cp -r shell-build/bundle bundle
 rm -f bundle/README
 cp meteor-bundle-main.js bundle/sandstorm-main.js
 
-# Meteor wants us to do "npm install" in the bundle to prepare it.
-(cd bundle/programs/server && "$METEOR_DEV_BUNDLE/bin/npm" install)
+# Meteor wants us to do `npm install` in the bundle to prepare it.
+# The fibers package builds native extensions, choosing the target v8 version based on
+# the version of `/usr/bin/env node`. We need to make it does not pick up the wrong binary,
+# so we prepend `METEOR_DEV_BUNDLE/bin` to `PATH`.
+(cd bundle/programs/server && \
+ PATH=$METEOR_DEV_BUNDLE/bin:$PATH "$METEOR_DEV_BUNDLE/bin/npm" install)
 
 # Copy over key binaries.
 mkdir -p bundle/bin


### PR DESCRIPTION
If the system's `node --version` is not 0.10, then the built Sandstorm bundle will crash with errors like 

```
Error: `/programs/server/node_modules/fibers/bin/linux-x64-v8-3.14/fibers.node` is missing. Try reinstalling `node-fibers`
```

This fixes the problem. See also https://github.com/sandstorm-io/meteor-spk/pull/16.