### PR TITLE
Request access button: prevent redirect loop when grain owner has unlinked the sharer identity.

### DIFF
--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -176,8 +176,6 @@ Meteor.publish("requestingAccess", function (grainId) {
     throw new Meteor.Error(403, "Must be logged in to request access.");
   }
 
-  const identityIds = SandstormDb.getUserIdentityIds(Meteor.users.findOne({ _id: this.userId }));
-
   const grain = globalDb.getGrain(grainId);
   if (!grain) {
     throw new Meteor.Error(404, "Grain not found.");
@@ -188,8 +186,12 @@ Meteor.publish("requestingAccess", function (grainId) {
                Random.id(), { grainId: grainId, identityId: grain.identityId });
   }
 
+  const identityIds = SandstormDb.getUserIdentityIds(Meteor.users.findOne({ _id: this.userId }));
+  const ownerIdentityIds = SandstormDb.getUserIdentityIds(
+      Meteor.users.findOne({ _id: grain.userId }));
+
   const _this = this;
-  const query = ApiTokens.find({ grainId: grainId, accountId: grain.userId,
+  const query = ApiTokens.find({ grainId: grainId, identityId: { $in: ownerIdentityIds },
                                  parentToken: { $exists: false },
                                  "owner.user.identityId": { $in: identityIds },
                                  revoked: { $ne: true }, });


### PR DESCRIPTION
Alice owns a grain. Alice shares the grain to Bob through the identity `alice@example.com`. Alice unlinks her `alice@example.com` identity. Bob no longer has access, as expected. What's not expected is that when Bob visits the grain URL, he now sees an infinite redirect loop. The problem is that the `accountId` on Bob's token still points to Alice, the grain owner, so it looks kind of like Bob should have access, and therefore the client retries again and again. The solution proposed here is to base the decision to retry on more reliable data: the `identityId` field.