### PR TITLE
IdP settings: vendor in and improve Google/GitHub OAuth instructions

### DIFF
--- a/shell/client/admin/identity-providers.html
+++ b/shell/client/admin/identity-providers.html
@@ -54,6 +54,21 @@
 {{/modalDialogWithBackdrop}}
 </template>
 
+<template name="googleLoginSetupInstructions">
+  <p>
+    First, you'll need to get a Google Client ID. Follow these steps:
+  </p>
+  <ol>
+    <li>Visit <a href="https://console.developers.google.com/" target="blank">https://console.developers.google.com/</a></li>
+    <li>"Create Project", if needed. Wait for Google to finish provisioning.</li>
+    <li>On the left sidebar, go to "Credentials" and, on the right, "OAuth Consent Screen". Make sure to enter an email address and a product name, and save.</li>
+    <li>On the left sidebar, go to "Credentials".  Press the "Create credentials" button, then select "Web application" as the type.</li>
+    <li>Set Authorized Javascript Origins to: <span class="idp-config-url">{{siteUrlNoSlash}}</span></li>
+    <li>Set Authorized Redirect URI to: <span class="idp-config-url">{{siteUrlNoSlash}}/_oauth/google</span></li>
+    <li>Finish by clicking "Create".</li>
+  </ol>
+</template>
+
 <template name="adminIdentityProviderConfigureGoogle">
 {{#modalDialogWithBackdrop onDismiss=onDismiss}}
   <h2>Google Login Configuration</h2>
@@ -65,16 +80,15 @@
   {{/if}}
 
   <form class="setup-idp-form">
+    {{> googleLoginSetupInstructions }}
+
+    <p>Then, copy over your Client ID and Client Secret below:</p>
+
     <div class="form-group">
       <label>
         <input type="checkbox" name="enableGoogle" checked="{{googleChecked}}"/>Enable login with Google
       </label>
     </div>
-
-    {{!-- TODO: replace these instructions with our own, which we can keep more up-to-date. --}}
-    {{> configureLoginServiceDialogForGoogle}}
-
-    <p>Now, copy over some details:</p>
     <div class="form-group">
       <label>
         Client ID:
@@ -100,21 +114,30 @@
 {{/modalDialogWithBackdrop}}
 </template>
 
+<template name="githubLoginSetupInstructions">
+  <p>
+    First, you'll need to get a Github Client ID and Client Secret. Follow these steps:
+  </p>
+  <ol>
+    <li>Visit <a href="https://github.com/settings/applications/new" target="blank">https://github.com/settings/applications/new</a></li>
+    <li>Set Homepage URL to: <span class="idp-config-url">{{siteUrl}}</span></li>
+    <li>Set Authorization callback URL to: <span class="idp-config-url">{{siteUrl}}_oauth/github</span></li>
+  </ol>
+</template>
+
 <template name="adminIdentityProviderConfigureGitHub">
 {{#modalDialogWithBackdrop onDismiss=onDismiss}}
   <h2>GitHub Configuration</h2>
 
   <form class="setup-idp-form">
+    {{> githubLoginSetupInstructions }}
+
+    <p>Then, copy over your Client ID and Client Secret below:</p>
     <div class="form-group">
       <label>
         <input type="checkbox" name="enableGithub" checked="{{githubChecked}}"/>Enable login with GitHub
       </label>
     </div>
-
-    {{!-- TODO: replace these instructions with our own, which we can keep more up-to-date. --}}
-    {{> configureLoginServiceDialogForGithub}}
-
-    <p>Now, copy over some details:</p>
     <div class="form-group">
       <label>
         Client ID:

--- a/shell/client/admin/identity-providers.js
+++ b/shell/client/admin/identity-providers.js
@@ -198,6 +198,17 @@ Template.adminIdentityProviderConfigureEmail.helpers({
   },
 });
 
+Template.googleLoginSetupInstructions.helpers({
+  siteUrlNoSlash() {
+    // Google complains if the Javascript origin contains a trailing slash - it wants just the
+    // scheme/host/port, no path.
+    const urlWithTrailingSlash = Meteor.absoluteUrl();
+    return urlWithTrailingSlash[urlWithTrailingSlash.length - 1] === "/" ?
+           urlWithTrailingSlash.slice(0, urlWithTrailingSlash.length - 1) :
+           urlWithTrailingSlash;
+  },
+});
+
 // Google form.
 Template.adminIdentityProviderConfigureGoogle.onCreated(function () {
   const googleChecked = globalDb.getSettingWithFallback("google", false);
@@ -298,6 +309,12 @@ Template.adminIdentityProviderConfigureGoogle.events({
     // double invocation because there's no way to pass a callback function around in Blaze without
     // invoking it, and we need to pass it to modalDialogWithBackdrop
     instance.data.onDismiss()();
+  },
+});
+
+Template.githubLoginSetupInstructions.helpers({
+  siteUrl() {
+    return Meteor.absoluteUrl();
   },
 });
 

--- a/shell/client/styles/_admin-identity.scss
+++ b/shell/client/styles/_admin-identity.scss
@@ -145,4 +145,7 @@
   }
 }
 
-
+.idp-config-url {
+  display: block;
+  font-family: monospace;
+}


### PR DESCRIPTION
We need to be able to keep this up to date in our releases,
since Google changes their workflow more frequently than
Meteor manages to update their setup instructions.

This change includes the copy updates from @ocdtrekkie aka Jacob Weisz from
https://github.com/meteor/meteor/pull/6757

This change strips the trailing slash from the Javascript origin in the Google
instructions, since Google's form complains if you include a path in that
scheme/host/port.

Fixes #1756, #1188, #953.