### PR TITLE
Clickable identity cards in share-by-wrong-identity.

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -472,36 +472,12 @@ Template.grainSharePopup.helpers({
   },
 });
 
-Template.wrongIdentity.onCreated(function () {
-  this._clicked = new ReactiveVar(false);
-});
-
-Template.wrongIdentity.events({
-  "click button.sign-in": function (event, instance) {
-    instance._clicked.set(true);
-
-    const oneClick = instance.data.login.oneClick;
-    if (oneClick) {
-      const obj = oneClick.windowMethod ? window : Meteor;
-      obj[oneClick.method].apply(null, oneClick.args);
-    }
-  },
-});
-
 Template.wrongIdentity.helpers({
-  clicked: function () {
-    return Template.instance()._clicked.get();
-  },
-
-  loginTemplate: function () {
-    const data = Template.instance().data;
-    const login = data.login;
-    if (login.form) {
-      const name = data.recipient.profile.service;
-      const service = Accounts.identityServices[name];
-      if (service.isEnabled()) {
-        return service.loginTemplate;
-      }
+  unclickedMessage: function () {
+    if (Meteor.userId()) {
+      return "Click to sign out of your current session and sign in as the above identity.";
+    } else {
+      return "Click to sign in.";
     }
   },
 });

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -185,23 +185,9 @@ limitations under the License.
 <template name="wrongIdentity">
   <div class="grain-interstitial">
     <p>
-      Access through this URL is restricted to this identity:
+      Access through this URL is restricted to the identity:
     </p>
-    <button class="sign-in" title="sign in as {{recipient.profile.name}}" disabled={{clicked}}>
-      {{> identityCard recipient }}
-    </button>
-    {{#if clicked}}
-    {{#if login.form}}
-       <h4>Sign in</h4>
-       <div class="login-buttons-list">
-       {{#with data=loginTemplate.data name=loginTemplate.name
-              loginFormInitializer=login.form.initializer}}
-         {{> Template.dynamic template=name}}
-       {{/with}}
-       </div>
-     {{/if}}
-    {{> _loginButtonsMessages}}
-   {{/if}}
+    {{> identityCardSignInButton identity=recipient unclickedMessage=unclickedMessage}}
   </div>
 </template>
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -174,32 +174,35 @@ limitations under the License.
         {{/if}}
       </div>
     {{else}}
-      {{#if interstitial.directShare}}
-        <div class="grain-interstitial">
-          <p>
-            Access through this URL is restricted to this identity:
-          </p>
-          {{> identityCard interstitial.directShare.recipient }}
-          {{#if currentUser}}
-            <p>
-              To gain access,
-              <a href="/account">link the above identity to your account</a>
-              or sign in with the appropriate account.
-            </p>
-          {{else}}
-            <p>
-              Please sign in to gain access.
-            </p>
-          {{/if}}
-        </div>
-      {{else}}
-        {{> _grainSpinner}}
-      {{/if}}
+      {{> _grainSpinner}}
     {{/if}}
     {{/if}}
     {{/if}}
     </div>
   {{/with}}
+</template>
+
+<template name="wrongIdentity">
+  <div class="grain-interstitial">
+    <p>
+      Access through this URL is restricted to this identity:
+    </p>
+    <button class="sign-in" title="sign in as {{recipient.profile.name}}" disabled={{clicked}}>
+      {{> identityCard recipient }}
+    </button>
+    {{#if clicked}}
+    {{#if login.form}}
+       <h4>Sign in</h4>
+       <div class="login-buttons-list">
+       {{#with data=loginTemplate.data name=loginTemplate.name
+              loginFormInitializer=login.form.initializer}}
+         {{> Template.dynamic template=name}}
+       {{/with}}
+       </div>
+     {{/if}}
+    {{> _loginButtonsMessages}}
+   {{/if}}
+  </div>
 </template>
 
 <template name="requestAccess">

--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -100,7 +100,7 @@ body>.popup.account>.frame-container {
 
   >button.login, >form, >a {
     display: block;
-    width: 200px;
+    width: 100%;
     height: 32px;
     box-sizing: border-box;
     text-decoration: none;
@@ -232,7 +232,6 @@ body>.popup.account>.frame-container {
 
     label {
       display: block;
-      height: 32px;
       line-height: normal;
       font-size: 8pt;
       text-indent: 0;
@@ -1497,8 +1496,8 @@ body>.popup.billing-prompt>.frame-container>.frame, .first-time-billing-prompt {
     text-align: center;
     width: 400px;
     background-color: white;
-    h1 {
-      padding: 20px;
+    >.identity-card {
+      border: 1px solid gray;
     }
     .warning-banner {
       padding: 10px;
@@ -1515,19 +1514,31 @@ body>.popup.billing-prompt>.frame-container>.frame, .first-time-billing-prompt {
           @extend %button-base;
           @extend %button-secondary;
           position: absolute;
-          right: 30px;
-          top: 15px;
+          right: 25px;
+          top: 20px;
         }
       }
-    }
-    .identity-card {
-      margin: auto;
-      border: 2px solid gray;
     }
     button.logout {
       @extend %button-base;
       @extend %button-primary;
     }
+  }
+}
+
+.identity-card-sign-in {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  button.sign-in {
+    @extend %button-base;
+    background-color: white;
+  }
+  h4 {
+    margin-bottom: 5px;
+  }
+  .light-border {
+    border: 1px solid gray;
   }
 }
 

--- a/shell/client/styles/shell.scss
+++ b/shell/client/styles/shell.scss
@@ -200,7 +200,9 @@ button.revoke-token, button.revoke-access {
 }
 
 .main-content .grain-interstitial {
-  text-align: center;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
   background-color: $default-content-background-color;
   button.request-access, button.incognito-button {
     @extend %button-base;
@@ -208,6 +210,13 @@ button.revoke-token, button.revoke-access {
     font-weight: 600;
     padding: 8px;
     line-height: 1.33;
+  }
+  button.sign-in {
+    @extend %button-base;
+    background-color: white;
+  }
+  h4 {
+    margin-bottom: 5px;
   }
 }
 

--- a/shell/client/styles/shell.scss
+++ b/shell/client/styles/shell.scss
@@ -211,13 +211,6 @@ button.revoke-token, button.revoke-access {
     padding: 8px;
     line-height: 1.33;
   }
-  button.sign-in {
-    @extend %button-base;
-    background-color: white;
-  }
-  h4 {
-    margin-bottom: 5px;
-  }
 }
 
 #intro {

--- a/shell/packages/accounts-identity/accounts-identity-client.js
+++ b/shell/packages/accounts-identity/accounts-identity-client.js
@@ -52,8 +52,8 @@ Template.identityLoginInterstitial.onCreated(function () {
       Meteor.loginWithToken(token, () => linkingNewIdentity.set(false));
     });
   } else {
-    const sub = this.subscribe("accountsOfIdentity", Meteor.userId());
     this.autorun(() => {
+      const sub = this.subscribe("accountsOfIdentity", Meteor.userId());
       if (sub.ready()) {
         const loginAccount = LoginIdentitiesOfLinkedAccounts.findOne({
           _id: Meteor.userId(),
@@ -236,6 +236,37 @@ Template.identityCard.helpers({
     } else {
       return this.profile && this.profile.intrinsicName;
     }
+  },
+});
+
+Template.identityCardSignInButton.onCreated(function () {
+  this._clicked = new ReactiveVar(false);
+  this._form = new ReactiveVar();
+});
+
+Template.identityCardSignInButton.events({
+  "click button.sign-in": function (event, instance) {
+    instance._clicked.set(true);
+
+    const data = Template.instance().data;
+    const name = data.identity.profile.service;
+    const result = Accounts.identityServices[name].initiateLogin(data.identity.loginId);
+    if ("form" in result) {
+      const loginTemplate = Accounts.identityServices[name].loginTemplate;
+      instance._form.set({ loginId: data.identity.loginId,
+                           data: loginTemplate.data,
+                           name: loginTemplate.name, });
+    }
+  },
+});
+
+Template.identityCardSignInButton.helpers({
+  clicked: function () {
+    return Template.instance()._clicked.get();
+  },
+
+  form: function () {
+    return Template.instance()._form.get();
   },
 });
 

--- a/shell/packages/accounts-identity/accounts-identity-server.js
+++ b/shell/packages/accounts-identity/accounts-identity-server.js
@@ -281,7 +281,8 @@ Meteor.publish("accountsOfIdentity", function (identityId) {
         if (user) {
           SandstormDb.fillInProfileDefaults(user);
           SandstormDb.fillInIntrinsicName(user);
-          const filteredUser = _.pick(user, "_id", "profile");
+          SandstormDb.fillInLoginId(user);
+          const filteredUser = _.pick(user, "_id", "profile", "loginId");
           filteredUser.loginAccountId = account._id;
           filteredUser.sourceIdentityId = identityId;
           _this.added("loginIdentitiesOfLinkedAccounts", user._id, filteredUser);

--- a/shell/packages/accounts-identity/accounts-identity.html
+++ b/shell/packages/accounts-identity/accounts-identity.html
@@ -31,9 +31,7 @@ limitations under the License.
       <p>
         You have authenticated as this identity
       </p>
-      {{#with currentIdentity}}
-      {{>identityCard .}}
-      {{/with}}
+      {{>identityCard currentIdentity}}
       <p class="warning-banner"> but that is not a login identity for any account.
       </p>
       <p> The following identities can log in to your identity's accounts
@@ -41,8 +39,11 @@ limitations under the License.
       <ul>
         {{#each nonloginAccounts}}
         <li>
-          {{> identityCard .}}
-          <button class="unlink" data-user-id="{{loginAccountId}}">unlink</button>
+          {{> identityCardSignInButton identity=.}}
+          <button class="unlink" data-user-id="{{loginAccountId}}"
+                  title="Unlink your identity from this account.">
+            unlink
+          </button>
         </li>
         {{/each}}
       </ul>
@@ -121,4 +122,26 @@ limitations under the License.
   <div class="name">{{profile.name}}</div>
   <div class="intrinsic-name">{{intrinsicName}}</div>
  </div>
+</template>
+
+<template name="identityCardSignInButton">
+  <div class="identity-card-sign-in">
+  <button class="sign-in" title="sign in as {{identity.profile.name}}"
+          disabled={{clicked}}>
+    {{> identityCard identity }}
+  </button>
+  {{#if clicked}}
+    {{#with form}}
+      <h4>Sign in</h4>
+       <div class="login-buttons-list light-border">
+         {{> Template.dynamic template=name}}
+       </div>
+    {{/with}}
+    {{> _loginButtonsMessages}}
+   {{else}}
+     {{#with unclickedMessage}}
+       <p>{{.}}</p>
+     {{/with}}
+   {{/if}}
+  </div>
 </template>

--- a/shell/packages/sandstorm-accounts-packages/accounts.js
+++ b/shell/packages/sandstorm-accounts-packages/accounts.js
@@ -36,15 +36,25 @@ Accounts.identityServices = {};
 //
 //   isEnabled: A function of no arguments. Returns a boolean indicating whether this service is
 //              currently configured to be active.
+//
+//   getLoginId: A function that takes an identity record and returns a string that uniquely
+//               identifies that identity with respect to its login service.
+//
+//   initiateLogin: A function that takes the result of getLoginId() and initiates login as the
+//                  appropriate identity. Only works on the client side.
+//
 //   loginTemplate: An object indicating how to render this service's login UI. Contains the
 //                  following fields:
 //       name: The name of the template to render.
 //       priority: Number representing this template's sort order when it appears within a list
 //                 with other login templates. Lower priority means higher in the list.
-//       data: An object to pass along to the template when it is rendered. The value of this
-//             field will be placed in the `data` field. In addition, there will be a
-//             boolean `linkingNewIdentity` field, which is true if the component is currently being
-//             used to link a new identity, rather than just to log in.
+//       data: An object to pass along to the template when it is rendered. The data context of
+//             the template when it is rendered will contain the following fields:
+//                data: The value of loginTemplate.data.
+//                linkingNewIdentity: A boolean which is true if the template is currently being
+//                                    used to link a new identity, rather than just to log in.
+//                loginId: Optionally, A login ID to initialize the form.
+
 //
 // TODO(someday): It probably makes sense also to collect in these objects the service-specific
 // user initialization logic currently found in sandstorm-db/user.js and sandstorm-db/profile.js.

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -160,7 +160,7 @@
 <template name="emailLoginForm">
   {{> emailAuthenticationForm linkingNewIdentity=linkingNewIdentity description="with e-mail"
                               prompt="email" sendButtonText="send Login Email"
-                              loginFormInitializer=loginFormInitializer}}
+                              loginId=loginId}}
 </template>
 
 <template name="emailAuthenticationForm">
@@ -169,7 +169,7 @@
 
     <label class="email {{#if awaitingToken}}hidden{{/if}}">{{prompt}}
       <span title="Passwordless E-mail Login allows you to log in using an e-mail address. No password is required; instead, every time you log in, we send you a new email confirmation code. You will only need to log in once per device." class="info">i</span>
-      <input name="email" type="email" disabled={{disabled}} value={{loginFormInitializer}}>
+      <input name="email" type="email" disabled={{disabled}} value={{loginId}}>
     </label>
 
     {{#with awaitingToken}}
@@ -201,7 +201,7 @@
 
     <label class="username">username
       <span title="This is your LDAP username. It will be the name that you normally use to log in to other internal services at your company." class="info">i</span>
-      <input name="username" type="text" value="{{loginFormInitializer}}">
+      <input name="username" type="text" value="{{loginId}}">
     </label>
 
     <label class="password">password

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -159,7 +159,8 @@
 
 <template name="emailLoginForm">
   {{> emailAuthenticationForm linkingNewIdentity=linkingNewIdentity description="with e-mail"
-                              prompt="email" sendButtonText="send Login Email"}}
+                              prompt="email" sendButtonText="send Login Email"
+                              loginFormInitializer=loginFormInitializer}}
 </template>
 
 <template name="emailAuthenticationForm">
@@ -168,7 +169,7 @@
 
     <label class="email {{#if awaitingToken}}hidden{{/if}}">{{prompt}}
       <span title="Passwordless E-mail Login allows you to log in using an e-mail address. No password is required; instead, every time you log in, we send you a new email confirmation code. You will only need to log in once per device." class="info">i</span>
-      <input name="email" type="email" disabled={{disabled}}>
+      <input name="email" type="email" disabled={{disabled}} value={{loginFormInitializer}}>
     </label>
 
     {{#with awaitingToken}}
@@ -200,7 +201,7 @@
 
     <label class="username">username
       <span title="This is your LDAP username. It will be the name that you normally use to log in to other internal services at your company." class="info">i</span>
-      <input name="username" type="text">
+      <input name="username" type="text" value="{{loginFormInitializer}}">
     </label>
 
     <label class="password">password

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -97,12 +97,6 @@ Accounts.onPageLoadLogin(function (attemptInfo) {
     loginResultCallback(attemptInfo.type, attemptInfo.error);
 });
 
-// XXX from http://epeli.github.com/underscore.string/lib/underscore.string.js
-const capitalize = function (str) {
-  str = str == null ? "" : String(str);
-  return str.charAt(0).toUpperCase() + str.slice(1);
-};
-
 Template._loginButtonsLoggedOutDropdown.onCreated(function () {
   this._topbar = Template.parentData(3);
   this._choseLogin = new ReactiveVar(false);
@@ -287,6 +281,12 @@ Template.emailAuthenticationForm.helpers({
 Template.ldapLoginForm.events({
   "submit form": function (event, instance) {
     event.preventDefault();
+    if (instance.data.linkingNewIdentity) {
+      sessionStorage.setItem("linkingIdentityLoginToken", Accounts._storedLoginToken());
+    }
+
+    loginButtonsSession.resetMessages();
+
     const form = event.currentTarget;
 
     const username = form.username.value;
@@ -344,6 +344,12 @@ Template.devLoginForm.events({
 
 Template.samlLoginForm.events({
   "click button": function (event, instance) {
+    if (linkingNewIdentity) {
+      sessionStorage.setItem("linkingIdentityLoginToken", Accounts._storedLoginToken());
+    }
+
+    loginButtonsSession.resetMessages();
+
     Meteor.loginWithSaml({
       provider: "default",
     }, function (error, result) {

--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -245,6 +245,11 @@ SandstormDb.fillInIntrinsicName = function (user) {
   }
 };
 
+SandstormDb.fillInLoginId = function (identity) {
+  const service = identity.profile.service;
+  identity.loginId = Accounts.identityServices[service].getLoginId(identity);
+};
+
 SandstormDb.getVerifiedEmails = function (identity) {
   if (identity.services.google && identity.services.google.email &&
       identity.services.google.verified_email) { // jscs:ignore requireCamelCaseOrUpperCaseIdentifiers

--- a/shell/packages/sandstorm-ui-grainview/grainview.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview.js
@@ -481,12 +481,6 @@ GrainView = class GrainView {
         chooseIdentity: {},
         showIncognito: !globalDb.getOrganizationDisallowGuests(),
       };
-    } else if (this._tokenInfo.identityOwner) {
-      return {
-        directShare: {
-          recipient: this._tokenInfo.identityOwner,
-        },
-      };
     } else {
       throw new Error("unrecognized tokenInfo: ", this._tokenInfo);
     }

--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -121,10 +121,34 @@ Meteor.publish("tokenInfo", function (token) {
         let identity = globalDb.getIdentity(apiToken.owner.user.identityId);
         let metadata = apiToken.owner.user.denormalizedGrainMetadata;
         if (identity && metadata) {
+          const login = {};
+          // TODO(cleanup): This switching logic does not belong here. Perhaps it should go
+          //   in sandstorm-db/profile.js or be added as a method on Accounts.identityServices[].
+          if (identity.profile.service === "google") {
+            login.oneClick = { method: "loginWithGoogle",
+                               args: [{ loginHint: identity.services.google.email }], };
+          } else if (identity.profile.service === "github") {
+            login.oneClick = { method: "loginWithGithub", args: [] };
+          } else if (identity.profile.service === "email") {
+            login.form = { initializer: identity.services.email.email };
+          } else if (identity.profile.service === "ldap") {
+            login.form = { initializer: identity.services.ldap.username };
+          } else if (identity.profile.service === "saml") {
+            login.oneClick = { method: "loginWithSaml", args: [{ provider: "default" }] };
+          } else if (identity.profile.service === "dev") {
+            // TODO(cleanup): The dev login method is unusual in that it lives on the global
+            //   `window` object rather than the global `Meteor` object. Perhaps we should
+            //   move it to `Meteor`.
+            login.oneClick = { method: "loginDevAccount", args: [identity.services.dev.name],
+                               windowMethod: true, };
+          }
+
           this.added("tokenInfo", token,
                      { identityOwner: _.pick(identity, "_id", "profile"),
                        grainId: grainId,
-                       grainMetadata: metadata, });
+                       grainMetadata: metadata,
+                       login: login,
+                     });
         } else {
           this.added("tokenInfo", token, { invalidToken: true });
         }
@@ -440,6 +464,10 @@ Meteor.methods({
                 loginNote = "Github account with username " + intrinsicName;
               } else if (contact.profile.service === "email") {
                 loginNote = "email address " + intrinsicName;
+              } else if (contact.profile.service === "ldap") {
+                loginNote = "LDAP username " + intrinsicName;
+              } else if (contact.profile.service === "saml") {
+                loginNote = "SAML ID " + intrinsicName;
               } else {
                 throw new Meteor.Error(500, "Unknown service to email share link.");
               }

--- a/shell/shared/admin.js
+++ b/shell/shared/admin.js
@@ -24,6 +24,15 @@ Accounts.identityServices.github = {
     return serviceEnabled("github");
   },
 
+  getLoginId: function (identity) {
+    return identity.services.github.username;
+  },
+
+  initiateLogin: function (loginId) {
+    Meteor.loginWithGithub();
+    return { oneClick: true };
+  },
+
   loginTemplate: {
     name: "oauthLoginButton",
     priority: 1,
@@ -39,6 +48,15 @@ Accounts.identityServices.github = {
 Accounts.identityServices.google = {
   isEnabled: function () {
     return serviceEnabled("google");
+  },
+
+  getLoginId: function (identity) {
+    return identity.services.google.email;
+  },
+
+  initiateLogin: function (loginId) {
+    Meteor.loginWithGoogle({ loginHint: loginId });
+    return { oneClick: true };
   },
 
   loginTemplate: {
@@ -58,6 +76,14 @@ Accounts.identityServices.email = {
     return serviceEnabled("emailToken");
   },
 
+  getLoginId: function (identity) {
+    return identity.services.email.email;
+  },
+
+  initiateLogin: function (loginId) {
+    return { form: true };
+  },
+
   loginTemplate: {
     name: "emailLoginForm",
     priority: 10,
@@ -67,6 +93,14 @@ Accounts.identityServices.email = {
 Accounts.identityServices.ldap = {
   isEnabled: function () {
     return serviceEnabled("ldap") && globalDb.isFeatureKeyValid();
+  },
+
+  getLoginId: function (identity) {
+    return identity.services.ldap.username;
+  },
+
+  initiateLogin: function (loginId) {
+    return { form: true };
   },
 
   loginTemplate: {
@@ -80,8 +114,33 @@ Accounts.identityServices.saml = {
     return serviceEnabled("saml") && globalDb.isFeatureKeyValid();
   },
 
+  getLoginId: function (identity) {
+    return user.services.saml.id;
+  },
+
+  initiateLogin: function (loginId) {
+    Meteor.loginWithSaml();
+    return { oneClick: true };
+  },
+
   loginTemplate: {
     name: "samlLoginForm",
     priority: 20, // Put it at the bottom of the list.
   },
+};
+
+Accounts.identityServices.demo = {
+  isEnabled: function () {
+    return false; // You can never authenticate as a demo user.
+  },
+
+  getLoginId: function (identity) {
+    return identity._id;
+  },
+
+  initiateLogin: function (loginId) {
+    return { demoCannotLogin: true };
+  },
+
+  loginTemplate: {},
 };

--- a/shell/shared/dev-accounts.js
+++ b/shell/shared/dev-accounts.js
@@ -19,6 +19,15 @@ Accounts.identityServices.dev = {
     return globalDb.allowDevAccounts();
   },
 
+  getLoginId: function (identity) {
+    return identity.services.dev.name;
+  },
+
+  initiateLogin: function (loginId) {
+    loginDevAccount(loginId);
+    return { oneClick: true };
+  },
+
   loginTemplate: {
     name: "devLoginForm",
     priority: -10, // Put it at the top.

--- a/tests/tests/sharing.js
+++ b/tests/tests/sharing.js
@@ -49,8 +49,47 @@ module.exports["Test open direct share link"] = function (browser) {
     }, [devIdentityId2], function (result) {
       browser.assert.equal(!result.value.error, true)
       browser
+
+         // First, try visiting the link while already logged in.
         .loginDevAccount(devName2)
         .url(browser.launch_url + "/shared/" + result.value.result.token)
+        .waitForElementVisible("#grain-frame", medium_wait)
+        .waitForElementVisible("#grainTitle", medium_wait)
+        .assert.containsText("#grainTitle", "user2 title")
+        .url(function(grainUrl) {
+          browser.assert.equal(0, grainUrl.value.indexOf(browser.launch_url + "/grain/"));
+        })
+        .frame("grain-frame")
+        .waitForElementPresent("#publish", medium_wait)
+        .assert.containsText("#publish", "Publish")
+        .frame(null)
+
+        // Next, try visiting the link while not logged in.
+        .execute("window.Meteor.logout()")
+        .url(browser.launch_url + "/shared/" + result.value.result.token)
+        .waitForElementVisible(".grain-interstitial", short_wait)
+        .assert.containsText(".grain-interstitial",
+                             "Access through this URL is restricted to this identity:")
+        .click(".grain-interstitial button.sign-in")
+        .waitForElementVisible("#grain-frame", medium_wait)
+        .waitForElementVisible("#grainTitle", medium_wait)
+        .assert.containsText("#grainTitle", "user2 title")
+        .url(function(grainUrl) {
+          browser.assert.equal(0, grainUrl.value.indexOf(browser.launch_url + "/grain/"));
+        })
+        .frame("grain-frame")
+        .waitForElementPresent("#publish", medium_wait)
+        .assert.containsText("#publish", "Publish")
+        .frame(null)
+
+        // Now try while logged in as a third user.
+        .execute("window.Meteor.logout()")
+        .loginDevAccount()
+        .url(browser.launch_url + "/shared/" + result.value.result.token)
+        .waitForElementVisible(".grain-interstitial", short_wait)
+        .assert.containsText(".grain-interstitial",
+                             "Access through this URL is restricted to this identity:")
+        .click(".grain-interstitial button.sign-in")
         .waitForElementVisible("#grain-frame", medium_wait)
         .waitForElementVisible("#grainTitle", medium_wait)
         .assert.containsText("#grainTitle", "user2 title")

--- a/tests/tests/sharing.js
+++ b/tests/tests/sharing.js
@@ -69,7 +69,7 @@ module.exports["Test open direct share link"] = function (browser) {
         .url(browser.launch_url + "/shared/" + result.value.result.token)
         .waitForElementVisible(".grain-interstitial", short_wait)
         .assert.containsText(".grain-interstitial",
-                             "Access through this URL is restricted to this identity:")
+                             "Access through this URL is restricted to the identity:")
         .click(".grain-interstitial button.sign-in")
         .waitForElementVisible("#grain-frame", medium_wait)
         .waitForElementVisible("#grainTitle", medium_wait)
@@ -88,7 +88,7 @@ module.exports["Test open direct share link"] = function (browser) {
         .url(browser.launch_url + "/shared/" + result.value.result.token)
         .waitForElementVisible(".grain-interstitial", short_wait)
         .assert.containsText(".grain-interstitial",
-                             "Access through this URL is restricted to this identity:")
+                             "Access through this URL is restricted to the identity:")
         .click(".grain-interstitial button.sign-in")
         .waitForElementVisible("#grain-frame", medium_wait)
         .waitForElementVisible("#grainTitle", medium_wait)


### PR DESCRIPTION
Alice shares to Bob by identity. Bob clicks the link in the email, but is either not signed in or is signed in to a different account. In this situation, we currently display an identity card for the shared-to identity and we indicate that Bob needs to sign is as that identity in order to access the grain. With the changes in this pull request, that identity card becomes a button. If Bob clicks on it, he initiates sign-in as that identity.

For example, for a github identity, the identity card button looks like this:

![github](https://cloud.githubusercontent.com/assets/495768/14531014/9eea41ae-0229-11e6-8e9e-c4f1d43c9301.png)

and one click is sufficient to sign in. For an email identity, the sign-in sequence looks like:

![email](https://cloud.githubusercontent.com/assets/495768/14531124/128af11c-022a-11e6-9ed4-13a3230cef78.png)
![email1](https://cloud.githubusercontent.com/assets/495768/14531132/1745df1e-022a-11e6-89ec-7f0b9825c561.png)
![email2](https://cloud.githubusercontent.com/assets/495768/14531137/1abe0dd8-022a-11e6-8abb-fda85905bd9e.png)

Fixes #1624.

This also fixes a few other things that I noticed were broken, such as linking of LDAP or SAML identities, and email notifications for share-by-identity to LDAP or SAML identities.