### PR TITLE
Remove superfluous instances of 'box-sizing: border-box'.

### DIFF
--- a/shell/client/styles/_about.scss
+++ b/shell/client/styles/_about.scss
@@ -24,7 +24,6 @@
     background-position: top left;
     background-repeat: no-repeat;
     padding-left: 200px;
-    box-sizing: border-box;
 
     @media (max-width: 625px) {
       padding-left: 0;
@@ -88,14 +87,12 @@
         img {
           padding: 0 16px;
           display: block;
-          box-sizing: border-box;
           max-width: 154px;
           max-height: 121px;
         }
         .uniregistry-image {
           @extend %pseudo-img-tag;
           width: 154px;
-          box-sizing: border-box;
           height: 121px;
           background-image: url("/logos/uniregistry.svg");
         }
@@ -105,14 +102,11 @@
 
   >section.developers {
     max-width: 632px;
-    box-sizing: border-box;
   }
   >section.advisors {
     max-width: 478px;
-    box-sizing: border-box;
   }
   >section.corporate, >section.individual {
-    box-sizing: border-box;
     width: 555px;
     @media (max-width: 560px) {
       width: auto;
@@ -266,7 +260,6 @@
 
   padding: 64px;
   max-width: 1238px;
-  box-sizing: border-box;
   @media #{$mobile} {
     padding: 8px;
   }

--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -46,7 +46,6 @@ body>.popup.account>.frame-container {
     display: block;
     width: 250px;
     height: 32px;
-    box-sizing: border-box;
     text-decoration: none;
     color: black;
     font-weight: normal;
@@ -102,7 +101,6 @@ body>.popup.account>.frame-container {
     display: block;
     width: 100%;
     height: 32px;
-    box-sizing: border-box;
     text-decoration: none;
     color: black;
     font-weight: normal;
@@ -251,7 +249,6 @@ body>.popup.account>.frame-container {
     }
 
     input {
-      box-sizing: border-box;
       width: 100%;
       padding: 2px 4px;
       border: 1px solid #9e9e9e;
@@ -473,7 +470,6 @@ body>.main-content>.account {
   h3.title-bar {
     background-color: white;
     width: 660px;
-    box-sizing: border-box;
     margin-bottom: 5px;
     border: none;
     font-size: 12pt;
@@ -585,7 +581,6 @@ body>.main-content>.account {
           white-space: nowrap;
           margin-top: 4px;
           span.email {
-            box-sizing: border-box;
             line-height: 30px;
             overflow: hidden;
             text-overflow: ellipsis;
@@ -596,7 +591,6 @@ body>.main-content>.account {
           button.make-primary {
             @extend %button-base;
             @extend %button-secondary;
-            box-sizing: border-box;
             width: 33%;
             height: 26px;
             margin-top: 2px;
@@ -641,7 +635,6 @@ div.billing {
   >section.payment-methods {
     display: inline-block;
     vertical-align: top;
-    box-sizing: border-box;
 
     h3 {
       margin: 0.5em 0;
@@ -652,7 +645,6 @@ div.billing {
 
     >.balance {
       margin-left: 16px;
-      box-sizing: border-box;
       margin: 1em auto 2em;
       text-align: left;
 
@@ -796,7 +788,6 @@ div.billing {
     display: inline-block;
     vertical-align: top;
     margin-right: 32px;
-    box-sizing: border-box;
 
     h3 {
       margin: 0.5em 0;
@@ -954,7 +945,6 @@ div.billing {
 
 div.identity-editor {
   width: 435px;
-  box-sizing: border-box;
   background-color: white;
   padding: 15px 22px;
 
@@ -1040,7 +1030,6 @@ div.identity-editor {
         input[type="text"], select {
           display: block;
           width: 230px;
-          box-sizing: border-box;
           font-size: inherit;
           line-height: inherit;
           background-color: white;
@@ -1183,7 +1172,6 @@ body>.popup.billing-prompt>.frame-container>.frame, .first-time-billing-prompt {
   }
 
   >p.success-note {
-    box-sizing: border-box;
     background-color: #cff4c6;
     padding: 32px;
     max-width: 564px;

--- a/shell/client/styles/_admin.scss
+++ b/shell/client/styles/_admin.scss
@@ -8,7 +8,6 @@
       float: left;
       position: relative;
       display: block;
-      box-sizing: border-box;
       >a {
         padding: 10px;
         border-radius: 4px;
@@ -140,7 +139,6 @@ input.autoSelect {
     font: inherit;
     font-size: inherit;
     width: 80%;
-    box-sizing: border-box;
   }
   input#key-quota {
     width: 40%;
@@ -152,7 +150,6 @@ input.autoSelect {
     height: 200px;
     font: inherit;
     font-size: inherit;
-    box-sizing: border-box;
   }
   button {
     @extend %button-base;
@@ -235,7 +232,6 @@ button#offer-ipnetwork, button#offer-ipinterface {
 }
 
 .websocket-broken-warning, .wildcard-host-warning {
-  box-sizing: border-box;
   min-height: 3em;
   width: 100%;
   padding: 0.5em;

--- a/shell/client/styles/_app-details.scss
+++ b/shell/client/styles/_app-details.scss
@@ -37,7 +37,6 @@
         background-size: 24px 24px;
         background-position: center;
         display: inline-block;
-        box-sizing: border-box;
         width: 32px;
         height: 32px;
         vertical-align: top;
@@ -45,7 +44,6 @@
       >input.search-bar {
         font-size: 16pt;
         height: 32px;
-        box-sizing: border-box;
         background-color: $app-details-searchbar-background-color;
         border: 1px solid $app-details-searchbar-outline-color;
         &:focus {
@@ -201,7 +199,6 @@
           display: block;
           width: 100%;
         }
-        box-sizing: border-box;
         padding: 8px;
         list-style: none;
         >li.publisher-proof {

--- a/shell/client/styles/_applist.scss
+++ b/shell/client/styles/_applist.scss
@@ -41,7 +41,6 @@
         background-size: 24px 24px;
         background-position: center;
         display: inline-block;
-        box-sizing: border-box;
         width: 32px;
         height: 32px;
         vertical-align: top;
@@ -54,7 +53,6 @@
         height: 32px;
         background-color: $grainlist-searchbar-background-color;
         border: 1px solid $grainlist-searchbar-outline-color;
-        box-sizing: border-box;
         &:focus {
           border: 1px solid $grainlist-searchbar-outline-color-focus;
         }

--- a/shell/client/styles/_grainlist.scss
+++ b/shell/client/styles/_grainlist.scss
@@ -36,7 +36,6 @@
           background-size: 24px 24px;
           background-position: center;
           display: inline-block;
-          box-sizing: border-box;
           width: 32px;
           height: 32px;
           vertical-align: top;
@@ -44,7 +43,6 @@
         >input.search-bar {
           font-size: 16pt;
           height: 32px;
-          box-sizing: border-box;
           background-color: $grainlist-searchbar-background-color;
           border: 1px solid $grainlist-searchbar-outline-color;
           &:focus {
@@ -127,7 +125,6 @@
         }
       }
       &.td-app-icon {
-        box-sizing: border-box;
         width: 64px;
         padding-left: 16px;
       }

--- a/shell/client/styles/_partials.scss
+++ b/shell/client/styles/_partials.scss
@@ -46,7 +46,6 @@
   cursor: pointer;
   border-radius: 5px;
   padding: 4px 8px;
-  box-sizing: border-box;
   min-height: 26px;
   font-size: 13px;
   font-family: inherit;

--- a/shell/client/styles/_powerbox.scss
+++ b/shell/client/styles/_powerbox.scss
@@ -17,7 +17,6 @@ body>.popup.request>.frame-container>.frame {
     margin: 0px;
     padding-left: 10px;
     padding-right: 10px;
-    box-sizing: border-box;
     vertical-align: top;
     >label {
       >span.search-icon {
@@ -26,7 +25,6 @@ body>.popup.request>.frame-container>.frame {
         background-size: 24px 24px;
         background-position: center;
         display: inline-block;
-        box-sizing: border-box;
         width: 32px;
         height: 32px;
         vertical-align: top;
@@ -35,7 +33,6 @@ body>.popup.request>.frame-container>.frame {
         font-size: 16pt;
         height: 32px;
         width: calc(100% - 36px);
-        box-sizing: border-box;
         background-color: $grainlist-searchbar-background-color;
         border: 1px solid $grainlist-searchbar-outline-color;
         &:focus {
@@ -57,9 +54,7 @@ body>.popup.request>.frame-container>.frame {
   }
   >.selected-card {
     flex: none;
-    box-sizing: border-box;
     >div.powerbox-card {
-      box-sizing: border-box;
       border: 1px solid #dddddd;
       background-color: #eeeeee;
       display: block;

--- a/shell/client/styles/_referrals.scss
+++ b/shell/client/styles/_referrals.scss
@@ -27,7 +27,6 @@
 
   section {
     @extend %content-section;
-    box-sizing: border-box;
     width: 100%;
     padding-left: 50px;
     padding-right: 50px;

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -154,7 +154,6 @@ body>.topbar {
 
   %hamburger-menu-item {
     // Common styling for topbar items that are displayed as a hamburger menu item on mobile.
-    box-sizing: border-box;
     @media #{$desktop} {
       height: $topbar-height-desktop;
     }
@@ -203,7 +202,6 @@ body>.topbar {
   >.menubar {
     padding-left: 0;
     margin-left: 0;
-    box-sizing: border-box;
     border-bottom: 1px solid $topbar-border-color;
     overflow: hidden;
     @media #{$desktop} {
@@ -540,11 +538,9 @@ body>.topbar {
         position: relative;
         border-bottom: 1px solid $topbar-border-color;
         margin: 0;
-        box-sizing: border-box;
         list-style-type: none;
         a {
           display: block;
-          box-sizing: border-box;
           min-height: 32px;
           padding-left: $navbar-width-desktop-shrunk;
           text-decoration: none;
@@ -603,10 +599,8 @@ body>.topbar {
         position: relative;
         border-bottom: 1px solid #676767;
         margin: 0;
-        box-sizing: border-box;
         a {
           display: block;
-          box-sizing: border-box;
           padding-left: 48px;
           text-decoration: none;
           text-overflow: ellipsis;
@@ -659,7 +653,6 @@ body>.topbar {
         }
         .close-button {
           @extend %unstyled-button;
-          box-sizing: border-box;
           position: absolute;
           top: 1px;
           right: 0px;
@@ -681,7 +674,6 @@ body>.topbar {
     .demo-notice {
       width: 100%;
       overflow: hidden;
-      box-sizing: border-box;
 
       p {
         color: $topbar-foreground-color;
@@ -722,7 +714,6 @@ body>.topbar {
         border: 1px solid $topbar-foreground-color;
         border-radius: 4px;
         width: 100%;
-        box-sizing: border-box;
         text-align: center;
         padding: 4px;
         background-color: $topbar-background-color-active;
@@ -935,7 +926,6 @@ body>.popup {
           display: block;
           border: 1px solid rgba(0, 0, 0, 0);
           border-bottom: 1px solid #e4e4e4;
-          box-sizing: border-box;
           cursor: pointer;
 
           &.selected {
@@ -954,7 +944,6 @@ body>.popup {
         border: 0px;
         outline: 0px;
         width: 100%;
-        box-sizing: border-box;
       }
       &.active {
         outline: $focus-outline-color solid 1px;
@@ -1128,7 +1117,6 @@ body>.popup {
 
     .label, .personal-message {
       width: 100%;
-      box-sizing: border-box;
     }
     .personal-message {
       height: 100px;


### PR DESCRIPTION
We declare `box-sizing: border-box` [at the top level](https://github.com/sandstorm-io/sandstorm/blob/v0.158/shell/client/styles/shell.scss#L30-L52) and we don't use `box-sizing: content-box` anywhere, so all of the other instances of `box-sizing: border-box` can be removed.