### PR TITLE
Implement reordering of grains in navbar by dragging

### DIFF
--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -62,56 +62,6 @@ body>.topbar-update {
   }
 }
 
-body>li.navitem-grain {
-  height: 32px;
-  line-height: 32px;
-  list-style-type: none;
-
-  a {
-    color: inherit;
-    display: block;
-    overflow-x: hidden;
-    overflow-y: hidden;
-    padding-left: 48px;
-    padding-right: 32px;
-    position: relative;
-    text-decoration: none;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  background-color: $topbar-background-color-hover;
-  color: $topbar-foreground-color-hover;
-
-  &.current {
-    background-color: $topbar-background-color-active;
-    color: $topbar-foreground-color-active;
-  }
-
-  .app-icon {
-    @extend %pseudo-img-tag;
-    position: absolute;
-    top: 4px;
-    left: (($navbar-width-desktop-shrunk - 24px) / 2);
-    width: 24px;
-    height: 24px;
-  }
-
-  .close-button {
-    @extend %unstyled-button;
-    position: absolute;
-    top: 1px;
-    right: 0px;
-    width: 24px;
-    height: 24px;
-    margin: 2px;
-    display: block;
-    background-image: url("/close.svg");
-    border: 1px transparent;
-    border-radius: 4px;
-  }
-}
-
 body>.topbar {
   position: fixed;
   top: 0;

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -62,6 +62,56 @@ body>.topbar-update {
   }
 }
 
+body>li.navitem-grain {
+  height: 32px;
+  line-height: 32px;
+  list-style-type: none;
+
+  a {
+    color: inherit;
+    display: block;
+    overflow-x: hidden;
+    overflow-y: hidden;
+    padding-left: 48px;
+    padding-right: 32px;
+    position: relative;
+    text-decoration: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  background-color: $topbar-background-color-hover;
+  color: $topbar-foreground-color-hover;
+
+  &.current {
+    background-color: $topbar-background-color-active;
+    color: $topbar-foreground-color-active;
+  }
+
+  .app-icon {
+    @extend %pseudo-img-tag;
+    position: absolute;
+    top: 4px;
+    left: (($navbar-width-desktop-shrunk - 24px) / 2);
+    width: 24px;
+    height: 24px;
+  }
+
+  .close-button {
+    @extend %unstyled-button;
+    position: absolute;
+    top: 1px;
+    right: 0px;
+    width: 24px;
+    height: 24px;
+    margin: 2px;
+    display: block;
+    background-image: url("/close.svg");
+    border: 1px transparent;
+    border-radius: 4px;
+  }
+}
+
 body>.topbar {
   position: fixed;
   top: 0;

--- a/shell/client/styles/dragula.css
+++ b/shell/client/styles/dragula.css
@@ -1,0 +1,1 @@
+../../node_modules/dragula/dist/dragula.css

--- a/shell/npm-shrinkwrap.json
+++ b/shell/npm-shrinkwrap.json
@@ -2,6 +2,42 @@
   "name": "sandstorm-shell",
   "version": "1.0.0",
   "dependencies": {
+    "dragula": {
+      "version": "3.6.8",
+      "from": "dragula@latest",
+      "resolved": "https://registry.npmjs.org/dragula/-/dragula-3.6.8.tgz",
+      "dependencies": {
+        "contra": {
+          "version": "1.9.1",
+          "from": "contra@1.9.1",
+          "resolved": "https://registry.npmjs.org/contra/-/contra-1.9.1.tgz",
+          "dependencies": {
+            "atoa": {
+              "version": "1.0.0",
+              "from": "atoa@1.0.0",
+              "resolved": "https://registry.npmjs.org/atoa/-/atoa-1.0.0.tgz"
+            },
+            "ticky": {
+              "version": "1.0.0",
+              "from": "ticky@1.0.0",
+              "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.0.tgz"
+            }
+          }
+        },
+        "crossvent": {
+          "version": "1.5.4",
+          "from": "crossvent@1.5.4",
+          "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.4.tgz",
+          "dependencies": {
+            "custom-event": {
+              "version": "1.0.0",
+              "from": "custom-event@1.0.0",
+              "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
     "intro.js": {
       "version": "2.0.0",
       "from": "git+https://github.com/sandstorm-io/intro.js.git#sandstorm",

--- a/shell/package.json
+++ b/shell/package.json
@@ -13,6 +13,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "dragula": "^3.6.8",
     "intro.js": "git+https://github.com/sandstorm-io/intro.js.git#sandstorm"
   }
 }

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -42,7 +42,7 @@ limitations under the License.
       </li>
 
       {{!-- TODO(cleanup): ul's can only contain li's, so this ul is not really valid --}}
-      <ul class="navbar-grains">
+      <ul id="navbar-grains" class="navbar-grains">
         {{#each grains}}
         <li data-grainid="{{grainId}}" class="navitem-grain {{#if active}}current{{/if}}" title={{title}}>
           <div class="app-icon" style="background-image: url('{{iconSrc}}');" alt="{{appTitle}}"></div>

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import dragula from "dragula";
+
 let reloadBlockingCount = 0;
 const blockedReload = new ReactiveVar(null);
 let explicitlyUnblocked = false;
@@ -44,6 +46,10 @@ Template.sandstormTopbarBlockReload.onDestroyed(function () {
   }
 });
 
+Template.sandstormTopbar.onRendered(function () {
+  this.drag = dragula([document.getElementById("navbar-grains")]);
+});
+
 Template.sandstormTopbar.onCreated(function () {
   Template.instance().popupPosition = new ReactiveVar(undefined, _.isEqual);
 
@@ -59,6 +65,7 @@ Template.sandstormTopbar.onCreated(function () {
 
 Template.sandstormTopbar.onDestroyed(function () {
   document.getElementsByTagName("body")[0].removeEventListener("keydown", this.escapeHandler);
+  this.drag.destroy();
 });
 
 Template.sandstormTopbar.helpers({

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -47,10 +47,29 @@ Template.sandstormTopbarBlockReload.onDestroyed(function () {
 });
 
 Template.sandstormTopbar.onRendered(function () {
-  if (this.drag !== undefined) this.drag.destroy();
-  this.drag = dragula({
+  if (this.drake !== undefined) this.drake.destroy();
+
+  this.drake = dragula({
     containers: [document.getElementById("navbar-grains")],
     mirrorContainer: document.getElementById("navbar-grains")
+  });
+
+  const topbar = this.data;
+
+  this.drake.on("drop", function (drag, _, _, sibling) {
+    const grains = topbar._grains.getAll();
+
+    const dragId = drag.dataset.grainid;
+    const dragIdx = grains.findIndex(function(g) { return g.grainId() == dragId; });
+
+    if (sibling == null || sibling.dataset.grainid == dragId) { // moved to end of list
+      grains.push(grains.splice(dragIdx, 1)[0]);
+    } else {
+      const siblingId = sibling.dataset.grainid;
+      const siblingIdx = grains.findIndex(function(g) { return g.grainId() == siblingId; });
+
+      grains.splice(siblingIdx - (dragIdx < siblingIdx ? 1 : 0), 0, grains.splice(dragIdx, 1)[0]);
+    }
   });
 });
 
@@ -69,7 +88,7 @@ Template.sandstormTopbar.onCreated(function () {
 
 Template.sandstormTopbar.onDestroyed(function () {
   document.getElementsByTagName("body")[0].removeEventListener("keydown", this.escapeHandler);
-  this.drag.destroy();
+  this.drake.destroy();
 });
 
 Template.sandstormTopbar.helpers({

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -48,7 +48,10 @@ Template.sandstormTopbarBlockReload.onDestroyed(function () {
 
 Template.sandstormTopbar.onRendered(function () {
   if (this.drag !== undefined) this.drag.destroy();
-  this.drag = dragula([document.getElementById("navbar-grains")]);
+  this.drag = dragula({
+    containers: [document.getElementById("navbar-grains")],
+    mirrorContainer: document.getElementById("navbar-grains")
+  });
 });
 
 Template.sandstormTopbar.onCreated(function () {

--- a/shell/packages/sandstorm-ui-topbar/topbar.js
+++ b/shell/packages/sandstorm-ui-topbar/topbar.js
@@ -47,6 +47,7 @@ Template.sandstormTopbarBlockReload.onDestroyed(function () {
 });
 
 Template.sandstormTopbar.onRendered(function () {
+  if (this.drag !== undefined) this.drag.destroy();
   this.drag = dragula([document.getElementById("navbar-grains")]);
 });
 


### PR DESCRIPTION
This PR adds reordering of grains in the navbar by drag-and-drop. It looks like this:

![dragging-grains](https://dl.dropboxusercontent.com/u/7018537/sandstorm-navbar.gif)

The "shadow" element that's created is added to the body, so the inherited style from `navitem-grain` doesn't work, and I had to replicate the existing styles for the "shadow" element. This is obviously not a good solution and should be fixed (I don't know sass).

This is a feature that wasn't requested so I understand if you're not interested in merging this.
