### PR TITLE
Fix powerbox offer of UiView

### DIFF
--- a/shell/packages/sandstorm-backend/sandstorm-backend.js
+++ b/shell/packages/sandstorm-backend/sandstorm-backend.js
@@ -212,7 +212,7 @@ SandstormBackend.prototype.updateLastActive = function (grainId, userId, identit
     Meteor.users.update({ _id: identityId }, { $set: { lastActive: now } });
     // Update any API tokens that match this user/grain pairing as well
     ApiTokens.update({ grainId: grainId, "owner.user.identityId": identityId },
-        { $set: { "owner.user.lastUsed": now } });
+        { $set: { lastUsed: now } });
   }
 
   if (Meteor.settings.public.quotaEnabled) {

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -390,6 +390,7 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //   revoked:   If true, then this sturdyref has been revoked and can no longer be restored. It may
 //              become un-revoked in the future.
 //   expires:   Optional expiration Date. If undefined, the token does not expire.
+//   lastUsed:  Optional Date when this token was last used.
 //   owner:     A `ApiTokenOwner` (defined in `supervisor.capnp`, stored as a JSON object)
 //              as passed to the `save()` call that created this token. If not present, treat
 //              as `webkey` (the default for `ApiTokenOwner`).

--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -517,7 +517,6 @@ SandstormPermissions.createNewApiToken = function (db, provider, grainId, petnam
       user: {
         identityId: owner.user.identityId,
         title: owner.user.title,
-        // lastUsed: ??
         denormalizedGrainMetadata: grainInfo,
       }
     };

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -35,8 +35,9 @@ SandstormGrainListPage.mapApiTokensToTemplateObject = function (apiTokens, stati
   const grainIdsForApiTokens = Object.keys(tokensForGrain);
   return grainIdsForApiTokens.map(function (grainId) {
     // Pick the most recently used one.
-    const token = _.sortBy(tokensForGrain[grainId], function (t) {
-      if (t.owner && t.owner.user && t.owner.user.lastUsed) { return -t.owner.user.lastUsed; }    else {return 0; } })[0];
+    const token = _.sortBy(tokensForGrain[grainId], (t) => {
+      return t.lastUsed ? -t.lastUsed : 0;
+    })[0];
 
     const ownerData = token.owner.user;
     const grainInfo = ownerData.denormalizedGrainMetadata;
@@ -49,7 +50,7 @@ SandstormGrainListPage.mapApiTokensToTemplateObject = function (apiTokens, stati
       _id: grainId,
       title: ownerData.title,
       appTitle: appTitle,
-      lastUsed: ownerData.lastUsed,
+      lastUsed: token.lastUsed,
       iconSrc: iconSrc,
       isOwnedByMe: false,
     };

--- a/shell/packages/sandstorm-ui-grainview/grainview.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview.js
@@ -430,7 +430,7 @@ GrainView = class GrainView {
         grainId: this._grainId,
         "owner.user.identityId": { $in: myIdentityIds },
       }, {
-        sort:{ "owner.user.lastUsed": -1 },
+        sort: { lastUsed: -1 },
       });
 
       if (token) {

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -237,7 +237,7 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
           (window.location.protocol + "//" + staticAssetHost + "/" + grainInfo.icon.assetId) :
           Identicon.identiconForApp(
               (grainInfo && grainInfo.appId) || "00000000000000000000000000000000");
-      cardData.lastUsed = ownerData.lastUsed;
+      cardData.lastUsed = apiToken.lastUsed;
       cardData.apiTokenId = apiToken._id;
 
       cardData.callback = () => () => {

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -62,7 +62,6 @@ SessionContextImpl = class SessionContextImpl {
             identityId: this.identityId,
             // The following fields will be overwritten by PersistentUiView.save(), so no need to
             // pass them in:
-            //lastUsed: new Date(),
             //title: "", // This will be replaced by the token's title
             //denormalizedGrainMetadata: {}, // This will look up the package for the grain referenced.
           },

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -358,7 +358,7 @@ Meteor.methods({
             "owner.user.identityId": apiToken.identityId,
           }, {
             sort: {
-              "owner.user.lastUsed": -1,
+              lastUsed: -1,
             },
           });
       if (sharerToken) {

--- a/shell/server/stats-server.js
+++ b/shell/server/stats-server.js
@@ -93,6 +93,7 @@ computeStats = function (since) {
 
     const counts = ApiTokens.aggregate([
       { $match: {
+          "owner.user": { $exists: true },
           lastUsed: timeConstraint,
           grainId: { $in: grainIds },
         },

--- a/shell/server/stats-server.js
+++ b/shell/server/stats-server.js
@@ -93,7 +93,7 @@ computeStats = function (since) {
 
     const counts = ApiTokens.aggregate([
       { $match: {
-          "owner.user.lastUsed": timeConstraint,
+          lastUsed: timeConstraint,
           grainId: { $in: grainIds },
         },
       },

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -272,7 +272,7 @@ struct ApiTokenOwner {
       saveLabel @2 :Util.LocalizedText;
       # As passed to `save()` in Sandstorm's Persistent interface.
 
-      introducerIdentity @10 :Text;
+      introducerIdentity @9 :Text;
       # The identity ID through which a user's powerbox action caused the grain to receive this
       # token. This is the identity against which the `requiredPermissions` parameter
       # to `restore()` will be checked. This field is only intended to be filled in by the
@@ -298,7 +298,7 @@ struct ApiTokenOwner {
       # Owned by a user's identity. If the token represents a UiView, then it will show up in this
       # user's grain list.
 
-      identityId @11 :Text;
+      identityId @10 :Text;
       # The identity that is allowed to restore this token.
 
       title @7 :Text;
@@ -307,11 +307,7 @@ struct ApiTokenOwner {
       # Fields below this line are not actually allowed to be passed to save(), but are added
       # internally.
 
-      lastUsed @8 :Int64;
-      # The last time the user used this API token with the associated grain, in milliseconds
-      # since the epoch (equivalent to javascript's new Date().getTime())
-
-      denormalizedGrainMetadata @9 :DenormalizedGrainMetadata;
+      denormalizedGrainMetadata @8 :DenormalizedGrainMetadata;
       # Information needed to show the user an app title and icon in the grain list.
 
       userId @6 :Text;


### PR DESCRIPTION
The addition of `lastUsed` to `user` in `ApiTokenOwner` caused the field to propagate to `createNewChildToken()` where the presence of its default-value caused a shape check to fail.

`lastUsed` is useful in contexts other than `ApiTokenOwner`, is not actually needed as a part of any of the protocols that use `ApiTokenOwner`, and is better off removed from the `.capnp` and added as a top-level field on `ApiTokens`.

Usually, removing a field from a `.capnp` would be **strictly forbidden**, but the commit message of dfc260cea1c7a24cbefb95aa0b87c8d7bf6f9347 explains why this is actually okay in this particular case.