### PR TITLE
Bind to SMTP_LISTEN_PORT in C++-land (now ready for review/merge)

### DIFF
--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -29,19 +29,19 @@ function monkeypatchHttpAndHttps() {
   //
   // 1. Monkey-patch HTTP in the smallest way -- if someone calls
   // listen() but doesn't provide an FD, assume they are Meteor and
-  // they want to bind to FD #3.
+  // they want to bind to FD #4.
   var oldListen = http.Server.prototype.listen;
   http.Server.prototype.listen = function (port, host, cb) {
-    // Overridable by passing e.g. {fd: 4} as port.
+    // Overridable by passing e.g. {fd: 5} as port.
     if (typeof port == 'object') {
       return oldListen.call(this, port, host, cb);
     }
-    return oldListen.call(this, {fd: 3}, cb);
+    return oldListen.call(this, {fd: 4}, cb);
   }
 
   // 2. If we are in HTTPS mode, monkey-patch HTTP in a large way:
   // return a HTTPS server, not a HTTP server, so that Meteor gets a
-  // HTTPS server on FD #3 without Meteor being aware of the
+  // HTTPS server on FD #4 without Meteor being aware of the
   // complexity.
 
   // Stash the original function in createServerForSandstorm(), since
@@ -307,7 +307,7 @@ function monkeypatchHttpAndHttps() {
     };
 
     if (process.env.HTTPS_PORT) {
-      // Great! FD #3 will speak HTTPS.
+      // Great! FD #4 will speak HTTPS.
       //
       // NOTE: This assumes that the user will only set HTTPS_PORT if
       // there are valid certificates for us to use. This could be a
@@ -415,7 +415,7 @@ function monkeypatchHttpAndHttps() {
       // the HTTP message got parsed.
       httpsServer.setTimeout = function() {};
 
-      // When Meteor calls .listen() we bind to FD #3 and speak HTTPS.
+      // When Meteor calls .listen() we bind to FD #4 and speak HTTPS.
       var oldListen = https.Server.prototype.listen;
       httpsServer.listen = function (port, host, cb) {
         var server = this;
@@ -424,7 +424,7 @@ function monkeypatchHttpAndHttps() {
         var listenIfKey = function() {
           var shouldListen = !! sandcatsState.key;
           if (shouldListen) {
-            oldListen.call(server, {fd: 3}, cb);
+            oldListen.call(server, {fd: 4}, cb);
           }
           return shouldListen;
         };

--- a/shell/server/drivers/mail.js
+++ b/shell/server/drivers/mail.js
@@ -50,7 +50,7 @@ if (!Meteor.settings.replicaNumber) {  // only first replica
 }
 
 Meteor.startup(function () {
-  const SANDSTORM_SMTP_PORT = parseInt(process.env.SANDSTORM_SMTP_PORT, 10) || 30025;
+  const SANDSTORM_SMTP_FD_NUM = 3;
   const BIND_IP = process.env.BIND_IP || "127.0.0.1";
 
   simplesmtp.createSimpleServer({ SMTPBanner:"Sandstorm Mail Server" }, (req) => {
@@ -179,7 +179,7 @@ Meteor.startup(function () {
         req.reject(err.message);
       });
     });
-  }).listen(SANDSTORM_SMTP_PORT, BIND_IP);
+  }).listen({fd: SANDSTORM_SMTP_FD_NUM});
 });
 
 function formatAddress(field) {

--- a/shell/server/drivers/mail.js
+++ b/shell/server/drivers/mail.js
@@ -179,7 +179,7 @@ Meteor.startup(function () {
         req.reject(err.message);
       });
     });
-  }).listen({fd: SANDSTORM_SMTP_FD_NUM});
+  }).listen({ fd: SANDSTORM_SMTP_FD_NUM });
 });
 
 function formatAddress(field) {

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -431,7 +431,7 @@ Meteor.startup(() => {
   // port. For requests to the shell & grains, we redirect to the main
   // port. For static publishing, we serve it.
   //
-  // They are bound to FD #4 and higher.
+  // They are bound to FD #5 and higher.
 
   function getNumberOfAlternatePorts() {
     const numPorts = process.env.PORT.split(',').length;
@@ -461,7 +461,7 @@ Meteor.startup(() => {
   for (let i = 0; i < getNumberOfAlternatePorts(); i++) {
     // Call createServerForSandstorm() to skip our monkey patching.
     const alternatePortServer = Http.createServerForSandstorm(redirectToMeteorOrServeStaticPublishing);
-    alternatePortServer.listen({ fd: i + 4 });
+    alternatePortServer.listen({ fd: i + 5 });
   }
 
   const dispatchToMeteorOrStaticPublishing = (req, res, next, redirectRatherThanServeShell) => {

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1885,6 +1885,12 @@ private:
     Subprocess process([&]() -> int {
       // Create a listening socket for the meteor app on fd=3 and up
       uint socketFdStart = 3;
+
+      // First, bind the SMTP port to FD #3.
+      bindSocketToFd(config, config.smtpListenPort, socketFdStart);
+
+      // Then, bind the HTTP(S) port(s) to FD #4 and higher.
+      socketFdStart++;
       for (size_t i = 0; i < config.ports.size(); i++) {
         bindSocketToFd(config, config.ports[i], i + socketFdStart);
       }

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1918,7 +1918,6 @@ private:
         KJ_SYSCALL(setenv("HTTPS_PORT", kj::str(*httpsPort).cStr(), true));
       }
 
-      KJ_SYSCALL(setenv("SANDSTORM_SMTP_PORT", kj::str(config.smtpListenPort).cStr(), true));
       KJ_SYSCALL(setenv("MONGO_URL",
           kj::str("mongodb://", authPrefix, "127.0.0.1:", config.mongoPort,
                   "/meteor", authSuffix).cStr(),


### PR DESCRIPTION
Close: #1386 

Testing done so far:

- [x] Run this code on my laptop.
- [x] Verify that localhost:30025 is still routed to the Sandstorm SMTP server.
- [x] Verify that Sandstorm's HTTP service seems to work OK.

Testing still to do:

- [x] Run this on a real server somewhere and manually test that HTTPS and two alternate HTTP ports still work.

- [x] Manually test inbound email to a grain.

Notes to reviewers:

- I believe all this code works, so feel free to give me review feedback on the code right now, so I can get it merged faster.