### PR TITLE
Improve grain renaming behavior. Fixes #1087

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -633,9 +633,13 @@ Template.grain.helpers({
 });
 
 Template.grainTitle.helpers({
-  title: function () {
+  fullTitle: function () {
     const grain = globalGrains.getActive();
-    return (grain && grain.title()) || "(unknown grain)";
+    return (grain && grain.fullTitle()) || { title: "(unknown grain)" };
+  },
+
+  hasSubtitle: function () {
+    return !!(this.was || this.renamedFrom);
   },
 });
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -353,7 +353,23 @@ limitations under the License.
 </template>
 
 <template name="grainTitle">
-  <span class="editable" title="Rename" id="grainTitle" tabindex="0">{{title}}</span>
+  {{#with fullTitle}}
+    <div class="editable" title="Rename" id="grainTitle" tabindex="0">
+      {{#if hasSubtitle}}
+        <div class="main-title">{{title}}</div>
+        <div class="subtitle">
+          {{#with was}}
+            was: {{.}}
+          {{/with}}
+          {{#with renamedFrom}}
+            renamed from: {{.}}
+          {{/with}}
+        </div>
+      {{else}}
+        {{title}}
+      {{/if}}
+    </div>
+  {{/with}}
 </template>
 <template name="grainDeleteButton">
   <button class="grain-button" title="{{#if isOwner}}Delete{{else}}Forget{{/if}}" id="deleteGrain">Delete</button>

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -269,7 +269,7 @@ body>.topbar {
         font-size: 120%;
       }
 
-      >span.editable {
+      >div.editable {
         white-space: nowrap;
         text-overflow: ellipsis;  // Doesn't seem to work since size is dynamic. Left here in vain.
         overflow: hidden;
@@ -288,6 +288,29 @@ body>.topbar {
           cursor: pointer;
           color: $topbar-foreground-color-hover;
           background-color: $topbar-background-color-hover;
+        }
+
+        .main-title {
+          height: $topbar-height-desktop - 8px;
+          line-height: $topbar-height-desktop - 8px;
+          @media #{$mobile} {
+            height: $topbar-height-mobile - 12px;
+            line-height: $topbar-height-mobile - 12px;
+          }
+        }
+
+        .subtitle {
+          height: 10px;
+          line-height: 10px;
+          font-size: 10px;
+          margin-top: -2px;
+
+          @media #{$mobile} {
+            height: 12px;
+            line-height: 12px;
+            font-size: 12px;
+            margin-top: -4px;
+          }
         }
       }
     }

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -300,10 +300,11 @@ body>.topbar {
         }
 
         .subtitle {
+          color: #9b9b9b;
           height: 10px;
           line-height: 10px;
           font-size: 10px;
-          margin-top: -2px;
+          margin-top: -4px;
 
           @media #{$mobile} {
             height: 12px;

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -452,6 +452,8 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //   ...
 // }
 
+ApiTokens.ensureIndexOnServer("grainId", { sparse: 1 });
+
 ApiHosts = new Mongo.Collection("apiHosts");
 // Allows defining some limited static behavior for an API host when accessed unauthenticated. This
 // mainly exists to allow backwards-compatibility with client applications that expect to be able

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -46,7 +46,7 @@ SandstormGrainListPage.mapApiTokensToTemplateObject = function (apiTokens, stati
     const iconSrc = (grainInfo && grainInfo.icon && grainInfo.icon.assetId) ?
         (window.location.protocol + "//" + staticAssetHost + "/" + grainInfo.icon.assetId) :
         Identicon.identiconForApp((grainInfo && grainInfo.appId) || "00000000000000000000000000000000");
-    return {
+    const result = {
       _id: grainId,
       title: ownerData.title,
       appTitle: appTitle,
@@ -54,11 +54,24 @@ SandstormGrainListPage.mapApiTokensToTemplateObject = function (apiTokens, stati
       iconSrc: iconSrc,
       isOwnedByMe: false,
     };
+
+    if (ownerData.upstreamTitle) {
+      if (ownerData.renamed) {
+        result.renamedFrom = ownerData.upstreamTitle;
+      } else {
+        result.was = ownerData.title;
+        result.title = ownerData.upstreamTitle;
+      }
+    }
+
+    return result;
   });
 };
 
 const matchesAppOrGrainTitle = function (needle, grain) {
   if (grain.title && grain.title.toLowerCase().indexOf(needle) !== -1) return true;
+  if (grain.was && grain.was.toLowerCase().indexOf(needle) !== -1) return true;
+  if (grain.renamedFrom && grain.renamedFrom.toLowerCase().indexOf(needle) !== -1) return true;
   if (grain.appTitle && grain.appTitle.toLowerCase().indexOf(needle) !== -1) return true;
   return false;
 };

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.html
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.html
@@ -83,7 +83,15 @@
         {{#each grains}}
         <tr class="grain" data-grainid="{{ _id }}">
           <td class="td-app-icon"><div class="app-icon" title="{{appTitle}}" style="background-image: url('{{ iconSrc }}');"></div></td>
-          <td class="grain-name"><a href="{{ pathFor route='grain' grainId=_id }}">{{title}}</a></td>
+          <td class="grain-name">
+            <a href="{{ pathFor route='grain' grainId=_id }}">{{title}}</a>
+            {{#with was}}
+              (was: {{.}})
+            {{/with}}
+            {{#with renamedFrom}}
+              (renamed from: {{.}})
+            {{/with}}
+          </td>
           <td class="last-used">{{dateString lastUsed}}</td>
           <td class="shared-or-owned">{{#if isOwnedByMe }}My grain{{else}}Shared with me{{/if}}</td>
           {{!-- Collaborators, size TODO

--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -337,7 +337,8 @@ Meteor.methods({
           Grains.update({ _id: grainId, userId: this.userId }, { $set: { title: newTitle } });
 
           // Denormalize new title out to all sharing tokens.
-          ApiTokens.update({ grainId: grainId }, { $set: { "owner.user.upstreamTitle": newTitle } });
+          ApiTokens.update({ grainId: grainId, "owner.user": { $exists: true } },
+                           { $set: { "owner.user.upstreamTitle": newTitle } });
         } else {
           if (!globalDb.userHasIdentity(this.userId, identityId)) {
             throw new Meteor.Error(403, "Current user does not have identity " + identityId);

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -302,7 +302,7 @@ struct ApiTokenOwner {
       # The identity that is allowed to restore this token.
 
       title @7 :Text;
-      # Title as chosen by the user.
+      # Title as chosen by the user, or as copied from the sharer.
 
       # Fields below this line are not actually allowed to be passed to save(), but are added
       # internally.
@@ -312,6 +312,15 @@ struct ApiTokenOwner {
 
       userId @6 :Text;
       # Deprecated. See `identityId`.
+
+      upstreamTitle @11 :Text;
+      # Title as chosen by the grain owner. This field is directly updated whenever the grain owner
+      # changes the title. As an optimization, this field is omitted if the value would be
+      # identical to `title`.
+
+      renamed @12 :Bool;
+      # True if the user has explicitly renamed the grain to differ from the owner's title.
+      # Otherwise, `title` is a copy of either the current or previous value of `upstreamTitle`.
     }
   }
 }


### PR DESCRIPTION
Historically, when a grain is shared, the title would be copied and become the receiver's "petname" for the grain, displayed whenever the receiver opens the grain. If the owner renamed the grain post-sharing, the receiver would never see the rename, only their petname. If the receiver renamed the grain, it would change their petname. This was generally confusing to people.

However, the alternative of "always show the owner's title" is also problematic since:
- If the title changes in the recipient's grain list, they may be confused as to how this new grain that they don't remember got here.
- If the owner's title is poorly-chosen or similar to other grains in the receiver's grain list, the receiver may want to retitle the grain for themselves (hence the petname behavior).

This change implements a compromise by displaying both the petname and the owner's title:
- If the petname and original title are the same, we just display it.
- If the sharing recipient has explicitly modified their petname, we show their petname as the title, with subtext of "renamed from: [upstream title]". This allows the user to assign their own title if they need to disambiguate the grain, though most of the time they probably won't.
- If the sharing recipient has not explicitly modified their petname (i.e. it is a clone of the title from the time of sharing), but the upstream title has changed, we show the upstream title, with subtext of "was: [petname]". This allows the user to understand how this grain whose title they don't recognize arrived in their grain list.