### PR TITLE
Fix various corner cases with grain renaming.

### DIFF
--- a/shell/packages/sandstorm-backend/sandstorm-backend.js
+++ b/shell/packages/sandstorm-backend/sandstorm-backend.js
@@ -212,7 +212,8 @@ SandstormBackend.prototype.updateLastActive = function (grainId, userId, identit
     Meteor.users.update({ _id: identityId }, { $set: { lastActive: now } });
     // Update any API tokens that match this user/grain pairing as well
     ApiTokens.update({ grainId: grainId, "owner.user.identityId": identityId },
-        { $set: { lastUsed: now } });
+                     { $set: { lastUsed: now } },
+                     { multi: true });
   }
 
   if (Meteor.settings.public.quotaEnabled) {

--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -520,6 +520,10 @@ SandstormPermissions.createNewApiToken = function (db, provider, grainId, petnam
         denormalizedGrainMetadata: grainInfo,
       }
     };
+
+    if (grain.title !== owner.user.title) {
+      apiToken.owner.user.upstreamTitle = grain.title;
+    }
   } else {
     // Note: Also covers the case of `webkey: null`.
     apiToken.owner = owner;

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -34,10 +34,8 @@ SandstormGrainListPage.mapApiTokensToTemplateObject = function (apiTokens, stati
   const tokensForGrain = _.groupBy(apiTokens, "grainId");
   const grainIdsForApiTokens = Object.keys(tokensForGrain);
   return grainIdsForApiTokens.map(function (grainId) {
-    // Pick the most recently used one.
-    const token = _.sortBy(tokensForGrain[grainId], (t) => {
-      return t.lastUsed ? -t.lastUsed : 0;
-    })[0];
+    // Pick the oldest one.
+    const token = _.sortBy(tokensForGrain[grainId], "created")[0];
 
     const ownerData = token.owner.user;
     const grainInfo = ownerData.denormalizedGrainMetadata;

--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -349,7 +349,7 @@ Meteor.methods({
             objectId: { $exists: false },
             "owner.user.identityId": identityId,
           }, {
-            sort: { created: 1 },
+            sort: { created: 1 }, // The oldest token is our source of truth for the name.
           });
           if (token && token.owner.user.title !== newTitle) {
             if (token.owner.user.upstreamTitle === newTitle) {
@@ -370,7 +370,9 @@ Meteor.methods({
                 modification["owner.user.upstreamTitle"] = token.owner.user.title;
               }
 
-              ApiTokens.update(token._id, { $set: modification });
+              ApiTokens.update({ grainId: grainId, "owner.user.identityId": identityId },
+                               { $set: modification },
+                               { multi: true });
             }
           }
         }


### PR DESCRIPTION
We should actually write `upstreamTitle` when initially creating tokens.

A user can have multiple incoming tokens for a single grain. The `lastUsed` update in sandstorm-backend.js needs `{ multi: true }`, or else it just picks a single token nondeterministically.

The token used in the grainlist should be the oldest, not the most recently used. It would be weird if merely receiving a new share caused the title to change.

When the user updates the title on an incoming token, all incoming tokens for that grain should get renamed, for the sake of robustness.