### PR TITLE
Avoid using system node when installing webfont packages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ tmp/.shell-env: tmp/.ekam-run $(IMAGES) shell/client/changelog.html shell/client
 	@cd shell/ && meteor npm install
 
 icons/node_modules: icons/package.json
-	cd icons && $(METEOR_DEV_BUNDLE)/bin/npm install
+	cd icons && PATH=$(METEOR_DEV_BUNDLE)/bin:$$PATH $(METEOR_DEV_BUNDLE)/bin/npm install
 
 shell/client/styles/_icons.scss: icons/node_modules icons/*svg icons/Gruntfile.js
 	cd icons && PATH=$(METEOR_DEV_BUNDLE)/bin:$$PATH ./node_modules/.bin/grunt


### PR DESCRIPTION
Fixes #1922.

Meteor's bundled npm script now does

```
#!/usr/bin/env node
```

whereas it previously did

```
`dirname "$0"`/node "$0" "$@"
```

therefore we should set the PATH so that the correct node binary is found.