### PR TITLE
Clear upload error before starting a new upload.

### DIFF
--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -802,6 +802,7 @@ const startUpload = function (file, endpoint, onComplete) {
   //   progress callbacks (and officially document that binary input is accepted).
 
   Session.set("uploadStatus", "Uploading");
+  Session.set("uploadError", undefined);
 
   const xhr = new XMLHttpRequest();
 


### PR DESCRIPTION
Currently, the upload error is only set when actions complete. So if you upload an invalid zip, and then try uploading a valid one, you see `Upload failed: Invalid backup file. [500]` instead of the usual progress message, even through the upload is taking place.

