### PR TITLE
Update JSCS

### DIFF
--- a/shell/.jscsrc
+++ b/shell/.jscsrc
@@ -1,7 +1,5 @@
 {
   "preset": "airbnb",
-  "esnext": true,
-  "verbose": true,
   "fileExtensions": [".js"],
   "validateQuoteMarks": {"mark": "\"", "escape": true},
   "disallowVar": true,

--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -747,7 +747,7 @@ Template.adminLog.helpers({
     // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
     return AnsiUp.ansi_to_html(AdminLog.find({}, { $sort: { _id: 1 } })
             .map(function (entry) { return entry.text; })
-            .join(""), { use_classes:true });
+            .join(""), { use_classes: true });
     // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
   },
 });

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -905,7 +905,7 @@ Template.whoHasAccessPopup.helpers({
         identityId: Template.instance().identityId,
         forSharing: true,
         $or: [
-          { owner: { webkey:null } },
+          { owner: { webkey: null } },
           { owner: { $exists: false } },
         ],
       }).fetch();
@@ -1634,7 +1634,7 @@ Router.map(function () {
           // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
           html: AnsiUp.ansi_to_html(GrainLog.find({}, { $sort: { _id: 1 } })
               .map(function (entry) { return entry.text; })
-              .join(""), { use_classes:true }),
+              .join(""), { use_classes: true }),
           // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
         };
       }

--- a/shell/packages/accounts-email-token/token_client.js
+++ b/shell/packages/accounts-email-token/token_client.js
@@ -11,7 +11,8 @@ Meteor.loginWithEmailToken = function (email, token, callback) {
 
   Accounts.callLoginMethod({
     methodArguments: [
-      { email: {
+      {
+        email: {
           email: email,
           token: token,
         },

--- a/shell/packages/accounts-identity/accounts-identity-client.js
+++ b/shell/packages/accounts-identity/accounts-identity-client.js
@@ -157,7 +157,7 @@ Template.identityManagementButtons.helpers({
       }
     } else {
       if (LoginIdentitiesOfLinkedAccounts.findOne({ sourceIdentityId: this._id,
-                                                   loginAccountId: { $ne: Meteor.userId() }, })) {
+                                                    loginAccountId: { $ne: Meteor.userId() }, })) {
         return { why: "A shared identity is not allowed to be promoted to a login identity." };
       }
 
@@ -184,7 +184,7 @@ Template.loginIdentitiesOfLinkedAccounts.helpers({
   getOtherAccounts: function () {
     const id = Template.instance().data._id;
     return LoginIdentitiesOfLinkedAccounts.find({ sourceIdentityId: id,
-                                                 loginAccountId: { $ne: Meteor.userId() }, })
+                                                  loginAccountId: { $ne: Meteor.userId() }, })
         .fetch().map(function (identity) {
       SandstormDb.fillInPictureUrl(identity);
       return identity;
@@ -253,9 +253,11 @@ Template.identityCardSignInButton.events({
     const result = Accounts.identityServices[name].initiateLogin(data.identity.loginId);
     if ("form" in result) {
       const loginTemplate = Accounts.identityServices[name].loginTemplate;
-      instance._form.set({ loginId: data.identity.loginId,
-                           data: loginTemplate.data,
-                           name: loginTemplate.name, });
+      instance._form.set({
+        loginId: data.identity.loginId,
+        data: loginTemplate.data,
+        name: loginTemplate.name,
+      });
     }
   },
 });

--- a/shell/packages/accounts-identity/accounts-identity-server.js
+++ b/shell/packages/accounts-identity/accounts-identity-server.js
@@ -67,9 +67,11 @@ function linkIdentityToAccountInternal(db, backend, identityId, accountId) {
                                   "already linked to another account.");
     }
 
-    modifier = { $push: pushModifier,
-                 $unset: { expires: 1 },
-                 $set: { upgradedFromDemo: Date.now() }, };
+    modifier = {
+      $push: pushModifier,
+      $unset: { expires: 1 },
+      $set: { upgradedFromDemo: Date.now() },
+    };
     if (Meteor.settings.public.quotaEnabled) {
       // Demo users never got the referral notification. Send it now:
       db.sendReferralProgramNotification(accountUser._id);
@@ -89,15 +91,15 @@ function linkIdentityToAccountInternal(db, backend, identityId, accountId) {
     const demoIdentityId = SandstormDb.getUserIdentityIds(accountUser)[0];
     Meteor.users.update({ _id: demoIdentityId },
                         { $unset: { expires: 1 },
-                         $set: { upgradedFromDemo: Date.now() }, });
+                          $set: { upgradedFromDemo: Date.now() }, });
 
     // Mark the demo identity as nonlogin. It'd be nicer if the identity started out as nonlogin,
     // but to get that to work we would need to adjust the account creation and first login logic.
     Meteor.users.update({ _id: accountUser._id,
-                         "loginIdentities.id": demoIdentityId,
-                         "nonloginIdentities.id": { $not: { $eq: demoIdentityId } }, },
+                          "loginIdentities.id": demoIdentityId,
+                          "nonloginIdentities.id": { $not: { $eq: demoIdentityId } }, },
                         { $pull: { loginIdentities: { id: demoIdentityId } },
-                         $push: { nonloginIdentities: { id: demoIdentityId } }, });
+                          $push: { nonloginIdentities: { id: demoIdentityId } }, });
 
   }
 }
@@ -212,9 +214,14 @@ Meteor.methods({
     }
 
     const identityUser = Meteor.users.findOne({ _id: identityId });
-    Meteor.users.update({ _id: accountUserId },
-                        { $pull: { nonloginIdentities: { id: identityId },
-                                 loginIdentities: { id: identityId }, }, });
+    Meteor.users.update({
+      _id: accountUserId,
+    }, {
+      $pull: {
+        nonloginIdentities: { id: identityId },
+        loginIdentities: { id: identityId },
+      },
+    });
   },
 
   setIdentityAllowsLogin: function (identityId, allowLogin) {
@@ -232,16 +239,16 @@ Meteor.methods({
 
     if (allowLogin) {
       Meteor.users.update({ _id: this.userId,
-                           "nonloginIdentities.id": identityId,
-                           "loginIdentities.id": { $not: { $eq: identityId } }, },
+                            "nonloginIdentities.id": identityId,
+                            "loginIdentities.id": { $not: { $eq: identityId } }, },
                           { $pull: { nonloginIdentities: { id: identityId } },
-                           $push: { loginIdentities: { id: identityId } }, });
+                            $push: { loginIdentities: { id: identityId } }, });
     } else {
       Meteor.users.update({ _id: this.userId,
-                           "loginIdentities.id": identityId,
-                           "nonloginIdentities.id": { $not: { $eq: identityId } }, },
+                            "loginIdentities.id": identityId,
+                            "nonloginIdentities.id": { $not: { $eq: identityId } }, },
                           { $pull: { loginIdentities: { id: identityId } },
-                           $push: { nonloginIdentities: { id: identityId } }, });
+                            $push: { nonloginIdentities: { id: identityId } }, });
     }
   },
 

--- a/shell/packages/accounts-saml/package.js
+++ b/shell/packages/accounts-saml/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name:"accounts-saml",
+  name: "accounts-saml",
   summary: "saml login provider for meteor",
   version: "0.2.0",
   git: "https://github.com/nate-strauser/meteor-accounts-saml.git", // package was forked from here

--- a/shell/packages/accounts-saml/saml_client.js
+++ b/shell/packages/accounts-saml/saml_client.js
@@ -66,7 +66,7 @@ Meteor.loginWithSaml = function (options, callback) {
 
   Accounts.saml.initiateLogin(options, function (error, result) {
     Accounts.callLoginMethod({
-      methodArguments: [{ saml:true, credentialToken:credentialToken }],
+      methodArguments: [{ saml: true, credentialToken: credentialToken }],
       userCallback: callback,
     });
   });

--- a/shell/packages/accounts-saml/saml_server.js
+++ b/shell/packages/accounts-saml/saml_server.js
@@ -73,7 +73,7 @@ middleware = function (req, res, next) {
       throw new Error("Missing SAML action");
 
     const service = {
-      "provider":"default",
+      "provider": "default",
       "entryPoint": SandstormDb.prototype.getSamlEntryPoint(),
       // TODO(someday): find a better way to inject the DB
       "issuer": HOSTNAME,
@@ -138,9 +138,9 @@ const samlUrlToObject = function (url) {
     return null;
 
   return {
-    actionName:splitPath[2],
-    serviceName:splitPath[3],
-    credentialToken:splitPath[4],
+    actionName: splitPath[2],
+    serviceName: splitPath[3],
+    credentialToken: splitPath[4],
   };
 };
 

--- a/shell/packages/accounts-saml/saml_utils.js
+++ b/shell/packages/accounts-saml/saml_utils.js
@@ -197,7 +197,7 @@ SAML.prototype.getElement = function (parentElement, elementName) {
 SAML.prototype.validateResponse = function (samlResponse, callback) {
   const _this = this;
   const xml = new Buffer(samlResponse, "base64").toString("ascii");
-  const parser = new xml2js.Parser({ explicitRoot:true });
+  const parser = new xml2js.Parser({ explicitRoot: true });
   parser.parseString(xml, function (err, doc) {
     // Verify signature
     if (_this.options.cert && !_this.validateSignature(xml, _this.options.cert)) {

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.js
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.js
@@ -147,8 +147,11 @@ Template._loginButtonsLoggedInDropdown.helpers({
       Accounts.setCurrentIdentityId(identityId);
     }
 
-    return { identities: identities, onPicked: onPicked,
-             currentIdentityId: Accounts.getCurrentIdentityId(), };
+    return {
+      identities,
+      onPicked,
+      currentIdentityId: Accounts.getCurrentIdentityId(),
+    };
   },
 
 });

--- a/shell/packages/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
+++ b/shell/packages/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
@@ -47,19 +47,20 @@ const packageV0 = { _id: "mock-package-id1",
   progress: 1,
   isAutoUpdated: false,
   error: null,
-  manifest:
-   { minApiVersion: 0,
-     maxApiVersion: 0,
-     appMarketingVersion: { defaultText: "0.1" },
-     appTitle: { defaultText: "Mock App" },
-     actions: [
-       {
-         input: { none: null },
-         title: { defaultText: "New Mock App" },
-       },
-     ],
-     appVersion: 0,
-     minUpgradableAppVersion: 0, },
+  manifest: {
+    minApiVersion: 0,
+    maxApiVersion: 0,
+    appMarketingVersion: { defaultText: "0.1" },
+    appTitle: { defaultText: "Mock App" },
+    actions: [
+      {
+        input: { none: null },
+        title: { defaultText: "New Mock App" },
+      },
+    ],
+    appVersion: 0,
+    minUpgradableAppVersion: 0,
+  },
   appId: "mock-app-id",
 };
 
@@ -68,14 +69,15 @@ const packageV1 = { _id: "mock-package-id2",
   progress: 1,
   isAutoUpdated: false,
   error: null,
-  manifest:
-   { minApiVersion: 0,
-     maxApiVersion: 0,
-     appMarketingVersion: { defaultText: "0.2" },
-     appTitle: { defaultText: "Mock App" },
-     actions: [{ title: { defaultText: "New Mock App" } }],
-     appVersion: 2,
-     minUpgradableAppVersion: 0, },
+  manifest: {
+    minApiVersion: 0,
+    maxApiVersion: 0,
+    appMarketingVersion: { defaultText: "0.2" },
+    appTitle: { defaultText: "Mock App" },
+    actions: [{ title: { defaultText: "New Mock App" } }],
+    appVersion: 2,
+    minUpgradableAppVersion: 0,
+  },
   appId: "mock-app-id",
 };
 

--- a/shell/packages/sandstorm-backend/sandstorm-backend.js
+++ b/shell/packages/sandstorm-backend/sandstorm-backend.js
@@ -261,16 +261,17 @@ SandstormBackend.prototype.openSessionInternal = function (grainId, userId, iden
       console.error(e);
       throw e;
     } else {
-      return { supervisor: supervisor,
-               methodResult: {
-                 sessionId: session._id,
-                 title: title,
-                 grainId: grainId,
-                 hostId: session.hostId,
-                 tabId: session.tabId,
-                 salt: cachedSalt,
-               },
-             };
+      return {
+        supervisor: supervisor,
+        methodResult: {
+          sessionId: session._id,
+          title: title,
+          grainId: grainId,
+          hostId: session.hostId,
+          tabId: session.tabId,
+          salt: cachedSalt,
+        },
+      };
     }
   }
 
@@ -297,14 +298,15 @@ SandstormBackend.prototype.openSessionInternal = function (grainId, userId, iden
 
   Sessions.insert(session);
 
-  return { supervisor: supervisor,
-           methodResult: {
-             sessionId: session._id,
-             title: title,
-             grainId: grainId,
-             hostId: session.hostId,
-             tabId: session.tabId,
-             salt: cachedSalt,
-           },
-         };
+  return {
+    supervisor: supervisor,
+    methodResult: {
+      sessionId: session._id,
+      title: title,
+      grainId: grainId,
+      hostId: session.hostId,
+      tabId: session.tabId,
+      salt: cachedSalt,
+    },
+  };
 };

--- a/shell/packages/sandstorm-db/migrations.js
+++ b/shell/packages/sandstorm-db/migrations.js
@@ -87,8 +87,12 @@ function mergeRoleAssignmentsIntoApiTokens() {
       roleAssignment: roleAssignment.roleAssignment,
       petname: roleAssignment.petname,
       created: roleAssignment.created,
-      owner: { user: { userId: roleAssignment.recipient,
-                     title: roleAssignment.title, }, },
+      owner: {
+        user: {
+          userId: roleAssignment.recipient,
+          title: roleAssignment.title,
+        },
+      },
     });
   });
 }
@@ -233,7 +237,7 @@ function splitUserIdsIntoAccountIdsAndIdentityIds() {
 
     while (ApiTokens.update({ "requirements.permissionsHeld.userId": user._id },
                             { $set: { "requirements.$.permissionsHeld.identityId": identity.id },
-                             $unset: { "requirements.$.permissionsHeld.userId": 1 }, },
+                              $unset: { "requirements.$.permissionsHeld.userId": 1 }, },
                             { multi: true }) > 0);
     // The `$` operatorer modifies the first element in the array that matches the query. Since
     // there may be many matches, we need to repeat until no documents are modified.

--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -58,36 +58,37 @@ if (Meteor.isServer) {
 
     return Meteor.users.find({ _id: identityId },
       { fields: {
-        profile:1,
-        unverifiedEmail:1,
+        profile: 1,
+        unverifiedEmail: 1,
         expires: 1,
         createdAt: 1,
 
-        "services.dev.name":1,
+        "services.dev.name": 1,
 
-        "services.google.id":1,
-        "services.google.email":1,
-        "services.google.verified_email":1,
-        "services.google.name":1,
-        "services.google.picture":1,
-        "services.google.gender":1,
-        "services.google.hd":1,
+        "services.google.id": 1,
+        "services.google.email": 1,
+        "services.google.verified_email": 1,
+        "services.google.name": 1,
+        "services.google.picture": 1,
+        "services.google.gender": 1,
+        "services.google.hd": 1,
 
-        "services.github.id":1,
-        "services.github.email":1,
-        "services.github.emails":1,
-        "services.github.username":1,
+        "services.github.id": 1,
+        "services.github.email": 1,
+        "services.github.emails": 1,
+        "services.github.username": 1,
 
-        "services.email.email":1,
+        "services.email.email": 1,
 
-        "services.ldap.id":1,
-        "services.ldap.username":1,
-        "services.ldap.rawAttrs":1,
+        "services.ldap.id": 1,
+        "services.ldap.username": 1,
+        "services.ldap.rawAttrs": 1,
 
-        "services.saml.id":1,
-        "services.saml.email":1,
-        "services.saml.displayName":1,
-      }, });
+        "services.saml.id": 1,
+        "services.saml.email": 1,
+        "services.saml.displayName": 1,
+      },
+    });
   }),
 
   Meteor.publish("accountIdentities", function () {
@@ -347,8 +348,8 @@ SandstormDb.getUserEmails = function (user) {
   const result = [];
   _.keys(verifiedEmails).map(function (email) {
     result.push({ email: email,
-                 verified: true,
-                 primary: email === user.primaryEmail, });
+                  verified: true,
+                  primary: email === user.primaryEmail, });
   });
 
   _.keys(unverifiedEmails).map(function (email) {

--- a/shell/packages/sandstorm-db/user.js
+++ b/shell/packages/sandstorm-db/user.js
@@ -77,16 +77,16 @@ Accounts.onCreateUser(function (options, user) {
   if (user.loginIdentities) {
     // it's an account
     check(user, { _id: String,
-                 createdAt: Date,
-                 isAdmin: Match.Optional(Boolean),
-                 hasCompletedSignup: Match.Optional(Boolean),
-                 signupKey: Match.Optional(String),
-                 signupNote: Match.Optional(String),
-                 signupEmail: Match.Optional(String),
-                 expires: Match.Optional(Date),
-                 appDemoId: Match.Optional(String),
-                 loginIdentities: [{ id: String }],
-                 nonloginIdentities: [{ id: String }], });
+                  createdAt: Date,
+                  isAdmin: Match.Optional(Boolean),
+                  hasCompletedSignup: Match.Optional(Boolean),
+                  signupKey: Match.Optional(String),
+                  signupNote: Match.Optional(String),
+                  signupEmail: Match.Optional(String),
+                  expires: Match.Optional(Date),
+                  appDemoId: Match.Optional(String),
+                  loginIdentities: [{ id: String }],
+                  nonloginIdentities: [{ id: String }], });
 
     if (Meteor.settings.public.quotaEnabled) {
       user.experiments = user.experiments || {};
@@ -144,7 +144,7 @@ Accounts.onCreateUser(function (options, user) {
   } else if (user.services && user.services.email) {
     check(user.services.email,
           { email: String,
-           tokens: [{ digest: String, algorithm: String, createdAt: Date }], });
+            tokens: [{ digest: String, algorithm: String, createdAt: Date }], });
     serviceUserId = user.services.email.email;
     user.profile.service = "email";
   } else if (user.services && "google" in user.services) {

--- a/shell/packages/sandstorm-permissions/permissions-tests.js
+++ b/shell/packages/sandstorm-permissions/permissions-tests.js
@@ -112,8 +112,15 @@ class Identity {
     this.db = db;
     this.id = Accounts.insertUserDoc(
       { profile: { name: name }, },
-      { services: { dev: { name: name,
-                           isAdmin: false, hasCompletedSignup: true, }, }, });
+      {
+        services: {
+          dev: {
+            name: name,
+            isAdmin: false,
+            hasCompletedSignup: true,
+          },
+        },
+      });
   }
 
   mayOpenGrain(grain) {
@@ -216,8 +223,13 @@ Tinytest.add("permissions: legacy public grain", function (test) {
 
   // anonymous
   test.isTrue(
-    SandstormPermissions.mayOpenGrain(globalDb, { grain: { _id: grain.id,
-                                                           identityId: null, }, }));
+    SandstormPermissions.mayOpenGrain(globalDb, {
+      grain: {
+        _id: grain.id,
+        identityId: null,
+      },
+    })
+  );
 
   test.equal(alice.grainPermissions(grain), [true, true, true]);
   test.equal(bob.grainPermissions(grain), [true, false, false]);

--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -264,12 +264,13 @@ class RequirementSet {
     for (const grainId in this.permissionsHeldRequirements) {
       for (const identityId in this.permissionsHeldRequirements[grainId]) {
         const permissions = this.permissionsHeldRequirements[grainId][identityId];
-        func({ permissionsHeld:
-               { grainId: grainId,
-                 identityId: identityId,
-                 permissionSet: permissions,
-               },
-             });
+        func({
+          permissionsHeld: {
+            grainId: grainId,
+            identityId: identityId,
+            permissionSet: permissions,
+          },
+        });
       }
     }
   }
@@ -543,8 +544,11 @@ class Context {
       const permissions = PermissionSet.fromRoleAssignment(edge.role, viewInfo);
       const vertexId = "i:" + edge.identityId;
       forEachPermission(permissions.array, (permissionId) => {
-        this.setToTrueStack.push({ grainId: grainId, vertexId: vertexId,
-                                   permissionId: permissionId, });
+        this.setToTrueStack.push({
+          grainId: grainId,
+          vertexId: vertexId,
+          permissionId: permissionId,
+        });
       });
     });
   }
@@ -833,8 +837,10 @@ class Context {
         while (true) {
           let currentToken = this.tokensById[currentTokenId];
           if (!currentToken && db) {
-            currentToken = db.collections.apiTokens.findOne({ _id: currentTokenId,
-                                                             revoked: { $ne: true }, });
+            currentToken = db.collections.apiTokens.findOne({
+              _id: currentTokenId,
+              revoked: { $ne: true },
+            });
             this.tokensById[currentTokenId] = currentToken;
           }
 
@@ -1121,10 +1127,15 @@ function computeRelevantTokens(context, grainId, vertexId) {
   };
 }
 
-const vertexPattern = Match.OneOf({ token: Match.ObjectIncluding({ _id: String, grainId: String }) },
-                                  { grain: Match.ObjectIncluding(
-                                    { _id: String,
-                                     identityId: Match.OneOf(String, null, undefined), }), });
+const vertexPattern = Match.OneOf(
+  { token: Match.ObjectIncluding({ _id: String, grainId: String }) },
+  {
+    grain: Match.ObjectIncluding({
+      _id: String,
+      identityId: Match.OneOf(String, null, undefined),
+    }),
+  },
+);
 // A vertex in the sharing graph is a principal, e.g. a user (identity) or a token. Complicating
 // matters, we may have to traverse sharing graphs for multiple grains in the same computation. A
 // token is specific to one grain, but a user of course can have access to multiple grains, so in
@@ -1302,7 +1313,7 @@ SandstormPermissions.downstreamTokens = function (db, root) {
   if (!grain || !grain.private) { return result; }
 
   db.collections.apiTokens.find({ grainId: grainId,
-                                 revoked: { $ne: true }, }).forEach(function (token) {
+                                  revoked: { $ne: true }, }).forEach(function (token) {
     tokensById[token._id] = token;
     if (token.parentToken) {
       if (!tokensByParent[token.parentToken]) {
@@ -1382,18 +1393,28 @@ SandstormPermissions.createNewApiToken = function (db, provider, grainId, petnam
   // explicitly pass in undefined.
   check(provider, Match.OneOf({ identityId: String, accountId: String },
                               { rawParentToken: Match.OneOf(String, Buffer) }));
-  check(owner, Match.OneOf({ webkey: Match.OneOf(null,
-                                                 { forSharing: Boolean,
-                                                   expiresIfUnusedDuration: Match.Optional(Number),
-                                                 }), },
-                           { user: { identityId: String,
-                                     title: String,
-                                     renamed: Match.Optional(Boolean),
-                                     upstreamTitle: Match.Optional(String), }, },
-                           { grain: { grainId: String,
-                                      saveLabel: LocalizedString,
-                                      introducerIdentity: String, }, },
-                           { frontend: null }));
+  check(owner, Match.OneOf({
+    webkey: Match.OneOf(null, {
+      forSharing: Boolean,
+      expiresIfUnusedDuration: Match.Optional(Number),
+    }),
+  }, {
+    user: {
+      identityId: String,
+      title: String,
+      renamed: Match.Optional(Boolean),
+      upstreamTitle: Match.Optional(String),
+    },
+  }, {
+    grain: {
+      grainId: String,
+      saveLabel: LocalizedString,
+      introducerIdentity: String,
+    },
+  }, {
+    frontend: null,
+  }));
+
   check(unauthenticated, Match.OneOf(undefined, null, {
     options: Match.Optional({ dav: [Match.Optional(DavClass)] }),
     resources: Match.Optional(ResourceMap),

--- a/shell/packages/sandstorm-ui-applist/applist-client.js
+++ b/shell/packages/sandstorm-ui-applist/applist-client.js
@@ -55,32 +55,32 @@ const matchApps = function (searchString) {
   const db = Template.instance().data._db;
   const allActions = db.currentUserActions().fetch();
   const appsFromUserActionsByAppId = _.chain(allActions)
-                             .groupBy("packageId")
-                             .pairs()
-                             .map(function (pair) {
-                               const pkg = db.collections.packages.findOne(pair[0]);
-                               return {
-                                  packageId: pair[0],
-                                  actions: pair[1],
-                                  appId: pkg.appId,
-                                  pkg: pkg,
-                                  dev: false,
-                                };
-                             })
-                             .indexBy("appId")
-                             .value();
+      .groupBy("packageId")
+      .pairs()
+      .map(function (pair) {
+        const pkg = db.collections.packages.findOne(pair[0]);
+        return {
+          packageId: pair[0],
+          actions: pair[1],
+          appId: pkg.appId,
+          pkg: pkg,
+          dev: false,
+        };
+      })
+      .indexBy("appId")
+      .value();
   const devPackagesByAppId = _.chain(db.collections.devPackages.find().fetch())
-                        .map(function (devPackage) {
-                          return {
-                            packageId: devPackage._id,
-                            actions: devPackage.manifest.actions,
-                            appId: devPackage.appId,
-                            pkg: devPackage,
-                            dev: true,
-                          };
-                        })
-                        .indexBy("appId")
-                        .value();
+      .map(function (devPackage) {
+        return {
+          packageId: devPackage._id,
+          actions: devPackage.manifest.actions,
+          appId: devPackage.appId,
+          pkg: devPackage,
+          dev: true,
+        };
+      })
+      .indexBy("appId")
+      .value();
   // Merge, making sure that dev apps overwrite user actions if they share appId
   const allApps = _.chain({})
                  .extend(appsFromUserActionsByAppId, devPackagesByAppId)

--- a/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
+++ b/shell/packages/sandstorm-ui-autocomplete-input/autocomplete-client.js
@@ -4,20 +4,22 @@ Template.contactInputBox.onCreated(function () {
   this.selectedContacts = this.data.contacts;
   this.selectedContactsIds = new ReactiveVar([]);
   this.highlightedContact = new ReactiveVar({ _id: null });
-  this.subscribe("contactProfiles", false, { onReady: () => {
-    if (this.data.preselectedIdentityId) {
-      const contact = ContactProfiles.findOne({ _id: this.data.preselectedIdentityId });
-      if (contact) {
-        const contacts = this.selectedContacts.get();
-        contacts.push(contact);
-        this.selectedContacts.set(contacts);
+  this.subscribe("contactProfiles", false, {
+    onReady: () => {
+      if (this.data.preselectedIdentityId) {
+        const contact = ContactProfiles.findOne({ _id: this.data.preselectedIdentityId });
+        if (contact) {
+          const contacts = this.selectedContacts.get();
+          contacts.push(contact);
+          this.selectedContacts.set(contacts);
 
-        const ids = this.selectedContactsIds.get();
-        ids.push(contact._id);
-        this.selectedContactsIds.set(ids);
+          const ids = this.selectedContactsIds.get();
+          ids.push(contact._id);
+          this.selectedContactsIds.set(ids);
+        }
       }
-    }
-  }, });
+    },
+  });
 
   this.randomId = Random.id();  // For use with aria requiring ids in html
   this.autoCompleteContacts = new ReactiveVar([]);

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -1,4 +1,4 @@
-import {introJs} from "intro.js";
+import { introJs } from "intro.js";
 
 SandstormGrainListPage = function (db, quotaEnforcer) {
   this._filter = new ReactiveVar("");

--- a/shell/packages/sandstorm-ui-grainview/grainview-list.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview-list.js
@@ -83,7 +83,7 @@ GrainViewList = class GrainViewList {
         this._grainsUserId.set(currentUserId);
       }
     });
-  };
+  }
 
   clear() {
     const grains = this._grains.get();

--- a/shell/server/dev-accounts-server.js
+++ b/shell/server/dev-accounts-server.js
@@ -41,12 +41,18 @@ Meteor.methods({
     if (user) {
       userId = user._id;
     } else {
-      userId = Accounts.insertUserDoc({ profile: profile,
-                                        unverifiedEmail: unverifiedEmail, },
-                                      { services:
-                                          { dev: { name: displayName,
-                                                 isAdmin: isAdmin,
-                                                 hasCompletedSignup: hasCompletedSignup, }, }, });
+      userId = Accounts.insertUserDoc({
+        profile: profile,
+        unverifiedEmail: unverifiedEmail,
+      }, {
+        services: {
+          dev: {
+            name: displayName,
+            isAdmin: isAdmin,
+            hasCompletedSignup: hasCompletedSignup,
+          },
+        },
+      });
     }
     // Log them in on this connection.
     return Accounts._loginMethod(this, "createDevAccount", arguments,

--- a/shell/server/drivers/external-ui-view.js
+++ b/shell/server/drivers/external-ui-view.js
@@ -151,15 +151,15 @@ ExternalWebSession = class ExternalWebSession {
     return this._requestHelper("DELETE", path, context);
   }
 
-// TODO(someday): implement streaming and websockets for ExternalWebSession
-// postStreaming(path, mimeType, context) {
-// }
+  // TODO(someday): implement streaming and websockets for ExternalWebSession
+  //postStreaming(path, mimeType, context) {
+  //}
 
-// putStreaming(path, mimeType, context) {
-// }
+  //putStreaming(path, mimeType, context) {
+  //}
 
-// openWebSocket(path, context, protocol, clientStream) {
-// }
+  //openWebSocket(path, context, protocol, clientStream) {
+  //}
 
   _requestHelper(method, path, context, content, contentType) {
     const _this = this;

--- a/shell/server/drivers/mail.js
+++ b/shell/server/drivers/mail.js
@@ -49,7 +49,7 @@ if (!Meteor.settings.replicaNumber) {  // only first replica
 }
 
 Meteor.startup(function () {
-  const server = simplesmtp.createSimpleServer({ SMTPBanner:"Sandstorm Mail Server" }, (req) => {
+  const server = simplesmtp.createSimpleServer({ SMTPBanner: "Sandstorm Mail Server" }, (req) => {
     const mailparser = new MailParser();
     req.pipe(mailparser);
 

--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -122,11 +122,11 @@ Meteor.publish("tokenInfo", function (token) {
         let metadata = apiToken.owner.user.denormalizedGrainMetadata;
         if (identity && metadata) {
           SandstormDb.fillInLoginId(identity);
-          this.added("tokenInfo", token,
-                     { identityOwner: _.pick(identity, "_id", "profile", "loginId"),
-                       grainId: grainId,
-                       grainMetadata: metadata,
-                     });
+          this.added("tokenInfo", token, {
+            identityOwner: _.pick(identity, "_id", "profile", "loginId"),
+            grainId: grainId,
+            grainMetadata: metadata,
+          });
         } else {
           this.added("tokenInfo", token, { invalidToken: true });
         }
@@ -134,8 +134,10 @@ Meteor.publish("tokenInfo", function (token) {
         if (this.userId) {
           const user = Meteor.users.findOne({ _id: this.userId });
           const identityIds = SandstormDb.getUserIdentityIds(user);
-          const childToken = ApiTokens.findOne({ "owner.user.identityId": { $in: identityIds },
-                                                 parentToken: apiToken._id, });
+          const childToken = ApiTokens.findOne({
+            "owner.user.identityId": { $in: identityIds },
+            parentToken: apiToken._id,
+          });
           if (childToken || this.userId === grain.userId ||
               identityIds.indexOf(apiToken.identityId) >= 0) {
             this.added("tokenInfo", token, { alreadyRedeemed: true, grainId: apiToken.grainId, });
@@ -157,10 +159,11 @@ Meteor.publish("tokenInfo", function (token) {
           icon: appIcon,
           appId: appIcon ? undefined : grain.appId,
         };
-        this.added("tokenInfo", token,
-                   { webkey: true,
-                     grainId: grainId,
-                     grainMetadata: denormalizedGrainMetadata, });
+        this.added("tokenInfo", token, {
+          webkey: true,
+          grainId: grainId,
+          grainMetadata: denormalizedGrainMetadata,
+        });
       } else {
         this.added("tokenInfo", token, { invalidToken: true });
       }
@@ -193,10 +196,13 @@ Meteor.publish("requestingAccess", function (grainId) {
       Meteor.users.findOne({ _id: grain.userId }));
 
   const _this = this;
-  const query = ApiTokens.find({ grainId: grainId, identityId: { $in: ownerIdentityIds },
-                                 parentToken: { $exists: false },
-                                 "owner.user.identityId": { $in: identityIds },
-                                 revoked: { $ne: true }, });
+  const query = ApiTokens.find({
+    grainId: grainId,
+    identityId: { $in: ownerIdentityIds },
+    parentToken: { $exists: false },
+    "owner.user.identityId": { $in: identityIds },
+    revoked: { $ne: true },
+  });
   const handle = query.observe({
     added(apiToken) {
       _this.added("grantedAccessRequests",
@@ -356,11 +362,15 @@ Meteor.methods({
             if (token.owner.user.upstreamTitle === newTitle) {
               // User renamed grain to match upstream title. Act like they never renamed it at
               // all.
-              ApiTokens.update({ grainId: grainId, "owner.user.identityId": identityId },
-                               { $set: { "owner.user.title": newTitle },
-                                 $unset: { "owner.user.upstreamTitle": 1, "owner.user.renamed": 1 },
-                               },
-                               { multi: true });
+              ApiTokens.update({
+                grainId: grainId,
+                "owner.user.identityId": identityId,
+              }, {
+                $set: { "owner.user.title": newTitle },
+                $unset: { "owner.user.upstreamTitle": 1, "owner.user.renamed": 1 },
+              }, {
+                multi: true,
+              });
             } else {
               const modification = {
                 "owner.user.title": newTitle,

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -347,7 +347,7 @@ HackSessionContextImpl = class HackSessionContextImpl extends SessionContextImpl
     return inMeteor((function () {
       return this._getUserAddress();
     }).bind(this));
-  };
+  }
 
   obsoleteGenerateApiToken(petname, userInfo, expires) {
     throw new Error("generateApiToken() has been removed. Use offer templates instead.");

--- a/shell/server/installer.js
+++ b/shell/server/installer.js
@@ -42,7 +42,7 @@ const verifyIsMainReplica = () => {
 Meteor.methods({
   deleteUnusedPackages(appId) {
     check(appId, String);
-    Packages.find({ appId:appId }).forEach((pkg) => {deletePackage(pkg._id);});
+    Packages.find({ appId: appId }).forEach((pkg) => {deletePackage(pkg._id);});
   },
 });
 
@@ -63,12 +63,17 @@ const deletePackageInternal = (pkg) => {
   installers[packageId] = "uninstalling";
 
   try {
-    const action = UserActions.findOne({ packageId:packageId });
-    const grain = Grains.findOne({ packageId:packageId });
+    const action = UserActions.findOne({ packageId: packageId });
+    const grain = Grains.findOne({ packageId: packageId });
     const notificationQuery = {};
     notificationQuery["appUpdates." + pkg.appId] = { $exists: true };
     if (!grain && !action && !(pkg.isAutoUpdated && Notifications.findOne(notificationQuery))) {
-      Packages.update({ _id:packageId }, { $set: { status:"delete" }, $unset: { shouldCleanup: "" } });
+      Packages.update({
+        _id: packageId,
+      }, {
+        $set: { status: "delete" },
+        $unset: { shouldCleanup: "" },
+      });
       waitPromise(globalBackend.cap().deletePackage(packageId));
       Packages.remove(packageId);
 
@@ -77,7 +82,7 @@ const deletePackageInternal = (pkg) => {
         globalDb.unrefStaticAsset(assetId);
       });
     } else {
-      Packages.update({ _id:packageId }, { $unset: { shouldCleanup: "" } });
+      Packages.update({ _id: packageId }, { $unset: { shouldCleanup: "" } });
     }
 
     delete installers[packageId];

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1289,7 +1289,7 @@ class Proxy {
         }, (err) => {
           return this._callNewWebSession(request, userInfo);
         });
-  };
+  }
 
   _callNewSession(request, viewInfo) {
     const userInfo = _.clone(this.userInfo);
@@ -1358,7 +1358,7 @@ class Proxy {
         return _this._callNewWebSession(request, userInfo);
       }
     });
-  };
+  }
 
   getSession(request) {
     if (!this.session) {
@@ -1989,7 +1989,7 @@ class Proxy {
       });
     }
   }
-};
+}
 
 const PROTOCOL = Url.parse(process.env.ROOT_URL).protocol;
 

--- a/shell/server/stats-server.js
+++ b/shell/server/stats-server.js
@@ -33,9 +33,11 @@ computeStats = function (since) {
 
   // This calculates the number of user accounts that have been used
   // during the requested time period.
-  const currentlyActiveUsersCount = Meteor.users.find(
-    { expires: { $exists: false }, loginIdentities: { $exists: true },
-     lastActive: timeConstraint, }).count();
+  const currentlyActiveUsersCount = Meteor.users.find({
+    expires: { $exists: false },
+    loginIdentities: { $exists: true },
+    lastActive: timeConstraint,
+  }).count();
 
   // This calculates the number of grains that have been used during
   // the requested time period.
@@ -57,13 +59,15 @@ computeStats = function (since) {
 
   let apps = Grains.aggregate([
     { $match: { lastUsed: timeConstraint } },
-    { $group: {
+    {
+      $group: {
         _id: "$appId",
         grains: { $sum: 1 },
         userIds: { $addToSet: "$userId" },
       },
     },
-    { $project: {
+    {
+      $project: {
         grains: 1,
         owners: { $size: "$userIds" },
       },
@@ -92,14 +96,16 @@ computeStats = function (since) {
     const grainIds = _.pluck(grains, "_id");
 
     const counts = ApiTokens.aggregate([
-      { $match: {
+      {
+        $match: {
           "owner.user": { $exists: true },
           lastUsed: timeConstraint,
           grainId: { $in: grainIds },
         },
       },
       { $group: { _id: "$owner.user.identityId" } },
-      { $group: {
+      {
+        $group: {
           _id: "count",
           count: { $sum: 1 },
         },
@@ -117,12 +123,14 @@ computeStats = function (since) {
 
   // Count per-app appdemo users and deleted grains.
   DeleteStats.aggregate([
-    { $match: {
+    {
+      $match: {
         lastActive: timeConstraint,
         appId: { $exists: true },
       },
     },
-    { $group: {
+    {
+      $group: {
         _id: {
           appId: "$appId",
           type: "$type",


### PR DESCRIPTION
A new release of JSCS enforces some rules much more strictly.

It also happens to crash on particular instances of invalid ES6; in particular, class definitions and method definitions within a class definition should *not* have a semicolon after the function or class definition.

This changeset splits the change into two commits.

1. Don't make JSCS crash
2. Pass the more stringent updated JSCS rules (mostly issues of indentation consistency, but spacing after colons appeared frequently too).

@jparyani We'll need to coordinate merging this with updating JSCS on the build machine, or the removal of `esnext` and `verbose` from the `.jscsrc` will cause stylechecks to fail.  (Failing to remove those two options from the config causes JSCS to warn that the options are deprecated, not check any styles at all, and exit 1.)

Fixes #1933.