### PR TITLE
WIP notification / activity log design

### DIFF
--- a/src/sandstorm/activity.capnp
+++ b/src/sandstorm/activity.capnp
@@ -1,0 +1,180 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xa4e001d4cbcf33fa;
+
+$import "/capnp/c++.capnp".namespace("sandstorm");
+
+using Util = import "util.capnp";
+
+struct ActivityEvent {
+  # Describes an event in a grain's activity feed / log.
+  #
+  # Call SessionContext.activity() to post new activity. The activity is attributed to the user
+  # whose SessionContext was used.
+
+  path @0 :Text;
+  # Path (as in, URL) within the grain where the user can see this activity. Users inspecting the
+  # event will be linked to this location. Visiting this path implicitly marks the event as "read".
+  #
+  # This should NOT include a leading '/'. (So, an empty string -- the default -- goes to the grain
+  # root).
+  #
+  # Users are able to subscribe to events at specific paths to get notified on activity.
+  # Subscribing to the root (empty path) implies subscribing to all events, and subscribing to a
+  # specific path also implies subscribing to any path that has the subscription path as a prefix
+  # followed by an appropriate separator ('/', '?', '&', '#' depending on context). For example:
+  # * Users subscribed to "" will be notified on everything.
+  # * Users subscribed to "foo" will be notified on changes to "foo", "foo/bar", "foo?bar=baz",
+  #   but not "foobar".
+  # * Users subscribed to "foo?bar=baz" will be notified on changes to "foo?bar=baz&qux=corge" but
+  #   not "foo?bar=baz/qux" ('/' is not a separator inside a query).
+  # * Users subscribed to "foo#bar" will be notified on changes to "foo#bar" and "foo#bar/baz" but
+  #   not "foo#qux". (That is to say, the "fragment" -- aka "hash" -- part of a URL is treated as
+  #   another '/'-separated path.)
+
+  notification @1 :NotificationDisplayInfo;
+  # Optional metadata used to render a notification about this event. This metadata is not stored
+  # in the activity log long-term. It is used e.g. to construct a notification email message or
+  # to display in the notification "bell" menu (discarded once the notification is dismissed).
+  #
+  # It is OK to leave this null for simple events, especially events that don't by default send
+  # notifications.
+
+  type @2 :UInt16;
+  # Event type; index into UiView.ViewInfo.eventTypes. Users are able to choose which types of
+  # events should notify them.
+
+  users @3 :List(User);
+  # List of user identities connected to this event.
+
+  struct User {
+    # Information about a specific user's relationship with this event. At least one of the fields
+    # other than `identityId` should be non-default, otherwise listing the user has no purpose.
+
+    identityId @0 :Data;
+
+    mentioned @1 :Bool;
+    # This user is "mentioned" by this event. This is a hint that they should be more actively
+    # notified.
+
+    canView @2 :Bool;
+    # This user can view this event *even if* they do not meet the `requiredPermission` in the
+    # type definition. (However, if the user has no access to the grain at all, they still will
+    # not see the event.) This flag is useful when the app is doing its own internal access control
+    # rather than relying strictly on Sandstorm permissions.
+  }
+}
+
+struct ActivityTypeDef {
+  name @0 :Text;
+  # Name of the type, used as an identifier for the type in cases where string names
+  # are preferred. These names will never be used in Cap'n Proto interfaces, but could show up in
+  # HTTP or JSON translations.
+  #
+  # The name must be a valid identifier (alphanumerics only, starting with a letter) and must be
+  # unique among all types defined for a particular UiView.
+
+  verbPhrase @1 :Util.LocalizedText;
+  # Text of a verb phrase describing what the acting user did, e.g.:
+  # * "edited document"
+  # * "created new comment"
+  # * "replied to comment"
+  #
+  # The activity log, when displayed, may contain text like:
+  #
+  #     Kenton Varda - 3 hours ago
+  #     * edited document x13
+  #     * created new comment
+  #     * replied to comment x2
+  #     Jade Wang - 2 hours ago
+  #     * replied to comment x3
+  #     * edited document x5
+
+  description @2 :Util.LocalizedText;
+  # Prose describing what this activity type means, suitable for a tool tip or similar help text.
+  # Optional.
+
+  requiredPermission :union {
+    # Who is allowed to observe events of this type?
+
+    everyone @3 :Void;
+    # All users who have any access to this grain are allowed to observe this event.
+
+    permissionIndex @4 :UInt16;
+    # Users who have the given permission are allowed to observe this event.
+
+    explicitList @5 :Void;
+    # Only users explicitly listedg
+  }
+
+  defaultNotifyCondition @6 :NotifyCondition = notifyMentions;
+  # Who should be notified of an event of this type.
+
+  enum NotifyCondition {
+    notifyNone @0;
+    notifyMentions @1;
+    notifyAll @2;
+  }
+
+  obsolete @7 :Bool = false;
+  # If true, this activity type was relevant in a previous version of the application but is no
+  # longer used. The activity type will be hidden from the notification settings (and any events
+  # of this type will not generate notifications).
+
+  # TODO(someday): "silent :Bool" to indicate that the activity does not cause the grain to be
+  #   rendered as "unread"?
+}
+
+struct NotificationDisplayInfo {
+  caption @0 :Util.LocalizedText;
+  # Text to display inside the notification box.
+
+  # TODO(someday): "Body" containing extended text, for the body of an email or perhaps for display
+  #   in the bell menu after the user clicks on the notification (Google+ style).
+  # TODO(someday): Support notifications that can receive text replies. The replies are delivered
+  #   to a provided capability. When notifications are delivered via email, Sandstorm can
+  #   automatically support email replies. When notifications are delivered via the bell menu,
+  #   Sandstorm can render an inline reply textarea (like Google+ notifications).
+  # TODO(someday): Support rich interactive notifications, e.g. the ability to play/pause music
+  #   via buttons.
+}
+
+interface NotificationTarget @0xf0f87337d73020f0 {
+  # Represents a destination for notifications; usually, a user.
+  #
+  # TODO(someday): Expand on this and move it into `grain.capnp` when notifications are
+  #   fully-implemented.
+
+  addOngoing @0 (displayInfo :NotificationDisplayInfo, notification :OngoingNotification)
+             -> (handle :Util.Handle);
+  # Sends an ongoing notification to the notification target. `notification` must be persistent.
+  # The notification is removed when the returned `handle` is dropped. The handle is persistent.
+}
+
+interface OngoingNotification @0xfe851ddbb88940cd {
+  # Callback interface passed to the platform when registering a persistent notification.
+
+  cancel @0 ();
+  # Informs the notification creator that the user has requested cancellation of the task
+  # underlying this notification.
+  #
+  # In the case of a `SandstormApi.stayAwake()` notification, after `cancel()` is called, the app
+  # will no longer be held awake, so should prepare for shutdown.
+  #
+  # TODO(someday): We could allow the app to return some text to display to the user asking if
+  #   they really want to shut down.
+}

--- a/src/sandstorm/sandstorm.ekam-manifest
+++ b/src/sandstorm/sandstorm.ekam-manifest
@@ -16,3 +16,4 @@ persistentuiview.capnp node_modules/sandstorm/persistentuiview.capnp
 update-tool.capnp node_modules/sandstorm/update-tool.capnp
 feature-key.capnp node_modules/sandstorm/feature-key.capnp
 powerbox.capnp node_modules/sandstorm/powerbox.capnp
+activity.capnp node_modules/sandstorm/activity.capnp

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -23,6 +23,7 @@ $import "/capnp/c++.capnp".namespace("sandstorm");
 using Util = import "util.capnp";
 using Grain = import "grain.capnp";
 using Persistent = import "/capnp/persistent.capnp".Persistent;
+using Activity = import "activity.capnp";
 
 interface Supervisor {
   # Default capability exported by the supervisor process.
@@ -150,7 +151,7 @@ interface SandstormCore {
   # pointing to the same capability, where if the original token is revoked, the new token is
   # also transitively revoked.
 
-  getOwnerNotificationTarget @2 () -> (owner :Grain.NotificationTarget);
+  getOwnerNotificationTarget @2 () -> (owner :Activity.NotificationTarget);
   # Get the notification target to use for notifications relating to the grain itself, e.g.
   # presence of wake locks.
 
@@ -227,7 +228,7 @@ interface SystemPersistent extends(Persistent(Data, ApiTokenOwner)) {
 
 interface PersistentHandle extends(SystemPersistent, Util.Handle) {}
 
-interface PersistentOngoingNotification extends(SystemPersistent, Grain.OngoingNotification) {}
+interface PersistentOngoingNotification extends(SystemPersistent, Activity.OngoingNotification) {}
 
 struct DenormalizedGrainMetadata {
   # The metadata that we need to present contextual information for shared grains (in particular,


### PR DESCRIPTION
This is just an interface.

This has changed significantly from the design doc:
* The interface is now centered around an activity feed, logging events occurring on a grain. This is a common feature seen across many apps. Having a unified activity feed provided by Sandstorm seems valuable. Also, "activity feed" and "audit log" are basically the same thing.
* Events can generate notifications under various circumstances. It seems like in all the use cases we've been talking about, notifications are tied to an event, so this seemed more natural than defining separate activity() and notify() methods that need to be called.
* This also makes it easier to see how a user might tweak their notification settings -- e.g. amplifying or muting certain kinds of events. One can even imagine being able to define rules like: "Notify me via bell menu when I'm assigned to a card in Wekan, send me an e-mail if it was Jade that assigned me, and mute all notifications from this one grain that I don't care about." Obviously, we shouldn't rush into providing that much complexity, but the point is that it is _possible_ if the demand arises.

TODO: I have defined `ActivityTypeDef`, which is similar to `PermissionDef` or `RoleDef`: the application would provide a list of activity types upfront, then tag each event with the appropriate type. However, I have not figured out where the app should actually report this list. `ViewInfo` (next to permission and role definitions) seems like the obvious place, but has the problem that it makes it hard for Sandstorm to know if all grains from the app are expected to have the same set of activity types, which in turn makes it hard for Sandstorm to present the list of activity types to a user for them to choose notification preferences. Putting the definitions in the app manifest would fix that, but a non-main UiView might want to offer different activity types. OTOH, maybe we never really need to construct such a list, but instead give the user an interface like "mute messages like this" which they use reactively? Hmm.