### PR TITLE
Add an authentication method for API websockets

### DIFF
--- a/docs/developing/http-apis.md
+++ b/docs/developing/http-apis.md
@@ -242,3 +242,16 @@ that are allowed to use Basic auth. If your Sandstorm app has a client
 that cannot use an Authoriztion header, consider [filing a
 bug](https://github.com/sandstorm-io/sandstorm/issues) requesting the
 white-listing of its user-agent value.
+
+## WebSockets
+
+Unfortunately, WebSockets have no way to set headers in most languages (specifically Javascript). To work around this, you must pass the token as part of the URL path. It must be at the beginning of the path and of the form:
+```
+/.sandstorm-api-token/<token>
+```
+
+For example:
+```
+wss://api-qxJ58hKANkbmJLQdSDk4.oasis.sandstorm.io/.sandstorm-api-token/RfNqni4FEHXkWC5B8v6t/some/path
+```
+The "/.sandstorm-api-token/&lt;token&gt;" part of the path will be stripped, and the remaining segment of the path will be passed onto your app.

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -975,7 +975,7 @@ const apiTokenForRequest = (req, hostId, isWebsocket) => {
   } else if (auth && auth.slice(0, 6).toLowerCase() === "basic " &&
              apiUseBasicAuth(req, hostId)) {
     token = (new Buffer(auth.slice(6).trim(), "base64")).toString().split(":")[1];
-  } else if (isWebsocket && req.url.startsWith("/.sandstorm-api-token/")) {
+  } else if (isWebsocket && req.url.startsWith("/.sandstorm-token/")) {
     let parts = req.url.slice(1).split("/"); // remove leading / and split
     if (parts.length < 2) {
       token = undefined;

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -975,14 +975,14 @@ const apiTokenForRequest = (req, hostId, isWebsocket) => {
   } else if (auth && auth.slice(0, 6).toLowerCase() === "basic " &&
              apiUseBasicAuth(req, hostId)) {
     token = (new Buffer(auth.slice(6).trim(), "base64")).toString().split(":")[1];
-  } else if (isWebsocket && req.url.startsWith("/.sandstorm-well-known/token/")) {
+  } else if (isWebsocket && req.url.startsWith("/.sandstorm-api-token/")) {
     let parts = req.url.slice(1).split("/"); // remove leading / and split
-    if (parts.length < 3) {
+    if (parts.length < 2) {
       token = undefined;
     } else {
-      token = parts[2];
-      req.url = "/" + parts.slice(3).join("/");
-      // remove .sandstorm-well-known/token/$TOKEN from path
+      token = parts[1];
+      req.url = "/" + parts.slice(2).join("/");
+      // remove .sandstorm-api-token/$TOKEN from path
     }
   } else {
     token = undefined;

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -965,7 +965,7 @@ const apiUseBasicAuth = (req, hostId) => {
   return agent.match(BASIC_AUTH_USER_AGENTS_REGEX);
 };
 
-const apiTokenForRequest = (req, hostId, isWebsocket) => {
+const apiTokenForRequest = (req, hostId) => {
   // Extract the API token from the request.
 
   const auth = req.headers.authorization;
@@ -975,7 +975,7 @@ const apiTokenForRequest = (req, hostId, isWebsocket) => {
   } else if (auth && auth.slice(0, 6).toLowerCase() === "basic " &&
              apiUseBasicAuth(req, hostId)) {
     token = (new Buffer(auth.slice(6).trim(), "base64")).toString().split(":")[1];
-  } else if (isWebsocket && req.url.startsWith("/.sandstorm-token/")) {
+  } else if (req.url.startsWith("/.sandstorm-token/")) {
     let parts = req.url.slice(1).split("/"); // remove leading / and split
     if (parts.length < 2) {
       token = undefined;
@@ -1010,7 +1010,7 @@ tryProxyUpgrade = (hostId, req, socket, head) => {
   // request is definitely invalid.
 
   if (globalDb.isApiHostId(hostId)) {
-    const token = apiTokenForRequest(req, hostId, true);
+    const token = apiTokenForRequest(req, hostId);
     if (token) {
       return getProxyForApiToken(token, req).then((proxy) => {
         // Meteor sets the timeout to five seconds. Change that back to two
@@ -1110,7 +1110,7 @@ tryProxyRequest = (hostId, req, res) => {
       res.end(err.stack);
     };
 
-    const token = apiTokenForRequest(req, hostId, false);
+    const token = apiTokenForRequest(req, hostId);
     if (token && req.headers["x-sandstorm-token-keepalive"]) {
       inMeteor(() => {
         const keepaliveDuration = parseInt(req.headers["x-sandstorm-token-keepalive"]);


### PR DESCRIPTION
It turns out that sending an Authorization header is techincally not
allowed for cross origin websockets. To work around this, we will allow
websockets to provide the token as part of the path.