### PR TITLE
Implement trash bin and bulk grain action buttons.

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1464,7 +1464,12 @@ Router.map(function () {
         Router.go("root", {}, { replaceState: true });
       }
 
-      return new SandstormGrainListPage(globalDb, globalQuotaEnforcer);
+      return {
+        _db: globalDb,
+        _quotaEnforcer: globalQuotaEnforcer,
+        _staticHost: globalDb.makeWildcardHost("static"),
+        viewTrash: this.getParams().hash === "trash",
+      };
     },
   });
   this.route("grain", {

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -481,7 +481,6 @@ Template.grainSharePopup.helpers({
 Template.grainInMyTrash.events({
   "click button.restore-from-trash": function (event, instance) {
     const grain = globalGrains.getActive();
-    console.log("clicked restore button. ", this.grainId);
     Meteor.call("moveGrainsOutOfTrash", [this.grainId], function (err, result) {
       if (err) {
         console.error(error.stack);

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -141,19 +141,27 @@ limitations under the License.
   {{#with unpackedGrainState}}
     <div class="grain-container {{#if active}}active-grain{{else}}inactive-grain{{/if}}">
     {{#if error}}
-      {{#if unauthorized}}
-        {{#if token}}
-          {{> revokedShareLink}}
-        {{else}}
-          {{> requestAccess}}
-        {{/if}}
+      {{#if inMyTrash}}
+        {{> grainInMyTrash}}
       {{else}}
-        {{#if notFound}}
-           <p class="grain-not-found grain-interstitial">
-             No grain found with ID "{{grainId}}".
-           </p>
+        {{#if inOwnersTrash}}
+          {{> grainInOwnersTrash}}
         {{else}}
-          <pre>{{error}}</pre>
+          {{#if unauthorized}}
+            {{#if token}}
+              {{> revokedShareLink}}
+            {{else}}
+              {{> requestAccess}}
+            {{/if}}
+          {{else}}
+            {{#if notFound}}
+              <p class="grain-not-found grain-interstitial">
+                No grain found with ID "{{grainId}}".
+              </p>
+            {{else}}
+               <pre>{{error}}</pre>
+            {{/if}}
+          {{/if}}
         {{/if}}
       {{/if}}
     {{else}}
@@ -181,6 +189,24 @@ limitations under the License.
     </div>
   {{/with}}
 </template>
+
+<template name="grainInMyTrash">
+  <div class="grain-interstitial">
+    <p>
+      This grain is in your trash. You cannot access it unless you restore it to your main list.
+    </p>
+    <button class="restore-from-trash">Restore to main list</button>
+  </div>
+</template>
+
+<template name="grainInOwnersTrash">
+  <div class="grain-interstitial">
+    <p>
+      You can no longer access this grain because its owner has moved it to the trash.
+    </p>
+  </div>
+</template>
+
 
 <template name="wrongIdentity">
   <div class="grain-interstitial">
@@ -372,7 +398,7 @@ limitations under the License.
   {{/with}}
 </template>
 <template name="grainDeleteButton">
-  <button class="grain-button" title="{{#if isOwner}}Delete{{else}}Forget{{/if}}" id="deleteGrain">Delete</button>
+  <button class="grain-button" title="Move to trash" id="deleteGrain">Move to trash</button>
 </template>
 <template name="grainDebugLogButton">
   <button class="grain-button" title="Show Debug Log" id="openDebugLog">Log</button>
@@ -708,7 +734,7 @@ limitations under the License.
         popupTemplate="grainSharePopup"}}
   {{/if}}
 
-  {{#if currentUser}}
+  {{#if displayTrashButton}}
     {{>sandstormTopbarItem name="delete" topbar=globalTopbar template="grainDeleteButton"}}
   {{/if}}
 

--- a/shell/client/styles/_app-details.scss
+++ b/shell/client/styles/_app-details.scss
@@ -52,6 +52,35 @@
       }
     }
   }
+
+  >.trash-explanation {
+    display: inline-block;
+    margin-bottom: 4px;
+    margin-top: 20px;
+    width: 100%;
+    font-size: 10pt;
+  }
+
+  >.bulk-action-buttons {
+    @extend %bulk-action-buttons;
+  }
+
+  button.toggle-show-trash {
+    @extend %button-base;
+    @extend %button-secondary;
+  }
+
+  >.no-grains {
+    width: 100%;
+    background-color: white;
+    overflow: hidden;  // don't let margins escape box
+    >p {
+      max-width: 400px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+  }
+
   >table.grain-list-table {
     @extend %grain-table;
   }
@@ -161,7 +190,7 @@
         display: block;
         float: left;
       }
-      >button.uninstall-button, >button.restore-button {
+      >button.uninstall-button, >button.restore-button, >button.toggle-show-trash {
         @extend %button-base;
         @extend %button-secondary;
         display: block;

--- a/shell/client/styles/_grainlist.scss
+++ b/shell/client/styles/_grainlist.scss
@@ -64,6 +64,12 @@
     margin-top: 20px;
     width: 100%;
     font-size: 10pt;
+
+    button.empty-trash {
+      @extend %unstyled-button;
+      color: $sandstorm-purple-color;
+      font-weight: bold;
+    }
   }
   >.buttons {
     float: right;

--- a/shell/client/styles/_grainlist.scss
+++ b/shell/client/styles/_grainlist.scss
@@ -6,7 +6,7 @@
   }
   background-color: $grainlist-background-color;
   color: $grainlist-foreground-color;
-  >.non-usage-info {
+  >.top-row>.non-usage-info {
     float: left;
     @media #{$mobile} {
       float: none;
@@ -22,7 +22,6 @@
     >.search-row {
       display: inline-block;
       vertical-align: top;
-      margin-bottom: 36px;
       @media #{$mobile} {
         margin-bottom: 0;
         display: inline-block;
@@ -55,8 +54,20 @@
       }
     }
   }
+  button.show-trash, >button.show-main-list {
+    @extend %button-base;
+    @extend %button-secondary;
+  }
+  >.trash-explanation {
+    display: inline-block;
+    margin-bottom: 4px;
+    margin-top: 20px;
+    width: 100%;
+    font-size: 10pt;
+  }
   >.buttons {
     float: right;
+    clear: right;
     >button {
       @extend %button-base;
       @extend %button-secondary;
@@ -65,10 +76,12 @@
       font-size: 14pt;
       line-height: 16pt;
       height: 32px;
-      margin-top: 80px;
+      margin-top: 10px;
+      margin-bottom: 10px;
+      margin-left: 10px;
     }
   }
-  >.usage-info {
+  >.top-row>.usage-info {
     float: right;
     vertical-align: top;
     margin: 4px;
@@ -83,6 +96,10 @@
     }
   }
 
+  >.bulk-action-buttons {
+    @extend %bulk-action-buttons;
+  }
+
   >table {
     @extend %grain-table;
   }
@@ -95,6 +112,23 @@
       margin-left: auto;
       margin-right: auto;
     }
+  }
+}
+
+%bulk-action-buttons {
+  float: left;
+  clear: left;
+  >button {
+    @extend %button-base;
+    @extend %button-secondary;
+    display: inline-block;
+    float: left;
+    font-size: 14pt;
+    line-height: 16pt;
+    height: 32px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-right: 10px;
   }
 }
 
@@ -128,6 +162,9 @@
         width: 64px;
         padding-left: 16px;
       }
+      &.select-grain {
+        width: 20px;
+      }
     }
   }
   >tbody>tr {
@@ -139,7 +176,7 @@
     border-left: 1px solid #fff;
     border-right: 1px solid #fff;
     >td {
-      cursor: pointer;
+      position: relative;
       &.td-app-icon {
         >.app-icon {
           @extend %pseudo-img-tag;
@@ -148,6 +185,18 @@
         }
         width: 64px;
         padding-left: 16px;
+        &.in-trash {
+          padding-left: 30px;
+
+          @extend .icon-trash;
+          &::before {
+            position: absolute;
+            left: 4px;
+            top: 4px;
+            font-size: 20px;
+            @extend .icon;
+          }
+        }
       }
       &.last-used {
         width: 100px;
@@ -189,7 +238,9 @@
       }
     }
     &.grain {
-      cursor: pointer;
+      .click-to-go {
+        cursor: pointer;
+      }
       &:hover {
         background-color: $grainlist-table-row-background-color-hover;
       }

--- a/shell/client/styles/_grainlist.scss
+++ b/shell/client/styles/_grainlist.scss
@@ -162,7 +162,7 @@
         width: 64px;
         padding-left: 16px;
       }
-      &.select-grain {
+      &.select-all-grains {
         width: 20px;
       }
     }

--- a/shell/client/styles/_partials.scss
+++ b/shell/client/styles/_partials.scss
@@ -54,6 +54,7 @@
 }
 
 %button-disabled {
+  cursor: auto;
   color: #777777;
   background-color: #efefef;
   border: 1px solid lighten(#afafaf, 10%);

--- a/shell/client/styles/shell.scss
+++ b/shell/client/styles/shell.scss
@@ -204,7 +204,7 @@ button.revoke-token, button.revoke-access {
   align-items: center;
   flex-direction: column;
   background-color: $default-content-background-color;
-  button.request-access, button.incognito-button {
+  button.request-access, button.incognito-button, button.restore-from-trash {
     @extend %button-base;
     @extend %button-primary;
     font-weight: 600;

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -212,6 +212,8 @@ Grains = new Mongo.Collection("grains");
 //   private: If true, then knowledge of `_id` does not suffice to open this grain.
 //   cachedViewInfo: The JSON-encoded result of `UiView.getViewInfo()`, cached from the most recent
 //                   time a session to this grain was opened.
+//   trashed: If present, the Date when this grain was moved to the trash bin. Thirty days after
+//            this date, the grain will be automatically deleted.
 //
 // The following fields *might* also exist. These are temporary hacks used to implement e-mail and
 // web publishing functionality without powerbox support; they will be replaced once the powerbox
@@ -389,6 +391,8 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //   created:   Date when this token was created.
 //   revoked:   If true, then this sturdyref has been revoked and can no longer be restored. It may
 //              become un-revoked in the future.
+//   trashed:   If present, the Date when this token was moved to the trash bin. Thirty days after
+//              this date, the token will be automatically deleted.
 //   expires:   Optional expiration Date. If undefined, the token does not expire.
 //   lastUsed:  Optional Date when this token was last used.
 //   owner:     A `ApiTokenOwner` (defined in `supervisor.capnp`, stored as a JSON object)

--- a/shell/packages/sandstorm-ui-app-details/app-details-client.js
+++ b/shell/packages/sandstorm-ui-app-details/app-details-client.js
@@ -11,6 +11,7 @@ SandstormAppDetails = function (db, quotaEnforcer, appId) {
 
   this._newGrainIsLaunching = new ReactiveVar(false);
   this._showPublisherDetails = new ReactiveVar(false);
+  this._showTrash = new ReactiveVar(false);
 };
 
 const latestPackageForAppId = function (db, appId) {
@@ -59,14 +60,17 @@ const appGrains = function (db, appId) {
                   function (grain) {return grain.appId === appId; });
 };
 
-const filteredSortedGrains = function (db, staticAssetHost, appId, appTitle, filterText) {
+const filteredSortedGrains = function (db, staticAssetHost, appId, appTitle, filterText, showTrash) {
   const pkg = latestPackageForAppId(db, appId);
 
-  const grainsMatchingAppId = appGrains(db, appId);
+  const grainsMatchingAppId = appGrains(db, appId)
+        .filter((grain) => !!grain.trashed == showTrash);
   const tokensForGrain = _.groupBy(db.currentUserApiTokens().fetch(), "grainId");
   const grainIdsForApiTokens = Object.keys(tokensForGrain);
   // grainTokens is a list of all apiTokens, but guarantees at most one token per grain
-  const grainTokens = grainIdsForApiTokens.map(function (grainId) { return tokensForGrain[grainId][0]; });
+  const grainTokens = grainIdsForApiTokens
+        .map(function (grainId) { return tokensForGrain[grainId][0]; })
+      .filter((token) => !!token.trashed == showTrash);
 
   const grainTokensMatchingAppTitle = grainTokens.filter(function (token) {
     const tokenMetadata = token.owner.user.denormalizedGrainMetadata;
@@ -290,7 +294,8 @@ Template.sandstormAppDetailsPage.helpers({
 
   actions: function () {
     const ref = Template.instance().data;
-    if (ref._filter.get()) return []; // Hide actions when searching.
+    if (ref._filter.get()) return [];    // Hide actions when searching.
+    if (ref._showTrash.get()) return []; // Hide actions when viewing trash.
     const pkg = latestPackageForAppId(ref._db, ref._appId);
     if (!pkg) return []; // No package means no actions.
     const appTitle = getAppTitle(ref);
@@ -347,7 +352,19 @@ Template.sandstormAppDetailsPage.helpers({
 
   filteredSortedGrains: function () {
     const ref = Template.instance().data;
-    return filteredSortedGrains(ref._db, ref._staticHost, ref._appId, getAppTitle(ref), ref._filter.get());
+    return filteredSortedGrains(ref._db, ref._staticHost, ref._appId, getAppTitle(ref),
+                                ref._filter.get(), ref._showTrash.get());
+  },
+
+  filteredSortedTrashedGrains: function () {
+    const ref = Template.instance().data;
+    return filteredSortedGrains(ref._db, ref._staticHost, ref._appId, getAppTitle(ref),
+                                ref._filter.get(), true);
+  },
+
+  isFiltering: function () {
+    const ref = Template.instance().data;
+    return !!ref._filter.get();
   },
 
   lastUpdated: function () {
@@ -363,6 +380,11 @@ Template.sandstormAppDetailsPage.helpers({
   showPublisherDetails: function () {
     const ref = Template.instance().data;
     return ref._showPublisherDetails.get();
+  },
+
+  showTrash: function () {
+    const ref = Template.instance().data;
+    return ref._showTrash.get();
   },
 
   keybaseProfile: function () {
@@ -405,6 +427,11 @@ Template.sandstormAppDetailsPage.helpers({
            grain.packageId !== pkg._id);
     });
   },
+
+  bulkActionButtons: function () {
+    const ref = Template.instance().data;
+    return SandstormGrainListPage.bulkActionButtons(ref._showTrash.get());
+  },
 });
 Template.sandstormAppDetailsPage.events({
   "click .restore-button": function (event, instance) {
@@ -430,7 +457,7 @@ Template.sandstormAppDetailsPage.events({
     if (event.keyCode === 13) {
       // Enter pressed.  If a single grain is shown, open it.
       const grains = filteredSortedGrains(ref._db, ref._staticHost, ref._appId,
-                                        getAppTitle(ref), ref._filter.get());
+                                          getAppTitle(ref), ref._filter.get(), ref._showTrash.get());
       if (grains.length === 1) {
         // Unique grain found with current filter.  Activate it!
         const grainId = grains[0]._id;
@@ -462,5 +489,10 @@ Template.sandstormAppDetailsPage.events({
     const ref = Template.instance().data;
     const pkg = latestPackageForAppId(ref._db, ref._appId);
     Meteor.call("upgradeGrains", ref._appId, pkg.manifest.appVersion, pkg._id);
+  },
+
+  "click button.toggle-show-trash": function (event, instance) {
+    const ref = Template.instance().data;
+    ref._showTrash.set(!ref._showTrash.get());
   },
 });

--- a/shell/packages/sandstorm-ui-app-details/app-details-client.js
+++ b/shell/packages/sandstorm-ui-app-details/app-details-client.js
@@ -11,7 +11,7 @@ SandstormAppDetails = function (db, quotaEnforcer, appId) {
 
   this._newGrainIsLaunching = new ReactiveVar(false);
   this._showPublisherDetails = new ReactiveVar(false);
-  this._showTrash = new ReactiveVar(false);
+  this._viewingTrash = new ReactiveVar(false);
 };
 
 const latestPackageForAppId = function (db, appId) {
@@ -60,17 +60,17 @@ const appGrains = function (db, appId) {
                   function (grain) {return grain.appId === appId; });
 };
 
-const filteredSortedGrains = function (db, staticAssetHost, appId, appTitle, filterText, showTrash) {
+const filteredSortedGrains = function (db, staticAssetHost, appId, appTitle, filterText, viewingTrash) {
   const pkg = latestPackageForAppId(db, appId);
 
   const grainsMatchingAppId = appGrains(db, appId)
-        .filter((grain) => !!grain.trashed == showTrash);
+        .filter((grain) => !!grain.trashed == viewingTrash);
   const tokensForGrain = _.groupBy(db.currentUserApiTokens().fetch(), "grainId");
   const grainIdsForApiTokens = Object.keys(tokensForGrain);
   // grainTokens is a list of all apiTokens, but guarantees at most one token per grain
   const grainTokens = grainIdsForApiTokens
         .map(function (grainId) { return tokensForGrain[grainId][0]; })
-      .filter((token) => !!token.trashed == showTrash);
+      .filter((token) => !!token.trashed == viewingTrash);
 
   const grainTokensMatchingAppTitle = grainTokens.filter(function (token) {
     const tokenMetadata = token.owner.user.denormalizedGrainMetadata;
@@ -295,7 +295,7 @@ Template.sandstormAppDetailsPage.helpers({
   actions: function () {
     const ref = Template.instance().data;
     if (ref._filter.get()) return [];    // Hide actions when searching.
-    if (ref._showTrash.get()) return []; // Hide actions when viewing trash.
+    if (ref._viewingTrash.get()) return []; // Hide actions when viewing trash.
     const pkg = latestPackageForAppId(ref._db, ref._appId);
     if (!pkg) return []; // No package means no actions.
     const appTitle = getAppTitle(ref);
@@ -353,7 +353,7 @@ Template.sandstormAppDetailsPage.helpers({
   filteredSortedGrains: function () {
     const ref = Template.instance().data;
     return filteredSortedGrains(ref._db, ref._staticHost, ref._appId, getAppTitle(ref),
-                                ref._filter.get(), ref._showTrash.get());
+                                ref._filter.get(), ref._viewingTrash.get());
   },
 
   filteredSortedTrashedGrains: function () {
@@ -382,9 +382,9 @@ Template.sandstormAppDetailsPage.helpers({
     return ref._showPublisherDetails.get();
   },
 
-  showTrash: function () {
+  viewingTrash: function () {
     const ref = Template.instance().data;
-    return ref._showTrash.get();
+    return ref._viewingTrash.get();
   },
 
   keybaseProfile: function () {
@@ -430,7 +430,7 @@ Template.sandstormAppDetailsPage.helpers({
 
   bulkActionButtons: function () {
     const ref = Template.instance().data;
-    return SandstormGrainListPage.bulkActionButtons(ref._showTrash.get());
+    return SandstormGrainListPage.bulkActionButtons(ref._viewingTrash.get());
   },
 });
 Template.sandstormAppDetailsPage.events({
@@ -457,7 +457,7 @@ Template.sandstormAppDetailsPage.events({
     if (event.keyCode === 13) {
       // Enter pressed.  If a single grain is shown, open it.
       const grains = filteredSortedGrains(ref._db, ref._staticHost, ref._appId,
-                                          getAppTitle(ref), ref._filter.get(), ref._showTrash.get());
+                                          getAppTitle(ref), ref._filter.get(), ref._viewingTrash.get());
       if (grains.length === 1) {
         // Unique grain found with current filter.  Activate it!
         const grainId = grains[0]._id;
@@ -493,6 +493,6 @@ Template.sandstormAppDetailsPage.events({
 
   "click button.toggle-show-trash": function (event, instance) {
     const ref = Template.instance().data;
-    ref._showTrash.set(!ref._showTrash.get());
+    ref._viewingTrash.set(!ref._viewingTrash.get());
   },
 });

--- a/shell/packages/sandstorm-ui-app-details/app-details.html
+++ b/shell/packages/sandstorm-ui-app-details/app-details.html
@@ -9,6 +9,7 @@
 
   <div class="app-details{{#if isAppInDevMode}} dev-background{{/if}}">
     {{>sandstormAppDetails
+       showTrash=showTrash
        showPublisherDetails=showPublisherDetails
        showUninstall=isAppNotInDevMode
        showRestoreGrainBackup=true
@@ -37,7 +38,30 @@
       </label>
     </div>
 
-    {{>sandstormGrainTable grains=filteredSortedGrains actions=actions onGrainClicked=onGrainClicked _db=_db showHintIfEmpty=1}}
+    {{#if showTrash}}
+      <p class="trash-explanation">
+        Grains will be permanently removed after 30 days in the Trash. To keep a grain,
+        restore it to the Main list.
+      </p>
+    {{/if}}
+
+    {{#let grains=filteredSortedGrains}}
+      {{>sandstormGrainTable grains=grains actions=actions
+                             onGrainClicked=onGrainClicked _db=_db showHintIfEmpty=1
+                             bulkActionButtons=bulkActionButtons}}
+      {{#unless grains}}
+        {{#if isFiltering}}
+          <div class="no-grains">
+            <p><strong>No matching grains found.</strong></p>
+            {{#if filteredSortedTrashedGrains}}
+              <p>Some grains in your trash match your search.
+               <button class="toggle-show-trash">View Trash</button>
+              </p>
+            {{/if}}
+          </div>
+        {{/if}}
+      {{/unless}}
+    {{/let}}
   </div>
   {{/if}}
 </template>
@@ -63,6 +87,10 @@
         {{#if bugReportLink}}<li role="presentation"><a class="bug-report-link" target="_blank" href="{{bugReportLink}}">Report Issue</a></li>{{/if}}
       </ul>
       <div class="info-row">
+        <button class="toggle-show-trash">
+          {{#if showTrash}}View Main list{{else}}View Trash{{/if}}
+        </button>
+
         {{#if showUninstall}}
         <button class="uninstall-button">Uninstall</button>
         {{/if}}

--- a/shell/packages/sandstorm-ui-app-details/app-details.html
+++ b/shell/packages/sandstorm-ui-app-details/app-details.html
@@ -9,8 +9,9 @@
 
   <div class="app-details{{#if isAppInDevMode}} dev-background{{/if}}">
     {{>sandstormAppDetails
-       showTrash=showTrash
        showPublisherDetails=showPublisherDetails
+       viewingTrash=viewingTrash
+       showToggleTrash=true
        showUninstall=isAppNotInDevMode
        showRestoreGrainBackup=true
        pkg=pkg
@@ -38,7 +39,7 @@
       </label>
     </div>
 
-    {{#if showTrash}}
+    {{#if viewingTrash}}
       <p class="trash-explanation">
         Grains will be permanently removed after 30 days in the Trash. To keep a grain,
         restore it to the Main list.
@@ -69,6 +70,7 @@
 <template name="sandstormAppDetails">
   {{!-- Arguments to this template are:
        showPublisherDetails: Boolean.  Show Keybase/PGP infomation.
+       showToggleTrash: Boolean. Show the 'view trash' / 'view main list' button.
        showUninstall: Boolean.  Show the uninstall button.
        showRestoreGrainBackup: Boolean.  Show the "Restore grain backup" button.
        pkg: Object shaped like an element from the Packages collection.
@@ -87,9 +89,11 @@
         {{#if bugReportLink}}<li role="presentation"><a class="bug-report-link" target="_blank" href="{{bugReportLink}}">Report Issue</a></li>{{/if}}
       </ul>
       <div class="info-row">
-        <button class="toggle-show-trash">
-          {{#if showTrash}}View Main list{{else}}View Trash{{/if}}
-        </button>
+        {{#if showToggleTrash}}
+          <button class="toggle-show-trash">
+            {{#if viewingTrash}}View Main list{{else}}View Trash{{/if}}
+          </button>
+        {{/if}}
 
         {{#if showUninstall}}
         <button class="uninstall-button">Uninstall</button>

--- a/shell/packages/sandstorm-ui-app-install/install.html
+++ b/shell/packages/sandstorm-ui-app-install/install.html
@@ -48,6 +48,7 @@
         <h1>Install {{ appTitle }}?</h1>
         {{> sandstormAppDetails
            showPublisherDetails=true
+           showToggleTrash=false
            showUninstall=false
            showRestoreGrainBackup=false
            pkg=pkg

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -202,6 +202,10 @@ Template.sandstormGrainListPage.helpers({
     return Template.instance().data._db.currentUserGrains().count();
   },
 
+  trashCount: function () {
+    return filteredSortedGrains(true).length;
+  },
+
   hasAnyGrainsCreatedOrSharedWithMe: function () {
     const _db = Template.instance().data._db;
     return !!(_db.currentUserGrains().count() ||

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -357,6 +357,14 @@ Template.sandstormGrainTable.events({
     }
   },
 
+  "click td.select-grain": function (event, instance) {
+    if (event.target.tagName === "TD") {
+      // Assume the user meant to click on the actual checkbox.
+      const el = instance.find("td.select-grain>input[data-grainid='" + this._id + "']");
+      el.click();
+    }
+  },
+
   "click .bulk-action-buttons>button": function (event, instance) {
     const ownedGrainIds = [];
     instance.findAll(".select-grain.mine>input:checked").forEach((x) => {

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.html
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.html
@@ -29,7 +29,7 @@
       {{#if showTrash }}
         <button class="show-main-list">View Main list</button>
       {{else}}
-        <button class="show-trash">View Trash</button>
+        <button class="show-trash">View Trash ({{trashCount}})</button>
       {{/if}}
 
       <button class="restore-button">Restore backup...

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.html
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.html
@@ -51,10 +51,14 @@
               </p>
             {{/if}}
           {{else}}
-            <p><strong>You have no grains.</strong></p>
-            <p>A grain is an instance of a Sandstorm app. A grain might be a document, a chat room,
-              a mail box, a notebook, a blog, or more.</p>
-            <p><a href="{{ pathFor route='apps' }}">Install apps now to start creating.</a></p>
+            {{#if showTrash}}
+              <p><strong>Trash is empty.</strong></p>
+            {{else}}
+              <p><strong>You have no grains.</strong></p>
+              <p>A grain is an instance of a Sandstorm app. A grain might be a document, a chat room,
+                a mail box, a notebook, a blog, or more.</p>
+              <p><a href="{{ pathFor route='apps' }}">Install apps now to start creating.</a></p>
+            {{/if}}
           {{/if}}
         </div>
       {{/unless}}

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.html
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.html
@@ -128,7 +128,8 @@
         {{#each grains}}
         <tr class="grain" data-grainid="{{ _id }}">
           <td class="select-grain {{#if isOwnedByMe}}mine{{else}}shared{{/if}}">
-            <input type="checkbox" data-grainid="{{ _id }}" checked={{isChecked}}>
+            <input title="select this grain"
+                   type="checkbox" data-grainid="{{ _id }}" checked={{isChecked}}>
           </td>
           <td class="td-app-icon click-to-go {{#if trashed}}in-trash{{/if}}">
             <div class="app-icon" title="{{appTitle}}"

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.html
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.html
@@ -2,6 +2,7 @@
   {{setDocumentTitle}}
   {{#sandstormTopbarItem name="title" priority=5 topbar=globalTopbar }}Grains{{/sandstormTopbarItem}}
   <div class="grain-list">
+    <div class="top-row">
     <div class="non-usage-info">
     <h1>Grains</h1>
     <div class="search-row">
@@ -17,26 +18,47 @@
         <p class="grains-size"><strong>My grains' total size:</strong> {{ myGrainsSize }}</p>
       {{/if}}
     </div>
+    </div>
+    {{#if showTrash}}
+      <p class="trash-explanation">
+        Grains will be permanently removed after 30 days in the Trash. To keep a grain,
+        restore it to the Main list.
+      </p>
+    {{/if}}
     <div class="buttons">
-      <button class='restore-button'>Restore backup...
+      {{#if showTrash }}
+        <button class="show-main-list">View Main list</button>
+      {{else}}
+        <button class="show-trash">View Trash</button>
+      {{/if}}
+
+      <button class="restore-button">Restore backup...
         <input type="file" style="display:none" accept=".zip">
       </button>
     </div>
 
-    {{>sandstormGrainTable grains=filteredSortedGrains onGrainClicked=onGrainClicked}}
+    {{#let grains=filteredSortedGrains}}
+      {{>sandstormGrainTable grains=grains onGrainClicked=onGrainClicked
+                             bulkActionButtons=bulkActionButtons}}
 
-    {{#unless hasAnyGrainsCreatedOrSharedWithMe}}
-      {{#if Template.subscriptionsReady}}
+      {{#unless grains}}
         <div class="no-grains">
-          <p><strong>You have no grains.</strong></p>
-
-          <p>A grain is an instance of a Sandstorm app. A grain might be a document, a chat room,
-            a mail box, a notebook, a blog, or more.</p>
-
-          <p><a href="{{ pathFor route='apps' }}">Install apps now to start creating.</a></p>
+          {{#if searchText}}
+            <p><strong>No matching grains found.</strong></p>
+            {{#if filteredSortedTrashedGrains}}
+              <p>Some grains in your trash match your search.
+               <button class="show-trash">View Trash</button>
+              </p>
+            {{/if}}
+          {{else}}
+            <p><strong>You have no grains.</strong></p>
+            <p>A grain is an instance of a Sandstorm app. A grain might be a document, a chat room,
+              a mail box, a notebook, a blog, or more.</p>
+            <p><a href="{{ pathFor route='apps' }}">Install apps now to start creating.</a></p>
+          {{/if}}
         </div>
-      {{/if}}
-    {{/unless}}
+      {{/unless}}
+    {{/let}}
   </div>
 </template>
 
@@ -48,7 +70,8 @@
     iconSrc: String,
     title: String,
     lastUsed: Date,
-    isOwnedByMe: Boolean
+    isOwnedByMe: Boolean,
+    trashed: Optional(Date),
   }
   and (optionally):
   * a list "actions" containing objects with shape:
@@ -57,12 +80,33 @@
       onClick: parameterless callback function
     }, and/or
   * an onGrainClicked callback function, which takes a single argument grainId as a String
-
+  * a list "bulkActionButtons" containing object with shape
+    {
+      buttonClass: a string to be used in the button's class attribute
+      text(numMyGrainsSelected, numSharedWithMeGrainsSelected): function that returns a string
+         that will be displayed as the button's text.
+      disabled(numMyGrainsSelected, numSharedWithMeGrainsSelected): function that returns a
+         boolean, indicating whether the button should be diabled
+      onClicked(myGrainIds, sharedWithMeGrainIds): function that performs the action on the
+         selected grains.
+    }
   Future work: callbacks for requesting different sort orders?
   --}}
+  {{#let buttons=bulkActionButtons mine=mineSelected shared=sharedSelected}}
+  <div class="bulk-action-buttons">
+    {{#each buttons}}
+    <button class={{buttonClass}} disabled={{disabled mine shared}}
+            title="{{#if disabled mine shared}}To perform bulk actions, you must first select some grains in the list.{{else}}{{text mine shared}}{{/if}}">
+      {{text mine shared}}
+    </button>
+    {{/each}}
+  </div>
+  {{/let}}
+
     <table class="grain-list-table">
       <thead>
         <tr>
+            <td class="select-grain"></td>
             <td class="td-app-icon"></td>
             <td class="grain-name">Name</td>
             <td class="last-used">Last Activity</td>
@@ -76,14 +120,22 @@
       <tbody>
         {{#each actions}}
         <tr class="action">
+          <td class="select-grain"></td>
           <td class="td-app-icon"><div class="new-grain-icon"></div></td>
           <td class="action-button" colspan="3"><button class="action">{{buttonText}}</button></td>
         </tr>
         {{/each}}
         {{#each grains}}
         <tr class="grain" data-grainid="{{ _id }}">
-          <td class="td-app-icon"><div class="app-icon" title="{{appTitle}}" style="background-image: url('{{ iconSrc }}');"></div></td>
-          <td class="grain-name">
+          <td class="select-grain {{#if isOwnedByMe}}mine{{else}}shared{{/if}}">
+            <input type="checkbox" data-grainid="{{ _id }}" checked={{isChecked}}>
+          </td>
+          <td class="td-app-icon click-to-go {{#if trashed}}in-trash{{/if}}">
+            <div class="app-icon" title="{{appTitle}}"
+                 style="background-image: url('{{ iconSrc }}');">
+            </div>
+          </td>
+          <td class="grain-name click-to-go">
             <a href="{{ pathFor route='grain' grainId=_id }}">{{title}}</a>
             {{#with was}}
               (was: {{.}})
@@ -92,8 +144,8 @@
               (renamed from: {{.}})
             {{/with}}
           </td>
-          <td class="last-used">{{dateString lastUsed}}</td>
-          <td class="shared-or-owned">{{#if isOwnedByMe }}My grain{{else}}Shared with me{{/if}}</td>
+          <td class="last-used click-to-go">{{dateString lastUsed}}</td>
+          <td class="shared-or-owned click-to-go">{{#if isOwnedByMe }}My grain{{else}}Shared with me{{/if}}</td>
           {{!-- Collaborators, size TODO
           <td>TODO: collaborators</td>
           <td>{{ size }}</td>

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.html
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.html
@@ -21,8 +21,9 @@
     </div>
     {{#if showTrash}}
       <p class="trash-explanation">
-        Grains will be permanently removed after 30 days in the Trash. To keep a grain,
-        restore it to the Main list.
+        <button class="empty-trash">Empty all Trash</button>
+        (Grains will be permanently removed after 30 days in the Trash. To keep a grain,
+        restore it to the Main list.)
       </p>
     {{/if}}
     <div class="buttons">

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.html
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.html
@@ -106,7 +106,9 @@
     <table class="grain-list-table">
       <thead>
         <tr>
-            <td class="select-grain"></td>
+            <td class="select-all-grains">
+              <input title={{selectAllTitle}} type="checkbox">
+            </td>
             <td class="td-app-icon"></td>
             <td class="grain-name">Name</td>
             <td class="last-used">Last Activity</td>

--- a/shell/packages/sandstorm-ui-grainlist/package.js
+++ b/shell/packages/sandstorm-ui-grainlist/package.js
@@ -21,7 +21,7 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.use("ecmascript");
-  api.use(["check", "reactive-var", "reload", "templating", "tracker", "sandstorm-db", "sandstorm-identicons", "sandstorm-ui-topbar", "underscore"], "client");
+  api.use(["check", "reactive-dict", "reactive-var", "reload", "templating", "tracker", "sandstorm-db", "sandstorm-identicons", "sandstorm-ui-topbar", "underscore"], "client");
   api.addFiles(["grainlist.html", "grainlist-client.js"], "client");
   api.export("SandstormGrainListPage");
 });

--- a/shell/packages/sandstorm-ui-grainview/grainview.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview.js
@@ -809,6 +809,26 @@ GrainView = class GrainView {
       },
     };
   }
+
+  isInMyTrash() {
+    this._dep.depend();
+    const grain = this._db.collections.grains.findOne({ _id: this._grainId });
+
+    if (this._token) {
+      return false;
+    } else if (grain && Meteor.userId() === grain.userId) {
+      return !!grain.trashed;
+    } else {
+      const token = this._db.collections.apiTokens.findOne({
+        _id: this._grainId, });
+      const myIdentityIds = SandstormDb.getUserIdentityIds(Meteor.user());
+      return !!this._db.collections.apiTokens.findOne({
+        grainId: this._grainId,
+        "owner.user.identityId": { $in: myIdentityIds },
+        trashed: { $exists: true },
+      });
+    }
+  }
 };
 
 onceConditionIsTrue = (condition, continuation) => {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -294,8 +294,11 @@ Meteor.methods({
       throw new Meteor.Error(403, "Current user does not own the identity: " + identityId);
     }
 
-    if (!Grains.findOne({ _id: grainId })) {
+    const grain = Grains.findOne({ _id: grainId });
+    if (!grain) {
       throw new Meteor.Error(404, "Grain not found", "Grain ID: " + grainId);
+    } else if (grain.trashed) {
+      throw new Meteor.Error("grain-is-in-trash", "Grain is in trash", "Grain ID: " + grainId);
     }
 
     const db = this.connection.sandstormDb;

--- a/tests/tests/trash.js
+++ b/tests/tests/trash.js
@@ -1,0 +1,144 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+"use strict";
+
+var utils = require("../utils"),
+    short_wait = utils.short_wait,
+    medium_wait = utils.medium_wait,
+    long_wait = utils.long_wait,
+    very_long_wait = utils.very_long_wait;
+var expectedHackerCMSGrainTitle = "Untitled Hacker CMS site";
+var expectedGitWebGrainTitle = "Untitled GitWeb repository";
+var hackerCmsAppId = "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh";
+
+module.exports["Test grain trash"] = function (browser) {
+  var firstUserName;
+  var grainUrl;
+  var grainId;
+  var grainCheckboxSelector;
+
+  browser
+    .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
+                hackerCmsAppId)
+    .getDevName(function (result) {
+      firstUserName = result.value;
+    })
+    .waitForElementVisible('.grain-frame', medium_wait)
+    .url(function (urlResponse) {
+      grainUrl = urlResponse.value;
+      grainId = grainUrl.split("/").pop();
+      grainCheckboxSelector = ".grain-list td.select-grain input[data-grainid='" + grainId + "']";
+    })
+    .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
+    .waitForElementVisible('.topbar .share > .show-popup', short_wait)
+    .click('.topbar .share > .show-popup')
+    .waitForElementVisible("#shareable-link-tab-header", short_wait)
+    .click("#shareable-link-tab-header")
+    .waitForElementVisible(".new-share-token", short_wait)
+    .submitForm('.new-share-token')
+    .waitForElementVisible('#share-token-text', medium_wait)
+
+    .getText('#share-token-text', function(tokenResponse) {
+      browser
+        .loginDevAccount(null, false, function (secondUserName) {
+          browser
+            .url(tokenResponse.value)
+            .waitForElementVisible("button.pick-identity", short_wait)
+            .click("button.pick-identity")
+            .waitForElementVisible('.grain-frame', medium_wait)
+            .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
+            .frame('grain-frame')
+            .waitForElementPresent('#publish', medium_wait)
+            .assert.containsText('#publish', 'Publish')
+            .frame(null)
+
+            .waitForElementVisible(".navitem-open-grain>a", short_wait)
+            .click(".navitem-open-grain>a")
+            .waitForElementVisible(grainCheckboxSelector, medium_wait)
+            .click(grainCheckboxSelector)
+            .click(".bulk-action-buttons button.move-to-trash")
+            .click("button.show-trash")
+            .waitForElementVisible(grainCheckboxSelector, short_wait)
+            .click("button.show-main-list")
+            .waitForElementVisible("button.show-trash", short_wait)
+            .assert.elementNotPresent(grainCheckboxSelector)
+            .click(".navbar-grains>li[data-grainid='" + grainId + "']")
+            .waitForElementVisible(".grain-interstitial", short_wait)
+            .assert.containsText(".grain-interstitial>p", "This grain is in your trash.")
+            .click("button.restore-from-trash")
+            .waitForElementVisible('.grain-frame', medium_wait)
+            .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
+            .frame('grain-frame')
+            .waitForElementPresent('#publish', medium_wait)
+            .assert.containsText('#publish', 'Publish')
+            .frame(null)
+
+            .loginDevAccount(firstUserName)
+            .url(grainUrl)
+            .waitForElementVisible(".navitem-open-grain>a", short_wait)
+            .click(".navitem-open-grain>a")
+            .waitForElementVisible(grainCheckboxSelector, medium_wait)
+            .click(grainCheckboxSelector)
+            .click(".bulk-action-buttons button.move-to-trash")
+            .click("button.show-trash")
+            .waitForElementVisible(grainCheckboxSelector, short_wait)
+            .click("button.show-main-list")
+            .waitForElementVisible("button.show-trash", short_wait)
+            .assert.elementNotPresent(grainCheckboxSelector)
+            .click(".navbar-grains>li[data-grainid='" + grainId + "']")
+            .waitForElementVisible(".grain-interstitial", short_wait)
+            .assert.containsText(".grain-interstitial>p", "This grain is in your trash.")
+
+            .loginDevAccount(secondUserName)
+            .url(grainUrl)
+            .waitForElementVisible(".grain-interstitial", short_wait)
+            .assert.containsText(".grain-interstitial>p",
+                                 "You can no longer access this grain because its owner has moved it to the trash.")
+
+            .click(".navitem-open-grain>a")
+            .waitForElementVisible(grainCheckboxSelector, short_wait)
+            .click(grainCheckboxSelector)
+            .click(".bulk-action-buttons button.move-to-trash")
+            .click("button.show-trash")
+            .waitForElementVisible(grainCheckboxSelector, medium_wait)
+            .click(grainCheckboxSelector)
+            .click(".bulk-action-buttons button.remove-permanently")
+            .click("button.show-main-list")
+            .waitForElementVisible("button.show-trash", short_wait)
+            .assert.elementNotPresent(grainCheckboxSelector)
+            .click("button.show-trash")
+            .waitForElementVisible("button.show-main-list", short_wait)
+            .assert.elementNotPresent(grainCheckboxSelector)
+
+            .loginDevAccount(firstUserName)
+            .waitForElementVisible(".navitem-open-grain>a", short_wait)
+            .click(".navitem-open-grain>a")
+            .waitForElementVisible("button.show-trash", medium_wait)
+            .click("button.show-trash")
+            .waitForElementVisible(grainCheckboxSelector, medium_wait)
+            .click(grainCheckboxSelector)
+            .click(".bulk-action-buttons button.remove-permanently")
+            .click("button.show-main-list")
+            .waitForElementVisible("button.show-trash", short_wait)
+            .assert.elementNotPresent(grainCheckboxSelector)
+            .click("button.show-trash")
+            .waitForElementVisible("button.show-main-list", short_wait)
+            .assert.elementNotPresent(grainCheckboxSelector)
+            .end()
+        });
+    });
+}


### PR DESCRIPTION
This implements most of #1915.

The grain list looks like: 
![grains](https://cloud.githubusercontent.com/assets/495768/15087843/d79731a4-13ba-11e6-9ba8-dec212c94313.png)

When you click "View Trash", you get:
![trash](https://cloud.githubusercontent.com/assets/495768/15087845/e919eb24-13ba-11e6-9366-f20d413d0749.png)

The "Delete permanently" button updates its text depending on what's selected. If only "shared with me grains" are selected, it says "Forget permanently". If both kinds of grains are selected, it says "Delete/forget permanently".
![forget](https://cloud.githubusercontent.com/assets/495768/15087868/2376c79c-13bb-11e6-9de5-6d874c2399c3.png)

The app details page gets a similar update:
![app-details](https://cloud.githubusercontent.com/assets/495768/15087946/c8f667a4-13bb-11e6-8bf6-171810932064.png)


If you search for something in the main list and matches only exist in the trash list, you get a pointer like this: 
![no-match](https://cloud.githubusercontent.com/assets/495768/15087883/501119ce-13bb-11e6-8d5d-9dcd729a21d9.png)

If you try to open a grain that is in your trash, you get an error page like this:
![in-trash-interstitial](https://cloud.githubusercontent.com/assets/495768/15087900/6e36a84c-13bb-11e6-9cda-7491b7dc7760.png)

If you try to open a grain that is not owned by you and is in its owner's trash, you get an error page like this: 
![owner-trash](https://cloud.githubusercontent.com/assets/495768/15087927/a47d52ca-13bb-11e6-988d-23e6ccbf2156.png)

This also updates the permissions computation so that when a grain gets trashed or deleted, any sessions that depended on that grain are immediately closed.



