### PR TITLE
New Admin: System Status page

### DIFF
--- a/shell/client/admin/system-status-client.js
+++ b/shell/client/admin/system-status-client.js
@@ -64,9 +64,7 @@ Template.newAdminLog.onCreated(function () {
   // possible for the viewport to no longer be "scrolled to the bottom".  This event listener
   // makes sure that we do the right thing as the window resizes.
   window.addEventListener("resize", this.resizeHandler);
-  globalInstance = this;
 });
-
 
 Template.newAdminLog.onRendered(function () {
   // On initial render, force scroll to the bottom.
@@ -104,7 +102,7 @@ Template.newAdminLog.helpers({
     return () => {
       instance.maybeScrollToBottom();
     };
-  }
+  },
 });
 
 Template.newAdminStatus.onCreated(function () {

--- a/shell/client/admin/system-status-client.js
+++ b/shell/client/admin/system-status-client.js
@@ -1,4 +1,130 @@
+import { Meteor } from "meteor/meteor";
+import { Mongo } from "meteor/mongo";
+import { Template } from "meteor/templating";
+import downloadFile from "/imports/client/download-file.js";
+import getBuildInfo from "/imports/client/build-info.js";
+
+// Pseudocollection holding number of grains with open sessions and accounts with open sessions.
 const systemStatus = new Mongo.Collection("systemStatus");
+
+// This is some logic to make the log scroll to the bottom by default and also stick there.  It is
+// two template and more complicated than it needs to be because Blaze lacks the appropriate set
+// of lifecycle hooks to make it more straightforward.
+//
+// Some events will not trigger when you need them to - if you want to take an action on the DOM any
+// time a child calls a template helper, `onRendered` isn't going to cut it, because the parent
+// template isn't actually considered to be changing.  This is an artifact of opaquely sideloading
+// data through ReactiveVars, which are how Blaze's data context passes information around.
+//
+// Other events trigger before you want them to - a child template's `onRendered`, for instance,
+// will fire before the parent can reference things like `lastNode`.  So you can't just naively
+// have the child notify the parent on render or even data context change.
+//
+// The hack, then, is to store a boolean `renderedYet` in the parent (which controls the scroll
+// height) and guard any DOM interactions on that being true, and to split the content out into a
+// second template, so the content template can ask its parent template to run its hook whenever the
+// data context changes.  This is ugly, but appears to both work and not trigger any exceptions.
+Template.newAdminLogContents.onRendered(function () {
+  this.autorun(() => {
+    Template.currentData(); // establish reactive dependency on currentData
+    this.data.onRenderedHook && this.data.onRenderedHook();
+  });
+});
+
+Template.newAdminLog.onCreated(function () {
+  this.shouldScroll = true;
+  this.renderedYet = false;
+
+  this.forceScrollBottom = () => {
+    this.lastNode.scrollTop = this.lastNode.scrollHeight;
+    this.shouldScroll = true;
+  };
+
+  this.maybeScrollToBottom = () => {
+    if (this.shouldScroll && this.renderedYet) {
+      this.forceScrollBottom();
+    }
+  };
+
+  this.saveShouldScroll = () => {
+    // Save whether the current scrollTop is equal to the ~maximum scrollTop.
+    // If so, then we should make the log "stick" to the bottom, by manually scrolling to the bottom
+    // when needed.
+    messagePane = this.lastNode;
+
+    // Include a 5px fudge factor to account for bad scrolling and fractional pixels.
+    this.shouldScroll = (messagePane.clientHeight + messagePane.scrollTop + 5 >= messagePane.scrollHeight);
+  };
+
+  this.resizeHandler = (evt) => {
+    this.maybeScrollToBottom();
+  };
+
+  // As the window resizes, the space allocated to this template may grow, which would make it
+  // possible for the viewport to no longer be "scrolled to the bottom".  This event listener
+  // makes sure that we do the right thing as the window resizes.
+  window.addEventListener("resize", this.resizeHandler);
+  globalInstance = this;
+});
+
+
+Template.newAdminLog.onRendered(function () {
+  // On initial render, force scroll to the bottom.
+  if (!this.renderedYet) {
+    this.renderedYet = true;
+    this.maybeScrollToBottom();
+  }
+});
+
+Template.newAdminLog.onDestroyed(function () {
+  window.removeEventListener("resize", this.resizeHandler);
+});
+
+Template.newAdminLog.events({
+  "scroll .admin-log-box"(evt) {
+    const instance = Template.instance();
+    instance.saveShouldScroll();
+  },
+});
+
+Template.newAdminLog.helpers({
+  logHtml() {
+    // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+    return AnsiUp.ansi_to_html(
+      AdminLog.find({}, { $sort: { _id: 1 } })
+          .map(entry => entry.text)
+          .join(""),
+      { use_classes: true }
+    );
+    // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
+  },
+
+  maybeScrollToBottom() {
+    const instance = Template.instance();
+    return () => {
+      instance.maybeScrollToBottom();
+    };
+  }
+});
+
+Template.newAdminStatus.onCreated(function () {
+  this.subscribe("adminLog");
+  this.subscribe("systemStatus");
+  // global exported from lib/demo.js
+  if (allowDemo) {
+    this.subscribe("adminDemoUsers");
+  }
+  // We keep a reference date in a ReactiveVar so that we can update it ever so often and the demo
+  // user count will reflect users that are still not expired at the current time.
+  this.referenceDate = new ReactiveVar(new Date());
+  this.intervalHandle = window.setInterval(() => {
+    this.referenceDate.set(new Date());
+  }, 60000);
+});
+
+Template.newAdminStatus.onDestroyed(function () {
+  window.clearInterval(this.intervalHandle);
+});
 
 Template.newAdminStatus.helpers({
   grainsActive() {
@@ -11,23 +137,40 @@ Template.newAdminStatus.helpers({
     return data && data.activeUsers || 0;
   },
 
-  sandstormVersion() {
-    return "0.147";
+  allowDemo() {
+    // global exported from lib/demo.js
+    return allowDemo;
   },
 
-  logHtml() {
-    // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
-    return AnsiUp.ansi_to_html(
-      AdminLog.find({}, { $sort: { _id: 1 } })
-          .map(entry => entry.text)
-          .join(""),
-      { use_classes: true }
-    );
-    // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
+  demosActive() {
+    const instance = Template.instance();
+    const query = globalDb.collections.users.find({
+      expires: {
+        $gt: instance.referenceDate.get(),
+      },
+      loginIdentities: {
+        $exists: true,
+      },
+    });
+    return query.count();
+  },
+
+  sandstormVersion() {
+    const buildInfo = getBuildInfo();
+    return buildInfo.build;
   },
 });
 
-Template.newAdminStatus.onCreated(function () {
-  this.subscribe("adminLog");
-  this.subscribe("systemStatus");
+Template.newAdminStatus.events({
+  "click button[name=download-full-log]"(evt) {
+    Meteor.call("adminGetServerLogDownloadToken", (err, token) => {
+      if (err) {
+        console.log(err.message);
+      } else {
+        const url = "/admin/status/server-log/" + token;
+        const suggestedFilename = "sandstorm.log";
+        downloadFile(url, suggestedFilename);
+      }
+    });
+  },
 });

--- a/shell/client/admin/system-status.html
+++ b/shell/client/admin/system-status.html
@@ -1,12 +1,41 @@
+<template name="newAdminLogContents">
+  <pre>...{{{logHtml}}}</pre>
+</template>
+
+<template name="newAdminLog">
+  <div class="admin-log-box" aria-live="polite">
+    {{> newAdminLogContents logHtml=logHtml onRenderedHook=maybeScrollToBottom }}
+  </div>
+</template>
+
 <template name="newAdminStatus">
   <h1>System Status</h1>
 
-  <h2>Current Usage</h2>
-  <p>{{grainsActive}} open grains</p>
-  <p>{{usersActive}} users with grains open</p>
-
-  <h2>System Log</h2>
-  <div class="admin-log-box" aria-live="polite">
-    <pre>...{{{logHtml}}}</pre>
+  <div class="admin-status-row">
+    <div class="current-usage">
+      <h2>Current Usage</h2>
+      <ul>
+        <li>Grains open: {{grainsActive}}</li>
+        <li>User accounts with grains open: {{usersActive}}</li>
+        {{#if allowDemo}}
+          <li>Demo accounts active: {{demosActive}}</li>
+        {{/if}}
+      </ul>
+    </div>
+    <div class="version">
+      <h2>Sandstorm Version</h2>
+      <p>{{#linkTo route="about" }}{{ sandstormVersion }}{{/linkTo}}</p>
+    </div>
   </div>
+
+  <h2 class="system-log-header">
+    <span>System Log</span>
+    <form>
+      <button type="button" name="download-full-log">
+        Download full log
+      </button>
+    </form>
+  </h2>
+
+  {{> newAdminLog }}
 </template>

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -16,6 +16,8 @@
 
 // This file implements /grain, i.e. the main view into an app.
 
+import downloadFile from "/imports/client/download-file.js";
+
 // Pseudo-collections.
 TokenInfo = new Mongo.Collection("tokenInfo");
 // TokenInfo is used by grainview.js
@@ -176,24 +178,9 @@ Template.grainBackupButton.events({
       if (err) {
         alert("Backup failed: " + err); // TODO(someday): make this better UI
       } else {
-        // Firefox for some reason decides to kill all websockets when we try to download the file
-        // by navigating there. So we're left doing a dirty hack to get around the popup blocker.
-        const isFirefox = typeof InstallTrigger !== "undefined";
-
-        if (isFirefox) {
-          const save = document.createElement("a");
-          save.href = "/downloadBackup/" + id;
-
-          save.download = activeGrain.title() + ".zip";
-          const event = document.createEvent("MouseEvents");
-          event.initMouseEvent(
-                  "click", true, false, window, 0, 0, 0, 0, 0,
-                  false, false, false, false, 0, null
-          );
-          save.dispatchEvent(event);
-        } else {
-          window.location = "/downloadBackup/" + id;
-        }
+        const url = "/downloadBackup/" + id;
+        const suggestedFilename = activeGrain.title() + ".zip";
+        downloadFile(url, suggestedFilename);
       }
     });
   },

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -17,6 +17,8 @@
 // This file implements the common shell components such as the top bar.
 // It also covers the root page.
 
+import getBuildInfo from "/imports/client/build-info.js";
+
 // Subscribe to basic grain information first and foremost, since
 // without it we might e.g. redirect to the wrong place on login.
 globalSubs = [
@@ -771,21 +773,6 @@ if (Meteor.isClient) {
   Router.onBeforeAction("loading");
 }
 
-function getBuildInfo() {
-  let build = Meteor.settings && Meteor.settings.public && Meteor.settings.public.build;
-  const isNumber = typeof build === "number";
-  if (!build) {
-    build = "(unknown)";
-  } else if (isNumber) {
-    build = String(Math.floor(build / 1000)) + "." + String(build % 1000);
-  }
-
-  return {
-    build: build,
-    isUnofficial: !isNumber,
-  };
-}
-
 const promptForFile = function (input, callback) {
   // TODO(cleanup): Share code with "upload picture" and other upload buttons.
   function listener(e) {
@@ -1005,4 +992,3 @@ Router.map(function () {
     path: "/account/usage",
   });
 });
-

--- a/shell/client/styles/_admin-status.scss
+++ b/shell/client/styles/_admin-status.scss
@@ -1,6 +1,36 @@
+.admin-status-row {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
+
+  .current-usage {
+    flex: 1 1 50%;
+  }
+
+  .version {
+    flex: 1 1 50%;
+  }
+}
+
+.system-log-header {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  justify-content: space-between;
+  button {
+    @extend %button-base;
+    @extend %button-primary;
+  }
+}
+
 .admin-log-box {
   max-height: 60vh;
   overflow: scroll;
   background-color: white;
   border: 1px solid #ccc;
+
+  pre {
+    white-space: pre-wrap;
+  }
 }

--- a/shell/imports/client/build-info.js
+++ b/shell/imports/client/build-info.js
@@ -1,0 +1,18 @@
+import { Meteor } from "meteor/meteor";
+
+function getBuildInfo() {
+  let build = Meteor.settings && Meteor.settings.public && Meteor.settings.public.build;
+  const isNumber = typeof build === "number";
+  if (!build) {
+    build = "(unknown)";
+  } else if (isNumber) {
+    build = String(Math.floor(build / 1000)) + "." + String(build % 1000);
+  }
+
+  return {
+    build: build,
+    isUnofficial: !isNumber,
+  };
+}
+
+export default getBuildInfo;

--- a/shell/imports/client/download-file.js
+++ b/shell/imports/client/download-file.js
@@ -1,0 +1,21 @@
+function downloadFile(url, suggestedFilename) {
+  // Firefox for some reason decides to kill all websockets when we try to download the file
+  // by navigating there. So we're left doing a dirty hack to get around the popup blocker.
+  const isFirefox = typeof InstallTrigger !== "undefined";
+  if (isFirefox) {
+    const save = document.createElement("a");
+    save.href = url;
+
+    save.download = suggestedFilename;
+    const evt = document.createEvent("MouseEvents");
+    evt.initMouseEvent(
+            "click", true, false, window, 0, 0, 0, 0, 0,
+            false, false, false, false, 0, null
+    );
+    save.dispatchEvent(evt);
+  } else {
+    window.location = url;
+  }
+};
+
+export default downloadFile;

--- a/shell/server/admin/system-status-server.js
+++ b/shell/server/admin/system-status-server.js
@@ -33,7 +33,7 @@ Router.map(function () {
       const token = this.params.tokenId;
       const response = this.response;
       const issueDate = SYSTEM_LOG_DOWNLOAD_TOKENS[token];
-      SYSTEM_LOG_DOWNLOAD_TOKENS[token] = undefined; // Clear the token from the in-memory map.
+      delete SYSTEM_LOG_DOWNLOAD_TOKENS[token]; // Clear the token from the in-memory map.
       if (issueDate === undefined || issueDate + 60000 < Date.now()) {
         // Require download to start within 60 seconds of the adminGetServerLogDownloadToken
         // method being called.
@@ -118,7 +118,7 @@ Meteor.publish("systemStatus", function () {
             _.without(userIdToSessionHashes[session.userId], hashedSessionId);
 
         if (userIdToSessionHashes[session.userId].length === 0) {
-          userIdToSessionHashes[session.userId] = undefined;
+          delete userIdToSessionHashes[session.userId];
           userIdCount = userIdCount - 1;
           changed.activeUsers = userIdCount;
         }
@@ -128,7 +128,7 @@ Meteor.publish("systemStatus", function () {
           _.without(grainIdToSessionHashes[session.grainId], hashedSessionId);
 
       if (grainIdToSessionHashes[session.grainId].length === 0) {
-        grainIdToSessionHashes[session.grainId] = undefined;
+        delete grainIdToSessionHashes[session.grainId];
         grainIdCount = grainIdCount - 1;
         changed.activeGrains = grainIdCount;
       }

--- a/shell/server/admin/system-status-server.js
+++ b/shell/server/admin/system-status-server.js
@@ -42,16 +42,21 @@ Router.map(function () {
       }
 
       const logFilePath = SANDSTORM_LOGDIR + "/sandstorm.log";
-      // Lazily assume that this logfile won't be "too large" and we can just load it into memory
-      const logFileContents = Fs.readFileSync(logFilePath);
+      const fd = fs.openSync(logFilePath, "r");
+      const stats = fs.fstatSync(fd);
+      const initialSize = stats.size;
+      const readStream = fs.createReadStream(undefined, {
+        fd: fd,
+        start: 0,
+        end: initialSize,
+      });
 
       response.writeHead(200, {
-        "Content-Length": logFileContents.length,
+        "Content-Length": initialSize,
         "Content-Type": "text/plain",
         "content-Disposition": "attachment;filename=\"sandstorm.log\"",
       });
-
-      return response.end(logFileContents);
+      readStream.pipe(response);
     },
   });
 });

--- a/shell/server/admin/system-status-server.js
+++ b/shell/server/admin/system-status-server.js
@@ -20,7 +20,7 @@ Meteor.methods({
       throw new Meteor.Error(403, "User must be admin to download system log.");
     }
 
-    const token = Random.id();
+    const token = Random.id(22);
     SYSTEM_LOG_DOWNLOAD_TOKENS[token] = Date.now();
     setTimeout(() => {
       if (SYSTEM_LOG_DOWNLOAD_TOKENS[token]) {

--- a/shell/server/install-server.js
+++ b/shell/server/install-server.js
@@ -70,7 +70,7 @@ Meteor.methods({
       throw new Meteor.Error(403, "Unauthorized", "Only paid users can upload apps.");
     }
 
-    const token = Random.id();
+    const token = Random.id(22);
     uploadTokens[token] = setTimeout(function () {
       delete uploadTokens[token];
     }, 20 * 60 * 1000);


### PR DESCRIPTION
This marks the start of me attempting to use ES6 modules to deduplicate code,
as described in http://guide.meteor.com/structure.html#example-app-structure
Expect future work to attempt to avoid duplicating functions in various modules,
and to see existing mostly-UI packages to move out of Meteor packages and
into ES6 modules.

![system-status-page](https://cloud.githubusercontent.com/assets/307325/15088842/b3865644-13ad-11e6-8ec0-d16d27603e40.png)

One nice affordance I managed to get to work is that the log starts out scrolled to the **end** of the file, and will continue to follow the end as logs stream in if scrolled to the bottom, but will preserve the scroll position if you scroll up (so new input doesn't prevent you from seeing older input if you want).  I intend to replicate this behavior for the "Show Debug Log" pane some time, as the most recent logs are almost always the most interesting to see, and by default you won't see them until you switch focus and scroll because they are added below the fold.

Closes #1825.