### PR TITLE
New Admin: User invite

### DIFF
--- a/shell/client/admin/user-invite-client.js
+++ b/shell/client/admin/user-invite-client.js
@@ -1,0 +1,170 @@
+Template.autoSelectingInput.onRendered(function () {
+  this.lastNode.focus();
+});
+
+Template.autoSelectingInput.events({
+  "focus input"(evt) {
+    const instance = Template.instance();
+    // We use lastNode rather than firstNode because in its infinite wisdom, Blaze decides that our
+    // leading comment is in fact a text node and whitespace must be preserved, in case it happens
+    // to be part of a <pre> tag or something, I guess.
+    instance.lastNode.select();
+  },
+});
+
+Template.newAdminUserInviteLink.onCreated(function () {
+  this.formState = new ReactiveVar("default");
+  this.generatedLink = new ReactiveVar(undefined);
+  this.message = new ReactiveVar("");
+});
+
+Template.newAdminUserInviteLink.helpers({
+  hasSuccess() {
+    const instance = Template.instance();
+    return instance.formState.get() === "success";
+  },
+
+  hasError() {
+    const instance = Template.instance();
+    return instance.formState.get() === "error";
+  },
+
+  message() {
+    const instance = Template.instance();
+    return instance.message.get();
+  },
+
+  generatedLink() {
+    const instance = Template.instance();
+    return instance.generatedLink.get();
+  },
+});
+
+Template.newAdminUserInviteLink.events({
+  "submit .admin-invite-button-form"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    instance.formState.set("submitting");
+    // token, note, quota
+    Meteor.call("createSignupKey", undefined, "", undefined, (err, key) => {
+      if (err) {
+        instance.formState.set("error");
+        instance.message.set(err.message);
+      } else {
+        instance.formState.set("default");
+        instance.message.set("");
+        instance.generatedLink.set(getOrigin() + Router.routes.signup.path({ key }));
+      }
+    });
+  },
+});
+
+Template.newAdminUserInviteEmail.onCreated(function () {
+  this.toAddresses = new ReactiveVar("");
+  this.subject = new ReactiveVar("Invitation to Sandstorm on " + document.location.host);
+  this.messageBody = new ReactiveVar("Click on the following link to get access to my Sandstorm.io server.\n\n $KEY");
+
+  this.formState = new ReactiveVar("default");
+  this.message = new ReactiveVar("");
+});
+
+const emailConfigured = function () {
+  const smtpConfig = globalDb.getSmtpConfig();
+  return !!(smtpConfig && smtpConfig.hostname && smtpConfig.port && smtpConfig.returnAddress);
+};
+
+Template.newAdminUserInviteEmail.helpers({
+  emailConfigured() {
+    return emailConfigured();
+  },
+
+  emailFormDisabled() {
+    const instance = Template.instance();
+    return (
+      instance.formState.get() === "submitting" ||
+      !emailConfigured()
+    );
+  },
+
+  sendButtonDisabled() {
+    const instance = Template.instance();
+    return (
+      instance.formState.get() === "submitting" ||
+      !instance.toAddresses.get() ||
+      !instance.subject.get() ||
+      !instance.messageBody.get()
+    );
+  },
+
+  toAddresses() {
+    const instance = Template.instance();
+    return instance.toAddresses.get();
+  },
+
+  subject() {
+    const instance = Template.instance();
+    return instance.subject.get();
+  },
+
+  messageBody() {
+    const instance = Template.instance();
+    return instance.messageBody.get();
+  },
+
+  hasSuccess() {
+    const instance = Template.instance();
+    return instance.formState.get() === "success";
+  },
+
+  hasError() {
+    const instance = Template.instance();
+    return instance.formState.get() === "error";
+  },
+
+  message() {
+    const instance = Template.instance();
+    return instance.message.get();
+  },
+});
+
+Template.newAdminUserInviteEmail.events({
+  "input textarea[name=to-addresses]"(evt) {
+    const instance = Template.instance();
+    instance.toAddresses.set(evt.currentTarget.value);
+  },
+
+  "input input[name=subject]"(evt) {
+    const instance = Template.instance();
+    instance.subject.set(evt.currentTarget.value);
+  },
+
+  "input textarea[name=message-body]"(evt) {
+    const instance = Template.instance();
+    instance.messageBody.set(evt.currentTarget.value);
+  },
+
+  "submit .admin-invite-email-form"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    const origin = getOrigin();
+    const identityId = Accounts.getCurrentIdentityId();
+    const from = globalDb.getReturnAddressWithDisplayName(identityId);
+    const list = instance.toAddresses.get();
+    const subject = instance.subject.get();
+    const message = instance.messageBody.get();
+    instance.formState.set("submitting");
+    // token, origin, from, list, subject, message, quota
+    Meteor.call("sendInvites", undefined, origin, from, list, subject, message, undefined, (err) => {
+      if (err) {
+        instance.formState.set("error");
+        instance.message.set(err.message);
+      } else {
+        instance.formState.set("success");
+        instance.message.set("Sent invitation(s) successfully.");
+        instance.toAddresses.set("");
+      }
+    });
+  },
+});

--- a/shell/client/admin/user-invite.html
+++ b/shell/client/admin/user-invite.html
@@ -1,5 +1,95 @@
+<template name="autoSelectingInput">
+{{!-- expects a single argument:
+      value: String
+--}}
+  <input readonly="true" type="text" value="{{value}}" />
+</template>
+
+<template name="newAdminUserInviteLink">
+  <h2>Create a link</h2>
+
+  {{#if hasSuccess}}
+    {{#focusingSuccessBox}}
+      {{message}}
+    {{/focusingSuccessBox}}
+  {{/if}}
+
+  {{#if hasError}}
+    {{#focusingErrorBox}}
+      {{message}}
+    {{/focusingErrorBox}}
+  {{/if}}
+
+  <p>This will create a magic link which you can send to someone.</p>
+  <form class="admin-invite-button-form">
+    <button type="submit">Create link</button>
+    {{#if generatedLink}}
+      {{> autoSelectingInput value=generatedLink }}
+    {{/if}}
+  </form>
+</template>
+
+<template name="newAdminUserInviteEmail">
+  <h2>Send an email</h2>
+
+  {{#unless emailConfigured }}
+    <p class="flash-message warning-message">
+      Email has not been configured, so sending invites via email is disabled.
+      {{#linkTo route="newAdminEmailConfig"}}
+        Configure email
+      {{/linkTo}}
+    </p>
+  {{/unless}}
+
+  {{#if hasSuccess}}
+    {{#focusingSuccessBox}}
+      {{message}}
+    {{/focusingSuccessBox}}
+  {{/if}}
+
+  {{#if hasError}}
+    {{#focusingErrorBox}}
+      {{message}}
+    {{/focusingErrorBox}}
+  {{/if}}
+
+  <p>This will create a link and send it in an email.</p>
+
+  <form class="admin-invite-email-form" disabled="{{emailFormDisabled}}">
+    <div class="form-group">
+      <label>
+        To:
+        <textarea class="to-addresses" name="to-addresses" value="{{ toAddresses }}"
+            disabled="{{emailFormDisabled}}" required placeholder="alice@example.com
+bob@example.com"></textarea>
+      </label>
+      <span class="form-subtext">Email addresses, one per line.</span>
+    </div>
+
+    <div class="form-group">
+      <label>
+        Subject:
+        <input type="text" name="subject" value="{{ subject }}" disabled="{{emailFormDisabled}}" required />
+      </label>
+    </div>
+
+    <div class="form-group">
+      <label>
+        Body:
+        <textarea name="message-body" value="{{ messageBody }}" disabled="{{emailFormDisabled}}" required></textarea>
+      </label>
+      <span class="form-subtext"><code>$KEY</code> will be replaced with the newly-generated link.</span>
+    </div>
+
+    <div class="button-row">
+      <button type="submit" disabled="{{sendButtonDisabled}}">Send invite</button>
+    </div>
+  </form>
+</template>
+
 <template name="newAdminUserInvite">
   <h1>{{#linkTo route="newAdminUsers"}}Users{{/linkTo}} / Invite</h1>
-
-  <p>TODO</p>
+  {{> newAdminUserInviteLink }}
+  <hr>
+  {{> newAdminUserInviteEmail }}
 </template>

--- a/shell/client/styles/_admin-users.scss
+++ b/shell/client/styles/_admin-users.scss
@@ -557,3 +557,13 @@
     background-color: #efdcdd;
   }
 }
+
+.admin-invite-email-form, .admin-invite-button-form {
+  @extend %standard-form;
+}
+
+.admin-invite-email-form {
+  textarea {
+    min-height: 200px;
+  }
+}

--- a/shell/client/widgets/widgets-client.js
+++ b/shell/client/widgets/widgets-client.js
@@ -35,8 +35,10 @@ const focusAndScrollIntoView = function () {
   // When an error or success message appears on the page or is updated, we generally want to focus
   // it (for screenreader users) and scroll it into the view (for visual users), lest they miss the
   // message entirely.
-  this.firstNode.focus && this.firstNode.focus();
-  this.firstNode.scrollIntoView && this.firstNode.scrollIntoView();
+  // Apparently firstNode is a #text node, and lastNode is the actual <div>, which is the only
+  // actual node in the template source, because I have newlines and whitespace and comments.
+  this.lastNode.focus && this.lastNode.focus();
+  this.lastNode.scrollIntoView && this.lastNode.scrollIntoView();
 };
 
 Template.focusingErrorBox.onRendered(focusAndScrollIntoView);

--- a/shell/server/admin/admin-user-invite.js
+++ b/shell/server/admin/admin-user-invite.js
@@ -1,0 +1,8 @@
+Meteor.publish("allInviteTokens", function () {
+  const db = this.connection.sandstormDb;
+  if (!db.isAdminById(this.userId)) {
+    throw new Meteor.Error(403, "User must be admin to list invite tokens.");
+  }
+
+  return db.collections.signupKeys.find({});
+});


### PR DESCRIPTION
Improvements to previous iteration that I couldn't not make:

* Creating a link does not close the page
* Creating a link autofocuses the link text for easy copy/paste
* Email invite is disabled if email is not configured, and nudges
  admins to configure email
* Email invite has slightly better placeholders/details text.
* Styles match our standard forms.

References #1938.