### PR TITLE
New admin personalization

### DIFF
--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -1363,6 +1363,10 @@ Router.map(function () {
     path: "/admin-new/status",
     controller: newAdminRoute,
   });
+  this.route("newAdminPersonalization", {
+    path: "/admin-new/personalization",
+    controller: newAdminRoute,
+  });
   this.route("newAdminNetworkCapabilities", {
     path: "/admin-new/network-capabilities",
     controller: newAdminRoute,

--- a/shell/client/admin/admin.html
+++ b/shell/client/admin/admin.html
@@ -35,6 +35,7 @@
         {{#adminNavPill routeName="newAdminAppSources"}}App Sources{{/adminNavPill}}
         {{#adminNavPill routeName="newAdminMaintenance"}}Maintenance Message{{/adminNavPill}}
         {{#adminNavPill routeName="newAdminStatus"}}System Status{{/adminNavPill}}
+        {{#adminNavPill routeName="newAdminPersonalization"}}Personalization{{/adminNavPill}}
         {{#adminNavPill routeName="newAdminNetworkCapabilities"}}Network Capabilities{{/adminNavPill}}
         {{#adminNavPill routeName="newAdminStats"}}Stats{{/adminNavPill}}
         {{#adminNavPill routeName="newAdminFeatureKey"}}For Work{{/adminNavPill}}

--- a/shell/client/admin/personalization-client.js
+++ b/shell/client/admin/personalization-client.js
@@ -1,7 +1,6 @@
 const DEFAULT_SIGNUP_DIALOG = "You've been invited to join this Sandstorm server!";
 
 Template.newAdminPersonalization.onCreated(function () {
-  // TODO(now): pull these from config
   this.serverTitle = new ReactiveVar(globalDb.getSettingWithFallback("serverTitle", ""));
   this.splashUrl = new ReactiveVar(globalDb.getSettingWithFallback("splashUrl", ""));
   this.signupDialog = new ReactiveVar(globalDb.getSettingWithFallback("signupDialog", DEFAULT_SIGNUP_DIALOG));

--- a/shell/client/admin/personalization-client.js
+++ b/shell/client/admin/personalization-client.js
@@ -1,0 +1,116 @@
+const DEFAULT_SIGNUP_DIALOG = "You've been invited to join this Sandstorm server!";
+
+Template.newAdminPersonalization.onCreated(function () {
+  // TODO(now): pull these from config
+  this.serverTitle = new ReactiveVar(globalDb.getSettingWithFallback("serverTitle", ""));
+  this.splashUrl = new ReactiveVar(globalDb.getSettingWithFallback("splashUrl", ""));
+  this.signupDialog = new ReactiveVar(globalDb.getSettingWithFallback("signupDialog", DEFAULT_SIGNUP_DIALOG));
+  this.termsOfServiceUrl = new ReactiveVar(globalDb.getSetting("termsUrl"));
+  this.privacyPolicyUrl = new ReactiveVar(globalDb.getSetting("privacyUrl"));
+
+  this.formState = new ReactiveVar("default");
+  this.message = new ReactiveVar("");
+});
+
+Template.newAdminPersonalization.helpers({
+  formDisabled() {
+    const instance = Template.instance();
+    return instance.formState.get() === "submitting";
+  },
+
+  serverTitle() {
+    const instance = Template.instance();
+    return instance.serverTitle.get();
+  },
+
+  splashUrl() {
+    const instance = Template.instance();
+    return instance.splashUrl.get();
+  },
+
+  exampleSplashUrl() {
+    return window.location.protocol + "//" + globalDb.makeWildcardHost("0a3w6emamtxnncqky840");
+  },
+
+  signupDialog() {
+    const instance = Template.instance();
+    return instance.signupDialog.get();
+  },
+
+  termsOfServiceUrl() {
+    const instance = Template.instance();
+    return instance.termsOfServiceUrl.get();
+  },
+
+  privacyPolicyUrl() {
+    const instance = Template.instance();
+    return instance.privacyPolicyUrl.get();
+  },
+
+  hasError() {
+    const instance = Template.instance();
+    return instance.formState.get() === "error";
+  },
+
+  hasSuccess() {
+    const instance = Template.instance();
+    return instance.formState.get() === "success";
+  },
+
+  message() {
+    const instance = Template.instance();
+    return instance.message.get();
+  },
+});
+
+Template.newAdminPersonalization.events({
+  "input input[name=server-title]"(evt) {
+    const instance = Template.instance();
+    instance.serverTitle.set(evt.currentTarget.value);
+  },
+
+  "input input[name=splash-url]"(evt) {
+    const instance = Template.instance();
+    instance.splashUrl.set(evt.currentTarget.value);
+  },
+
+  "input input[name=signup-dialog]"(evt) {
+    const instance = Template.instance();
+    instance.signupDialog.set(evt.currentTarget.value);
+  },
+
+  "input input[name=terms-of-service]"(evt) {
+    const instance = Template.instance();
+    instance.termsOfServiceUrl.set(evt.currentTarget.value);
+  },
+
+  "input input[name=privacy-policy]"(evt) {
+    const instance = Template.instance();
+    instance.privacyPolicyUrl.set(evt.currentTarget.value);
+  },
+
+  "submit form.admin-personalization-form"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+
+    const options = {
+      serverTitle: instance.serverTitle.get(),
+      splashUrl: instance.splashUrl.get(),
+      signupDialog: instance.signupDialog.get(),
+      termsOfServiceUrl: instance.termsOfServiceUrl.get(),
+      privacyPolicyUrl: instance.privacyPolicyUrl.get(),
+    };
+
+    instance.formState.set("submitting");
+    Meteor.call("setPersonalizationSettings", options, (err) => {
+      if (err) {
+        instance.formState.set("error");
+        instance.message.set(err.message);
+      } else {
+        instance.formState.set("success");
+        instance.message.set("Saved changes.");
+      }
+    });
+  },
+});

--- a/shell/client/admin/personalization.html
+++ b/shell/client/admin/personalization.html
@@ -1,0 +1,87 @@
+<template name="newAdminPersonalization">
+  <h1>Personalization</h1>
+
+  {{#if hasSuccess }}
+    {{#focusingSuccessBox}}
+      {{message}}
+    {{/focusingSuccessBox}}
+  {{/if}}
+
+  {{#if hasError }}
+    {{#focusingErrorBox}}
+      {{message}}
+    {{/focusingErrorBox}}
+  {{/if}}
+
+  <form class="admin-personalization-form">
+    <div class="form-group">
+      <label>
+        Server title:
+        <input type="text" name="server-title" value="{{serverTitle}}" disabled="{{formDisabled}}"/>
+      </label>
+      <span class="form-subtext">
+        The name of this server, as used when communicating with users.
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label>
+        Splash URL (experimental):
+        <input type="text" name="splash-url" value="{{splashUrl}}"
+               placeholder="{{exampleSplashUrl}}" disabled="{{formDisabled}}"/>
+      </label>
+      <span class="form-subtext">
+        This web page will be displayed in the background behind the login dialog (the home page
+        when logged out). For security reasons, the page must be hosted within this Sandstorm
+        server's wildcard host (otherwise it will be blocked by <code>Content-Security-Policy</code>). We
+        suggest using a static web publishing app like
+        <a href="https://apps.sandstorm.io/app/nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh?host=http://local.sandstorm.io:6080">
+          Hacker CMS
+        </a>
+        to host the content.
+        <strong>
+          WARNING: This feature is experimental; in particular the style and positioning of
+          the login box is subject to change without notice.
+        </strong>
+        Please let us know if you'd like to see it stabilize.
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label>
+        Signup dialog:
+        <input type="text" name="signup-dialog" value="{{signupDialog}}"
+               disabled="{{formDisabled}}"/>
+      </label>
+      <span class="form-subtext">
+        This text will be displayed to users who click on signup links.
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label>
+        Terms of service URL:
+        <input type="text" name="terms-of-service" value="{{termsOfServiceUrl}}"
+               placeholder="https://example.com/tos" disabled="{{formDisabled}}"/>
+      </label>
+      <span class="form-subtext">
+        If provided, new users will be required to agree to the linked Terms of Service.
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label>
+        Privacy policy URL:
+        <input type="text" name="privacy-policy" value="{{privacyPolicyUrl}}"
+               placeholder="https://example.com/privacy" disabled="{{formDisabled}}"/>
+      </label>
+      <span class="form-subtext">
+        If provided, new users will be required to agree to the linked Privacy Policy.
+      </span>
+    </div>
+
+    <div class="button-row">
+      <button type="submit" disabled="{{formDisabled}}">Save</button>
+    </div>
+  </form>
+</template>

--- a/shell/client/styles/_admin-personalization.scss
+++ b/shell/client/styles/_admin-personalization.scss
@@ -1,0 +1,3 @@
+form.admin-personalization-form {
+  @extend %standard-form;
+}

--- a/shell/client/styles/_new-admin.scss
+++ b/shell/client/styles/_new-admin.scss
@@ -47,6 +47,7 @@ $darker-purple-color: #65468e;
 @import "_admin-email.scss";
 @import "_admin-organization.scss";
 @import "_admin-status.scss";
+@import "_admin-personalization.scss";
 @import "_admin-apps.scss";
 @import "_admin-maintenance.scss";
 @import "_admin-users.scss";

--- a/shell/imports/server/auth.js
+++ b/shell/imports/server/auth.js
@@ -1,0 +1,62 @@
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+import Crypto from "crypto";
+import Fs from "fs";
+// TODO(cleanup): globalDb is still an unbound global, but extracting it is Hard.
+
+const ADMIN_TOKEN_EXPIRATION_TIME = 15 * 60 * 1000;
+const SANDSTORM_ADMIN_TOKEN = SANDSTORM_VARDIR + "/adminToken";
+
+function clearAdminToken(token) {
+  if (tokenIsSetupSession(token)) {
+    const hash = Crypto.createHash("sha256").update(token).digest("base64");
+    globalDb.collections.setupSession.remove({
+      _id: "current-session",
+      hashedSessionId: hash,
+    });
+  }
+
+  if (tokenIsValid(token)) {
+    Fs.unlinkSync(SANDSTORM_ADMIN_TOKEN);
+    console.log("Admin token deleted.");
+  }
+}
+
+function tokenIsValid(token) {
+  if (token && Fs.existsSync(SANDSTORM_ADMIN_TOKEN)) {
+    const stats = Fs.statSync(SANDSTORM_ADMIN_TOKEN);
+    const expireTime = new Date(Date.now() - ADMIN_TOKEN_EXPIRATION_TIME);
+    if (stats.mtime < expireTime) {
+      return false;
+    } else {
+      return Fs.readFileSync(SANDSTORM_ADMIN_TOKEN, { encoding: "utf8" }) === token;
+    }
+  } else {
+    return false;
+  }
+}
+
+function tokenIsSetupSession(token) {
+  if (token) {
+    const setupSession = globalDb.collections.setupSession.findOne({ _id: "current-session" });
+    if (setupSession) {
+      const hash = Crypto.createHash("sha256").update(token).digest("base64");
+      const now = new Date();
+      const sessionLifetime = 24 * 60 * 60 * 1000; // length of setup session validity, in milliseconds: 1 day
+      if (setupSession.hashedSessionId === hash && ((now - setupSession.creationDate) < sessionLifetime)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function checkAuth(token) {
+  check(token, Match.OneOf(undefined, null, String));
+  if (!isAdmin() && !tokenIsValid(token) && !tokenIsSetupSession(token)) {
+    throw new Meteor.Error(403, "User must be admin or provide a valid token");
+  }
+}
+
+export { checkAuth, clearAdminToken, tokenIsValid, tokenIsSetupSession };

--- a/shell/server/admin/admin-alert-server.js
+++ b/shell/server/admin/admin-alert-server.js
@@ -1,3 +1,7 @@
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+import { checkAuth } from "/imports/server/auth.js";
+
 const maintenanceMessageShape = {
   text: String,
   time: Match.OneOf(Date, undefined, null),

--- a/shell/server/admin/personalization-server.js
+++ b/shell/server/admin/personalization-server.js
@@ -1,0 +1,25 @@
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+import { checkAuth } from "/imports/server/auth.js";
+
+const personalizationMessageShape = {
+  serverTitle: String,
+  splashUrl: String,
+  signupDialog: String,
+  termsOfServiceUrl: String,
+  privacyPolicyUrl: String,
+};
+
+Meteor.methods({
+  setPersonalizationSettings(params) {
+    checkAuth(undefined);
+    check(params, personalizationMessageShape);
+    const db = this.connection.sandstormDb;
+    // TODO(soon): make this a single write to a single settings object
+    db.collections.settings.upsert({ _id: "serverTitle" }, { value: params.serverTitle });
+    db.collections.settings.upsert({ _id: "splashUrl" }, { value: params.splashUrl });
+    db.collections.settings.upsert({ _id: "signupDialog" }, { value: params.signupDialog });
+    db.collections.settings.upsert({ _id: "termsUrl" }, { value: params.termsOfServiceUrl });
+    db.collections.settings.upsert({ _id: "privacyUrl" }, { value: params.privacyPolicyUrl });
+  },
+});


### PR DESCRIPTION
Includes a small backend refactor to extract a couple of previously-magic-global functions to be explicitly imported.

Adds a new home for a few one-off settings that were neglected in the new-admin redesign, but arguably fit together under a "server customization + personalization + whitelabeling" header.

Closes #1960.