### PR TITLE
Eliminate some out-of-scope usages of globalGrains.

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -450,7 +450,7 @@ Template.grainPowerboxOfferPopup.events({
 
 Template.grainSharePopup.helpers({
   incognito: function () {
-    return !Accounts.getCurrentIdentityId();
+    return !globalGrains.getActive().identityId();
   },
 
   currentTokenUrl: function () {
@@ -766,7 +766,7 @@ Template.whoHasAccessPopup.events({
     const transitiveShares = instance.transitiveShares.get();
     const tokensById = instance.downstreamTokensById.get();
     const recipientShares = _.findWhere(transitiveShares, { recipient: recipient });
-    const currentIdentityId = Accounts.getCurrentIdentityId();
+    const currentIdentityId = globalGrains.getActive().identityId();
     const recipientTokens = _.where(recipientShares.allShares, { identityId: currentIdentityId });
 
     // Two cases:
@@ -914,7 +914,7 @@ Template.whoHasAccessPopup.helpers({
   },
 
   isCurrentIdentity: function () {
-    if (this.identityId === Accounts.getCurrentIdentityId()) {
+    if (this.identityId === globalGrains.getActive().identityId()) {
       return true;
     }
   },
@@ -1046,7 +1046,8 @@ Template.emailInviteTab.helpers({
   },
 
   invitationExplanation: function () {
-    const primaryEmail = globalDb.getPrimaryEmail(Meteor.userId(), Accounts.getCurrentIdentityId());
+    const primaryEmail = globalDb.getPrimaryEmail(Meteor.userId(),
+                                                  globalGrains.getActive().identityId());
     if (primaryEmail) {
       return "Invitation will be from " + primaryEmail;
     } else {

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -497,6 +497,10 @@ Template.layout.helpers({
     return globalAccountsUi;
   },
 
+  globalGrains: function () {
+    return globalGrains;
+  },
+
   identityUser: function () {
     const user = Meteor.user();
     return user && user.profile;

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -507,7 +507,7 @@ Template.layout.helpers({
   },
 
   accountButtonsData: function () {
-    return { isAdmin: globalDb.isAdmin() };
+    return { isAdmin: globalDb.isAdmin(), grains: globalGrains };
   },
 
   firstLogin: function () {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -45,7 +45,7 @@ limitations under the License.
     </div>
   {{else}}
   {{#if identityUser}}
-      {{> identityLoginInterstitial}}
+      {{> identityLoginInterstitial grains=globalGrains}}
   {{else}}
   {{#if firstLogin}}
     <div class="first-sign-in-main-content {{#if hideNavbar}}hide-navbar{{else}}{{#if shrinkNavbar}}shrink-navbar{{/if}}{{/if}}">

--- a/shell/packages/accounts-identity/accounts-identity-client.js
+++ b/shell/packages/accounts-identity/accounts-identity-client.js
@@ -298,13 +298,6 @@ Meteor.loginWithIdentity = function (accountId, callback) {
 const CURRENT_IDENTITY_KEY = "Accounts.CurrentIdentityId";
 
 Accounts.getCurrentIdentityId = function () {
-  // TODO(cleanup): `globalGrains` is only in scope here because of a Meteor bug. We should figure
-  //   out a better way to track a reference to it.
-  const activeGrain = globalGrains.getActive();
-  if (activeGrain) {
-    return activeGrain.identityId();
-  }
-
   const identityId = Session.get(CURRENT_IDENTITY_KEY);
   const identityIds = SandstormDb.getUserIdentityIds(Meteor.user());
   if (identityId && (identityIds.indexOf(identityId) != -1)) {
@@ -316,13 +309,5 @@ Accounts.getCurrentIdentityId = function () {
 
 Accounts.setCurrentIdentityId = function (identityId) {
   check(identityId, String);
-
-  // TODO(cleanup): `globalGrains` is only in scope here because of a Meteor bug. We should figure
-  //   out a better way to track a reference to it.
-  const activeGrain = globalGrains.getActive();
-  if (activeGrain) {
-    return activeGrain.switchIdentity(identityId);
-  }
-
   Session.set(CURRENT_IDENTITY_KEY, identityId);
 };

--- a/shell/packages/sandstorm-ui-grainview/grainview-list.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview-list.js
@@ -68,7 +68,7 @@ GrainViewList = class GrainViewList {
 
     this._grainsUserId = new ReactiveVar(Meteor.userId());
 
-    // Although only ever construct a single global GrainViewList, and therefore we never need to
+    // Although we only ever construct a single global GrainViewList, and therefore we never need to
     // stop() the below autorun(), it's probably a good idea keep a reference to the handle, just in
     // case we need it someday.
     this._autoclearHandle = Tracker.autorun(() => {

--- a/shell/packages/sandstorm-ui-grainview/grainview.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview.js
@@ -438,7 +438,7 @@ GrainView = class GrainView {
     }
 
     const myIdentityIds = SandstormDb.getUserIdentityIds(Meteor.user());
-    let resultIdentityId = myIdentityIds[0];
+    let resultIdentityId = Accounts.getCurrentIdentityId();
     const grain = this._db.getGrain(this._grainId);
     if (identityId && myIdentityIds.indexOf(identityId) != -1) {
       resultIdentityId = identityId;

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -447,7 +447,7 @@ module.exports["Test grain identity chooser interstitial"] = function (browser) 
         .assert.containsText('#publish', 'Publish')
         .frame(null)
 
-        // Navigate to the url with an anonymous user
+        // Navigate to the url as a different user
         .loginDevAccount()
         .pause(short_wait)
         // Try incognito
@@ -457,7 +457,7 @@ module.exports["Test grain identity chooser interstitial"] = function (browser) 
         .waitForElementVisible('.grain-frame', medium_wait)
         .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
         .execute(function() {
-          return Accounts.getCurrentIdentityId();
+          return globalGrains.getActive().identityId();
         }, [], function (response) {
           browser.assert.equal(response.value, null);
         })
@@ -484,7 +484,7 @@ module.exports["Test grain identity chooser interstitial"] = function (browser) 
         .waitForElementVisible('.grain-frame', medium_wait)
         .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
         .execute(function() {
-          return Accounts.getCurrentIdentityId();
+          return globalGrains.getActive().identityId();
         }, [], function (response) {
           browser.assert.equal(!!response.value, true);
         })

--- a/tests/tests/trash.js
+++ b/tests/tests/trash.js
@@ -17,6 +17,7 @@
 "use strict";
 
 var utils = require("../utils"),
+    very_short_wait = utils.very_short_wait,
     short_wait = utils.short_wait,
     medium_wait = utils.medium_wait,
     long_wait = utils.long_wait,
@@ -94,6 +95,7 @@ module.exports["Test grain trash"] = function (browser) {
             .waitForElementVisible(grainCheckboxSelector, medium_wait)
             .click(grainCheckboxSelector)
             .click(".bulk-action-buttons button.move-to-trash")
+            .pause(very_short_wait)
             .click("button.show-trash")
             .waitForElementVisible(grainCheckboxSelector, short_wait)
             .click("button.show-main-list")


### PR DESCRIPTION
After this change, `Accounts.getCurrentIdentityId()` and `Accounts.setCurrentIdentityId()` do not deal with the grainview list at all. If you care about the active identity on a grainview, you need to call `globalGrains.getActive().identityId()`.

Closes https://github.com/sandstorm-io/sandstorm/issues/1291.