### PR TITLE
localhost -> BIND_IP in run-dev.sh

### DIFF
--- a/shell/run-dev.sh
+++ b/shell/run-dev.sh
@@ -56,7 +56,9 @@ if ! $SANDSTORM_HOME/sandstorm status >/dev/null 2>&1; then
   exit 1
 fi
 
-if curl http://localhost:$PORT >/dev/null 2>&1; then
+BIND_IP=${BIND_IP:-127.0.0.1}
+
+if curl http://$BIND_IP:$PORT >/dev/null 2>&1; then
   echo "Please shut down your Sandstorm front-end:" >&2
   echo "  sudo $SANDSTORM_HOME/sandstorm stop-fe" >&2
   exit 1
@@ -96,4 +98,4 @@ __EOF__
 # over its own bundled version, and the system gyp doesn't work.
 export PYTHONPATH=$("$SCRIPT_DIR/../find-meteor-dev-bundle.sh")/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib
 
-exec meteor run --port=${BIND_IP:-127.0.0.1}:$PORT --settings $SETTINGS
+exec meteor run --port=$BIND_IP:$PORT --settings $SETTINGS


### PR DESCRIPTION
https://github.com/sandstorm-io/sandstorm/pull/1958 did not completely solve my problem. When trying to run `run-dev.sh` just now, I kept getting the error "Please shut down your Sandstorm front-end", even though the frontend was most definitely already shut down. The problem was that I had a vagrant-spk VM running on localhost:6080, and run-dev.sh uses `localhost` to check if a frontend is running.

