### PR TITLE
New admin stats

### DIFF
--- a/shell/client/admin/admin.html
+++ b/shell/client/admin/admin.html
@@ -54,7 +54,3 @@
 <template name="newAdminNetworkCapabilities">
   <h1>Network Capabilities</h1>
 </template>
-
-<template name="newAdminStats">
-  <h1>Stats</h1>
-</template>

--- a/shell/client/admin/stats-client.js
+++ b/shell/client/admin/stats-client.js
@@ -1,0 +1,173 @@
+Template.newAdminStats.onCreated(function () {
+  this.formState = new ReactiveVar("default");
+  this.message = new ReactiveVar("");
+
+  this.currentPackageDate = new ReactiveVar(null);
+  this.autorun(() => {
+    const stat = ActivityStats.findOne({}, { sort: { timestamp: -1 } });
+    if (stat) {
+      this.currentPackageDate.set(stat._id);
+    }
+  });
+
+  this.subscribe("activityStats", undefined);
+  this.subscribe("realTimeStats", undefined);
+  this.subscribe("statsTokens", undefined);
+  this.subscribe("allPackages", undefined);
+
+  this.setReportStats = (newValue) => {
+    this.formState.set("submitting");
+    Meteor.call("setSetting", undefined, "reportStats", newValue, (err) => {
+      if (err) {
+        this.formState.set("error");
+        this.message.set(err.message);
+      } else {
+        this.formState.set("success");
+        this.message.set(
+          (newValue ? "Enabled" : "Disabled") +
+          " sending stats to the Sandstorm team." +
+          (newValue ? "  Thank you!" : "")
+        );
+        // TODO(someday): factor setting reportStats out into a separate method that implies
+        // dismissing the notifications
+        Meteor.call("dismissAdminStatsNotifications", undefined);
+      }
+    });
+  };
+});
+
+Template.newAdminStats.helpers({
+  undecided() {
+    const setting = Settings.findOne({ _id: "reportStats" });
+    return setting && setting.value === "unset";
+  },
+
+  sendStats() {
+    const setting = Settings.findOne({ _id: "reportStats" });
+    return setting && setting.value;
+  },
+
+  statsLink() {
+    const tokenObj = StatsTokens.findOne();
+    const token = tokenObj && tokenObj._id;
+    return token && (getOrigin() + "/fetchStats/" + token);
+  },
+
+  current: function () {
+    return RealTimeStats.findOne("now");
+  },
+
+  today: function () {
+    return RealTimeStats.findOne("today");
+  },
+
+  points() {
+    return ActivityStats.find({}, { sort: { timestamp: -1 } }).map((point) => {
+      return _.extend({
+        // Report date of midpoint of sample period.
+        day: new Date(point.timestamp.getTime() - 12 * 60 * 60 * 1000).toLocaleDateString(),
+      }, point);
+    });
+  },
+
+  appDates() {
+    const instance = Template.instance();
+    return ActivityStats.find({}, { sort: { timestamp: -1 }, fields: { timestamp: 1 } })
+        .map(function (point) {
+      return _.extend({
+        // Report date of midpoint of sample period.
+        day: new Date(point.timestamp.getTime() - 12 * 60 * 60 * 1000).toLocaleDateString(),
+        selected: point._id === instance.currentPackageDate.get(),
+      }, point);
+    });
+  },
+
+  apps() {
+    const instance = Template.instance();
+    const stats = ActivityStats.findOne({ _id: instance.currentPackageDate.get() });
+    if (!stats) {
+      return;
+    }
+
+    const apps = {};
+    const pivotApps = function (time) {
+      let data = stats[time];
+      if (!data) {
+        return;
+      }
+
+      data = data.apps;
+      for (const appId in data) {
+        const p = data[appId];
+        apps[appId] = apps[appId] || {};
+        apps[appId][time] = p;
+      }
+    };
+
+    pivotApps("daily");
+    pivotApps("weekly");
+    pivotApps("monthly");
+    pivotApps("forever");
+    return _.chain(apps)
+      .map(function (packObj, appId) {
+        packObj.appId = appId;
+        // Find the newest version of this app.
+        const p = Packages.findOne({
+          appId: appId,
+          manifest: { $exists: true },
+        }, {
+          sort: { "manifest.appVersion": -1 },
+        });
+        if (p) {
+          packObj.appTitle = SandstormDb.appNameFromPackage(p);
+        }
+
+        return packObj;
+      })
+      .sortBy(function (app) { return -((app.daily || {}).owners || 0); })
+      .value();
+  },
+
+  hasSuccess() {
+    const instance = Template.instance();
+    return instance.formState.get() === "success";
+  },
+
+  hasError() {
+    const instance = Template.instance();
+    return instance.formState.get() === "error";
+  },
+
+  message() {
+    const instance = Template.instance();
+    return instance.message.get();
+  },
+});
+
+Template.newAdminStats.events({
+  "submit form.stats-request"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const instance = Template.instance();
+    instance.setReportStats(true);
+  },
+
+  "click button[name=enable-stats]"(evt) {
+    const instance = Template.instance();
+    instance.setReportStats(true);
+  },
+
+  "click button[name=disable-stats]"(evt) {
+    const instance = Template.instance();
+    instance.setReportStats(false);
+  },
+
+  "click button[name=regenerate-stats-token]"(evt) {
+    Meteor.call("regenerateStatsToken");
+  },
+
+  "change select.package-date"(evt) {
+    const instance = Template.instance();
+    instance.currentPackageDate.set(evt.currentTarget.value);
+  },
+});

--- a/shell/client/admin/stats.html
+++ b/shell/client/admin/stats.html
@@ -1,0 +1,207 @@
+<template name="statsUserGrainsTable">
+{{!-- Takes an argument:
+   points: Array of Objects containing the fields in ActivityStats, plus `day`
+   --}}
+<table class="stats-users-grains">
+  <thead>
+    <tr>
+      <th rowspan="2">date</th>
+      <th colspan="4">users</th>
+      <th colspan="4">grains</th>
+    </tr>
+    <tr>
+      <th>daily</th>
+      <th>weekly</th>
+      <th>monthly</th>
+      <th>forever</th>
+      <th>daily</th>
+      <th>weekly</th>
+      <th>monthly</th>
+      <th>forever</th>
+    </tr>
+  </thead>
+  <tbody>
+  {{#each points}}
+    <tr>
+      <td>{{day}}</td>
+      <td>{{daily.activeUsers}}</td>
+      <td>{{weekly.activeUsers}}</td>
+      <td>{{monthly.activeUsers}}</td>
+      <td>{{forever.activeUsers}}</td>
+      <td>{{daily.activeGrains}}</td>
+      <td>{{weekly.activeGrains}}</td>
+      <td>{{monthly.activeGrains}}</td>
+      <td>{{forever.activeGrains}}</td>
+    </tr>
+  {{else}}
+    <tr>
+      <td colspan="7">There are no stats recorded yet.</td>
+    </tr>
+  {{/each}}
+  </tbody>
+</table>
+</template>
+
+<template name="statsAppsTable">
+{{!-- expects a single argument: 
+  apps: Array of Object like ActivityStats, plus `appTitle`
+--}}
+<table class="stats-apps">
+  <thead>
+    <tr>
+      <th rowspan="2">App Name</th>
+      <th colspan="4">owners</th>
+      <th colspan="4">sharedUsers</th>
+      <th colspan="4">grains</th>
+    </tr>
+    <tr>
+      <th>daily</th>
+      <th>weekly</th>
+      <th>monthly</th>
+      <th>forever</th>
+      <th>daily</th>
+      <th>weekly</th>
+      <th>monthly</th>
+      <th>forever</th>
+      <th>daily</th>
+      <th>weekly</th>
+      <th>monthly</th>
+      <th>forever</th>
+    </tr>
+  </thead>
+  <tbody>
+  {{#each apps}}
+    <tr>
+      <td title="{{appId}}">{{appTitle}}</td>
+      <td>{{daily.owners}}</td>
+      <td>{{weekly.owners}}</td>
+      <td>{{monthly.owners}}</td>
+      <td>{{forever.owners}}</td>
+      <td>{{daily.sharedUsers}}</td>
+      <td>{{weekly.sharedUsers}}</td>
+      <td>{{monthly.sharedUsers}}</td>
+      <td>{{forever.sharedUsers}}</td>
+      <td>{{daily.grains}}</td>
+      <td>{{weekly.grains}}</td>
+      <td>{{monthly.grains}}</td>
+      <td>{{forever.grains}}</td>
+    </tr>
+  {{else}}
+    <tr>
+      <td colspan="7">There are no stats recorded yet.</td>
+    </tr>
+  {{/each}}
+  </tbody>
+</table>
+</template>
+
+<template name="newAdminStats">
+  <h1>Stats</h1>
+
+  <h2>Publish anonymously to Sandstorm dev team</h2>
+
+  {{#if hasSuccess}}
+    {{#focusingSuccessBox}}
+      {{message}}
+    {{/focusingSuccessBox}}
+  {{/if}}
+
+  {{#if hasError}}
+    {{#focusingErrorBox}}
+      {{message}}
+    {{/focusingErrorBox}}
+  {{/if}}
+
+  {{#if undecided}}
+    <div class="flash-message info-message">
+      <p>
+        We'd like to know how many Sandstorm users there are, to make graphs
+        and such.  Is it okay to send the numbers on this page once a day to the
+        Sandstorm team, so that we can add them to the totals?  Any stats you send are
+        anonymous.
+      </p>
+
+      <form class="stats-request">
+        <div class="button-row">
+          <button type="submit" class="button-primary" name="enable-stats">
+            Send anonymous stats
+          </button>
+          <button type="button" class="button-link" name="disable-stats">
+            Don't send
+          </button>
+        </div>
+      </form>
+    </div>
+  {{else}}
+    <p>
+      The developers of Sandstorm like to know how many Sandstorm users there are, to make graphs
+      and such.  You can help us by opting in to sharing the numbers on this page once a day to the
+      Sandstorm team, so that we can add them to our totals.
+      Any stats shared are submitted anonymously.
+    </p>
+    <p>
+      Anonymous stats reporting to sandstorm.io:
+      {{#if sendStats}}
+        <span class="stats-enabled">Enabled</span>
+      {{else}}
+        <span class="stats-disabled">Disabled</span>
+      {{/if}}
+      <form class="stats-toggle">
+        {{#if sendStats}}
+        <button type="button" class="button-disable" name="disable-stats">Disable</button>
+        {{else}}
+        <button type="button" class="button-enable" name="enable-stats">Enable</button>
+        {{/if}}
+      </form>
+    </p>
+  {{/if}}
+
+  <h2>View as JSON</h2>
+  <p>
+    If you want to integrate Sandstorm stats with an internal stats tool, use this secret link to
+    retrieve the tables below as JSON.
+    You can revoke the current link at any time by generating a new link.
+  </p>
+
+  <form class="stats-json">
+    <div class="form-group">
+      <label>
+        Stats JSON link:
+        {{> autoSelectingInput value=statsLink}}
+      </label>
+    </div>
+
+    <div class="button-row">
+      <button type="button" name="regenerate-stats-token">
+        Generate new link
+      </button>
+    </div>
+  </form>
+
+  <h2>Statistics</h2>
+  <h3>Users and grains</h3>
+
+  {{#with current=current}}
+  <p>Right now: {{current.activeUsers}} users, {{current.activeGrains}} grains</p>
+  {{/with}}
+  {{#with today=today}}
+  <p>Today: {{today.activeUsers}} users, {{today.activeGrains}} grains</p>
+  {{/with}}
+
+  {{> statsUserGrainsTable points=points }}
+
+  <h3>Apps</h3>
+  <form class="stats-apps-date">
+    <label>
+      Select a date:
+      <select class="package-date">
+        {{#each appDates }}
+          <option value="{{_id}}" selected="{{#if selected}}true{{/if}}">{{day}}</option>
+        {{/each}}
+      </select>
+    </label>
+  </form>
+
+  {{> statsAppsTable apps=apps }}
+</template>
+

--- a/shell/client/admin/user-invite-client.js
+++ b/shell/client/admin/user-invite-client.js
@@ -1,17 +1,3 @@
-Template.autoSelectingInput.onRendered(function () {
-  this.lastNode.focus();
-});
-
-Template.autoSelectingInput.events({
-  "focus input"(evt) {
-    const instance = Template.instance();
-    // We use lastNode rather than firstNode because in its infinite wisdom, Blaze decides that our
-    // leading comment is in fact a text node and whitespace must be preserved, in case it happens
-    // to be part of a <pre> tag or something, I guess.
-    instance.lastNode.select();
-  },
-});
-
 Template.newAdminUserInviteLink.onCreated(function () {
   this.formState = new ReactiveVar("default");
   this.generatedLink = new ReactiveVar(undefined);

--- a/shell/client/admin/user-invite.html
+++ b/shell/client/admin/user-invite.html
@@ -1,10 +1,3 @@
-<template name="autoSelectingInput">
-{{!-- expects a single argument:
-      value: String
---}}
-  <input readonly="true" type="text" value="{{value}}" />
-</template>
-
 <template name="newAdminUserInviteLink">
   <h2>Create a link</h2>
 

--- a/shell/client/styles/_admin-stats.scss
+++ b/shell/client/styles/_admin-stats.scss
@@ -1,0 +1,84 @@
+form.stats-request {
+  // We eschew %standard-form here to avoid getting .button-link overridden by more specific
+  // selectors for button[type=button].
+  .button-row {
+    width: 100%;
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: baseline;
+    justify-content: flex-start;
+    >*:not(:first-child) {
+      margin-right: 10px;
+    }
+  }
+
+  button.button-link {
+    @extend %button-link;
+  }
+
+  button[name=enable-stats] {
+    @extend %button-base;
+    @extend %button-primary;
+  }
+}
+
+form.stats-json {
+  @extend %standard-form;
+  max-width: 500px;
+}
+
+form.stats-toggle {
+  @extend %standard-form;
+  display: inline-block;
+}
+
+%stats-status {
+  display: inline-block;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  min-height: 28px;
+  margin: 2px;
+}
+
+.stats-enabled {
+  @extend %stats-status;
+  color: #366456;
+  background-color: #d9ebcd;
+}
+
+.stats-disabled {
+  @extend %stats-status;
+  color: #333333;
+  background-color: #dcdcdc;
+}
+
+table.stats-users-grains, table.stats-apps {
+  border-collapse: collapse;
+  width: 100%;
+
+  thead {
+    tr:nth-child(2) {
+      font-size: 11px;
+    }
+  }
+
+  tbody tr:hover {
+    background-color: #f0f0f0;
+  }
+
+  th, td {
+    text-align: center;
+    vertical-align: middle;
+    padding: 8px;
+    border: 1px solid #aaa;
+  }
+
+  thead tr {
+    background-color: #ccc;
+  }
+  tbody tr {
+    background-color: #fff;
+  }
+}

--- a/shell/client/styles/_colors.scss
+++ b/shell/client/styles/_colors.scss
@@ -10,6 +10,7 @@ $focus-outline-color: $sandstorm-purple-color;
 $error-background-color: #ffdddd;
 $success-background-color: #ddffdd;
 $warning-background-color: #ffffaa;
+$info-background-color: #d8bfd8;
 
 ////////  General shell elements
 // Default shell background and text colors

--- a/shell/client/styles/_new-admin.scss
+++ b/shell/client/styles/_new-admin.scss
@@ -51,4 +51,5 @@ $darker-purple-color: #65468e;
 @import "_admin-apps.scss";
 @import "_admin-maintenance.scss";
 @import "_admin-users.scss";
+@import "_admin-stats.scss";
 @import "_admin-feature-key.scss";

--- a/shell/client/styles/_partials.scss
+++ b/shell/client/styles/_partials.scss
@@ -65,6 +65,13 @@
   }
 }
 
+%button-link {
+  background: none;
+  border: none;
+  color: black;
+  text-decoration: underline;
+}
+
 %button-primary {
   // A button coloring for the primary action of a form.
   background-color: #65468e;

--- a/shell/client/styles/_widgets.scss
+++ b/shell/client/styles/_widgets.scss
@@ -36,3 +36,7 @@
 .success-message {
   background-color: $success-background-color;
 }
+
+.info-message {
+  background-color: $info-background-color;
+}

--- a/shell/client/widgets/widgets-client.js
+++ b/shell/client/widgets/widgets-client.js
@@ -43,3 +43,17 @@ const focusAndScrollIntoView = function () {
 
 Template.focusingErrorBox.onRendered(focusAndScrollIntoView);
 Template.focusingSuccessBox.onRendered(focusAndScrollIntoView);
+
+Template.autoSelectingInput.onRendered(function () {
+  this.lastNode.focus();
+});
+
+Template.autoSelectingInput.events({
+  "focus input"(evt) {
+    const instance = Template.instance();
+    // We use lastNode rather than firstNode because in its infinite wisdom, Blaze decides that our
+    // leading comment is in fact a text node and whitespace must be preserved, in case it happens
+    // to be part of a <pre> tag or something, I guess.
+    instance.lastNode.select();
+  },
+});

--- a/shell/client/widgets/widgets.html
+++ b/shell/client/widgets/widgets.html
@@ -33,3 +33,10 @@
   {{> Template.contentBlock}}
 </p>
 </template>
+
+<template name="autoSelectingInput">
+{{!-- expects a single argument:
+      value: String
+--}}
+  <input readonly="true" type="text" value="{{value}}" />
+</template>


### PR DESCRIPTION
`reportStats` unset:
![undecided](https://cloud.githubusercontent.com/assets/307325/15203074/f1196ff4-17b4-11e6-8510-29de16ac58d4.png)

Click "Send anonymous stats":
![agreed](https://cloud.githubusercontent.com/assets/307325/15203079/0a9f68c0-17b5-11e6-8e3b-c7ffa35f9615.png)

You can disable reporting if you change your mind:
![disabled](https://cloud.githubusercontent.com/assets/307325/15203119/66c71a76-17b5-11e6-86aa-cfbdb61b9a56.png)

Tables have the same content as ever, but now also lightly highlight the row you're hovering over, to aid readability of wide rows:
![stats-tables](https://cloud.githubusercontent.com/assets/307325/15203105/363986aa-17b5-11e6-9b92-051bcc341f2c.png)

Closes #1826.