### PR TITLE
Fix exception on login and make sure to redirect to the correct place.

### DIFF
--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -871,17 +871,17 @@ promptUploadApp = function (input) {
 Router.map(function () {
   this.route("root", {
     path: "/",
-    waitOn: function () {
-      return [
-        Meteor.subscribe("hasUsers"),
-        Meteor.subscribe("grainsMenu"),
-      ];
+    subscriptions: function () {
+      this.subscribe("hasUsers").wait();
+      if (!Meteor.loggingIn() && Meteor.user() && Meteor.user().loginIdentities) {
+        this.subscribe("grainsMenu").wait();
+      }
     },
 
     data: function () {
       // If the user is logged-in, and can create new grains, and
       // has no grains yet, then send them to "new".
-      if (this.ready() && Meteor.userId() && !Meteor.loggingIn()) {
+      if (this.ready() && Meteor.userId() && !Meteor.loggingIn() && Meteor.user().loginIdentities) {
         if (globalDb.currentUserGrains({}, {}).count() === 0 &&
             globalDb.currentUserApiTokens().count() === 0) {
           Router.go("apps", {}, { replaceState: true });

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -342,7 +342,7 @@ Template.sandstormGrainTable.onCreated(function () {
     const data = Template.currentData();
     let mineResult = 0;
     let sharedResult = 0;
-    data.grains.forEach((grain) => {
+    data.grains && data.grains.forEach((grain) => {
       if (this._selectedMyGrainIds.get(grain._id)) {
         mineResult += 1;
       }


### PR DESCRIPTION
The "root" route is supposed to redirect to `/grain` on login if the user has any grains at all. Currently, the redirect logic can fail in a few ways: it can check for the existence of grains during the half-logged in state, and it can end up rendering the grainlist template with the "root" data context (?!). This patch fixes the former problem by waiting until the user is actually logged in as an account user. The latter problem is still mysterious to me, but my use of a `subscriptions` hook here seems to make it go away. By checking that `data.grains` exists before iterating over it, I ensure that even if the problem does come up again, it won't create a blank screen as it currently does.