### PR TITLE
New Admin: Network Capabilities

### DIFF
--- a/shell/client/admin/admin.html
+++ b/shell/client/admin/admin.html
@@ -50,7 +50,3 @@
     {{/if}}
   </div>
 </template>
-
-<template name="newAdminNetworkCapabilities">
-  <h1>Network Capabilities</h1>
-</template>

--- a/shell/client/admin/network-capabilities-client.js
+++ b/shell/client/admin/network-capabilities-client.js
@@ -15,13 +15,13 @@ const tokenIntroducer = function (token) {
   return identityId && lookupIdentityById(identityId);
 };
 
-const capDetails = function(cap) {
+const capDetails = function (cap) {
   const grainId = cap.owner.grain.grainId;
   const grain = Grains.findOne(grainId);
   const grainTitle = grain && grain.title;
   const packageId = grain && grain.packageId;
   const pkg = packageId && globalDb.collections.packages.findOne(packageId);
-  const appIcon = pkg && globalDb.iconSrcForPackage(pkg, "grain", globalDb.makeWildcardHost("static"))
+  const appIcon = pkg && globalDb.iconSrcForPackage(pkg, "grain", globalDb.makeWildcardHost("static"));
   const introducerIdentityId = cap && cap.owner && cap.owner.grain && cap.owner.grain.introducerIdentity;
   const introducer = lookupIdentityById(introducerIdentityId);
   const grainOwnerIdentity = (introducerIdentityId === grain.identityId) ? undefined : lookupIdentityById(grain.identityId);
@@ -53,6 +53,7 @@ Template.newAdminNetworkCapabilities.onCreated(function () {
     if (this.adminGrainInfoSub) {
       this.adminGrainInfoSub.stop();
     }
+
     this.adminGrainInfoSub = this.subscribe("adminGrainInfo", grainIds);
 
     const packageIds = Grains.find({
@@ -63,12 +64,14 @@ Template.newAdminNetworkCapabilities.onCreated(function () {
     if (this.adminPackagesSub) {
       this.adminPackagesSub.stop();
     }
+
     this.adminPackagesSub = this.subscribe("adminPackages", packageIds);
 
     const identityIds = apiTokens.map(token => token.owner.grain.introducerIdentity);
     if (this.adminIdentitiesSub) {
       this.adminIdentitiesSub.stop();
     }
+
     this.adminIdentitiesSub = this.subscribe("adminIdentities", identityIds);
   });
 });
@@ -104,7 +107,7 @@ const packageMatchesNeedle = function (needle, pkg) {
   return title.toLowerCase().indexOf(needle) !== -1;
 };
 
-const matchesCap = function(needle, cap) {
+const matchesCap = function (needle, cap) {
   if (cap.grainTitle.toLowerCase().indexOf(needle) !== -1) return true;
   if (identityMatchesNeedle(needle, cap.introducer)) return true;
   if (identityMatchesNeedle(needle, cap.grainOwnerIdentity)) return true;

--- a/shell/client/admin/network-capabilities-client.js
+++ b/shell/client/admin/network-capabilities-client.js
@@ -1,0 +1,249 @@
+const lookupIdentityById = function (identityId) {
+  const identity = Meteor.users.findOne({ _id: identityId });
+  if (identity) {
+    SandstormDb.fillInProfileDefaults(identity);
+    SandstormDb.fillInIntrinsicName(identity);
+    SandstormDb.fillInPictureUrl(identity);
+    return identity;
+  }
+
+  return undefined;
+};
+
+const tokenIntroducer = function (token) {
+  const identityId = token && token.owner && token.owner.grain && token.owner.grain.introducerIdentity;
+  return identityId && lookupIdentityById(identityId);
+};
+
+const capDetails = function(cap) {
+  const grainId = cap.owner.grain.grainId;
+  const grain = Grains.findOne(grainId);
+  const grainTitle = grain && grain.title;
+  const packageId = grain && grain.packageId;
+  const pkg = packageId && globalDb.collections.packages.findOne(packageId);
+  const appIcon = pkg && globalDb.iconSrcForPackage(pkg, "grain", globalDb.makeWildcardHost("static"))
+  const introducerIdentityId = cap && cap.owner && cap.owner.grain && cap.owner.grain.introducerIdentity;
+  const introducer = lookupIdentityById(introducerIdentityId);
+  const grainOwnerIdentity = (introducerIdentityId === grain.identityId) ? undefined : lookupIdentityById(grain.identityId);
+  return {
+    _id: cap._id,
+    revoked: cap.revoked,
+    created: cap.created,
+    introducer,
+    grainOwnerIdentity,
+    grainId,
+    grainTitle,
+    packageId,
+    pkg,
+    appIcon,
+  };
+};
+
+Template.newAdminNetworkCapabilities.onCreated(function () {
+  this.adminApiTokensSub = this.subscribe("adminApiTokens", undefined);
+
+  this.autorun(() => {
+    const apiTokens = ApiTokens.find({
+      $or: [
+        { "frontendRef.ipNetwork": { $exists: true } },
+        { "frontendRef.ipInterface": { $exists: true } },
+      ],
+    });
+    const grainIds = apiTokens.map(token => token.owner.grain.grainId);
+    if (this.adminGrainInfoSub) {
+      this.adminGrainInfoSub.stop();
+    }
+    this.adminGrainInfoSub = this.subscribe("adminGrainInfo", grainIds);
+
+    const packageIds = Grains.find({
+      _id: {
+        $in: grainIds,
+      },
+    }).map(grain => grain.packageId);
+    if (this.adminPackagesSub) {
+      this.adminPackagesSub.stop();
+    }
+    this.adminPackagesSub = this.subscribe("adminPackages", packageIds);
+
+    const identityIds = apiTokens.map(token => token.owner.grain.introducerIdentity);
+    if (this.adminIdentitiesSub) {
+      this.adminIdentitiesSub.stop();
+    }
+    this.adminIdentitiesSub = this.subscribe("adminIdentities", identityIds);
+  });
+});
+
+Template.newAdminNetworkCapabilities.helpers({
+  ipNetworkCaps() {
+    return ApiTokens.find({
+      "frontendRef.ipNetwork": { $exists: true },
+    }).map(capDetails);
+  },
+
+  ipInterfaceCaps() {
+    return ApiTokens.find({
+      "frontendRef.ipInterface": { $exists: true },
+    }).map(capDetails);
+  },
+});
+
+const identityMatchesNeedle = function (needle, identity) {
+  const profile = identity && identity.profile;
+  if (profile) {
+    if (profile.handle.toLowerCase().indexOf(needle) !== -1) return true;
+    if (profile.intrinsicName.toLowerCase().indexOf(needle) !== -1) return true;
+    if (profile.name.toLowerCase().indexOf(needle) !== -1) return true;
+    if (profile.service.toLowerCase().indexOf(needle) !== -1) return true;
+  }
+
+  return false;
+};
+
+const packageMatchesNeedle = function (needle, pkg) {
+  const title = pkg && pkg.manifest && pkg.manifest.appTitle && pkg.manifest.appTitle.defaultText;
+  return title.toLowerCase().indexOf(needle) !== -1;
+};
+
+const matchesCap = function(needle, cap) {
+  if (cap.grainTitle.toLowerCase().indexOf(needle) !== -1) return true;
+  if (identityMatchesNeedle(needle, cap.introducer)) return true;
+  if (identityMatchesNeedle(needle, cap.grainOwnerIdentity)) return true;
+  if (packageMatchesNeedle(needle, cap.pkg)) return true;
+  // Check for cap ID, grain ID, or app ID, but only as a prefix.
+  if (cap._id.toLowerCase().lastIndexOf(needle, 0) !== -1) return true;
+  if (cap.grainId.toLowerCase().lastIndexOf(needle, 0) !== -1) return true;
+  if (cap.pkg.appId.toLowerCase().lastIndexOf(needle, 0) !== -1) return true;
+  return false;
+};
+
+Template.newAdminNetworkCapabilitiesSection.onCreated(function () {
+  this.searchString = new ReactiveVar("");
+  this.activeChecked = new ReactiveVar(true);
+  this.revokedChecked = new ReactiveVar(false);
+
+  this.formState = new ReactiveVar("default");
+  this.message = new ReactiveVar("");
+
+  this.compileMatchFilter = () => {
+    const searchString = this.searchString.get();
+    const searchKeys = searchString.toLowerCase()
+        .split(" ")
+        .filter((k) => { return k !== ""; });
+
+    return function matchFilter(item) {
+      if (searchKeys.length === 0) return true;
+      return _.chain(searchKeys)
+          .map((searchKey) => { return matchesCap(searchKey, item); })
+          .reduce((a, b) => a && b)
+          .value();
+    };
+  };
+
+  this.currentFilter = () => {
+    // Returns a function which maps an object as returned from capDetails into a Boolean value
+    // (whether or not it should be displayed).
+    const searchStringMatchFilter = this.compileMatchFilter();
+    return (cap) => {
+      if (cap.revoked) {
+        if (!this.revokedChecked.get()) return false;
+      } else {
+        if (!this.activeChecked.get()) return false;
+      }
+
+      return searchStringMatchFilter(cap);
+    };
+  };
+});
+
+Template.newAdminNetworkCapabilitiesSection.helpers({
+  filterString() {
+    const instance = Template.instance();
+    return instance.searchString.get();
+  },
+
+  filterCaps(caps) {
+    const instance = Template.instance();
+    const filteredCaps = caps.filter(instance.currentFilter());
+    return filteredCaps;
+  },
+
+  callbacks() {
+    const instance = Template.instance();
+    // Passing this down through another template?  Better wrap it in another closure. :/
+    return {
+      onRevokeCap(capId) {
+        instance.formState.set("submitting");
+        Meteor.call("adminToggleDisableCap", undefined, capId, true, (err) => {
+          if (err) {
+            instance.formState.set("error");
+            instance.message.set(err.message);
+          } else {
+            instance.formState.set("success");
+            instance.message.set("Revoked capability.");
+          }
+        });
+      },
+    };
+  },
+
+  activeChecked() {
+    const instance = Template.instance();
+    return instance.activeChecked.get();
+  },
+
+  revokedChecked() {
+    const instance = Template.instance();
+    return instance.revokedChecked.get();
+  },
+
+  activeCount(caps) {
+    return caps.filter((cap) => {
+      return !cap.revoked && !cap.trashed;
+    }).length;
+  },
+
+  revokedCount(caps) {
+    return caps.filter((cap) => {
+      return cap.revoked || cap.trashed;
+    }).length;
+  },
+
+  hasSuccess() {
+    const instance = Template.instance();
+    return instance.formState.get() === "success";
+  },
+
+  hasError() {
+    const instance = Template.instance();
+    return instance.formState.get() === "error";
+  },
+
+  message() {
+    const instance = Template.instance();
+    return instance.message.get();
+  },
+});
+
+Template.newAdminNetworkCapabilitiesSection.events({
+  "input input[name=search-string]"(evt) {
+    const instance = Template.instance();
+    instance.searchString.set(evt.currentTarget.value);
+  },
+
+  "click input[name=active]"(evt) {
+    const instance = Template.instance();
+    instance.activeChecked.set(!instance.activeChecked.get());
+  },
+
+  "click input[name=revoked]"(evt) {
+    const instance = Template.instance();
+    instance.revokedChecked.set(!instance.revokedChecked.get());
+  },
+});
+
+Template.newAdminNetworkCapabilitiesTableCapabilityRow.events({
+  "click .actions button"(evt) {
+    const instance = Template.instance();
+    instance.data.callbacks.onRevokeCap && instance.data.callbacks.onRevokeCap(instance.data.capInfo._id);
+  },
+});

--- a/shell/client/admin/network-capabilities.html
+++ b/shell/client/admin/network-capabilities.html
@@ -1,0 +1,123 @@
+<template name="newAdminNetworkCapabilitiesTableCapabilityRow">
+{{!-- expects argument:
+  capInfo: Object containing:
+                 introducer: Identity object
+                 grainTitle: String
+                    appIcon: String
+         grainOwnerIdentity: Identity object
+                    created: Date
+                    revoked: Boolean
+  callbacks: Object containing:
+    onRevokeCap: Function to call when the Revoke button is clicked.
+--}}
+<div class="capability-row" role="row">
+  <div class="grant-by" role="gridcell">
+    {{> identityCard capInfo.introducer }}
+  </div>
+  <div class="grant-to" role="gridcell">
+    <div class="grain-context">
+      <div class="grain-details">
+        <div class="app-icon" style="background-image: url('{{capInfo.appIcon}}')"></div>
+        {{capInfo.grainTitle}}
+      </div>
+      {{#if capInfo.grainOwnerIdentity}}
+        {{> identityCard capInfo.grainOwnerIdentity }}
+      {{/if}}
+    </div>
+  </div>
+  <div class="grant-time" role="gridcell">{{dateString capInfo.created}}</div>
+  <div class="actions" role="gridcell">
+    {{#if capInfo.revoked}}
+      Revoked
+    {{else}}
+    <form class="standard-form">
+      <button type="button">
+        Revoke
+      </button>
+    </form>
+    {{/if}}
+  </div>
+</div>
+</template>
+
+<template name="newAdminNetworkCapabilitiesTable">
+{{!-- Takes arguments:
+  caps: cursor with list of Object like those returned by capDetails
+--}}
+<div class="admin-caps-table" role="grid">
+  <div class="thead" role="rowgroup">
+    <div class="header-row" role="row">
+      <div class="grant-by" role="columnheader">Granted by</div>
+      <div class="grant-to" role="columnheader">Granted to</div>
+      <div class="grant-time" role="columnheader">Time</div>
+      <div class="actions" role="columnheader">Actions</div>
+    </div>
+  </div>
+  <div class="tbody" role="rowgroup">
+    {{#each cap in caps}}
+      {{>newAdminNetworkCapabilitiesTableCapabilityRow capInfo=cap callbacks=callbacks }}
+    {{else}}
+    <div class="none-row" role="row">
+      <div role="gridcell" colspan="4">No capabilities found.</div>
+    </div>
+    {{/each}}
+  </div>
+</div>
+</template>
+
+<template name="newAdminNetworkCapabilitiesSection">
+{{!-- Takes arguments:
+  caps: Cursor of a list of ApiTokens.
+--}}
+
+{{#if hasSuccess}}
+  {{#focusingSuccessBox}}
+    {{message}}
+  {{/focusingSuccessBox}}
+{{/if}}
+
+{{#if hasError}}
+  {{#focusingErrorBox}}
+    {{message}}
+  {{/focusingErrorBox}}
+{{/if}}
+
+<div class="admin-caps-filter">
+  <div class="search-bar">
+    <div class="icon icon-search"></div>
+    <input type="text" name="search-string" value="{{ filterString }}"/>
+  </div>
+  <div class="filter-checkboxes">
+    <div class="filter-checkboxes-label">Showing:</div>
+    <ul>
+      <li>
+        <label>
+          <input type="checkbox" name="active" checked="{{ activeChecked }}" />
+          Active ({{ activeCount caps }})
+        </label>
+      </li>
+
+      <li>
+        <label>
+          <input type="checkbox" name="revoked" checked="{{ revokedChecked }}" />
+          Revoked ({{ revokedCount caps }})
+        </label>
+      </li>
+    </ul>
+  </div>
+</div>
+
+{{> newAdminNetworkCapabilitiesTable caps=(filterCaps caps) callbacks=callbacks }}
+</template>
+
+
+<template name="newAdminNetworkCapabilities">
+<h1>Network Capabilities</h1>
+
+<h2>Outbound Network Access</h2>
+{{>newAdminNetworkCapabilitiesSection caps=ipNetworkCaps}}
+
+<h2>Inbound Network Access</h2>
+{{>newAdminNetworkCapabilitiesSection caps=ipInterfaceCaps}}
+
+</template>

--- a/shell/client/styles/_admin-network-capabilities.scss
+++ b/shell/client/styles/_admin-network-capabilities.scss
@@ -1,0 +1,108 @@
+.admin-caps-filter {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
+  .search-bar {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: flex-start;
+    margin-right: 32px;
+  }
+  .filter-checkboxes {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: flex-start;
+    .filter-checkboxes-label, ul {
+      display: inline-block;
+    }
+    ul {
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+    }
+  }
+}
+
+.admin-caps-table {
+  border: 1px solid $default-table-border-color;
+
+  div[role=columnheader] {
+    // Column header text should "stick" to the bottom of the row, to be
+    // closest to the contents of the column.
+    display: flex;
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: flex-start;
+  }
+
+  div[role=columnheader], div[role=gridcell] {
+    padding: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  div[role=rowgroup].thead {
+    background-color: $default-table-header-background-color;
+    color: $default-table-header-foreground-color;
+  }
+
+  div[role=row], div[role=gridcell] {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+
+  .capability-row, .none-row {
+    background-color: $default-table-row-background-color;
+    color: $default-table-row-foreground-color;
+  }
+
+  .grant-by {
+    width: 218px; // Width of an identity-card
+    flex: none;
+  }
+
+  .grant-to {
+    flex: 1 1 auto;
+  }
+
+  .grant-time {
+    width: 100px;
+    flex: none;
+  }
+
+  .actions {
+    width: 70px;
+    flex: none;
+  }
+
+  .grain-context {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    .grain-details {
+      flex: 1 1 auto;
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      justify-content: flex-start;
+      margin-right: 10px;
+      .app-icon {
+        @extend %pseudo-img-tag;
+        display: inline-block;
+        width: 24px;
+        height: 24px;
+      }
+    }
+    .identity-card {
+      flex: 0 1 auto;
+    }
+  }
+}
+

--- a/shell/client/styles/_new-admin.scss
+++ b/shell/client/styles/_new-admin.scss
@@ -48,6 +48,7 @@ $darker-purple-color: #65468e;
 @import "_admin-organization.scss";
 @import "_admin-status.scss";
 @import "_admin-personalization.scss";
+@import "_admin-network-capabilities.scss";
 @import "_admin-apps.scss";
 @import "_admin-maintenance.scss";
 @import "_admin-users.scss";

--- a/shell/client/styles/_widgets.scss
+++ b/shell/client/styles/_widgets.scss
@@ -40,3 +40,7 @@
 .info-message {
   background-color: $info-background-color;
 }
+
+.standard-form {
+  @extend %standard-form;
+}

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -605,6 +605,7 @@ Meteor.publish("adminApiTokens", function (token) {
       created: 1,
       requirements: 1,
       revoked: 1,
+      owner: 1,
     },
   });
 });

--- a/shell/server/admin/network-capabilities-server.js
+++ b/shell/server/admin/network-capabilities-server.js
@@ -1,0 +1,55 @@
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+import { checkAuth } from "/imports/server/auth.js";
+
+Meteor.publish("adminGrains", function (grainIds) {
+  // If the caller is an admin, publishes the Grains referred to by the provided list of grain IDs.
+  // Otherwise, does nothing.
+  if (!isAdminById(this.userId)) return [];
+  check(grainIds, [String]);
+
+  const db = this.connection.sandstormDb;
+  return db.collections.grains.find({
+    _id: {
+      $in: grainIds,
+    },
+  }, {
+    fields: {
+      identityId: 1,
+      title: 1,
+      packageId: 1,
+    },
+  });
+});
+
+Meteor.publish("adminPackages", function (packageIds) {
+  // If the caller is an admin, publishes the Packages referred to by the provided list of package
+  // IDs.  Otherwise, does nothing.
+  if (!isAdminById(this.userId)) return [];
+  check(packageIds, [String]);
+
+  const db = this.connection.sandstormDb;
+  return db.collections.packages.find({
+    _id: {
+      $in: packageIds,
+    },
+  }, {
+    fields: {
+      manifest: 1,
+    },
+  });
+});
+
+Meteor.publish("adminIdentities", function (identityIds) {
+  // If the caller is an admin, publishes the identity Users listed by ID in identityIds.
+  // Otherwise, does nothing.
+  if (!isAdminById(this.userId)) return [];
+  check(identityIds, [String]);
+
+  const db = this.connection.sandstormDb;
+  return db.collections.users.find({
+    _id: {
+      $in: identityIds,
+    },
+  });
+});


### PR DESCRIPTION
I'm not super thrilled with the fact that:

1. There's no way to sanely assign width to the grain title vs. grain owner boxes, short of just making both fixed width.  (Note that the `.identity-card` is already a fixed width box.)
2. We only show grain owner if it's different from who granted the capability.  The two people I've shown this design to were both confused by this behavior.

But I think this is still better than what existed before (provides more context about the capability, offers search/filtering), and we're likely to make more changes in the future that will obsolete this design, so I think we can roll with this.

![admin-capabilities](https://cloud.githubusercontent.com/assets/307325/15270301/4b5278f0-19cf-11e6-9bfb-6fa374a8f2f7.png)

Closes #1823.