### PR TITLE
Fix a few bugs pertaining to grainviews and login/logout.

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1469,6 +1469,9 @@ Router.map(function () {
     },
 
     onBeforeAction: function () {
+      // Don't do anything for non-account users.
+      if (Meteor.userId() && !Meteor.user().loginIdentities) return;
+
       // Only run the hook once.
       if (this.state.get("beforeActionHookRan")) return this.next();
 
@@ -1542,6 +1545,9 @@ Router.map(function () {
     },
 
     onBeforeAction: function () {
+      // Don't do anything for non-account users.
+      if (Meteor.userId() && !Meteor.user().loginIdentities) return;
+
       // Only run the hook once.
       if (this.state.get("beforeActionHookRan")) return this.next();
       this.state.set("beforeActionHookRan", true);
@@ -1570,6 +1576,8 @@ Router.map(function () {
           Router.go("/grain/" + tokenInfo.grainId + path, {}, { replaceState: true });
         } else if (tokenInfo.grainId) {
           const grainId = tokenInfo.grainId;
+          const identityChosenByLogin = this.state.get("identity-chosen-by-login");
+          this.state.set("identity.chosen-by-login", undefined);
 
           const openView = function openView() {
             // If the grain is already open in a tab, switch to that tab. We have to re-check this
@@ -1587,6 +1595,10 @@ Router.map(function () {
                                                                mainContentElement);
               grainToOpen.openSession();
               globalGrains.setActive(grainId);
+
+              if (identityChosenByLogin) {
+                grainToOpen.revealIdentity(identityChosenByLogin);
+              }
 
               if (!Meteor.userId()) {
                 // Suggest to the user that they log in by opening the login menu.

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1577,7 +1577,7 @@ Router.map(function () {
         } else if (tokenInfo.grainId) {
           const grainId = tokenInfo.grainId;
           const identityChosenByLogin = this.state.get("identity-chosen-by-login");
-          this.state.set("identity.chosen-by-login", undefined);
+          this.state.set("identity-chosen-by-login", undefined);
 
           const openView = function openView() {
             // If the grain is already open in a tab, switch to that tab. We have to re-check this

--- a/shell/packages/accounts-identity/accounts-identity-client.js
+++ b/shell/packages/accounts-identity/accounts-identity-client.js
@@ -64,9 +64,9 @@ Template.identityLoginInterstitial.onCreated(function () {
           Meteor.loginWithIdentity(loginAccount.loginAccountId, () => {
             // If the user is already visiting a grain, assume the identity with which they've
             // logged in is the identity they would like to use on that grain.
-            const activeGrain = this.data.grains.getActive();
-            if (activeGrain) {
-              activeGrain.switchIdentity(identityId);
+            const current = Router.current();
+            if (current.route.getName() === "shared") {
+              current.state.set("identity-chosen-by-login", identityId);
             }
           });
         } else if (!LoginIdentitiesOfLinkedAccounts.findOne({ sourceIdentityId: identityId })) {

--- a/shell/packages/sandstorm-ui-grainview/grainview-list.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview-list.js
@@ -125,6 +125,10 @@ GrainViewList = class GrainViewList {
     return null;
   }
 
+  contains(grainView) {
+    return this._grains.get().indexOf(grainView) != -1;
+  }
+
   addNewGrainView(grainId, path, tokenInfo, parentElement) {
     const grains = this._grains.get();
     const grainview = new GrainView(this, this._db, grainId, path, tokenInfo, parentElement);

--- a/shell/packages/sandstorm-ui-grainview/grainview.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview.js
@@ -148,7 +148,9 @@ GrainView = class GrainView {
 
     // We want the iframe to receive the most recently-set path whenever we rerender.
     this._originalPath = this._path;
-    this._blazeView = Blaze.renderWithData(Template.grainView, this, this._parentElement);
+    if (this._grains.contains(this)) {
+      this._blazeView = Blaze.renderWithData(Template.grainView, this, this._parentElement);
+    }
   }
 
   switchIdentity(identityId) {


### PR DESCRIPTION
Fixes #1984. The problem was that, during login, we would attempt to open a session during the half-logged in state. This would result in two separate redirects from `/shared/:tokenId` to `/grain/:grainId`, the second of which would remove the grainview added by the first, due to [this logic](https://github.com/sandstorm-io/sandstorm/blob/d54130627e0c18fb33604dffbe65b5618d22ed31/shell/packages/sandstorm-ui-grainview/grainview.js#L514).

This also fixes a problem where we were sometimes attaching multiple Blaze views for the same grain at the same time. (You could see this behavior by doing `Meteor.logout()` while visiting a grain.) The fix here is somewhat crude: in `GrainView.reset()`, before attaching a new Blaze view, we verify that the current `GrainView` is in fact in grainview list. This cover all of the problem cases I've seen, where race conditions could lead to a GrainView being `reset()` after it has been removed from the list.