### PR TITLE
Delete keys from objects, rather than assigning "undefined"

### DIFF
--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -437,7 +437,7 @@ Meteor.publish("adminUserDetails", function (userId) {
     }
 
     const observeHandle = identitySubs[identityId];
-    identitySubs[identityId] = undefined;
+    delete identitySubs[identityId];
     observeHandle.stop();
     this.removed("users", identityId);
   };


### PR DESCRIPTION
Fixes a bug where if a user unlinked an identity while you had the admin user details page open, a subscription would not close cleanly.

I checked the rest of the codebase for instances of `] = undefined;` and this was happily the only one.