### PR TITLE
Admin panel users page: deal with corrupted DBs

### DIFF
--- a/shell/client/admin/user-accounts-client.js
+++ b/shell/client/admin/user-accounts-client.js
@@ -13,6 +13,8 @@ const matchesUser = function (searchKey, user) {
 
   for (let i = 0; i < user.identities.length; i++) {
     const identity = user.identities[i];
+    if (!identity) continue; // Sometimes we have identity IDs but no identity object. :(
+
     if (identity._id.indexOf(searchKey) !== -1) return true;
 
     if (identity.profile.intrinsicName.toLowerCase().indexOf(searchKey) !== -1) return true;
@@ -105,8 +107,13 @@ Template.newAdminUsers.onCreated(function () {
       // Identity IDs are given in creation order.
       const identities = identityIds.map((identityId) => {
         const identity = Meteor.users.findOne({ _id: identityId });
-        SandstormDb.fillInProfileDefaults(identity);
-        SandstormDb.fillInIntrinsicName(identity);
+        if (identity) {
+          // For some reason, various servers (including alpha) appear to have accounts that
+          // reference identities which do not exist in the database.
+          SandstormDb.fillInProfileDefaults(identity);
+          SandstormDb.fillInIntrinsicName(identity);
+        }
+
         return identity;
       });
       return {

--- a/shell/client/admin/user-accounts.html
+++ b/shell/client/admin/user-accounts.html
@@ -17,6 +17,7 @@
     <div class="identities" role="gridcell">
       <ul class="identity-list">
         {{#each identity in user.identities}}
+          {{#if identity}}
           <li class="identity">
             <div class="identity-provider-icon">
               <span class="provider-icon {{identity.profile.service}}">{{identity.profile.service}}</span>
@@ -24,6 +25,15 @@
             <div class="identity-name">{{ identity.profile.name }}</div>
             <div class="identity-intrinsic-name">{{ identity.profile.intrinsicName }}</div>
           </li>
+          {{else}}
+          <li class="identity">
+            <div class="identity-provider-icon">
+              <span class="provider-icon">Unknown identity</span>
+            </div>
+            <div class="identity-name">unknown name</div>
+            <div class="identity-intrinsic-name">unknown identifier</div>
+          </li>
+          {{/if}}
         {{/each}}
       </ul>
     </div>

--- a/shell/client/admin/user-details-client.js
+++ b/shell/client/admin/user-details-client.js
@@ -29,9 +29,14 @@ Template.newAdminUserDetailsIdentityTableRow.helpers({
 
 const lookupIdentityId = (identityId) => {
   const identity = Meteor.users.findOne({ _id: identityId });
-  SandstormDb.fillInProfileDefaults(identity);
-  SandstormDb.fillInIntrinsicName(identity);
-  SandstormDb.fillInPictureUrl(identity);
+  if (identity) {
+    // Sometimes, DBs lack the corresponding user identity document.
+    // Defensively avoid dereferencing a possibly-undefined identity.
+    SandstormDb.fillInProfileDefaults(identity);
+    SandstormDb.fillInIntrinsicName(identity);
+    SandstormDb.fillInPictureUrl(identity);
+  }
+
   return identity;
 };
 

--- a/shell/client/admin/user-details.html
+++ b/shell/client/admin/user-details.html
@@ -83,6 +83,66 @@
   </div>
 </template>
 
+<template name="newAdminUserDetailsIdentityMIATableRow">
+{{!-- Filler row to deal with the fact that sometimes identities are missing in
+      the database. --}}
+  <div class="admin-user-identity-body-row" role="row">
+    <div class="admin-user-identity-body-cell identity" role="gridcell">
+      <ul class="identity-information">
+        <li class="identity-picture-name">
+          <div class="identity-profile-picture">
+            Profile picture
+          </div>
+          <span class="identity-name">
+            (unknown name)
+          </span>
+        </li>
+        <li class="identity-provider">
+          <div class="identity-provider-icon" title="unknown service">
+            <span class="provider-icon">
+              (unknown service)
+            </span>
+          </div>
+          <span class="intrinsic-name">
+            (unknown name)
+          </span>
+        </li>
+        <li class="identity-handle">
+          <div class="identity-handle-decorator" role="presentation" title="Handle">
+            @
+          </div>
+          <code>(unknown handle)</code>
+        </li>
+        <li class="identity-pronouns">
+          <div class="identity-pronouns-decorator" role="presentation" title="Pronouns">
+            <span class="identity-pronouns-icon">
+              Pronouns
+            </span>
+          </div>
+          <span class="identity-pronouns-preference">
+            (unknown pronouns)
+          </span>
+        </li>
+        <li class="identity-emails">
+          <div class="identity-emails-decorator" role="presentation" title="Emails">
+            <span class="identity-emails-icon">
+              Emails
+            </span>
+          </div>
+          <ul class="identity-emails-list">
+            <li>
+              No known emails.
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+    <div class="admin-user-identity-body-cell created" role="gridcell">unknown creation date</div>
+    <div class="admin-user-identity-body-cell last-active" role="gridcell">unknown activity date</div>
+    <div class="admin-user-identity-body-cell properties" role="gridcell"></div>
+  </div>
+</template>
+
 <template name="newAdminUserDetailsIdentityTable">
 {{!-- Expects: 
   account: Object
@@ -99,18 +159,26 @@
 
     <div class="admin-user-identity-body" role="rowgroup">
       {{#each identity in (loginIdentities account) }}
-        {{> newAdminUserDetailsIdentityTableRow
-              identity=identity
-              isLoginIdentity=true
-              primaryEmail=account.primaryEmail
-              }}
+        {{#if identity}}
+          {{> newAdminUserDetailsIdentityTableRow
+                identity=identity
+                isLoginIdentity=true
+                primaryEmail=account.primaryEmail
+                }}
+        {{else}}
+          {{> newAdminUserDetailsIdentityMIATableRow }}
+        {{/if}}
       {{/each}}
       {{#each identity in (nonLoginIdentities account) }}
-        {{> newAdminUserDetailsIdentityTableRow
-              identity=identity
-              isLoginIdentity=false
-              primaryEmail=account.primaryEmail
-              }}
+        {{#if identity}}
+          {{> newAdminUserDetailsIdentityTableRow
+                identity=identity
+                isLoginIdentity=false
+                primaryEmail=account.primaryEmail
+                }}
+        {{else}}
+          {{> newAdminUserDetailsIdentityMIATableRow }}
+        {{/if}}
       {{/each}}
     </div>
   </div>
@@ -194,27 +262,6 @@
 
     <h2>Identities</h2>
     {{> newAdminUserDetailsIdentityTable account=account }}
-
-    {{!--
-    {{#each identity in identities}}
-    <ul>
-      <li>service: {{identity.profile.service}}</li>
-      <li>name: {{identity.profile.name}}</li>
-      <li>intrinsicName: {{identity.profile.name}}</li>
-      <li>pronoun: {{identity.profile.pronoun}}</li>
-      <li>handle: {{identity.profile.handle}}</li>
-      <li>emails:
-        <ul>
-        {{#each email in (emailsForIdentity identity)}}
-        <li>email: {{email.email}} {{#if email.primary}}primary{{/if}} {{#unless email.verified}}unverified{{/unless}}</li>
-        {{else}}
-          <li>no email address on file for identity</li>
-        {{/each}}
-        </ul>
-      </li>
-    </ul>
-    {{/each}}
-    --}}
 
     {{/with}}
   {{else}}


### PR DESCRIPTION
...where accounts reference missing identities.

On at least alpha.sandstorm.io and zero (@kentonv's dev instance), there are
user accounts in Mongo's users collection with a loginIdentities field that
references an identity account for which there is no document in the
collection.

Theoretically this is supposed to be impossible, since we only ever delete
identities that are demo identities, and at least alpha has never enabled demo
accounts.  In practice, these DBs exist, and we'd do well to handle their
(surprising) contents a little more defensively.