### PR TITLE
sandcats https: Use UTF8STRING in certificate signing request

### DIFF
--- a/shell/server/sandcats.js
+++ b/shell/server/sandcats.js
@@ -131,6 +131,10 @@ const generateKeyAndCsr = (commonName) => {
     {
       name: "commonName",
       value: commonName,
+      valueTagClass: this.forge.asn1.Type.UTF8,
+      // We specify UTF8 to encode a UTF8String (rather than the default of PRINTABLESTRING) in the
+      // commonName so that GlobalSign does not report a warning, and also because that happens to
+      // be what openssl(1) does when asked to create a CSR.
     },
   ]);
   csr.sign(keys.privateKey);


### PR DESCRIPTION
This makes us do the same thing as install.sh (which delegates to openssl(1)) , and also
makes us stop triggering warnings from GlobalSign, who for some reason is shocked to see
an asterisk character in a PRINTABLESTRING.