### PR TITLE
New admin users bugfixes

### DIFF
--- a/shell/client/admin/user-details-client.js
+++ b/shell/client/admin/user-details-client.js
@@ -7,15 +7,18 @@ Template.newAdminUserDetailsIdentityTableRow.helpers({
     if (!identity) return [];
 
     const verifiedEmails = SandstormDb.getVerifiedEmails(identity);
-    const emails = verifiedEmails.map((email) => {
-      return {
+    const verifiedEmailSet = {};
+    const emails = [];
+    verifiedEmails.forEach((email) => {
+      verifiedEmailSet[email.email] = true;
+      emails.push({
         email: email.email,
         verified: true,
         primary: email === primaryEmail,
-      };
+      });
     });
 
-    if (identity.unverifiedEmail) {
+    if (identity.unverifiedEmail && !verifiedEmailSet[identity.unverifiedEmail]) {
       emails.push({
         email: identity.unverifiedEmail,
         verified: false,

--- a/shell/client/styles/_admin-users.scss
+++ b/shell/client/styles/_admin-users.scss
@@ -101,7 +101,7 @@
       background-image: url('/ldap.svg');
     }
     &.saml {
-      background-image: url('/saml.svg');
+      background-image: url('/ldap.svg');
     }
   }
 }


### PR DESCRIPTION
Fix a couple of bugs @kentonv pointed out during testing:

* reuse the LDAP icon for SAML logins
* avoid showing unverified email addresses if the identity has a matching verified email.