### PR TITLE
Improve error logging in WILDCARD_HOST self-test

### DIFF
--- a/docs/administering/faq.md
+++ b/docs/administering/faq.md
@@ -154,9 +154,11 @@ issue](https://github.com/sandstorm-io/sandstorm/issues/220).
 
 ## Why do I see an error when I try to launch an app, even when the Sandstorm interface works fine?
 
-Sometimes Sandstorm seems to be working fine but can launch no apps.
+Sometimes Sandstorm seems to be working fine but can launch no apps. This typically relates to
+Sandstorm's need for **wildcard DNS**. If you use HTTPS, you will also need **wildcard HTTPS**.
+You can read [technical details](wildcard.md) if you wish.
 
-If you see an error screen like this:
+You might see an error screen like this:
 
 ![Unable to resolve the server's DNS address, screenshot in Chromium](https://alpha-evgl4wnivwih0k6mzxt3.sandstorm.io/unable-to-resolve.png)
 
@@ -164,23 +166,49 @@ even when the app management interface seems to work fine:
 
 ![Skinny Sandstorm admin interface, showing your app instance](https://alpha-evgl4wnivwih0k6mzxt3.sandstorm.io/works-fine.png)
 
-This typically relates to Sandstorm's need for **wildcard DNS**. If you use HTTPS, you
-will also need **wildcard HTTPS**. Keep reading for more information.
+You can trigger Sandstorm's `WILDCARD_HOST` self-test by visiting the admin settings page at
+`/admin/settings` and reloading your web browser. A big red error will appear if your configuration
+fails the self-test. If so, **read the Javascript console.** Sandstorm will log details in your
+browser's Javascript console, [although those details might be
+minimal](http://stackoverflow.com/questions/31058764/determine-if-ajax-call-failed-due-to-insecure-response-or-connection-refused);
+thankfully, your web browser will typically provide further details about the failed connection in
+the Javascript console. Here are some hints, based on errors you might see.
 
-**Wildcard DNS.** Sandstorm runs each app _session_ on a unique,
-temporary subdomain. Here's what to check:
+- `Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource`: This
+  usually means your WILDCARD_HOST and BASE_URL disagree about port number, or the WILDCARD_HOST and
+  BASE_URL disagree about your domain name.
 
-- **Make sure the `WILDCARD_HOST` has valid syntax.** In the Sandstorm config file (typically `/opt/sandstorm/sandstorm.conf`, look for the `WILDCARD_HOST` config item. Note that this should not have a protocol as part of it. A valid line might be:
+- `Connection refused` or `net::ERR_CONNECTION_REFUSED`: This can occur if your WILDCARD_HOST
+  specifies the wrong domain name or if the WILDCARD_HOST and BASE_URL disagree about port number.
+
+- `HTTPS security error` or `net::ERR_INSECURE_RESPONSE`: This can occur if you are using a
+  self-signed certificate for Sandstorm but have not set up a self-signed CA. Read our docs on
+  [self-signed SSL for Sandstorm.](self-signed.md)
+
+Keep in mind the following configuration guidelines.
+
+- **Make sure the `WILDCARD_HOST` has valid syntax.** In the Sandstorm config file (typically
+    `/opt/sandstorm/sandstorm.conf`, look for the `WILDCARD_HOST` config item. Note that this should
+    **not** have a protocol as part of it but **does** need a port number if `BASE_URL` specifies a
+    port number. A valid line might be:
 
 ```
 WILDCARD_HOST=*.yourname.sandcats.io:6080
 ```
 
-- **Make sure wildcard DNS works for your chosen domain**. See also [this issue in our repository](https://github.com/sandstorm-io/sandstorm/issues/114). If setting up wildcard DNS is a hassle for you, consider using our free [Sandcats dynamic DNS](sandcats.md) service for your `WILDCARD_HOST`.
+- **Make sure wildcard DNS works for your chosen domain**. See also [this issue in our
+  repository](https://github.com/sandstorm-io/sandstorm/issues/114). If setting up wildcard DNS is
+  a hassle for you, consider using our free [Sandcats dynamic DNS](sandcats.md) service for your
+  `WILDCARD_HOST`.
 
-- You can read [more about Sandstorm and wildcard DNS](wildcard.md).
-
-**Wildcard HTTPS.** If wildcard DNS is configured properly, and you can access the Sandstorm shell, but you get an error accessing grains, keep in mind that your browser must trust `*.sandstorm.example.com` not just `sandstorm.example.com`. You can test this by visiting a random HTTPS URL within your Sandstorm domain, such as [https://just-testing.sandstorm.example.com](https://just-testing.sandstorm.example.com). If you see a browser certificate warning, then that is the root of your problem. You can read more about configuring HTTPS in our [HTTPS topic guide](ssl.md).
+- If you are using HTTPS, **make sure wildcard HTTPS works on your server.** If wildcard DNS is
+  configured properly, and you can access the Sandstorm shell, but you get an error accessing
+  grains, keep in mind that your browser must trust `*.sandstorm.example.com` not just
+  `sandstorm.example.com`. You can test this by visiting a random HTTPS URL within your Sandstorm
+  domain, such as
+  [https://just-testing.sandstorm.example.com](https://just-testing.sandstorm.example.com). If you
+  see a browser certificate warning, then that is the root of your problem. You can read more about
+  configuring HTTPS in our [HTTPS topic guide](ssl.md).
 
 ## Can I customize the root page of my Sandstorm install?
 

--- a/docs/administering/self-signed.md
+++ b/docs/administering/self-signed.md
@@ -1,8 +1,22 @@
 ## Self-hosted HTTPS with a custom certificate authority
 
-The following is a process for self-hosted instances of Sandstorm to use SSL with any DNS name, including a sandcats.io hostname. These steps create a Certificate Authority (CA), corresponding CA Certificate, and the private and public keys for the `[anything]` and `*.[anything]` domains.
+To use Sandstorm with a self-signed certificate, you must create a certificate authority (CA)
+certificate and import the CA certificate into all web browsers where you want the Sandstorm server
+to able to be viewed. Web browsers do not show a "OK to continue?" prompt for IFRAMEs, and Sandstorm
+embeds IFRAMEs to subdomains of its main domain, so there is no warning that users can click
+through. Therefore you must add the CA certificate to web browsers.
 
-Note: Web browsers will display a big red certificate error when you try to connect to this install. This tutorial is appropriate if you are OK with **reconfiguring web browsers to trust a custom certificate authority** that you will create during this tutorial. To read about other options for configuring HTTPS/SSL, including a **free auto-renewing HTTPS certificate**, visit the [HTTPS/SSL topic guide](ssl.md).
+This document explains one way to for self-hosted instances of Sandstorm to use SSL with any DNS
+name, including a sandcats.io hostname. These steps create a Certificate Authority (CA),
+corresponding CA Certificate, and the private and public keys for the `[anything]` and
+`*.[anything]` domains, and provides a link to information on installing the certificate in web
+browsers.
+
+**Web browsers will display a big red certificate error when you try to connect to this install
+unless you install the certificate in them.** Therefore, this tutorial is appropriate if you are OK
+with reconfiguring web browsers to trust a custom certificate authority that you will create during
+this tutorial. To read about other options for configuring HTTPS/SSL, including a **free
+globally-trusted auto-renewing HTTPS certificate**, visit the [HTTPS/SSL topic guide](ssl.md).
 
 1. Make a copy openssl.cnf:
 

--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -1185,8 +1185,8 @@ const adminRoute = RouteController.extend({
                     console.log("Sandstorm WILDCARD_HOST self-test failed. Details:");
                     console.log(error);
                     console.log(
-                      "Further details may be available in the JS console provided by your web " +
-                        "browser. Look for errors involving a domain starting with selftest-*.");
+                      "Error messages above or below this one may relate to this error; look for " +
+                        "messages involving a domain starting with selftest-*.");
                     console.log(
                       "See also docs: https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine");
                     console.log(

--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -1198,7 +1198,7 @@ const adminRoute = RouteController.extend({
                       looksGood = true;
                     } else {
                       console.log(
-                        "Sandstorm WILDCARD_HOST self-test failed. Received status code:")
+                        "Sandstorm WILDCARD_HOST self-test failed. Received status code:");
                       console.log(response.statusCode);
                       looksGood = false;
                     }

--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -1182,11 +1182,24 @@ const adminRoute = RouteController.extend({
                   let looksGood;
                   if (error) {
                     looksGood = false;
+                    console.log("Sandstorm WILDCARD_HOST self-test failed. Details:");
+                    console.log(error);
+                    console.log(
+                      "Further details may be available in the JS console provided by your web " +
+                        "browser. Look for errors involving a domain starting with selftest-*.");
+                    console.log(
+                      "See also docs: https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine");
+                    console.log(
+                      "Slow DNS or intermittent Internet connectivity can cause this message " +
+                        "to appear unnecessarily; in that case, reloading the page should make " +
+                        "it go away.");
                   } else {
                     if (response.statusCode === 200) {
                       looksGood = true;
                     } else {
-                      console.log("Surpring status code from self test domain", response.statusCode);
+                      console.log(
+                        "Sandstorm WILDCARD_HOST self-test failed. Received status code:")
+                      console.log(response.statusCode);
                       looksGood = false;
                     }
                   }

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -974,12 +974,13 @@ limitations under the License.
   {{#if wildcardHostSeemsBroken}}
   <div class="wildcard-host-warning">
     WARNING: This server seems to have its WILDCARD_HOST misconfigured.  Until you fix it, you will
-    not be able to use any apps.
-    <a target="_blank"
-       href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
-      Learn more.</a>  You'll need to adjust DNS, SSL/TLS certificates, or edit the sandstorm.conf
-    file. Once you have addressed the issue, reload this page. If you're still having problems,
-    <a href="https://github.com/sandstorm-io/sandstorm/issues">please file an issue.</a>
+    not be able to use any apps. You can read <a target="_blank"
+    href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
+    more info in the Sandstorm docs</a> and in your browser's Javascript console. You'll need to
+    adjust DNS, SSL/TLS certificates, or edit the sandstorm.conf file. If you see no information in
+    the JS console, or wish to test if you have fixed the problem, reload this page to re-run the
+    test. If you're still having
+    problems, <a href="https://github.com/sandstorm-io/sandstorm/issues">please file an issue.</a>
   </div>
   {{/if}}
 


### PR DESCRIPTION
Close #1987

Note that since the self-test is performed client-side, it is difficult to get
detailed information about XHR failures. Therefore, this commit adds documentation
with information on how decode errors that I have seen with Chrome and Firefox.