### PR TITLE
Further clarity improvements in tutorial

### DIFF
--- a/docs/vagrant-spk/packaging-tutorial.md
+++ b/docs/vagrant-spk/packaging-tutorial.md
@@ -64,10 +64,10 @@ The app's code will be stored at
 `~/projects/php-app-to-package-for-sandstorm`.  We will spend the rest
 of the tutorial in that directory and its sub-directories.
 
-**Note**: Feel free to spend a moment looking around this [folder you
-just downloaded](https://github.com/sandstorm-io/php-app-to-package-for-sandstorm).
-You'll find an `index.php` and some CSS and
-Javascript.
+**Note**: Feel free to spend a moment looking around this folder you
+just downloaded (or [view its contents on
+GitHub](https://github.com/sandstorm-io/php-app-to-package-for-sandstorm)).
+You'll find an `index.php` and some CSS and Javascript.
 
 ## Create .sandstorm, to store packaging information for the app
 
@@ -79,7 +79,7 @@ create the package.
 We'll use the `vagrant-spk` tool to create this directory.
 
 The purpose of `vagrant-spk` is to create a Linux system where Sandstorm and
-your app run successfully. It acts differently based on which [language platform]
+your app run successfully. It acts differently based on which [platform stack]
 (https://docs.sandstorm.io/en/latest/vagrant-spk/platform-stacks/)
 you want to use. In our case, we'll use the _lemp_ platform: Linux, nginx, MySQL,
 and PHP.


### PR DESCRIPTION
- When linking to the sample app, indicate that the link is to an online view,
  rather than the files on your own computer.

- When talking about platform stacks, consistently call them platform stacks.

Refs #1953