### PR TITLE
New admin reorganization

### DIFF
--- a/shell/client/admin/admin-new-client.js
+++ b/shell/client/admin/admin-new-client.js
@@ -1,9 +1,3 @@
-Template.adminNavPill.helpers({
-  currentRouteNameIs(name) {
-    return Router.current().route.getName() === name;
-  },
-});
-
 Template.newAdmin.helpers({
   adminTab() {
     return Router.current().route.getName();

--- a/shell/client/admin/admin.html
+++ b/shell/client/admin/admin.html
@@ -1,52 +1,109 @@
-<template name="adminNavPill">
+<template name="adminNavItem">
 {{!--
   Takes as arguments:
 
   routeName: String
        data: String
+      class: String
 --}}
-<li class="nav-pill {{#if currentRouteNameIs routeName}}active{{/if}}">
-  {{#linkTo route=routeName data=data}}{{> Template.contentBlock}}{{/linkTo}}
+<li class="nav-item">
+  {{#linkTo route=routeName class=class data=data}}
+    {{> Template.contentBlock}}
+  {{/linkTo}}
 </li>
 </template>
 
 <template name="newAdmin">
-  {{>title "(new) Admin Settings"}}
+  {{>title "Admin panel"}}
+
   {{#if wildcardHostSeemsBroken}}
-  <div class="wildcard-host-warning">
+  <div class="flash-message warning-message">
     WARNING: This server seems to have its WILDCARD_HOST misconfigured.  Until you fix it, you will
     not be able to use any apps.
     <a target="_blank"
        href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
       Learn more.</a>  You'll need to adjust DNS, SSL/TLS certificates, or edit the sandstorm.conf
     file. Once you have addressed the issue, reload this page. If you're still having problems,
-    email us at support@sandstorm.io.
+    email us at <a href="mailto:support@sandstorm.io">support@sandstorm.io</a>.
   </div>
   {{/if}}
 
-  {{> _adminConfigureLoginServiceDialog}}
   <div class="admin-settings">
     {{#if isUserPermitted}}
-      <ul class="nav-pills">
-        {{#adminNavPill routeName="newAdminIdentity"}}Identity Providers{{/adminNavPill}}
-        {{#adminNavPill routeName="newAdminOrganization"}}Organization Settings{{/adminNavPill}}
-        {{#adminNavPill routeName="newAdminEmailConfig"}}Email Configuration{{/adminNavPill}}
-        {{#adminNavPill routeName="newAdminUsers"}}Users{{/adminNavPill}}
-        {{#adminNavPill routeName="newAdminAppSources"}}App Sources{{/adminNavPill}}
-        {{#adminNavPill routeName="newAdminMaintenance"}}Maintenance Message{{/adminNavPill}}
-        {{#adminNavPill routeName="newAdminStatus"}}System Status{{/adminNavPill}}
-        {{#adminNavPill routeName="newAdminPersonalization"}}Personalization{{/adminNavPill}}
-        {{#adminNavPill routeName="newAdminNetworkCapabilities"}}Network Capabilities{{/adminNavPill}}
-        {{#adminNavPill routeName="newAdminStats"}}Stats{{/adminNavPill}}
-        {{#adminNavPill routeName="newAdminFeatureKey"}}For Work{{/adminNavPill}}
-      </ul>
       {{> Template.dynamic template=adminTab}}
     {{else}}
       <p>
-        You are not logged in as admin and there isn't a valid token specified. You should
-        either log in as an admin user or generate a token from the command line by doing
-        `sandstorm admin-token` in order to access the admin settings page.
+        You are not logged in as an admin. To access the admin panel, log in as an admin user or
+        generate a token from the command line by running `sandstorm admin-token`.
       </p>
     {{/if}}
   </div>
+</template>
+
+<template name="newAdminRoot">
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>Admin</li>
+    </ul>
+  </h1>
+
+  <nav>
+    <ul class="nav-sections">
+      <li>
+        <h2>Configuration</h2>
+        <ul class="nav-items">
+          {{#adminNavItem routeName="newAdminIdentity"}}
+            <div class="item-name">Identity providers</div>
+            <div class="item-subtext">How users log in.</div>
+          {{/adminNavItem}}
+          {{#adminNavItem routeName="newAdminOrganization"}}
+            <div class="item-name">Organization settings</div>
+            <div class="item-subtext">Smoother onboarding and collaboration for larger teams.</div>
+          {{/adminNavItem}}
+          {{#adminNavItem routeName="newAdminEmailConfig"}}
+            <div class="item-name">Email configuration</div>
+            <div class="item-subtext">How email gets sent to users.</div>
+          {{/adminNavItem}}
+          {{#adminNavItem routeName="newAdminFeatureKey"}}
+            <div class="item-name">Sandstorm for Work</div>
+            <div class="item-subtext">Get a feature key and unlock advanced features.</div>
+          {{/adminNavItem}}
+          {{#adminNavItem routeName="newAdminPersonalization"}}
+            <div class="item-name">Personalization</div>
+            <div class="item-subtext">Customize a splash page, terms of service, privacy policy,
+                etc.</div>
+          {{/adminNavItem}}
+          {{#adminNavItem routeName="newAdminAppSources"}}
+            <div class="item-name">App sources</div>
+            <div class="item-subtext">Where to look for apps and app updates.</div>
+          {{/adminNavItem}}
+        </ul>
+      </li>
+      <li>
+        <h2>Management</h2>
+        <ul class="nav-items">
+          {{#adminNavItem routeName="newAdminUsers"}}
+            <div class="item-name">Users</div>
+            <div class="item-subtext">Manage all users on this Sandstorm installation.</div>
+          {{/adminNavItem}}
+          {{#adminNavItem routeName="newAdminStatus"}}
+            <div class="item-name">System log</div>
+            <div class="item-subtext">View Sandstorm's debug log.</div>
+          {{/adminNavItem}}
+          {{#adminNavItem routeName="newAdminStats"}}
+            <div class="item-name">Statistics</div>
+            <div class="item-subtext">View usage statistics for this server.</div>
+          {{/adminNavItem}}
+          {{#adminNavItem routeName="newAdminMaintenance"}}
+            <div class="item-name">Maintenance message</div>
+            <div class="item-subtext">Communicate potential downtime to users</div>
+          {{/adminNavItem}}
+          {{#adminNavItem routeName="newAdminNetworkCapabilities"}}
+            <div class="item-name">Network capabilities</div>
+            <div class="item-subtext">Manage direct network access for grains.</div>
+          {{/adminNavItem}}
+        </ul>
+      </li>
+    </ul>
+  </nav>
 </template>

--- a/shell/client/admin/app-sources.html
+++ b/shell/client/admin/app-sources.html
@@ -1,5 +1,11 @@
 <template name="newAdminAppSources">
-  <h1>App Sources</h1>
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+      <li>App sources</li>
+    </ul>
+  </h1>
+
   {{#if hasSuccess}}
     {{#focusingSuccessBox}}
       {{message}}
@@ -13,7 +19,7 @@
   <form class="admin-app-sources">
     <div class="form-group">
       <label>
-        App Market URL
+        App market URL
         <input type="text" name="appMarketUrl" value="{{appMarketUrl}}" />
       </label>
       <span class="form-subtext">
@@ -35,7 +41,7 @@
     {{#if enableAppUpdates}}
     <div class="form-group">
       <label>
-        App Index URL
+        App index URL
         <input type="text" name="appIndexUrl" value="{{appIndexUrl}}" />
       </label>
       <span class="form-subtext">

--- a/shell/client/admin/email-config.html
+++ b/shell/client/admin/email-config.html
@@ -1,5 +1,10 @@
 <template name="newAdminEmailConfig">
-  <h1>Email Configuration</h1>
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+      <li>Email configuration</li>
+    </ul>
+  </h1>
 
   <h2>Outbound email</h2>
 

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -1,5 +1,10 @@
 <template name="newAdminFeatureKey">
-  <h1>Sandstorm for Work</h1>
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+      <li>Sandstorm for Work</li>
+    </ul>
+  </h1>
 
   {{#if currentFeatureKey}}
     <h2>Current feature key</h2>

--- a/shell/client/admin/identity-providers.html
+++ b/shell/client/admin/identity-providers.html
@@ -1,19 +1,25 @@
 <template name="newAdminIdentity">
-  <h1>Identity Providers</h1>
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+      <li>Identity providers</li>
+    </ul>
+  </h1>
+
   <p>Choose which services users may use to identify themselves.  Anyone can log in, but only users you invite will be able to install apps or create grains.</p>
   {{>adminIdentityProviderTable idpData=idpData featureKeyRoute="newAdminFeatureKey"}}
 
   {{#if hasFeatureKey}}
     <p>
     To configure organization membership and settings, see
-    {{#linkTo route="newAdminOrganization"}}Organization Settings{{/linkTo}}.
+    {{#linkTo route="newAdminOrganization"}}organization settings{{/linkTo}}.
     </p>
   {{/if}}
 </template>
 
 <template name="adminIdentityProviderConfigureEmail">
 {{#modalDialogWithBackdrop onDismiss=onDismiss}}
-  <h2>Email Login Configuration</h2>
+  <h2>Email login configuration</h2>
 
   {{#if errorMessage}}
     {{#focusingErrorBox}}
@@ -62,7 +68,7 @@
 
 <template name="adminIdentityProviderConfigureGoogle">
 {{#modalDialogWithBackdrop onDismiss=onDismiss}}
-  <h2>Google Login Configuration</h2>
+  <h2>Google login configuration</h2>
 
   {{#if errorMessage}}
     {{#focusingErrorBox}}
@@ -73,7 +79,7 @@
   <form class="setup-idp-form">
     {{> googleLoginSetupInstructions }}
 
-    <p>Then, copy over your Client ID and Client Secret below:</p>
+    <p>Then, copy over your Client ID and Client secret below:</p>
 
     <div class="form-group">
       <label>
@@ -83,7 +89,7 @@
     </div>
     <div class="form-group">
       <label>
-        Client Secret:
+        Client secret:
         <input type="text" name="clientSecret" value="{{clientSecret}}"/>
       </label>
     </div>
@@ -111,7 +117,7 @@
 
 <template name="githubLoginSetupInstructions">
   <p>
-    First, you'll need to get a Github Client ID and Client Secret. Follow these steps:
+    First, you'll need to get a Github Client ID and Client secret. Follow these steps:
   </p>
   <ol>
     <li>Visit <a href="https://github.com/settings/applications/new" target="blank">https://github.com/settings/applications/new</a></li>
@@ -122,12 +128,12 @@
 
 <template name="adminIdentityProviderConfigureGitHub">
 {{#modalDialogWithBackdrop onDismiss=onDismiss}}
-  <h2>GitHub Configuration</h2>
+  <h2>GitHub login configuration</h2>
 
   <form class="setup-idp-form">
     {{> githubLoginSetupInstructions }}
 
-    <p>Then, copy over your Client ID and Client Secret below:</p>
+    <p>Then, copy over your Client ID and Client secret below:</p>
     <div class="form-group">
       <label>
         Client ID:
@@ -136,7 +142,7 @@
     </div>
     <div class="form-group">
       <label>
-        Client Secret:
+        Client secret:
         <input type="text" name="clientSecret" value="{{clientSecret}}"/>
       </label>
     </div>
@@ -164,7 +170,7 @@
 
 <template name="adminIdentityProviderConfigureLdap">
 {{#modalDialogWithBackdrop onDismiss=onDismiss}}
-  <h2>LDAP Configuration</h2>
+  <h2>LDAP login configuration</h2>
 
   {{#if errorMessage}}
     {{#focusingErrorBox}}
@@ -274,7 +280,7 @@
 
 <template name="adminIdentityProviderConfigureSaml">
 {{#modalDialogWithBackdrop onDismiss=onDismiss}}
-  <h2>SAML Login Configuration</h2>
+  <h2>SAML login configuration</h2>
 
   <p>
     Your SAML IDP should be configured to return a persistent nameID. In addition you <strong>must</strong>
@@ -333,7 +339,7 @@
 <div class="identity-provider-table" role="grid">
   <div class="idp-table-header" role="rowgroup">
     <div class="idp-header-row" role="row">
-      <span class="idp" role="rowheader">Identity Provider</span>
+      <span class="idp" role="rowheader">Identity provider</span>
       <span class="idp-status" role="rowheader">Status</span>
     </div>
   </div>
@@ -359,7 +365,7 @@
     {{#if idp.enabled}}
       <span class="idp-enabled">Enabled</span>
     {{else}}
-      <span class="idp-disabled">Not Enabled</span>
+      <span class="idp-disabled">Not enabled</span>
     {{/if}}
 
     {{#if needsFeatureKey}}

--- a/shell/client/admin/maintenance-message.html
+++ b/shell/client/admin/maintenance-message.html
@@ -1,5 +1,10 @@
 <template name="newAdminMaintenance">
-  <h1>Maintenance message</h1>
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+      <li>Maintenance message</li>
+    </ul>
+  </h1>
 
   <p>
     You can set a maintenance message which will be shown to all users in the menu bar, on the top right.
@@ -8,14 +13,14 @@
   </p>
 
   <p>
-    You may use the following variables in the "Message Text" field, which will be automatically
+    You may use the following variables in the "Message text" field, which will be automatically
     substituted with useful values:
   </p>
 
   <ul>
-    <li><code>$TIME</code> : The time component of "Maintenance Time", converted to the user's local time (eg. "1:15:45 PM")</li>
-    <li><code>$DATE</code> : The date component of "Maintenance Time", converted to the user's local time (eg. "6/19/2015")</li>
-    <li><code>$IN_COUNTDOWN</code> : An active countdown until "Maintenance Time" (eg. "in 3 days" or "in 1 minute"). Displays "any moment" at the time specified in "Maintenance Time" and then disappears after an hour.</li>
+    <li><code>$TIME</code> : The time component of "Maintenance time", converted to the user's local time (eg. "1:15:45 PM")</li>
+    <li><code>$DATE</code> : The date component of "Maintenance time", converted to the user's local time (eg. "6/19/2015")</li>
+    <li><code>$IN_COUNTDOWN</code> : An active countdown until "Maintenance time" (eg. "in 3 days" or "in 1 minute"). Displays "any moment" at the time specified in "Maintenance time" and then disappears after an hour.</li>
   </ul>
 
   {{#if hasSuccess}}
@@ -32,7 +37,7 @@
   <form class="maintenance-message-form">
     <div class="form-group">
       <label>
-        Message Text:
+        Message text:
         <input type="text" name="message-text" value="{{messageText}}" />
       </label>
       <span class="form-subtext">
@@ -41,17 +46,17 @@
 
     <div class="form-group">
       <label>
-        Maintenance Time:
+        Maintenance time:
         <input type="text" name="maintenance-time" value="{{maintenanceTime}}" />
       </label>
       <span class="form-subtext">
-		The time you intend to start performing maintenance, formatted like "{{ exampleDate }}".
+        The time you intend to start performing maintenance, formatted like "{{ exampleDate }}".
       </span>
     </div>
 
     <div class="form-group">
       <label>
-        Link Url (optional):
+        Link URL (optional):
         <input type="text" name="url" value="{{linkUrl}}" />
       </label>
       <span class="form-subtext">

--- a/shell/client/admin/network-capabilities.html
+++ b/shell/client/admin/network-capabilities.html
@@ -132,12 +132,17 @@
 
 
 <template name="newAdminNetworkCapabilities">
-<h1>Network Capabilities</h1>
+<h1>
+  <ul class="admin-breadcrumbs">
+    <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+    <li>Network capabilities</li>
+  </ul>
+</h1>
 
-<h2>Outbound Network Access</h2>
+<h2>Outbound network access</h2>
 {{>newAdminNetworkCapabilitiesSection caps=ipNetworkCaps}}
 
-<h2>Inbound Network Access</h2>
+<h2>Inbound network access</h2>
 {{>newAdminNetworkCapabilitiesSection caps=ipInterfaceCaps}}
 
 </template>

--- a/shell/client/admin/organization.html
+++ b/shell/client/admin/organization.html
@@ -7,11 +7,16 @@
 </template>
 
 <template name="newAdminOrganization">
-  <h1>Organization Settings</h1>
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+      <li>Organization settings</li>
+    </ul>
+  </h1>
 
   {{#unless hasFeatureKey }}
     <div class="flash-message warning-message">
-        To enable Organization Settings, enter your
+        To enable organization settings, enter your
         {{#linkTo route="newAdminFeatureKey"}}
           Sandstorm for Work feature key
         {{/linkTo}}.

--- a/shell/client/admin/personalization.html
+++ b/shell/client/admin/personalization.html
@@ -1,5 +1,10 @@
 <template name="newAdminPersonalization">
-  <h1>Personalization</h1>
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+      <li>Personalization</li>
+    </ul>
+  </h1>
 
   {{#if hasSuccess }}
     {{#focusingSuccessBox}}
@@ -65,7 +70,7 @@
                placeholder="https://example.com/tos" disabled="{{formDisabled}}"/>
       </label>
       <span class="form-subtext">
-        If provided, new users will be required to agree to the linked Terms of Service.
+        If provided, new users will be required to agree to the linked terms of service.
       </span>
     </div>
 
@@ -76,7 +81,7 @@
                placeholder="https://example.com/privacy" disabled="{{formDisabled}}"/>
       </label>
       <span class="form-subtext">
-        If provided, new users will be required to agree to the linked Privacy Policy.
+        If provided, new users will be required to agree to the linked privacy policy.
       </span>
     </div>
 

--- a/shell/client/admin/stats.html
+++ b/shell/client/admin/stats.html
@@ -110,7 +110,12 @@
 </template>
 
 <template name="newAdminStats">
-  <h1>Stats</h1>
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+      <li>Statistics</li>
+    </ul>
+  </h1>
 
   <h2>Publish anonymously to Sandstorm dev team</h2>
 

--- a/shell/client/admin/system-status.html
+++ b/shell/client/admin/system-status.html
@@ -9,27 +9,15 @@
 </template>
 
 <template name="newAdminStatus">
-  <h1>System Status</h1>
-
-  <div class="admin-status-row">
-    <div class="current-usage">
-      <h2>Current Usage</h2>
-      <ul>
-        <li>Grains open: {{grainsActive}}</li>
-        <li>User accounts with grains open: {{usersActive}}</li>
-        {{#if allowDemo}}
-          <li>Demo accounts active: {{demosActive}}</li>
-        {{/if}}
-      </ul>
-    </div>
-    <div class="version">
-      <h2>Sandstorm Version</h2>
-      <p>{{#linkTo route="about" }}{{ sandstormVersion }}{{/linkTo}}</p>
-    </div>
-  </div>
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+      <li>System log</li>
+    </ul>
+  </h1>
 
   <h2 class="system-log-header">
-    <span>System Log</span>
+    <span>System log</span>
     <form>
       <button type="button" name="download-full-log">
         Download full log

--- a/shell/client/admin/user-accounts.html
+++ b/shell/client/admin/user-accounts.html
@@ -96,7 +96,12 @@
 
 
 <template name="newAdminUsers">
-  <h1>Users</h1>
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+      <li>Users</li>
+    </ul>
+  </h1>
 
   {{#with users=allUsers ready=userSubReady}}
   <div class="admin-user-filters">

--- a/shell/client/admin/user-details.html
+++ b/shell/client/admin/user-details.html
@@ -185,7 +185,13 @@
 </template>
 
 <template name="newAdminUserDetails">
-  <h1>{{#linkTo route="newAdminUsers"}}Users{{/linkTo}} / {{ guessUserName }}</h1>
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+      <li>{{#linkTo route="newAdminUsers"}}Users{{/linkTo}}</li>
+      <li>{{ guessUserName }}</li>
+    </ul>
+  </h1>
 
   {{#if ready}}
     {{#with account=targetAccount}}

--- a/shell/client/admin/user-invite.html
+++ b/shell/client/admin/user-invite.html
@@ -81,7 +81,14 @@ bob@example.com"></textarea>
 </template>
 
 <template name="newAdminUserInvite">
-  <h1>{{#linkTo route="newAdminUsers"}}Users{{/linkTo}} / Invite</h1>
+  <h1>
+    <ul class="admin-breadcrumbs">
+      <li>{{#linkTo route="newAdminRoot"}}Admin{{/linkTo}}</li>
+      <li>{{#linkTo route="newAdminUsers"}}Users{{/linkTo}}</li>
+      <li>Invite</li>
+    </ul>
+  </h1>
+
   {{> newAdminUserInviteLink }}
   <hr>
   {{> newAdminUserInviteEmail }}

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -281,7 +281,7 @@ limitations under the License.
         {{> notificationItem}}
       </li>
     {{else}}
-    <li>No Notifications...</li>
+    <li>No notifications...</li>
     {{/each}}
   </ul>
 </template>
@@ -1695,13 +1695,13 @@ limitations under the License.
     </section>
 
     <section class="changelog">
-      <h2>Recent Changes</h2>
+      <h2>Recent changes</h2>
 
       {{> changelog}}
     </section>
 
     <section class="developers">
-      <h2>Core Developers</h2>
+      <h2>Core developers</h2>
       <ul>
         <li><a href="https://github.com/kentonv">
             <img src="/logos/kenton.png" alt="Kenton Varda">
@@ -1750,7 +1750,7 @@ limitations under the License.
     </section>
     <br>
     <section class="corporate">
-      <h2>Corporate Sponsors</h2>
+      <h2>Corporate sponsors</h2>
       <p>These companies contributed heavily to Sandstorm's <a href="http://igg.me/at/sandstorm">crowdfunding campaign</a>.</p>
       <ul>
         <li><a href="http://draw.io"><img width="92.75" height="121" src="/logos/draw.io-logo.svg">&nbsp;</a></li><li>
@@ -1759,7 +1759,7 @@ limitations under the License.
       </ul>
       <div class="strut"></div>
     </section><section class="individual">
-      <h2>Key Invididual Sponsors</h2>
+      <h2>Key invididual sponsors</h2>
       <p>These individuals contributed heavily to Sandstorm's <a href="http://igg.me/at/sandstorm">crowdfunding campaign</a>.</p>
       <ul>
       <li><a href="http://rogerwagner.com/">
@@ -1835,8 +1835,8 @@ limitations under the License.
     <section class="terms">
       <ul>
         <li><a href="https://github.com/sandstorm-io/sandstorm/blob/master/LICENSE">License</a></li>
-        {{#with termsUrl}}<li><a href="{{.}}">Terms of Service</a></li>{{/with}}
-        {{#with privacyUrl}}<li><a href="{{.}}">Privacy Policy</a></li>{{/with}}
+        {{#with termsUrl}}<li><a href="{{.}}">Terms of service</a></li>{{/with}}
+        {{#with privacyUrl}}<li><a href="{{.}}">Privacy policy</a></li>{{/with}}
       </ul>
     </section>
   </div>

--- a/shell/client/styles/_about.scss
+++ b/shell/client/styles/_about.scss
@@ -174,7 +174,7 @@
           display: block;
           color: black;
           &:hover {
-            color: #65468e;
+            color: $darker-purple-color;
           }
 
           &::after {
@@ -247,7 +247,7 @@
           color: black;
           font-weight: normal;
           &:hover {
-            color: #65468e;
+            color: $darker-purple-color;
           }
         }
       }

--- a/shell/client/styles/_admin-status.scss
+++ b/shell/client/styles/_admin-status.scss
@@ -1,18 +1,3 @@
-.admin-status-row {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-
-  .current-usage {
-    flex: 1 1 50%;
-  }
-
-  .version {
-    flex: 1 1 50%;
-  }
-}
-
 .system-log-header {
   display: flex;
   flex-direction: row;
@@ -25,7 +10,7 @@
 }
 
 .admin-log-box {
-  max-height: 60vh;
+  max-height: calc(100vh - 230px);
   overflow: scroll;
   background-color: white;
   border: 1px solid #ccc;

--- a/shell/client/styles/_colors.scss
+++ b/shell/client/styles/_colors.scss
@@ -2,6 +2,7 @@
 
 // The purple that we use for
 $sandstorm-purple-color: #762F87;
+$darker-purple-color: #65468e;
 
 // The color that we use to outline focused elements, for accessibility
 $focus-outline-color: $sandstorm-purple-color;
@@ -62,7 +63,7 @@ $default-table-row-action-background-color-hover: lighten($sandstorm-purple-colo
 // Default text input field colors
 $default-textinput-background-color: #ffffff;
 $default-textinput-outline-color: #9e9e9e;
-$default-textinput-outline-color-focus: #65468e;
+$default-textinput-outline-color-focus: $darker-purple-color;
 
 //////// Grain list ("Open...") styles
 $grainlist-background-color: $default-content-background-color;

--- a/shell/client/styles/_new-admin.scss
+++ b/shell/client/styles/_new-admin.scss
@@ -1,12 +1,10 @@
-// The purple used for the new design's nav pills.
-$darker-purple-color: #65468e;
-
 .admin-settings {
   padding: 32px;
 
   h1 {
     font-weight: normal;
-    padding-top: 12px;
+    margin-top: 0;
+    //padding-top: 12px;
     padding-bottom: 12px;
     border-bottom: 1px solid #a2a2a2;
   }
@@ -17,30 +15,81 @@ $darker-purple-color: #65468e;
   }
 }
 
-.nav-pills {
+.admin-breadcrumbs {
   margin: 0;
   padding: 0;
+  list-style-type: none;
   >li {
     display: inline-block;
-    list-style-type: none;
-    height: 32px;
-    margin: 2px;
-    a {
-      display: inline-block;
-      height: 32px;
-      border: 1px solid #dddddd;
-      border-radius: 4px;
-      padding: 4px 8px;
-      font-weight: normal;
-      color: black;
-      background-color: white;
-    }
-
-    &.active a {
-      color: white;
-      background-color: $darker-purple-color;
+  }
+  >li:not(:last-child) {
+    &:after {
+      content: " / ";
     }
   }
+}
+
+.nav-sections {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+
+  margin: 0;
+  padding: 0;
+
+  list-style-type: none;
+  font-size: 24px;
+  >li {
+    min-width: 260px;
+    max-width: 360px;
+    flex: 1 1 0;
+    &:not(:last-child) {
+      margin-right: 32px;
+    }
+  }
+}
+
+.nav-items {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+
+  >li {
+    list-style-type: none;
+    display: block;
+
+    a {
+      display: block;
+
+      border: 1px solid #e8e8e8;
+      border-radius: 4px;
+
+      min-height: 32px;
+      padding: 8px 8px;
+      margin-bottom: 4px;
+
+      font-weight: normal;
+      color: black;
+      background-color: #fff;
+      &:hover {
+        background-color: #d8d8d8;
+      }
+
+      .item-name {
+        color: $darker-purple-color;
+        font-weight: 600;
+        font-size: 16px;
+      }
+
+      .item-subtext {
+        font-size: 14px;
+        color: #666;
+      }
+    }
+  }
+
 }
 
 @import "_admin-identity.scss";

--- a/shell/client/styles/_partials.scss
+++ b/shell/client/styles/_partials.scss
@@ -74,9 +74,9 @@
 
 %button-primary {
   // A button coloring for the primary action of a form.
-  background-color: #65468e;
+  background-color: $darker-purple-color;
   color: white;
-  border: 1px solid darken($sandstorm-purple-color, 10%);
+  border: 1px solid darken($darker-purple-color, 10%);
   &:hover {
     background-color: #714daa;
   }

--- a/shell/client/styles/shell.scss
+++ b/shell/client/styles/shell.scss
@@ -147,7 +147,7 @@ button.revoke-token, button.revoke-access {
   a {
     font-weight: bold;
     text-decoration: none;
-    color: #65468e;
+    color: $darker-purple-color;
   }
 }
 
@@ -397,7 +397,7 @@ div.popup h2 {
     text-align: left;
     >a {
       font-weight: 600;
-      color: #65468e;
+      color: $darker-purple-color;
     }
   }
 

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -20,12 +20,12 @@ limitations under the License.
   {{setDocumentTitle}}
 
   {{#sandstormTopbarItem name="title" priority=5 topbar=_topbar}}
-    Account Settings
+    Account settings
   {{/sandstormTopbarItem}}
 
-  <h2>My Account</h2>
+  <h2>My account</h2>
   <div class="identities-editor">
-  <h3 class="title-bar"> Linked Identities </h3>
+  <h3 class="title-bar">Linked identities</h3>
   <div class="identities-tabs">
   {{#unless isLinkingNewIdentity}}
   <ul role="tablist" >

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -35,7 +35,9 @@
   <h4>Account</h4>
 
   <div class="account-buttons-list" role="menu">
-    <a href="/account" role="menuitem">Account settings</a>
+    {{#linkTo route="account" role="menuitem"}}
+      Account settings
+    {{/linkTo}}
     {{#if showIdentitySwitcher}}
     <button class="switch-identity">
       Switch identity {{#if identitySwitcherExpanded}}▴{{else}}▾{{/if}}
@@ -47,13 +49,13 @@
     {{/if}}
     {{/if}}
     {{#if isAdmin}}
-    <a href="/admin" role="menuitem">Admin settings</a>
+      {{#linkTo route="adminOld" role="menuitem"}}Admin panel{{/linkTo}}
     {{/if}}
-    <a href="mailto:support@sandstorm.io" target="_blank" role="menuitem">Send Feedback</a>
+    <a href="mailto:support@sandstorm.io" target="_blank" role="menuitem">Send feedback</a>
     {{#if quotaEnabled }}
-    <a href="{{pathFor route='referrals'}}">Referral program</a>
+      {{#linkTo route="referrals" role="menuitem"}}Referral program{{/linkTo}}
     {{/if}}
-    <a href="/about" role="menuitem">About Sandstorm</a>
+    {{#linkTo route="about" role="menuitem"}}About Sandstorm{{/linkTo}}
 
     <button class="logout" role="menuitem">
       Sign out
@@ -106,7 +108,9 @@
       {{> Template.dynamic template=../loginTemplate.name }}
     {{/with}}
   {{else}}
-    <a class="troubleshooting" href="/admin">configure login</a>
+    {{#linkTo route="adminSettings" class="troubleshooting"}}
+      configure login
+    {{/linkTo}}
   {{/each}}
 
   {{> _loginButtonsMessages}}
@@ -116,7 +120,7 @@
     <a class="troubleshooting" href="https://docs.sandstorm.io/en/latest/administering/faq/" target="_blank">troubleshooting</a>
   {{/if}}
 
-  <a href="/about">about Sandstorm</a>
+  {{#linkTo route="about"}}about Sandstorm{{/linkTo}}
   </div>
 </template>
 

--- a/shell/packages/sandstorm-ui-app-details/app-details.html
+++ b/shell/packages/sandstorm-ui-app-details/app-details.html
@@ -41,7 +41,7 @@
 
     {{#if viewingTrash}}
       <p class="trash-explanation">
-        Grains will be permanently removed after 30 days in the Trash. To keep a grain,
+        Grains will be permanently removed after 30 days in the trash. To keep a grain,
         restore it to the Main list.
       </p>
     {{/if}}
@@ -56,7 +56,7 @@
             <p><strong>No matching grains found.</strong></p>
             {{#if filteredSortedTrashedGrains}}
               <p>Some grains in your trash match your search.
-               <button class="toggle-show-trash">View Trash</button>
+               <button class="toggle-show-trash">View trash</button>
               </p>
             {{/if}}
           </div>
@@ -84,14 +84,14 @@
       <h1 class="app-title">{{appTitle}}</h1>
       <ul class="app-links">
         {{#if website}}<li role="presentation"><a class="website-link" target="_blank" href="{{website}}">Website</a></li>{{/if}}
-        <li role="presentation"><a class="app-market-link" target="_blank" href="https://apps.sandstorm.io/app/{{appId}}">App Market</a></li>
+        <li role="presentation"><a class="app-market-link" target="_blank" href="https://apps.sandstorm.io/app/{{appId}}">App market</a></li>
         {{#if codeUrl}}<li role="presentation"><a class="source-code-link" target="_blank" href="{{codeUrl}}">Source</a></li>{{/if}}
-        {{#if bugReportLink}}<li role="presentation"><a class="bug-report-link" target="_blank" href="{{bugReportLink}}">Report Issue</a></li>{{/if}}
+        {{#if bugReportLink}}<li role="presentation"><a class="bug-report-link" target="_blank" href="{{bugReportLink}}">Report issue</a></li>{{/if}}
       </ul>
       <div class="info-row">
         {{#if showToggleTrash}}
           <button class="toggle-show-trash">
-            {{#if viewingTrash}}View Main list{{else}}View Trash{{/if}}
+            {{#if viewingTrash}}View main list{{else}}View trash{{/if}}
           </button>
         {{/if}}
 

--- a/shell/packages/sandstorm-ui-applist/applist.html
+++ b/shell/packages/sandstorm-ui-applist/applist.html
@@ -28,6 +28,7 @@
     <div class="popular-container">
       <h2 class="">Most used</h2>
       {{#each popularApps }}
+
       <a class="app-button {{#if dev}}dev-background {{/if}}" href="/apps/{{appId}}">
         <div class="app-icon" style="background-image: url('{{ iconSrc }}');"></div>
         <span class="app-title">{{appTitle}}</span>
@@ -42,7 +43,7 @@
     <a class="app-button install-button {{#if searching}}hide{{/if}}" href="{{appMarketUrl}}">
       <div class="app-icon pseudoapp install-icon"></div>
       <span class="action-title">Install...</span>
-      <span class="action-text">from App Market</span>
+      <span class="action-text">from app market</span>
     </a>
 
     {{!-- data-app-id is only used for testing purposes --}}
@@ -77,7 +78,7 @@
       <div class="not-signed-up">
         <h1>Unauthorized! :(</h1>
         <p>This is a private Sandstorm server. In order to install apps, you need to be invited
-          by the admin. The admin can create invites in the admin settings panel.</p>
+          by the admin. The admin can invite you from the admin panel.</p>
       </div>
     {{/if}}
   {{/if}}

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.html
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.html
@@ -21,16 +21,16 @@
     </div>
     {{#if showTrash}}
       <p class="trash-explanation">
-        <button class="empty-trash">Empty all Trash</button>
-        (Grains will be permanently removed after 30 days in the Trash. To keep a grain,
+        <button class="empty-trash">Empty all trash</button>
+        (Grains will be permanently removed after 30 days in the trash. To keep a grain,
         restore it to the Main list.)
       </p>
     {{/if}}
     <div class="buttons">
       {{#if showTrash }}
-        <button class="show-main-list">View Main list</button>
+        <button class="show-main-list">View main list</button>
       {{else}}
-        <button class="show-trash">View Trash ({{trashCount}})</button>
+        <button class="show-trash">View trash ({{trashCount}})</button>
       {{/if}}
 
       <button class="restore-button">Restore backup...
@@ -48,7 +48,7 @@
             <p><strong>No matching grains found.</strong></p>
             {{#if filteredSortedTrashedGrains}}
               <p>Some grains in your trash match your search.
-               <button class="show-trash">View Trash</button>
+               <button class="show-trash">View trash</button>
               </p>
             {{/if}}
           {{else}}
@@ -116,7 +116,7 @@
             </td>
             <td class="td-app-icon"></td>
             <td class="grain-name">Name</td>
-            <td class="last-used">Last Activity</td>
+            <td class="last-used">Last activity</td>
             <td class="shared-or-owned">Mine/Shared</td>
             {{!-- Collaborators, size TODO
             <td>Collaborators</td>


### PR DESCRIPTION
* Adds a root admin panel page
* Divides admin panel pages into Configuration (server settings) and Management (day-to-day operational task support).
* Moves to breadcrumb-based hierarchical navigation for individual admin pages (which works very nicely for e.g. `Admin / Users / Invite`)
* Corrects a good deal of inconsistent capitalization in the product.  The standard we (attempt to) follow is to capitalize the first letter of a heading, label, or button, but no other words, unless they are proper nouns.  For example, "Sandstorm for Work" and "Sandstorm" are always capitalized as written here.
  * I don't think "Trash" and "Main list" qualify as proper nouns.
  * App market is not a proper noun when we write it on our blog, so I assumed it needn't be here either.
  * I didn't bother fixing capitalization in the old admin panel since I intend to deprecate/remove it Soon™.

![admin-panel-root](https://cloud.githubusercontent.com/assets/307325/15379667/62f01b90-1d24-11e6-919e-64c7af0ae19a.png)

![admin-users-invite-breadcrumbs](https://cloud.githubusercontent.com/assets/307325/15379776/4759ec20-1d25-11e6-8825-7d400df2bc79.png)