### PR TITLE
New admin panel

### DIFF
--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -1213,39 +1213,39 @@ const adminRoute = RouteController.extend({
 
 Router.map(function () {
   this.route("adminSettings", {
-    path: "/admin/settings/:_token?",
+    path: "/admin-old/settings/:_token?",
     controller: adminRoute,
   });
   this.route("adminUsers", {
-    path: "/admin/users/:_token?",
+    path: "/admin-old/users/:_token?",
     controller: adminRoute,
   });
   this.route("adminStats", {
-    path: "/admin/stats/:_token?",
+    path: "/admin-old/stats/:_token?",
     controller: adminRoute,
   });
   this.route("adminLog", {
-    path: "/admin/log/:_token?",
+    path: "/admin-old/log/:_token?",
     controller: adminRoute,
   });
   this.route("adminInvites", {
-    path: "/admin/invites/:_token?",
+    path: "/admin-old/invites/:_token?",
     controller: adminRoute,
   });
   this.route("adminCaps", {
-    path: "/admin/capabilities/:_token?",
+    path: "/admin-old/capabilities/:_token?",
     controller: adminRoute,
   });
   this.route("adminAdvanced", {
-    path: "/admin/advanced/:_token?",
+    path: "/admin-old/advanced/:_token?",
     controller: adminRoute,
   });
   this.route("adminFeatureKeyPage", {
-    path: "/admin/features/:_token?",
+    path: "/admin-old/features/:_token?",
     controller: adminRoute,
   });
   this.route("adminOld", {
-    path: "/admin/:_token?",
+    path: "/admin-old/:_token?",
     action: function () {
       this.redirect("adminSettings", this.params);
     },
@@ -1306,59 +1306,59 @@ const newAdminRoute = RouteController.extend({
 
 Router.map(function () {
   this.route("newAdminRoot", {
-    path: "/admin-new",
+    path: "/admin",
     controller: newAdminRoute,
   });
   this.route("newAdminIdentity", {
-    path: "/admin-new/identity",
+    path: "/admin/identity",
     controller: newAdminRoute,
   });
   this.route("newAdminEmailConfig", {
-    path: "/admin-new/email",
+    path: "/admin/email",
     controller: newAdminRoute,
   });
   this.route("newAdminUsers", {
-    path: "/admin-new/users",
+    path: "/admin/users",
     controller: newAdminRoute,
   });
   this.route("newAdminUserInvite", {
-    path: "/admin-new/users/invite",
+    path: "/admin/users/invite",
     controller: newAdminRoute,
   });
   this.route("newAdminUserDetails", {
-    path: "/admin-new/users/:userId",
+    path: "/admin/users/:userId",
     controller: newAdminRoute,
   });
   this.route("newAdminAppSources", {
-    path: "/admin-new/app-sources",
+    path: "/admin/app-sources",
     controller: newAdminRoute,
   });
   this.route("newAdminMaintenance", {
-    path: "/admin-new/maintenance",
+    path: "/admin/maintenance",
     controller: newAdminRoute,
   });
   this.route("newAdminStatus", {
-    path: "/admin-new/status",
+    path: "/admin/status",
     controller: newAdminRoute,
   });
   this.route("newAdminPersonalization", {
-    path: "/admin-new/personalization",
+    path: "/admin/personalization",
     controller: newAdminRoute,
   });
   this.route("newAdminNetworkCapabilities", {
-    path: "/admin-new/network-capabilities",
+    path: "/admin/network-capabilities",
     controller: newAdminRoute,
   });
   this.route("newAdminStats", {
-    path: "/admin-new/stats",
+    path: "/admin/stats",
     controller: newAdminRoute,
   });
   this.route("newAdminFeatureKey", {
-    path: "/admin-new/feature-key",
+    path: "/admin/feature-key",
     controller: newAdminRoute,
   });
   this.route("newAdminOrganization", {
-    path: "/admin-new/organization",
+    path: "/admin/organization",
     controller: newAdminRoute,
   });
 });

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -136,7 +136,7 @@
     {{#if currentUser}}
       {{#if currentUserIsAdmin}}
         <p class="center">
-          {{#linkTo route="adminSettings" class="admin-settings-button"}}Proceed to Admin Panel{{/linkTo}}
+          {{#linkTo route="newAdminRoot" class="admin-settings-button"}}Proceed to admin panel{{/linkTo}}
         </p>
       {{else}}
         {{#if identityUser}}
@@ -538,11 +538,11 @@
 
   <div class="setup-next-steps">
     {{#unless someOrgMembershipEnabled}}
-      {{#linkTo route="adminInvites" class="setup-button-secondary"}}
+      {{#linkTo route="newAdminUserInvite" class="setup-button-secondary"}}
         Add users
       {{/linkTo}}
     {{/unless}}
-    {{#linkTo route="adminSettings" class="setup-button-secondary"}}
+    {{#linkTo route="newAdminRoot" class="setup-button-secondary"}}
       Edit other settings
     {{/linkTo}}
     {{#linkTo route="apps" class="setup-button-primary"}}
@@ -580,7 +580,7 @@
   {{#if hasUsers}}
   <p>
   This server is already set up, so we recommend administering it via the main
-  {{#linkTo route="adminSettings"}}administration panel{{/linkTo}}.
+  {{#linkTo route="newAdminRoot"}}administration panel{{/linkTo}}.
   </p>
   {{/if}}
 

--- a/shell/packages/sandstorm-accounts-ui/login_buttons.html
+++ b/shell/packages/sandstorm-accounts-ui/login_buttons.html
@@ -49,7 +49,7 @@
     {{/if}}
     {{/if}}
     {{#if isAdmin}}
-      {{#linkTo route="adminOld" role="menuitem"}}Admin panel{{/linkTo}}
+      {{#linkTo route="newAdminRoot" role="menuitem"}}Admin panel{{/linkTo}}
     {{/if}}
     <a href="mailto:support@sandstorm.io" target="_blank" role="menuitem">Send feedback</a>
     {{#if quotaEnabled }}
@@ -108,7 +108,7 @@
       {{> Template.dynamic template=../loginTemplate.name }}
     {{/with}}
   {{else}}
-    {{#linkTo route="adminSettings" class="troubleshooting"}}
+    {{#linkTo route="newAdminIdentity" class="troubleshooting"}}
       configure login
     {{/linkTo}}
   {{/each}}

--- a/tests/apps/ip-networking.js
+++ b/tests/apps/ip-networking.js
@@ -31,55 +31,44 @@ module.exports = {};
 
 module.exports["Test Ip Networking"] = function (browser) {
   browser
-    .loginDevAccount(null, true)
-    .url(browser.launch_url + "/admin/capabilities")
-    .waitForElementVisible("#offer-ipnetwork", short_wait)
-    .click("#offer-ipnetwork")
-    .waitForElementVisible("#powerbox-offer-url", short_wait)
-    .getText("#powerbox-offer-url", function(result) {
-      browser
-        .installApp("http://sandstorm.io/apps/jparyani/ip-networking-0.spk", "4829503496b793dffb29040208e35921", "u30m2tdzecypfv9wf11u28dgmu4wjmz3tny80dqgq5aq4ge9z460")
-        .assert.containsText("#grainTitle", "Untitled IpNetworkTest")
-        .waitForElementVisible('.grain-frame', short_wait)
-        .frame("grain-frame")
-        .waitForElementVisible("#request", short_wait)
-        .click("#request")
-        .frame()
-        .waitForElementVisible("#powerbox-request-input", short_wait)
-        .setValue("#powerbox-request-input", result.value)
-        .click("#powerbox-request-form button.submit")
-        .frame("grain-frame")
-        .waitForElementVisible("#request-result", short_wait)
-        .assert.containsText("#request-result", "301 Moved Permanently")
-        .end();
-    });
+    // sandstorm-test-python, v0.0.8
+    .installApp("https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-8.spk", "164ac8a38076c88d05296f1bf1114d10", "rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh", false, true)
+    .assert.containsText("#grainTitle", "Untitled Test App test page")
+    .waitForElementVisible('.grain-frame', short_wait)
+    .frame("grain-frame")
+      .waitForElementVisible("#powerbox-request-ipnetwork", short_wait)
+      .click("#powerbox-request-ipnetwork")
+    .frameParent()
+    .waitForElementVisible(".popup.request .candidate-cards .powerbox-card button[data-card-id=frontendref-ipnetwork]", short_wait)
+    .click(".popup.request .candidate-cards .powerbox-card button[data-card-id=frontendref-ipnetwork]")
+    .frame("grain-frame")
+      .waitForElementVisible("span.token", short_wait)
+      .waitForElementVisible("form.test-ip-network input[type=text]", short_wait)
+      .setValue("form.test-ip-network input[type=text]", "http://build.sandstorm.io")
+      .click("form.test-ip-network button")
+      .waitForElementVisible("form.test-ip-network div.result", short_wait)
+      .assert.containsText("form.test-ip-network div.result", "301 Moved Permanently")
+    .frameParent()
 };
 
 module.exports["Test Ip Interface"] = function (browser) {
   browser
-    .loginDevAccount(null, true)
-    .url(browser.launch_url + "/admin/capabilities")
-    .waitForElementVisible("#offer-ipinterface", short_wait)
-    .click("#offer-ipinterface")
-    .waitForElementVisible("#powerbox-offer-url", short_wait)
-    .getText("#powerbox-offer-url", function(result) {
-      browser
-        .installApp("http://sandstorm.io/apps/jparyani/ip-interface-1.spk", "0b2d293e7701341a4db74f365aef6832", "xnk8j642gzvxuxq5axts9qzg578rc4gmg1kr8qqqad81wgvan6z0")
-        .assert.containsText("#grainTitle", "Untitled IpInterfaceTest")
-        .waitForElementVisible('.grain-frame', short_wait)
-        .frame("grain-frame")
-        .waitForElementVisible("#request-port", short_wait)
-        .setValue("#request-port", IP_INTERFACE_TEST_PORT)
-        .click("#request")
-        .frame()
-        .waitForElementVisible("#powerbox-request-input", short_wait)
-        .setValue("#powerbox-request-input", result.value)
-        .click("#powerbox-request-form button.submit")
-        .frame("grain-frame")
-        .waitForElementVisible("#request-result", short_wait)
-        .assert.containsText("#request-result", "request:")
-        .assertTcpConnection(IP_INTERFACE_TEST_PORT, "tcptest")
-        .end();
-    });
+    // sandstorm-test-python, v0.0.8
+    .installApp("https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-8.spk", "164ac8a38076c88d05296f1bf1114d10", "rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh", false, true)
+    .assert.containsText("#grainTitle", "Untitled Test App test page")
+    .waitForElementVisible('.grain-frame', short_wait)
+    .frame("grain-frame")
+      .waitForElementVisible("#powerbox-request-ipinterface", short_wait)
+      .click("#powerbox-request-ipinterface")
+    .frameParent()
+    .waitForElementVisible(".popup.request .candidate-cards .powerbox-card button[data-card-id=frontendref-ipinterface]", short_wait)
+    .click(".popup.request .candidate-cards .powerbox-card button[data-card-id=frontendref-ipinterface]")
+    .frame("grain-frame")
+      .waitForElementVisible("span.token", short_wait)
+      .waitForElementVisible("form.test-ip-interface input[type=number]", short_wait)
+      .setValue("form.test-ip-interface input[type=number]", IP_INTERFACE_TEST_PORT)
+      .click("form.test-ip-interface button")
+    .frameParent()
+    .assertTcpConnection(IP_INTERFACE_TEST_PORT, "tcptest")
 };
 

--- a/tests/commands/installApp.js
+++ b/tests/commands/installApp.js
@@ -24,9 +24,9 @@ var utils = require("../utils"),
     long_wait = utils.long_wait,
     very_long_wait = utils.very_long_wait;
 
-exports.command = function(url, packageId, appId, dontStartGrain, callback) {
+exports.command = function(url, packageId, appId, dontStartGrain, asAdmin, callback) {
   var ret = this
-    .loginDevAccount()
+    .loginDevAccount(null, asAdmin)
     .url(this.launch_url + "/install/" + packageId + "?url=" + url)
     .waitForElementVisible("#step-confirm", very_long_wait)
     .click("#confirmInstall")


### PR DESCRIPTION
This change replaces the old admin UI with the new admin UI (which previously lived at `/admin-new`), and places the old admin UI at `/admin-old`.  We intend to remove the latter after some settling period to make sure users aren't missing essential functionality that was available in the old UI.

This also replaces the old powerbox IpNetwork and IpInterface tests with new ones that use the appropriate powerbox descriptors.

Merging this change marks the completion of the admin panel project.  I'm pretty excited about how much more well-organized, consistent, and altogether *usable* things feel.  And it's quite pretty!  A huge thanks to @neynah, @kentonv, and @paulproteus for voluminous discussion and feedback, both on the admin panel and the setup wizard.

I want to tag @ndarilek here - this is a significant change to basically all the admin functionality.  I've done my best to make sure that every interactive element is reachable for keyboard-only users, that success and failure messages grab focus when they appear, and that markup is reasonably structured.  If there's something you can't find, or something which we've made unpleasantly hard for screenreader users, or something we could do better, please let me know so I can promptly fix it before we remove `/admin-old`. :)

Screenshot below demonstrates the IpNetwork test app fetching any file you name over (unencrypted) HTTP.

![ipnetwork-fetch-anything-over-http](https://cloud.githubusercontent.com/assets/307325/15414097/3812ac62-1dec-11e6-9635-9b6d5fd55345.png)