### PR TITLE
Grainlog smarter autoscroll

### DIFF
--- a/shell/client/admin/system-status-client.js
+++ b/shell/client/admin/system-status-client.js
@@ -50,7 +50,7 @@ Template.newAdminLog.onCreated(function () {
     // Save whether the current scrollTop is equal to the ~maximum scrollTop.
     // If so, then we should make the log "stick" to the bottom, by manually scrolling to the bottom
     // when needed.
-    messagePane = this.lastNode;
+    const messagePane = this.lastNode;
 
     // Include a 5px fudge factor to account for bad scrolling and fractional pixels.
     this.shouldScroll = (messagePane.clientHeight + messagePane.scrollTop + 5 >= messagePane.scrollHeight);

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1420,7 +1420,7 @@ Template.grainLog.onCreated(function () {
   };
 
   this.saveShouldScroll = () => {
-    const messagePane = this.lastNode
+    const messagePane = this.lastNode;
     this.shouldScroll = (messagePane.clientHeight + messagePane.scrollTop + 5 >= messagePane.scrollHeight);
   };
 

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -789,10 +789,14 @@ limitations under the License.
   </div>
 </template>
 
+<template name="grainLogContents">
+  <pre>...{{{logHtml}}}</pre>
+</template>
+
 <template name="grainLog">
   <div class="grainlog-title">Debug log: {{title}}</div>
   <div class="grainlog-contents" aria-live="polite">
-    <pre>...{{{html}}}</pre>
+    {{> grainLogContents logHtml=html onRenderedHook=maybeScrollToBottom }}
   </div>
 </template>
 

--- a/shell/client/styles/_grainlog.scss
+++ b/shell/client/styles/_grainlog.scss
@@ -9,6 +9,7 @@
   overflow: auto;
   >pre {
     margin: 8px;
+    white-space: pre-wrap;
   }
   .ansi-black-fg   { color:rgb(0, 0, 0);        }
   .ansi-red-fg     { color:rgb(160, 0, 0);      }


### PR DESCRIPTION
The previous grainlog behavior attempted to tail the log, but failed to do so
reliably for various reasons:

* not dealing with fractional pixels or "almost at the bottom" scroll states
* recomputing whether the scroll position was at the bottom *after* the additional
  content had been added (causing the window to never scroll to the bottom on
  content change)
* didn't pay attention to resize events, which can knock the view off the "bottom"
  of the log

Reusing the design from the new admin system log page, we fix all of these issues
and make the log window actually reliably tail the log when scrolled to the bottom,
while leaving the scroll position untouched if you scroll elsewhere.