### PR TITLE
Add UiView.PowerboxTag struct and fill it in for powerbox request results.

### DIFF
--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -882,7 +882,7 @@ Router.map(function () {
       // If the user is logged-in, and can create new grains, and
       // has no grains yet, then send them to "new".
       if (this.ready() && Meteor.userId() && !Meteor.loggingIn() && Meteor.user().loginIdentities) {
-        if (globalDb.currentUserGrains({}, {}).count() === 0 &&
+        if (globalDb.currentUserGrains().count() === 0 &&
             globalDb.currentUserApiTokens().count() === 0) {
           Router.go("apps", {}, { replaceState: true });
         } else {

--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -1575,6 +1575,11 @@ Meteor.methods({
 
   newApiToken: function (provider, grainId, petname, roleAssignment, owner, unauthenticated) {
     check(provider, Match.OneOf({ identityId: String }, { rawParentToken: String }));
+    if (!owner.user && !owner.webkey) {
+      throw new Meteor.Error(403,
+                             "'webkey' and 'user' are the only allowed owners in newApiToken()");
+    }
+
     // other check()s happen in SandstormPermissions.createNewApiToken().
     const db = this.connection.sandstormDb;
     if (provider.identityId) {

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -62,38 +62,27 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
   completeUiView(roleAssignment) {
     const fulfillingProvider = this._selectedProvider.get();
     if (fulfillingProvider.type === "frontendref-uiview") {
-      const fulfillingGrainId = fulfillingProvider.grainId;
       const fulfillingGrainTitle = fulfillingProvider.title;
-
       const saveLabel = this._requestInfo.saveLabel || { defaultText: fulfillingGrainTitle };
-      const owner = {
-        grain: {
-          grainId: this._requestInfo.grainId,
-          saveLabel: saveLabel,
-          introducerIdentity: this._requestInfo.identityId,
-        },
-      };
-      const provider = {
-        identityId: this._requestInfo.identityId,
-      };
-      Meteor.call("newApiToken",
-        provider,
-        fulfillingGrainId,
+      Meteor.call(
+        "fulfillUiViewRequest",
+        this._requestInfo.identityId,
+        fulfillingProvider.grainId,
         fulfillingGrainTitle, // petname: for UiViews, just use the grain title.
         roleAssignment,
-        owner,
+        saveLabel,
+        this._requestInfo.grainId,
         (err, result) => {
           if (err) {
             console.log("error:", err);
             this._error.set(err.toString());
           } else {
-            const apiToken = result.token;
+            const apiToken = result.sturdyRef;
             this._completed = true;
             this._requestInfo.source.postMessage({
               rpcId: this._requestInfo.rpcId,
               token: apiToken,
-              // encoded/packed/base64url of (tags = [(id = 15831515641881813735)])
-              descriptor: "EAZQAQEAABEBF1EEAQH_5-Jn6pjXtNsAAAA",
+              descriptor: result.descriptor,
             }, this._requestInfo.origin);
             // Completion event closes popup.
             this._requestInfo.onCompleted();

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -302,8 +302,8 @@ Meteor.publish("powerboxOptions", function (requestId, descriptorList) {
   // packed format and base64-encoded. The publish populates a pseudo-collection called
   // `powerboxOptions`. Each item has the following fields:
   //
-  //   _id: Object with two fields: `requestId` (as passed when subscribing) and `optionId` (a
-  //       unique identifier for the option).
+  //   _id: Unique identifier string.
+  //   requestId: The value of `requestId` that was passed in when subscribing.
   //   matchQuality: "preferred" or "acceptable" ("unacceptable" options aren't returned).
   //   frontendRef: If present, selecting this option means creating a simple frontendRef. The
   //       field value should be passed back to the method `newFrontendRef` verbatim. The format

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -153,7 +153,7 @@ Meteor.methods({
 
     const descriptor = encodePowerboxDescriptor({
       tags: [
-        { id: "15831515641881813735",
+        { id: Grain.UiView.typeId,
           value: Capnp.serialize(Grain.UiView.PowerboxTag, { metadata, title }),
         },
       ],

--- a/src/sandstorm/grain.capnp
+++ b/src/sandstorm/grain.capnp
@@ -336,6 +336,29 @@ interface SandstormApi(AppObjectId) {
   #   failure.
 }
 
+struct DenormalizedGrainMetadata {
+  # The metadata that we need to present contextual information for shared grains (in particular,
+  # information about the app providing that grain, like icon and title).
+
+  appTitle @0 :Util.LocalizedText;
+  # A copy of the app name for the corresponding UIView for presentation in the grain list.
+
+  union {
+    icon :group {
+      format @1 :Text;
+      # Icon asset format, if present.  One of "png" or "svg"
+
+      assetId @2 :Text;
+      # The asset ID associated with the grain-size icon for this token
+
+      assetId2xDpi @3 :Text;
+      # If present, the asset ID for the equivalent asset as assetId at twice-resolution
+    }
+    appId @4 :Text;
+    # App ID, needed to generate a favicon if no icon is provided.
+  }
+}
+
 interface UiView @0xdbb4d798ea67e2e7 {
   # Implements a user interface with which a user can interact with the grain.  We call this a
   # "view" because a single grain may actually have multiple "views" that provide different
@@ -449,6 +472,16 @@ interface UiView @0xdbb4d798ea67e2e7 {
     # Indicates what kinds of powerbox offers this grain is interested in accepting. If the grain
     # is chosen by the user during a powerbox offer, then `newOfferSession()` will be called
     # to start a session around this.
+  }
+
+  struct PowerboxTag {
+    # Tag to be used in a `PowerboxDescriptor` when requesting a `UiView`.
+
+    metadata @0 :DenormalizedGrainMetadata;
+    # Information needed to display an app title and icon for this `UiView`.
+
+    title @1 :Text;
+    # The title of the `UiView` as chosen by the introducer identity.
   }
 
   newSession @1 (userInfo :UserInfo, context :SessionContext,

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -224,29 +224,6 @@ interface PersistentHandle extends(SystemPersistent, Util.Handle) {}
 
 interface PersistentOngoingNotification extends(SystemPersistent, Grain.OngoingNotification) {}
 
-struct DenormalizedGrainMetadata {
-  # The metadata that we need to present contextual information for shared grains (in particular,
-  # information about the app providing that grain, like icon and title).
-
-  appTitle @0 :Util.LocalizedText;
-  # A copy of the app name for the corresponding UIView for presentation in the grain list.
-
-  union {
-    icon :group {
-      format @1 :Text;
-      # Icon asset format, if present.  One of "png" or "svg"
-
-      assetId @2 :Text;
-      # The asset ID associated with the grain-size icon for this token
-
-      assetId2xDpi @3 :Text;
-      # If present, the asset ID for the equivalent asset as assetId at twice-resolution
-    }
-    appId @4 :Text;
-    # App ID, needed to generate a favicon if no icon is provided.
-  }
-}
-
 struct ApiTokenOwner {
   # Defines who is permitted to use a particular API token.
 
@@ -307,7 +284,7 @@ struct ApiTokenOwner {
       # Fields below this line are not actually allowed to be passed to save(), but are added
       # internally.
 
-      denormalizedGrainMetadata @8 :DenormalizedGrainMetadata;
+      denormalizedGrainMetadata @8 :Grain.DenormalizedGrainMetadata;
       # Information needed to show the user an app title and icon in the grain list.
 
       userId @6 :Text;


### PR DESCRIPTION
This also updates the `newApiToken()` Meteor method to no longer allow creation of grain-owned tokens, mainly to prevent the caller form specifying arbitrary values in `owner.user.introducerIdentity`. 