### PR TITLE
Authorization code

### DIFF
--- a/shell/lib/db-deprecated.js
+++ b/shell/lib/db-deprecated.js
@@ -64,6 +64,8 @@ if (Meteor.isServer) {
     connection.sandstormDb = globalDb;
   });
   SandstormDb.periodicCleanup(5 * 60 * 1000, SandstormPermissions.cleanupSelfDestructing(globalDb));
+  SandstormDb.periodicCleanup(10 * 60 * 1000,
+                              SandstormPermissions.cleanupClientPowerboxRequests(globalDb));
   SandstormDb.periodicCleanup(24 * 60 * 60 * 1000, () => {
     SandstormAutoupdateApps.updateAppIndex(globalDb);
   });

--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -1562,6 +1562,16 @@ SandstormPermissions.cleanupSelfDestructing = function (db) {
   };
 };
 
+SandstormPermissions.cleanupClientPowerboxRequests = function (db) {
+  return function () {
+    const tenMinutesAgo = new Date(Date.now() - 1000 * 60 * 10);
+    db.removeApiTokens({
+      "owner.clientPowerboxRequest": { $exists: true },
+      created: { $lt: tenMinutesAgo },
+    });
+  };
+};
+
 Meteor.methods({
   transitiveShares: function (identityId, grainId) {
     check(identityId, String);

--- a/src/sandstorm/grain.capnp
+++ b/src/sandstorm/grain.capnp
@@ -693,12 +693,8 @@ interface SessionContext {
   #     powerboxRequest: {
   #       rpcId: myRpcId,
   #       query: [
-  #         {
-  #           tags: [
-  #             // encoded/packed/base64url of (tags = [(id = 15831515641881813735)])
-  #             "EAZQAQEAABEBF1EEAQH_5-Jn6pjXtNsAAAA",
-  #           ],
-  #         },
+  #         // encoded/packed/base64url of (tags = [(id = 15831515641881813735)])
+  #         "EAZQAQEAABEBF1EEAQH_5-Jn6pjXtNsAAAA",
   #       ],
   #       saveLabel: { defaultText: "Linked grain" },
   #     },

--- a/src/sandstorm/grain.capnp
+++ b/src/sandstorm/grain.capnp
@@ -673,7 +673,8 @@ interface SessionContext {
   #
   # The capability is implicitly tied to the user as if via `tieToUser()`.
 
-  request @3 (query :List(PowerboxDescriptor)) -> (cap :Capability, descriptor :PowerboxDescriptor);
+  request @3 (query :List(PowerboxDescriptor), requiredPermissions :PermissionSet)
+          -> (cap :Capability, descriptor :PowerboxDescriptor);
   # Although this method exists, it is unimplemented and currently you are meant to use the
   # postMessage api to get a token, and then restore that token with SandstormApi.restore().
   #

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1813,6 +1813,14 @@ public:
   kj::Promise<void> restore(RestoreContext context) override {
     auto req = sandstormCore.restoreRequest();
     req.setToken(context.getParams().getToken());
+    return req.send().then([context](auto args) mutable -> void {
+      context.getResults().setCap(args.getCap());
+    });
+  }
+
+  kj::Promise<void> claimRequest(ClaimRequestContext context) override {
+    auto req = sandstormCore.claimRequestRequest();
+    req.setToken(context.getParams().getRequestToken());
     req.setRequiredPermissions(context.getParams().getRequiredPermissions());
     return req.send().then([context](auto args) mutable -> void {
       context.getResults().setCap(args.getCap());

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -114,14 +114,18 @@ interface SandstormCore {
   # after restart. In the meantime, the supervisor should queue any RPCs to this interface and
   # retry them after the front-end has reconnected.
 
-  restore @0 (token :Data, requiredPermissions :Grain.PermissionSet) -> (cap :Capability);
-  # Restores an API token to a live capability. Fails if this grain is not the token's owner
-  # (including if the ref has no owner).
+  claimRequest @0 (token :Data, requiredPermissions :Grain.PermissionSet) -> (cap :Capability);
+  # Restores a client powerbox request token to a live capability, which can then be saved to get
+  # a proper sturdyref.
   #
-  # `requiredPermissions` has the same meaning as in SandstormApi.restore(). Note that the callee
-  # will not only check these requirements, but will automatically ensure that the returned
+  # `requiredPermissions` has the same meaning as in SandstormApi.claimRequest(). Note that the
+  # callee will not only check these requirements, but will automatically ensure that the returned
   # capability has an appropriate `MembraneRequirement` applied; the caller need not concern
   # itself with this.
+
+  restore @6 (token :Data) -> (cap :Capability);
+  # Restores an API token to a live capability. Fails if this grain is not the token's owner
+  # (including if the ref has no owner).
 
   drop @3 (token :Data);
   # Deletes the corresponding API token. See `MainView.drop()` for discussion of dropping.
@@ -281,6 +285,18 @@ struct ApiTokenOwner {
 
       introducerUser @5 :Text;
       # Deprecated. See `introducerIdentity`.
+    }
+
+    clientPowerboxRequest :group {
+      # Owned by a local grain, but only halfway through a client-side powerbox request flow.
+      # The token will be automatically deleted after a short amount of time. Before then, the
+      # grain must call `SandstormApi.claimRequest()` to get a proper sturdyref.
+
+      grainId @13 :Text;
+      # Grain ID owning the ref.
+
+      introducerIdentity @14 :Text;
+      # The ID of the identity who caused this request code to be generated.
     }
 
     internet @3 :AnyPointer;


### PR DESCRIPTION
This implements the first step of the changes proposed in #1892.

The second step will be to update a few places in powerbox-server.js to use the new `clientPowerboxRequest` owner (this will need to build on #2016's new `fulfillUiViewRequest` method), and to update the impls of `restore()` and `claimRequest()` in core.js to enforce the restrictions on the new owner variant.

There are at least two things that need to happen before this second step can land:
  1. We need to update the feature key vendor app to use the new API.
  2. We need to update the sandstorm-test-python app to use the new API


We had talked about maybe putting in both steps at once. I would be open to that option, but would need to coordinate with @zarvox to get the python app updated. The main advantage to this approach is that it would open the possibility of changing the token parameter of `claimRequest()` to `Text`, which does seem desirable, but I'm not sure if it's worth the coordination that it will require.