### PR TITLE
Add symlinks for new libseccomp files.

### DIFF
--- a/src/libseccomp/arch-parisc-syscalls.c
+++ b/src/libseccomp/arch-parisc-syscalls.c
@@ -1,0 +1,1 @@
+../../deps/libseccomp/src/arch-parisc-syscalls.c

--- a/src/libseccomp/arch-parisc.c
+++ b/src/libseccomp/arch-parisc.c
@@ -1,0 +1,1 @@
+../../deps/libseccomp/src/arch-parisc.c

--- a/src/libseccomp/arch-parisc.h
+++ b/src/libseccomp/arch-parisc.h
@@ -1,0 +1,1 @@
+../../deps/libseccomp/src/arch-parisc.h

--- a/src/libseccomp/arch-parisc64.c
+++ b/src/libseccomp/arch-parisc64.c
@@ -1,0 +1,1 @@
+../../deps/libseccomp/src/arch-parisc64.c


### PR DESCRIPTION
The changes in https://github.com/seccomp/libseccomp/commit/c86e1f565537b28b73ebd63f0239b4a446925534 are causing our integration tests to fail. This should fix things.