### PR TITLE
Add websockets warning to new-admin

### DIFF
--- a/docs/administering/faq.md
+++ b/docs/administering/faq.md
@@ -154,9 +154,11 @@ issue](https://github.com/sandstorm-io/sandstorm/issues/220).
 
 ## Why do I see an error when I try to launch an app, even when the Sandstorm interface works fine?
 
-Sometimes Sandstorm seems to be working fine but can launch no apps.
+Sometimes Sandstorm seems to be working fine but can launch no apps. This typically relates to
+Sandstorm's need for **wildcard DNS**. If you use HTTPS, you will also need **wildcard HTTPS**.
+You can read [technical details](wildcard.md) if you wish.
 
-If you see an error screen like this:
+You might see an error screen like this:
 
 ![Unable to resolve the server's DNS address, screenshot in Chromium](https://alpha-evgl4wnivwih0k6mzxt3.sandstorm.io/unable-to-resolve.png)
 
@@ -164,23 +166,46 @@ even when the app management interface seems to work fine:
 
 ![Skinny Sandstorm admin interface, showing your app instance](https://alpha-evgl4wnivwih0k6mzxt3.sandstorm.io/works-fine.png)
 
-This typically relates to Sandstorm's need for **wildcard DNS**. If you use HTTPS, you
-will also need **wildcard HTTPS**. Keep reading for more information.
+You might also have seen a warning from the Sandstorm admin settings area. An error will appear if
+your configuration fails the self-test. If so, **read the Javascript console.** Sandstorm will log
+details in your browser's Javascript console, [although those details might be
+minimal](http://stackoverflow.com/questions/31058764/determine-if-ajax-call-failed-due-to-insecure-response-or-connection-refused);
+thankfully, your web browser will typically provide further details about the failed connection in
+the Javascript console. Here are some hints, based on errors you might see.
 
-**Wildcard DNS.** Sandstorm runs each app _session_ on a unique,
-temporary subdomain. Here's what to check:
+- `Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource`: This
+  usually means your WILDCARD_HOST and BASE_URL disagree about port number, or the WILDCARD_HOST and
+  BASE_URL disagree about your domain name.
 
-- **Make sure the `WILDCARD_HOST` has valid syntax.** In the Sandstorm config file (typically `/opt/sandstorm/sandstorm.conf`, look for the `WILDCARD_HOST` config item. Note that this should not have a protocol as part of it. A valid line might be:
+- `Connection refused` or `net::ERR_CONNECTION_REFUSED`: This can occur if your WILDCARD_HOST
+  specifies the wrong domain name or if the WILDCARD_HOST and BASE_URL disagree about port number.
+
+- `HTTPS security error` or `net::ERR_INSECURE_RESPONSE`: This can occur if you are using a
+  self-signed certificate for Sandstorm but have not set up a self-signed CA. Read our docs on
+  [self-signed SSL for Sandstorm.](self-signed.md)
+
+Here are some tips to fix configuration issues that can cause WILDCARD_HOST problems.
+
+- **Make sure the `WILDCARD_HOST` has valid syntax.** In the Sandstorm config file (typically
+  `/opt/sandstorm/sandstorm.conf`), look for the `WILDCARD_HOST` config item. Note that this should
+  **not** have a protocol as part of it but **does** need a port number if `BASE_URL` specifies a
+  port number. A valid line might be:
 
 ```
 WILDCARD_HOST=*.yourname.sandcats.io:6080
 ```
 
-- **Make sure wildcard DNS works for your chosen domain**. See also [this issue in our repository](https://github.com/sandstorm-io/sandstorm/issues/114). If setting up wildcard DNS is a hassle for you, consider using our free [Sandcats dynamic DNS](sandcats.md) service for your `WILDCARD_HOST`.
+- **Make sure wildcard DNS works for your chosen domain**. See also [our documentation on wildcard
+  DNS](wildcard.md). If setting up wildcard DNS is a hassle for you, consider using our free
+  [Sandcats dynamic DNS](sandcats.md) service for your `BASE_URL` and `WILDCARD_HOST`.
 
-- You can read [more about Sandstorm and wildcard DNS](wildcard.md).
-
-**Wildcard HTTPS.** If wildcard DNS is configured properly, and you can access the Sandstorm shell, but you get an error accessing grains, keep in mind that your browser must trust `*.sandstorm.example.com` not just `sandstorm.example.com`. You can test this by visiting a random HTTPS URL within your Sandstorm domain, such as [https://just-testing.sandstorm.example.com](https://just-testing.sandstorm.example.com). If you see a browser certificate warning, then that is the root of your problem. You can read more about configuring HTTPS in our [HTTPS topic guide](ssl.md).
+- **Make sure wildcard HTTPS works on your server** if your server uses HTTPS. Consider using our
+  free [Sandcats dynamic DNS and HTTPS](sandcats.md) service if you are OK choosing a subdomain of
+  sandcats.io as your server's name, e.g. example.sandcats.io. If you are using a self-signed
+  certificate, note that you must import a CA certificate into all web browsers where you want the
+  Sandstorm server to able to be viewed. Web browsers do not show a "OK to continue?" prompt for
+  IFRAMEs, and Sandstorm uses IFRAMEs. Read more in the [self-signed SSL guide](self-signed.md).
+  You can also read our [HTTPS topic guide](ssl.md).
 
 ## Can I customize the root page of my Sandstorm install?
 

--- a/docs/administering/self-signed.md
+++ b/docs/administering/self-signed.md
@@ -1,8 +1,22 @@
 ## Self-hosted HTTPS with a custom certificate authority
 
-The following is a process for self-hosted instances of Sandstorm to use SSL with any DNS name, including a sandcats.io hostname. These steps create a Certificate Authority (CA), corresponding CA Certificate, and the private and public keys for the `[anything]` and `*.[anything]` domains.
+To use Sandstorm with a self-signed certificate, you must create a certificate authority (CA)
+certificate and import the CA certificate into all web browsers where you want the Sandstorm server
+to able to be viewed. Web browsers do not show a "OK to continue?" prompt for IFRAMEs, and Sandstorm
+embeds IFRAMEs to subdomains of its main domain, so there is no warning that users can click
+through. Therefore you must add the CA certificate to web browsers.
 
-Note: Web browsers will display a big red certificate error when you try to connect to this install. This tutorial is appropriate if you are OK with **reconfiguring web browsers to trust a custom certificate authority** that you will create during this tutorial. To read about other options for configuring HTTPS/SSL, including a **free auto-renewing HTTPS certificate**, visit the [HTTPS/SSL topic guide](ssl.md).
+This document explains one way to for self-hosted instances of Sandstorm to use SSL with any DNS
+name, including a sandcats.io hostname. These steps create a Certificate Authority (CA),
+corresponding CA Certificate, and the private and public keys for the `[anything]` and
+`*.[anything]` domains, and provides a link to information on installing the certificate in web
+browsers.
+
+**Web browsers will display a big red certificate error when you try to connect to this install
+unless you install the certificate in them.** Therefore, this tutorial is appropriate if you are OK
+with reconfiguring web browsers to trust a custom certificate authority that you will create during
+this tutorial. To read about other options for configuring HTTPS/SSL, including a **free
+globally-trusted auto-renewing HTTPS certificate**, visit the [HTTPS/SSL topic guide](ssl.md).
 
 1. Make a copy openssl.cnf:
 

--- a/docs/administering/wildcard.md
+++ b/docs/administering/wildcard.md
@@ -68,6 +68,16 @@ numeric IP address because you cannot configure wildcard DNS, consider reading a
 Sandstorm with an internal IP address and
 xip.io](faq.md#how-do-i-use-sandstorm-with-an-internal-ip-address).
 
+## Testing wildcard HTTPS
+
+If your server uses SSL or HTTPS, you will also need working HTTPS for all possible subdomains of
+your server's domain name. This is also known as wildcard HTTPS.
+
+If your server is at https://example.com/, you can visit https://testing.example.com/ and
+https://testing2.example.com/ in your browser. If you see any kind of certificate warning or error,
+then note that you need to adjust your configuration for Sandstorm to work properly. Read more in
+our [SSL topic guide.](ssl.md)
+
 ## local.sandstorm.io and sandcats.io provide wildcard DNS
 
 If you are using `vagrant-spk` to develop Sandstorm apps, or are developing Sandstorm itself, you

--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -1279,7 +1279,7 @@ const newAdminRoute = RouteController.extend({
   },
 
   action: function () {
-    const testWebsocket = function() {
+    const testWebsocket = function () {
       if (Meteor &&
           Meteor.connection &&
           Meteor.connection._stream &&
@@ -1292,13 +1292,15 @@ const newAdminRoute = RouteController.extend({
       }
     };
 
-    const testWildcardHost = function() {
+    const testWildcardHost = function () {
       if (Session.get("alreadyTestedWildcardHost")) {
         return;
       }
+
       if (Session.get("alreadyBeganTestingWildcardHost")) {
         return;
       }
+
       Session.set("alreadyBeganTestingWildcardHost", true);
 
       HTTP.call(
@@ -1326,6 +1328,7 @@ const newAdminRoute = RouteController.extend({
               looksGood = false;
             }
           }
+
           Session.set("wildcardHostWorks", looksGood);
         });
     };

--- a/shell/client/admin/admin.html
+++ b/shell/client/admin/admin.html
@@ -19,12 +19,25 @@
   {{#if wildcardHostSeemsBroken}}
   <div class="flash-message warning-message">
     WARNING: This server seems to have its WILDCARD_HOST misconfigured.  Until you fix it, you will
-    not be able to use any apps.
+    not be able to use any apps. You can read <a target="_blank"
+    href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
+    more info in the Sandstorm docs</a> and in your browser's Javascript console. You'll need to
+    adjust DNS, SSL/TLS certificates, or edit the sandstorm.conf file. If you see no information in
+    the JS console, or wish to test if you have fixed the problem, reload this page to re-run the
+    test. If you're still having
+    problems, <a href="https://github.com/sandstorm-io/sandstorm/issues">please file an issue.</a>
+  </div>
+  {{/if}}
+
+  {{#if websocketSeemsBroken}}
+  <div class="flash-message warning-message">
+    WARNING: This server seems to be unable to create a WebSocket. Sandstorm may appear to run fine,
+    but many apps will fail to run properly.
     <a target="_blank"
-       href="https://docs.sandstorm.io/en/latest/administering/faq/#why-do-i-see-an-error-when-i-try-to-launch-an-app-even-when-the-sandstorm-interface-works-fine">
-      Learn more.</a>  You'll need to adjust DNS, SSL/TLS certificates, or edit the sandstorm.conf
-    file. Once you have addressed the issue, reload this page. If you're still having problems,
-    email us at <a href="mailto:support@sandstorm.io">support@sandstorm.io</a>.
+       href="https://docs.sandstorm.io/en/latest/administering/faq/#how-do-i-enable-websockets-proxying-or-why-do-some-apps-seem-to-crash-reload">
+      Learn more.</a>  Usually this is caused by a reverse proxy like nginx or Apache that needs to
+      be reconfigured. If you think you are seeing this message in error, please reload this page or
+    <a href="https://github.com/sandstorm-io/sandstorm/issues">file an issue.</a>
   </div>
   {{/if}}
 


### PR DESCRIPTION
Also:

- Make the WILDCARD_HOST self-test log things to the JS console.

- Explain more clearly in the docs that wildcard HTTPS is needed.

- In the docs, remark that you _might_ see this message in the admin
  area; this way, we do not promise you would see it in the admin area,
  which is good since there's no way to actively trigger the self-test.

- Close #1987 (by improving error logging to the JS console, and linking
  to the docs from the JS console, and indicating in the docs how to fix
  a variety of different things the user might see in the JS console.)