### PR TITLE
install.sh: Make error reporting enabled by default

### DIFF
--- a/docs/administering/install-script.md
+++ b/docs/administering/install-script.md
@@ -89,6 +89,10 @@ free HTTPS certificate service.
 - `OVERRIDE_SANDCATS_BASE_DOMAIN`: If you run a different instance of the sandcats.io software,
   adjust this variable.
 
+- `REPORT`: This controls if install.sh should ask you to report an installation error to us. Set
+  it to a non-`yes` value (e.g. `no`) if you want to disable that question. Most headless installations
+  would want to set `REPORT=no`.
+
 ### Examples
 
 To pass an environment variable to the Sandstorm installer, you can do as follows.

--- a/installer-tests/automatic-dev-install-on-jessie.t
+++ b/installer-tests/automatic-dev-install-on-jessie.t
@@ -5,7 +5,7 @@ Cleanup: uninstall_sandstorm
 
 $[run]sudo cat /proc/sys/kernel/unprivileged_userns_clone
 $[slow]0
-$[run]sudo CURL_USER_AGENT=testing bash /vagrant/install.sh -d
+$[run]sudo CURL_USER_AGENT=testing REPORT=no bash /vagrant/install.sh -d
 $[slow]Sandstorm requires sysctl kernel.unprivileged_userns_clone to be enabled.
 Config written to /opt/sandstorm/sandstorm.conf.
 Finding latest build for dev channel...

--- a/installer-tests/fail-on-32-bit-system.t
+++ b/installer-tests/fail-on-32-bit-system.t
@@ -1,7 +1,7 @@
 Title: Ensure that Sandstorm installer bails early on 32-bit machines with an error message
 Vagrant-Box: debian-7.8-32-nocm
 
-$[run]CURL_USER_AGENT=testing /vagrant/install.sh
+$[run]CURL_USER_AGENT=testing REPORT=no /vagrant/install.sh
 $[slow]*** INSTALLATION FAILED ***
 Sorry, the Sandstorm server currently only runs on x86_64 machines.
 You can report bugs at: http://github.com/sandstorm-io/sandstorm

--- a/installer-tests/fail-on-old-kernel.t
+++ b/installer-tests/fail-on-old-kernel.t
@@ -1,7 +1,7 @@
 Title: Ensure that Sandstorm bails early on old kernels, with an error message
 Vagrant-Box: precise64
 
-$[run]CURL_USER_AGENT=testing /vagrant/install.sh
+$[run]CURL_USER_AGENT=testing REPORT=no /vagrant/install.sh
 $[slow]Detected Linux kernel version:
 *** INSTALLATION FAILED ***
 Sorry, your kernel is too old to run Sandstorm.

--- a/installer-tests/full-server-install-nmap-netcat.t
+++ b/installer-tests/full-server-install-nmap-netcat.t
@@ -11,7 +11,7 @@ $[run]sudo DEBIAN_FRONTEND=noninteractive apt-get install -d -y --no-install-rec
 $[veryslow]nmap-downloaded
 $[run]sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nmap && echo nmap-installed
 $[veryslow]nmap-installed
-$[run]CURL_USER_AGENT=testing OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k OVERRIDE_NC_PATH=/usr/bin/ncat bash /vagrant/install.sh -i
+$[run]CURL_USER_AGENT=testing REPORT=no OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k OVERRIDE_NC_PATH=/usr/bin/ncat bash /vagrant/install.sh -i
 $[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
 
 1. A typical install, to use Sandstorm (press enter to accept this default)

--- a/installer-tests/full-server-install-on-jessie-with-broken-hostname.t
+++ b/installer-tests/full-server-install-on-jessie-with-broken-hostname.t
@@ -8,7 +8,7 @@ $[slow]0
 $[run]sudo hostname nonexistentbroken ; hostname
 $[slow]nonexistentbroken
 $[exitcode]0
-$[run]CURL_USER_AGENT=testing OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh -i
+$[run]CURL_USER_AGENT=testing REPORT=no OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh -i
 $[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
 
 1. A typical install, to use Sandstorm (press enter to accept this default)

--- a/installer-tests/full-server-install-on-jessie-with-userns-sysctl.t
+++ b/installer-tests/full-server-install-on-jessie-with-userns-sysctl.t
@@ -5,7 +5,7 @@ Cleanup: uninstall_sandstorm
 
 $[run]sudo cat /proc/sys/kernel/unprivileged_userns_clone
 $[slow]0
-$[run]CURL_USER_AGENT=testing OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh -i
+$[run]CURL_USER_AGENT=testing REPORT=no OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh -i
 $[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
 
 1. A typical install, to use Sandstorm (press enter to accept this default)

--- a/installer-tests/full-server-install-on-opensuse.t
+++ b/installer-tests/full-server-install-on-opensuse.t
@@ -3,7 +3,7 @@ Vagrant-Box: opensuse42.1
 Precondition: sandstorm_not_installed
 Cleanup: uninstall_sandstorm
 
-$[run]CURL_USER_AGENT=testing OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh -i
+$[run]CURL_USER_AGENT=testing REPORT=no OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh -i
 $[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
 
 1. A typical install, to use Sandstorm (press enter to accept this default)

--- a/installer-tests/full-server-install-with-domain-reservation-token.t
+++ b/installer-tests/full-server-install-with-domain-reservation-token.t
@@ -14,7 +14,7 @@ $[run]curl -k https://sandcats-dev-machine.sandstorm.io/reserve --data 'email=sa
 $[slow]ok
 $[run]cat /tmp/json| sed -r 's/.*.token.:.([a-zA-Z0-9]*).*/\1/' > /tmp/domain-reservation-token ; echo ok
 $[slow]ok
-$[run]sudo ADMIN_TOKEN=$(</tmp/admin-token) CHOSEN_INSTALL_MODE=1 SANDCATS_DOMAIN_RESERVATION_TOKEN=$(</tmp/domain-reservation-token) DESIRED_SANDCATS_NAME=$(</tmp/sandcats-domain-name) CURL_USER_AGENT=testing OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh -d
+$[run]sudo ADMIN_TOKEN=$(</tmp/admin-token) CHOSEN_INSTALL_MODE=1 SANDCATS_DOMAIN_RESERVATION_TOKEN=$(</tmp/domain-reservation-token) DESIRED_SANDCATS_NAME=$(</tmp/sandcats-domain-name) CURL_USER_AGENT=testing REPORT=no OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh -d
 $[slow]As a Sandstorm user, you are invited to use a free Internet hostname as a subdomain of sandcats.io
 $[veryslow]Registering your pre-reserved domain
 $[slow]Congratulations! We have registered your

--- a/installer-tests/full-server-install-with-sandcats-https-invalid-domain-first.t
+++ b/installer-tests/full-server-install-with-sandcats-https-invalid-domain-first.t
@@ -5,7 +5,7 @@ Cleanup: uninstall_sandstorm
 
 $[run]sudo cat /proc/sys/kernel/unprivileged_userns_clone
 $[slow]0
-$[run]sudo CURL_USER_AGENT=testing OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh
+$[run]sudo CURL_USER_AGENT=testing REPORT=no OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh
 $[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
 
 1. A typical install, to use Sandstorm (press enter to accept this default)

--- a/installer-tests/full-server-install-with-sandcats-https.t
+++ b/installer-tests/full-server-install-with-sandcats-https.t
@@ -5,7 +5,7 @@ Cleanup: uninstall_sandstorm
 
 $[run]sudo cat /proc/sys/kernel/unprivileged_userns_clone
 $[slow]0
-$[run]sudo CURL_USER_AGENT=testing OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh
+$[run]sudo CURL_USER_AGENT=testing REPORT=no OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh
 $[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
 
 1. A typical install, to use Sandstorm (press enter to accept this default)

--- a/installer-tests/full-server-install-with-unwritable-usr-local.t
+++ b/installer-tests/full-server-install-with-unwritable-usr-local.t
@@ -7,7 +7,7 @@ $[run]sudo cat /proc/sys/kernel/unprivileged_userns_clone
 $[slow]0
 $[run]sudo chattr +i /usr/local/bin && echo now-unwritable
 now-unwritable
-$[run]CURL_USER_AGENT=testing OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh -i
+$[run]CURL_USER_AGENT=testing REPORT=no OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh -i
 $[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
 
 1. A typical install, to use Sandstorm (press enter to accept this default)

--- a/installer-tests/install-without-root.t
+++ b/installer-tests/install-without-root.t
@@ -3,7 +3,7 @@ Vagrant-Box: jessie
 Vagrant-Destroy-If-bash: -d $HOME/sandstorm
 Cleanup: uninstall_sandstorm
 
-$[run]CURL_USER_AGENT=testing /vagrant/install.sh -u
+$[run]CURL_USER_AGENT=testing REPORT=no /vagrant/install.sh -u
 $[slow]Sandstorm makes it easy to run web apps on your own server.
 Expose to localhost only? [yes] $[type]
 Where would you like to put Sandstorm? $[type]

--- a/installer-tests/interactive-dev-install.t
+++ b/installer-tests/interactive-dev-install.t
@@ -5,7 +5,7 @@ Cleanup: uninstall_sandstorm
 
 $[run]sudo cat /proc/sys/kernel/unprivileged_userns_clone
 $[slow]0
-$[run]CURL_USER_AGENT=testing bash /vagrant/install.sh
+$[run]CURL_USER_AGENT=testing REPORT=no bash /vagrant/install.sh
 $[slow]How are you going to use this Sandstorm install? [1]$[type]2
 OK to continue? [yes]$[type]
 $[slow]We're going to:

--- a/installer-tests/no-root.t
+++ b/installer-tests/no-root.t
@@ -4,7 +4,7 @@ Precondition: sandstorm_not_installed
 Vagrant-Postcondition-bash: ! -d $HOME/sandstorm
 Vagrant-Postcondition-bash: ! -d /opt/sandstorm
 
-$[run]CURL_USER_AGENT=testing /vagrant/install.sh
+$[run]CURL_USER_AGENT=testing REPORT=no /vagrant/install.sh
 $[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
 
 1. A typical install, to use Sandstorm (press enter to accept this default)

--- a/installer-tests/prepare-for-tests.sh
+++ b/installer-tests/prepare-for-tests.sh
@@ -27,10 +27,13 @@ done
 
 # If on a Debian/Ubuntu system, and the dependencies for installing the Vagrant plugins we
 # need aren't present, bail out and print an error message.
-if [ -f /etc/debian_version ] &&
-   ! [ -e /usr/share/doc/zlib1g-dev ] ; then
-  echo 'Seems you should run: sudo apt-get install -y zlib1g-dev'
-  exit 1
+if [ -f /etc/debian_version ] ; then
+  for package in zlib1g-dev ruby-dev libvirt-dev libxml2-dev; do
+    if ! [ -e /usr/share/doc/${package} ] ; then
+      echo "Seems you should run: sudo apt-get install -y ${package}"
+      exit 1
+    fi
+  done
 fi
 # Check if Vagrant has plugins we need; if not, we install them.
 #


### PR DESCRIPTION
Details:

- Stop using curl args from the future, e.g. use data-ascii

- Text change: Clarify that failure is failure.

- Logic change: When asking if the user wants to report failures to us, insist
  on prompting them.

- IMPORTANT CHANGE: Pass ENVVARS when running script from current working
  directory. The lack of this was prevent the CURL_USER_AGENT environment
  variable from being passed into the script when it re-exec'd itself as
  root, if and only if the script decided it was being run from a local
  filename. However, this presumably does affect the test suite.

- While at it, adjust prepare-for-tests.sh to request a few more dependencies.

- Adjust existing installer-tests to not report errors, for simplicity.

- Adjust install.sh reference docs to remark on REPORT=no.