### PR TITLE
Fix bug in permissions computation.

### DIFF
--- a/shell/packages/sandstorm-permissions/permissions-tests.js
+++ b/shell/packages/sandstorm-permissions/permissions-tests.js
@@ -716,7 +716,6 @@ Tinytest.add("permissions: tokenValid requirements", function (test) {
   const aliceAccount = new Account(globalDb, [alice], false);
   const bob = new Identity(globalDb);
   const bobAccount = new Account(globalDb, [bob], false);
-  const carol = new Identity(globalDb);
   const aliceGrain = new Grain(globalDb, aliceAccount, alice, commonViewInfo);
   const bobGrain = new Grain(globalDb, bobAccount, bob, commonViewInfo);
 
@@ -763,4 +762,47 @@ Tinytest.add("permissions: tokenValid requirements", function (test) {
 
   test.isFalse(webkey2.mayOpenGrain());
   test.isFalse(!!webkey2.grainPermissions());
+});
+
+Tinytest.add("permissions: collections app basic requirements", function (test) {
+  const alice = new Identity(globalDb);
+  const aliceAccount = new Account(globalDb, [alice], false);
+  const bob = new Identity(globalDb);
+  const collectionGrain = new Grain(globalDb, aliceAccount, alice, commonViewInfo);
+  const otherGrain = new Grain(globalDb, aliceAccount, alice, commonViewInfo);
+
+  alice.shareToIdentity(collectionGrain, bob, { allAccess: null });
+
+  test.isTrue(bob.mayOpenGrain(collectionGrain));
+  test.isFalse(bob.mayOpenGrain(otherGrain));
+
+  const webkey = alice.shareToWebkey(otherGrain, { allAccess: null },
+                                     [
+                                       {
+                                        permissionsHeld: {
+                                          permissions: [],
+                                          identityId: alice.id,
+                                          grainId: collectionGrain.id,
+                                        },
+                                      },
+                                     ]
+                                    );
+
+  test.isTrue(bob.mayOpenGrain(collectionGrain));
+  test.isFalse(bob.mayOpenGrain(otherGrain));
+
+  webkey.shareToIdentity(bob, { allAccess: null },
+                         [
+                           {
+                            permissionsHeld: {
+                              permissions: [],
+                              identityId: bob.id,
+                              grainId: collectionGrain.id,
+                            },
+                          },
+                         ]
+                        );
+
+  test.isTrue(bob.mayOpenGrain(collectionGrain));
+  test.isTrue(bob.mayOpenGrain(otherGrain));
 });

--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -553,6 +553,8 @@ class Context {
         });
       });
     });
+
+    return edges.length > 0;
   }
 
   registerInterestInRequirements(tokenId, requirements) {
@@ -791,7 +793,10 @@ class Context {
 
     let result = false;
     const relevant = computeRelevantTokens(this, grainId, vertexId);
-    this.activateOwnerEdges(grainId, relevant.ownerEdges);
+    if (this.activateOwnerEdges(grainId, relevant.ownerEdges)) {
+      result = true;
+    }
+
     relevant.tokenIds.forEach((tokenId) => {
       if (this.activateToken(tokenId)) {
         result = true;


### PR DESCRIPTION
Fixes a bug found by @zarvox when trying out the new powerbox flow: https://github.com/zarvox/sandstorm-test-python/pull/4#issuecomment-223857013. Adds a testcase that fails before the fix and succeeds afterwards.

 `activateRelevantTokens()` is supposed to return `true` if any new activations may have made more progress possible. Currently it incorrectly returns false in the case where there are no new relevant tokens, but there are some new "grain owner edges".