### PR TITLE
Change names of user levels in docs

### DIFF
--- a/docs/administering/for-work.md
+++ b/docs/administering/for-work.md
@@ -70,7 +70,7 @@ To enable this feature:
 - Enable and configure your organization on a per-login-provider basis.
 
 This feature is important because, by default, when a user signs into a Sandstorm server for the
-first time, Sandstorm creates a _Visitor_ account for them. Visitors can see grains that have been
+first time, Sandstorm creates a _Visitor_ account for them. Visitors can use grains that have been
 shared with them but cannot create grains of their own. The setting **Disallow collaboration with users outside the organization** can disable the ability for users not a part of your organization to log in.
 
 At the moment, this feature does not actively synchronize status; it checks for organization

--- a/docs/administering/for-work.md
+++ b/docs/administering/for-work.md
@@ -70,8 +70,8 @@ To enable this feature:
 - Enable and configure your organization on a per-login-provider basis.
 
 This feature is important because, by default, when a user signs into a Sandstorm server for the
-first time, Sandstorm creates a _guest_ account for them. Guest users can see grains that have been
-shared with them but cannot create grains of their own.
+first time, Sandstorm creates a _Visitor_ account for them. Visitors can see grains that have been
+shared with them but cannot create grains of their own. The setting **Disallow collaboration with users outside the organization** can disable the ability for users not a part of your organization to log in.
 
 At the moment, this feature does not actively synchronize status; it checks for organization
 membership at the time the user's account is created. Therefore, when a person leaves your

--- a/docs/administering/guide.md
+++ b/docs/administering/guide.md
@@ -151,14 +151,15 @@ Key concepts:
 
 - Sandstorm supports multiple **login providers** which be enabled/disabled from **Admin Settings**.
 
-There are three levels of users.
+There are three standard levels of users.
 
-- **Visitors** can use and re-share grains that have been shared with them. By default, anyone can click
-  **Sign in** and become a Visitor. They cannot create grains of their own nor install apps.
+- **Visitors** can use and re-share grains that have been shared with them. They cannot create grains of their own nor install apps. By default, anyone can click **Sign in** and become a Visitor. (This can be disabled on Sandstorm for Work servers.)
 
 - **Users** can install apps for their own use, create grains, and share them with others. By default, these users must be invited by an Admin.
 
 - **Admins** can also see the **Admin Settings** control panel, allowing them to invite users, modify user levels, and configure server settings like login providers and email settings.
+
+Additionally, Sandstorm has **Demo Accounts** which are not enabled by default. See the [Demo mode](demo.md) documentation for details.
 
 If you see a message saying your Sandstorm install has no users, read the [How do I log in, if
 there's a problem with logging in via the

--- a/docs/administering/guide.md
+++ b/docs/administering/guide.md
@@ -153,13 +153,12 @@ Key concepts:
 
 There are three levels of users.
 
-- **Guest** users can see grains that have been shared with them. By default, anyone can click
-  **Sign in** and become a guest user.
+- **Visitors** can see and re-share grains that have been shared with them. By default, anyone can click
+  **Sign in** and become a Visitor. They cannot create grains of their own nor install apps.
 
-- **Invited users** can install apps for their own use, create grains, and share them.
+- **Users** can install apps for their own use, create grains, and share them with others. By default, these users must be invited by an Admin.
 
-- **Admin users** can also see the **Admin Settings** control panel, allowing them to change a user
-  between these user levels. They can also invite users via the **Admin Settings** control panel.
+- **Admins** can also see the **Admin Settings** control panel, allowing them to invite users, modify user levels, and configure server settings like login providers and email settings.
 
 If you see a message saying your Sandstorm install has no users, read the [How do I log in, if
 there's a problem with logging in via the

--- a/docs/administering/guide.md
+++ b/docs/administering/guide.md
@@ -153,7 +153,7 @@ Key concepts:
 
 There are three levels of users.
 
-- **Visitors** can see and re-share grains that have been shared with them. By default, anyone can click
+- **Visitors** can use and re-share grains that have been shared with them. By default, anyone can click
   **Sign in** and become a Visitor. They cannot create grains of their own nor install apps.
 
 - **Users** can install apps for their own use, create grains, and share them with others. By default, these users must be invited by an Admin.

--- a/shell/client/admin/user-details.html
+++ b/shell/client/admin/user-details.html
@@ -267,7 +267,7 @@
           </span>
         </span>
         <span class="explanation">
-          Can see and re-share shared grains, but cannot create grains of their own nor install apps.
+          Can use and re-share shared grains, but cannot create grains of their own nor install apps.
         </span>
         <span class="status-or-actions">
           {{#if (isPreciselyVisitor account)}}

--- a/shell/client/admin/user-details.html
+++ b/shell/client/admin/user-details.html
@@ -267,7 +267,7 @@
           </span>
         </span>
         <span class="explanation">
-          Can visit and re-share shared grains, but cannot create grains of their own nor install apps.
+          Can see and re-share shared grains, but cannot create grains of their own nor install apps.
         </span>
         <span class="status-or-actions">
           {{#if (isPreciselyVisitor account)}}


### PR DESCRIPTION
Fixes #2040.

Query: Should some note be here about Demo users? People trying Oasis may wonder why there is no "Demo" user level, or they may wonder how they can configure their server to grant that behavior.