### PR TITLE
install.sh: Verify that numeric inputs are numeric

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -199,6 +199,20 @@ prompt() {
   echo "$VALUE"
 }
 
+prompt-numeric() {
+  local NUMERIC_REGEX="^[0-9]+$"
+  while true; do
+    local VALUE=$(prompt "$@")
+
+    if ! [[ "$VALUE" =~ $NUMERIC_REGEX ]] ; then
+      echo "You entered '$VALUE'. Please enter a number." >&3
+    else
+      echo "$VALUE"
+      return
+    fi
+  done
+}
+
 prompt-yesno() {
   while true; do
     local VALUE=$(prompt "$@")
@@ -662,7 +676,7 @@ choose_install_mode() {
     echo "1. A typical install, to use Sandstorm (press enter to accept this default)"
     echo "2. A development server, for working on Sandstorm itself or localhost-based app development"
     echo ""
-    CHOSEN_INSTALL_MODE=$(prompt "How are you going to use this Sandstorm install?" "1")
+    CHOSEN_INSTALL_MODE=$(prompt-numeric "How are you going to use this Sandstorm install?" "1")
   fi
 
   if [ "1" = "$CHOSEN_INSTALL_MODE" ] ; then
@@ -1153,14 +1167,14 @@ choose_port() {
     return
   fi
 
-  PORT=$(prompt "Server main HTTP port:" $DEFAULT_PORT)
+  PORT=$(prompt-numeric "Server main HTTP port:" $DEFAULT_PORT)
 
   while [ "$PORT" -lt 1024 ]; do
     echo "Ports below 1024 require root privileges. Sandstorm does not run as root."
     echo "To use port $PORT, you'll need to set up a reverse proxy like nginx that "
     echo "forwards to the internal higher-numbered port. The Sandstorm git repo "
     echo "contains an example nginx config for this."
-    PORT=$(prompt "Server main HTTP port:" $DEFAULT_PORT)
+    PORT=$(prompt-numeric "Server main HTTP port:" $DEFAULT_PORT)
   done
 }
 
@@ -1170,7 +1184,7 @@ choose_mongo_port() {
     return
   fi
 
-  MONGO_PORT=$(prompt "Database port (choose any unused port):" "$((PORT + 1))")
+  MONGO_PORT=$(prompt-numeric "Database port (choose any unused port):" "$((PORT + 1))")
 }
 
 choose_external_or_internal() {

--- a/installer-tests/full-server-install-say-y.t
+++ b/installer-tests/full-server-install-say-y.t
@@ -1,0 +1,51 @@
+Title: Ensure a typical install works when started as root (including sandcats HTTPS)
+Vagrant-Box: jessie
+Precondition: sandstorm_not_installed
+Cleanup: uninstall_sandstorm
+
+$[run]sudo cat /proc/sys/kernel/unprivileged_userns_clone
+$[slow]0
+$[run]sudo CURL_USER_AGENT=testing REPORT=no OVERRIDE_SANDCATS_BASE_DOMAIN=sandcats-dev.sandstorm.io OVERRIDE_SANDCATS_API_BASE=https://sandcats-dev-machine.sandstorm.io OVERRIDE_SANDCATS_CURL_PARAMS=-k bash /vagrant/install.sh
+$[slow]Sandstorm makes it easy to run web apps on your own server. You can have:
+
+1. A typical install, to use Sandstorm (press enter to accept this default)
+2. A development server, for working on Sandstorm itself or localhost-based app development
+
+How are you going to use this Sandstorm install? [1] $[type]y
+You entered 'y'. Please enter a number.
+How are you going to use this Sandstorm install? [1] $[type]1
+We're going to:
+
+* Install Sandstorm in /opt/sandstorm
+* Automatically keep Sandstorm up-to-date
+* Configure auto-renewing HTTPS
+* Create a service user (sandstorm) that owns Sandstorm's files
+* Configure Sandstorm to start on system boot (with sysvinit)
+* Configure your system to enable unprivileged user namespaces, via sysctl.
+
+OK to continue? [yes] $[type]
+$[slow]As a Sandstorm user, you are invited to use a free Internet hostname as a subdomain of sandcats.io
+$[slow]Choose your desired Sandcats subdomain (alphanumeric, max 20 characters).
+Type the word none to skip this step, or help for help.
+What *.sandcats-dev.sandstorm.io subdomain would you like? []$[type]gensym
+We need your email on file so we can help you recover your domain if you lose access. No spam.
+Enter your email address: [] $[type]install-script@asheesh.org
+Registering your domain.
+$[slow]Congratulations! We have registered your
+Your credentials to use it are in /opt/sandstorm/var/sandcats; consider making a backup.
+$[slow]Now we're going to auto-configure HTTPS for your server.
+$[veryslow]Requesting certificate
+$[veryslow]Successfully auto-configured HTTPS
+$[veryslow]Downloading: https://dl.sandstorm.io
+$[veryslow]GPG signature is valid.
+$[veryslow]Sandstorm started. PID =
+Your server is coming online
+$[veryslow]Visit this link to start using it:
+  https://
+To learn how to control the server, run:
+  sandstorm help
+$[exitcode]0
+$[run]nc -z localhost 443 && echo yay
+$[slow]yay
+$[run]nc -z localhost 80 && echo yay
+$[slow]yay


### PR DESCRIPTION
- Rationale: We discovered in user-testing that a person typed "y" rather than
  pressing enter (or typing "1"). This resulted in install.sh choosing mode 2,
  which is development mode, which resulted in a server bound to localhost.

- This commit also adds a test to verify the behavior.

Close #2036