### PR TITLE
Free feature keys

### DIFF
--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -1048,7 +1048,7 @@ Template.featureKeyUploadForm.helpers({
 
 Template.adminFeatureKey.helpers({
   currentFeatureKey: function () {
-    return globalDb.collections.featureKey.findOne();
+    return globalDb.currentFeatureKey();
   },
 });
 
@@ -1064,7 +1064,7 @@ Template.adminFeatureKeyPage.helpers({
   },
 
   hasFeatureKey: function () {
-    return !!globalDb.collections.featureKey.findOne();
+    return !!globalDb.currentFeatureKey();
   },
 });
 

--- a/shell/client/admin/feature-key-client.js
+++ b/shell/client/admin/feature-key-client.js
@@ -4,7 +4,7 @@ Template.newAdminFeatureKey.onCreated(function () {
 
 Template.newAdminFeatureKey.helpers({
   currentFeatureKey() {
-    return globalDb.collections.featureKey.findOne();
+    return globalDb.currentFeatureKey();
   },
 
   showForm() {

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -55,20 +55,26 @@
       <div class="feature-key-property-row">
         <span class="feature-key-property-key">Plan</span>
         <span class="feature-key-property-value">{{featureKey.userLimit}} users
-          {{#if featureKey.isTrial}}<span class="feature-key-label feature-key-trial">Trial</span>{{/if}}
-          {{#with validity=(computeValidity featureKey)}}
-            <span class="feature-key-label feature-key-{{validity.className}}">{{validity.labelText}}</span>
-          {{/with}}
+          {{#if featureKey.isFreeKey}}
+            <span class="feature-key-label feature-key-free">Free</span>
+          {{else}}
+            {{#if featureKey.isTrial}}<span class="feature-key-label feature-key-trial">Trial</span>{{/if}}
+            {{#with validity=(computeValidity featureKey)}}
+              <span class="feature-key-label feature-key-{{validity.className}}">{{validity.labelText}}</span>
+            {{/with}}
+          {{/if}}
         </span>
       </div>
       <div class="feature-key-property-row">
         <span class="feature-key-property-key">Issued</span>
         <span class="feature-key-property-value">{{renderDateString featureKey.issued}}</span>
       </div>
+      {{#unless featureKey.isFreeKey}}
       <div class="feature-key-property-row">
         <span class="feature-key-property-key">Expires</span>
         <span class="feature-key-property-value">{{renderDateString featureKey.expires}}</span>
       </div>
+      {{/unless}}
     </div>
     <div class="feature-key-org-info">
       {{#with customer=featureKey.customer}}

--- a/shell/client/admin/organization-client.js
+++ b/shell/client/admin/organization-client.js
@@ -4,7 +4,7 @@ Template.newAdminOrganization.onCreated(function () {
   const ldapChecked = globalDb.getOrganizationLdapEnabled() || false;
   const samlChecked = globalDb.getOrganizationSamlEnabled() || false;
 
-  const featureKey = globalDb.collections.featureKey.findOne();
+  const featureKey = globalDb.currentFeatureKey();
   const featureKeyContactAddress = featureKey && featureKey.customer && featureKey.customer.contactEmail;
   const inferredDomain = featureKeyContactAddress && featureKeyContactAddress.split("@")[1] || "";
 

--- a/shell/client/setup-wizard/wizard.js
+++ b/shell/client/setup-wizard/wizard.js
@@ -264,7 +264,7 @@ Template.setupWizardOrganization.onCreated(function () {
   const gappsChecked = globalDb.getOrganizationGoogleEnabled() || false;
   const emailChecked = globalDb.getOrganizationEmailEnabled() || false;
 
-  const featureKey = globalDb.collections.featureKey.findOne();
+  const featureKey = globalDb.currentFeatureKey();
   const featureKeyContactAddress = featureKey && featureKey.customer && featureKey.customer.contactEmail;
   const inferredDomain = featureKeyContactAddress && featureKeyContactAddress.split("@")[1] || "";
 

--- a/shell/client/styles/_admin.scss
+++ b/shell/client/styles/_admin.scss
@@ -287,7 +287,8 @@ button#offer-ipnetwork, button#offer-ipinterface {
   border-radius: 2px;
 }
 
-.feature-key-valid {
+
+.feature-key-free, .feature-key-valid {
   background-color: #c5e8b1;
   color: #2f4336;
 }

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -2081,6 +2081,17 @@ if (Meteor.isServer) {
   };
 } else {
   SandstormDb.prototype.currentFeatureKey = function () {
-    return this.collections.featureKey.findOne({ _id: "currentFeatureKey" });
+    const featureKey = this.collections.featureKey.findOne({ _id: "currentFeatureKey" });
+    if (featureKey &&
+        !featureKey.isFreeKey &&
+        featureKey.isTrial &&
+        parseInt(featureKey.expires) * 1000 < Date.now()) {
+      // If feature key was a trial (but not explicitly a free key), and the trial is past its
+      // expiration date, mark as a free key instead, with a 15-user limit.
+      featureKey.isFreeKey = true;
+      featureKey.userLimit = 15;
+    }
+
+    return featureKey;
   };
 }

--- a/src/sandstorm/feature-key.capnp
+++ b/src/sandstorm/feature-key.capnp
@@ -81,6 +81,9 @@ struct FeatureKey {
     orgManagement @9 :Bool = true;
   }
 
+  isFreeKey @11 :Bool;
+  # Is this key a "free key"?  We also treat trial keys which have expired as free keys.
+
   const signingKey :PublicSigningKey =
       (key0 = 0x86ada8b5d9f65036, key1 = 0x183909ba08aac323,
        key2 = 0x6d778da453c9560d, key3 = 0xdf94f532f33a7ea8);


### PR DESCRIPTION
This patch series sits atop #2044 since it moves some feature key related templates around.

We add an optional Bool field `isFreeKey` to feature keys.

Feature keys which do not have isFreeKey=true but do have isTrial=true will automatically convert to free keys with 15 (is this the right number?) seats after the expiry date.

The UI has been updated so that a free key (or converted expired trial key) looks like the following:

![screenshot1](https://cloud.githubusercontent.com/assets/307325/15972604/5bdd959e-2ef4-11e6-83e8-2af9690997db.png)

The colored tags are replaced with one that reads "Free", and the row about expiry date is removed.