### PR TITLE
Reshuffle hierarchy on stats

### DIFF
--- a/shell/client/admin/stats.html
+++ b/shell/client/admin/stats.html
@@ -175,7 +175,9 @@
     </p>
   {{/if}}
 
-  <h2>View as JSON</h2>
+
+  <h2>Statistics</h2>
+  <h3>View as JSON</h3>
   <p>
     If you want to integrate Sandstorm stats with an internal stats tool, use this secret link to
     retrieve the tables below as JSON.
@@ -196,8 +198,6 @@
       </button>
     </div>
   </form>
-
-  <h2>Statistics</h2>
   <h3>Users and grains</h3>
 
   {{#with current=current}}


### PR DESCRIPTION
Very minor content organization change - puts "View as JSON" under the "Statistics" heading, which I think makes slightly more sense in terms of content hierarchy.