### PR TITLE
SAML: make Entity ID configurable; show Service URL

### DIFF
--- a/shell/client/admin/identity-providers.html
+++ b/shell/client/admin/identity-providers.html
@@ -288,7 +288,7 @@
   </p>
 
   <p>
-    The Entity ID of this server is <code>{{entityId}}</code>. Please supply that to your IDP.
+    The Service URL of this server is: <code>{{ serviceUrl }}</code>
   </p>
 
   {{#if errorMessage}}
@@ -307,6 +307,12 @@
     <div class="form-group">
       <label>SAML cert for above provider:
         <textarea type="text" name="publicCert" value="{{samlPublicCert}}" placeholder="base64 encoded cert (e.g. MIID...8F==)"></textarea>
+      </label>
+    </div>
+
+    <div class="form-group">
+      <label>Entity ID:
+        <input type="text" name="entityId" value="{{samlEntityId}}" placeholder="{{exampleEntityId}}" />
       </label>
     </div>
   </form>

--- a/shell/packages/accounts-saml/saml_server.js
+++ b/shell/packages/accounts-saml/saml_server.js
@@ -72,11 +72,12 @@ middleware = function (req, res, next) {
     if (!samlObject.actionName)
       throw new Error("Missing SAML action");
 
+    const entityId = SandstormDb.prototype.getSamlEntityId();
     const service = {
       "provider": "default",
       "entryPoint": SandstormDb.prototype.getSamlEntryPoint(),
       // TODO(someday): find a better way to inject the DB
-      "issuer": HOSTNAME,
+      "issuer": entityId || HOSTNAME,
       "cert": SandstormDb.prototype.getSamlPublicCert(),
     };
 

--- a/shell/packages/accounts-saml/saml_utils.js
+++ b/shell/packages/accounts-saml/saml_utils.js
@@ -82,7 +82,10 @@ SAML.prototype.generateAuthorizeRequest = function (req) {
 
   request +=
     "<samlp:RequestedAuthnContext xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Comparison=\"exact\">" +
-    "<saml:AuthnContextClassRef xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></samlp:RequestedAuthnContext>\n" +
+      "<saml:AuthnContextClassRef xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">" +
+        "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport" +
+      "</saml:AuthnContextClassRef>" +
+    "</samlp:RequestedAuthnContext>\n" +
   "</samlp:AuthnRequest>";
 
   return request;

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1500,6 +1500,11 @@ _.extend(SandstormDb.prototype, {
     const setting = Settings.findOne({ _id: "samlPublicCert" });
     return setting ? setting.value : "";  // empty if subscription is not ready.
   },
+
+  getSamlEntityId: function () {
+    const setting = Settings.findOne({ _id: "samlEntityId" });
+    return setting ? setting.value : ""; // empty if subscription is not ready.
+  },
 });
 
 SandstormDb.escapeMongoKey = (key) => {


### PR DESCRIPTION
We add a sentence to the SAML configuration which mentions what the Service URL is.

We make Entity ID a required, configurable field, with a default value of the hostname (which was the previous implicit behavior).

I verified that the configured Entity ID is indeed passed in the SAMLRequest passed to the provider entry point correctly, but I have not actually configured a SAML server and tested this end-to-end.  But SAML is a pretty strongly-specified protocol, and I appear to be making only a very small change here.

![screenshot1](https://cloud.githubusercontent.com/assets/307325/15981419/ec279f0c-2f29-11e6-9109-75628ac7283d.png)