### PR TITLE
Finish moving enter-grain docs to debugging/

### DIFF
--- a/docs/developing/troubleshooting.md
+++ b/docs/developing/troubleshooting.md
@@ -17,7 +17,7 @@ language-specific guide pages, namely:
 
 `vagrant-spk enter-grain` allows you to run a shell (e.g. `bash`) in the context of a grain. This can
 illuminate why an app is behaving in a particular way. For details and limitations, read [the
-docs about the `vagrant-spk enter-grain` command](../vagrant-spk/debugging.md).
+docs about the `vagrant-spk enter-grain` command](debugging.md).
 
 ## Clicking a link in the app does not open the link
 


### PR DESCRIPTION
I noticed a warning from mkdocs so I thought I'd fix it.