### PR TITLE
Update Google Client ID instructions

### DIFF
--- a/shell/client/admin/identity-providers.html
+++ b/shell/client/admin/identity-providers.html
@@ -58,8 +58,9 @@
   <ol>
     <li>Visit <a href="https://console.developers.google.com/" target="blank">https://console.developers.google.com/</a></li>
     <li>"Create Project", if needed. Wait for Google to finish provisioning.</li>
-    <li>On the left sidebar, go to "Credentials" and, on the right, "OAuth Consent Screen". Make sure to enter an email address and a product name, and save.</li>
-    <li>On the left sidebar, go to "Credentials".  Press the "Create credentials" button, then select "Web application" as the type.</li>
+    <li>On the left sidebar, go to "Credentials" and, on the right, "OAuth consent screen". Make sure to enter an email address and a product name, and save.</li>
+    <li>On the left sidebar, go to "Credentials".  Click the "Create credentials" button, then select "OAuth client ID" as the type.</li>
+    <li>Select "Web application" as your application type.</li>
     <li>Set Authorized Javascript Origins to: <span class="idp-config-url">{{siteUrlNoSlash}}</span></li>
     <li>Set Authorized Redirect URI to: <span class="idp-config-url">{{siteUrlNoSlash}}/_oauth/google</span></li>
     <li>Finish by clicking "Create".</li>


### PR DESCRIPTION
Should be more clear with the updated UI. Google added an extra step in there. I also decided I liked the verb "click" better than my original choice, "press".