### PR TITLE
Dismiss offers and end after IP networking tests

### DIFF
--- a/tests/apps/ip-networking.js
+++ b/tests/apps/ip-networking.js
@@ -70,5 +70,6 @@ module.exports["Test Ip Interface"] = function (browser) {
       .click("form.test-ip-interface button")
     .frameParent()
     .assertTcpConnection(IP_INTERFACE_TEST_PORT, "tcptest")
+    .end()
 };
 

--- a/tests/apps/powerbox.js
+++ b/tests/apps/powerbox.js
@@ -47,6 +47,7 @@ module.exports["Test Powerbox"] = function (browser) {
     .waitForElementVisible("#powerbox-offer-url", short_wait)
     .getText("#powerbox-offer-url", function (result) {
         browser
+          .click(".popup.offer .frame button.dismiss")
           .frame("grain-frame")
             .click("#request")
           .frameParent()
@@ -79,6 +80,7 @@ module.exports["Test PowerboxSave"] = function (browser) {
     .waitForElementVisible("#powerbox-offer-url", short_wait)
     .getText("#powerbox-offer-url", function (result) {
         browser
+          .click(".popup.offer .frame button.dismiss")
           .frame("grain-frame")
             .click("#request")
           .frameParent()
@@ -115,6 +117,7 @@ module.exports["Test Powerbox with failing requirements"] = function (browser) {
     .waitForElementVisible("#powerbox-offer-url", short_wait)
     .getText("#powerbox-offer-url", function (result) {
         browser
+          .click(".popup.offer .frame button.dismiss")
           .frame("grain-frame")
             .click("#request")
           .frame()

--- a/tests/commands/assertReceiveEmail.js
+++ b/tests/commands/assertReceiveEmail.js
@@ -42,7 +42,13 @@ ReceiveEmail.prototype.command = function(selector, expectedMessage, timeout, cb
     req.accept();
     mailparser.on("end", function (mail) {
       clearTimeout(timeoutHandle);
-      server.server.end(function () {});
+      server.server.end(function () {
+        if (cb) {
+          cb.call(self.client.api);
+        }
+
+        self.emit("complete");
+      });
 
       var expected = expectedMessage;
 
@@ -53,12 +59,6 @@ ReceiveEmail.prototype.command = function(selector, expectedMessage, timeout, cb
       Object.keys(expected).forEach(function (key) {
         self.client.api.assert.equal(expected[key], mail[key]);
       });
-
-      if (cb) {
-        cb.call(self.client.api);
-      }
-
-      self.emit("complete");
     });
   });
 

--- a/tests/run-local.sh
+++ b/tests/run-local.sh
@@ -71,13 +71,6 @@ checkInstalled() {
   fi
 }
 
-getNewPort() {
-  "$NODEJS" -e 'var net = require("net");
-  var sock = net.connect({port: 0});
-  console.log(sock.address().port);
-  sock.destroy()';
-}
-
 # Parse arguments.
 while [ $# -gt 0 ] ; do
   case $1 in
@@ -117,11 +110,13 @@ fi
 
 export SANDSTORM_DIR=$THIS_DIR/tmp-sandstorm
 export OVERRIDE_SANDSTORM_DEFAULT_DIR=$SANDSTORM_DIR
-export PORT=$(getNewPort)
-export MONGO_PORT=$(getNewPort)
-export SMTP_LISTEN_PORT=$(getNewPort)
-export SMTP_OUTGOING_PORT=$(getNewPort)
-export IP_INTERFACE_TEST_PORT=$(getNewPort)
+# Picking some fixed ports because email tests are being flaky with system-assigned ports and we
+# don't do parallel tests yet anyway.
+export PORT=9000
+export MONGO_PORT=9001
+export SMTP_LISTEN_PORT=9002
+export SMTP_OUTGOING_PORT=9003
+export IP_INTERFACE_TEST_PORT=9004
 export LAUNCH_URL="http://local.sandstorm.io:$PORT"
 
 rm -rf "$SANDSTORM_DIR"


### PR DESCRIPTION
Dismissing the offer prompts is something we should be doing explicitly anyway.

We should end the browser session at the end of the IP networking testsuite to avoid leaking a browser window when running tests.