### PR TITLE
fix resumable sessions

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -271,6 +271,7 @@ Sessions = new Mongo.Collection("sessions");
 //       until newSession is called on the UiView.
 //   hasLoaded: Marked as true by the proxy when the underlying UiSession has responded to its first
 //       request
+//   invalidated: True if this session has become invalid due to a change in the sharing graph.
 
 SignupKeys = new Mongo.Collection("signupKeys");
 // Invite keys which may be used by users to get access to Sandstorm.

--- a/shell/packages/sandstorm-ui-grainview/grainview.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview.js
@@ -532,15 +532,23 @@ GrainView = class GrainView {
         }
 
         Meteor.defer(() => {
-          _this.reset(_this.identityId());
           _this.openSession();
         });
       },
 
-      changed(session) {
+      changed(session, oldSession) {
         _this._viewInfo = session.viewInfo || _this._viewInfo;
         _this._permissions = session.permissions || _this._permissions;
         _this._dep.changed();
+
+        if (session.invalidated && !oldSession.invalidated) {
+          _this._sessionSub.stop();
+          _this._sessionSub = undefined;
+          Meteor.defer(() => {
+            _this.reset(_this.identityId());
+            _this.openSession();
+          });
+        }
       },
 
       added(session) {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1352,6 +1352,9 @@ class Proxy {
           viewInfo: viewInfo,
           permissions: permissions.permissions,
         },
+        $unset: {
+          invalidated: true,
+        },
       });
 
       return permissions.permissions;


### PR DESCRIPTION
Currently, if a client loses connectivity for more than a few minutes, when it reconnects it will automatically refresh any open grains, causing them to get new sessions with new hostIds. This is because the GrainView's `sessionObserver` calls `GrainView.reset()` when it observes that its session has been removed from the `Sessions` table, and `GrainView.reset()` clears the session salt. The fix is to not call `GrainView.reset()` in this case. We still want to call reset in the case where there permissions have changed, so we add an `invalidated` field to signal that case.