### PR TITLE
use already-opened supervisor capabiliy when constructing proxy

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -406,7 +406,8 @@ Meteor.methods({
 
       const result = opened.methodResult;
       const proxy = new Proxy(apiToken.grainId, grain.userId, result.sessionId,
-                              result.hostId, result.tabId, identityId, false);
+                              result.hostId, result.tabId, identityId, false,
+                              opened.supervisor);
       proxy.apiToken = apiToken;
       proxiesByHostId[result.hostId] = proxy;
       return result;


### PR DESCRIPTION
We might as well use the already-opened supervisor capability that `openSessionInternal()` returns. (Looks like I just forgot to do this in https://github.com/sandstorm-io/sandstorm/commit/0084bc458a3c4b516af738ce94705f41fd5de09f)