### PR TITLE
Admin docs: update based on new admin UI

### DIFF
--- a/docs/administering/email.md
+++ b/docs/administering/email.md
@@ -8,21 +8,21 @@ form `publicId`@`hostname`. `publicId` is randomly generated for every
 grain that handles e-mail, and `hostname` is extracted from the
 `BASE_URL` parameter in sandstorm.conf (which is initially created by
 the installer script). Outgoing e-mail is sent through an external
-SMTP server, controllable by the `SMTP Url` configuration under Admin
-Settings (the `MAIL_URL` parameter in `sandstorm.conf` has been
-deprecated). When sending e-mails, the only valid "From" addresses are
+SMTP server, controllable from the Admin settings -> Email configuration page.
+(Note that the `MAIL_URL` parameter in `sandstorm.conf` has been
+deprecated.) When sending e-mails, the only valid "From" addresses are
 the grain's generated `publicId`@`hostname` address, or the verified
 email from the user's account (e.g. the e-mail address obtained via
-Google or Github login). The interfaces for sending/receiving e-mails
+e.g. Google or Github or email login). The interfaces for sending/receiving e-mails
 are available in
 [hack-session.capnp](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/hack-session.capnp).
 
 ## Outgoing SMTP
 
-All you need to do is provide an appropriate SMTP relay in the `SMTP Configuration` fields under
-Admin Settings.  Your configuration should point Sandstorm to a working SMTP server that will accept
-e-mails with the SMTP envelope's bounce address set to your grain's local address, or to the "Return
-Address" address.
+All you need to do is provide an appropriate SMTP relay in the `Email configuration` page of the
+Admin panel.  Your configuration should point Sandstorm to a working SMTP server that will accept
+e-mails with the SMTP envelope's bounce address set to your grain's local address, or to the
+"Sandstorm server's own email address" address.
 
 If running at home, you can usually use your ISP's SMTP server.
 Otherwise, [Sendgrid](https://sendgrid.com/), [Mailgun](http://www.mailgun.com/), and

--- a/docs/administering/faq.md
+++ b/docs/administering/faq.md
@@ -220,8 +220,8 @@ This is by contrast with the default, which you can see on our older
 ![Uncustomized front page](https://alpha-evgl4wnivwih0k6mzxt3.sandstorm.io/uncustomized-home.png)
 
 This is achieved by configuring a web page to be displayed in the background behind the login dialog
-(the home page when logged out). To configure this setting, visit your server's **Admin Settings**
-screen and click **Advanced**. You can enter a URL as the **Splash URL** at the top of that screen.
+(the home page when logged out). To configure this setting, visit your server's **Admin panel**
+screen and click **Personalization**. You can enter a URL as the **Splash URL (experimental)**.
 
 For security reasons, the page must be hosted within your Sandstorm server's wildcard host
 (otherwise it will be blocked by `Content-Security-Policy`). We suggest using a static web

--- a/docs/administering/for-work.md
+++ b/docs/administering/for-work.md
@@ -19,33 +19,38 @@ other systems.
 
 To enable either of these login providers, take the following steps:
 
-- Log into your Sandstorm server.
+- Log into your Sandstorm server as an administrator.
 
 - Make sure you have enabled [Sandstorm for Work on your server](#enabling-sandstorm-for-work).
 
-- Click **Admin Settings** within your Sandstorm server; this should take you to `/admin/settings`.
+- Click **Admin panel** within your Sandstorm server; this should take you to `/admin`.
 
-You should now see a checkbox that allows you to enable LDAP login.
+- Under "Configuration", click on "Identity providers"; this should take you to `/admin/identity`.
+
+- In the Identity providers table, click the "Configure" button in the LDAP row.
+
+- Complete the form and enabled LDAP login.
 
 Implementation notes for LDAP that may apply to your site:
 
-- A typical LDAP configuration (e.g. Active Directory) will use an **LDAP Base Search Dn** of
+- A typical LDAP configuration (e.g. Active Directory) will use an **Base DN** of
   `ou=People` followed by the LDAP version of your domain name. For `example.com`, this would be
   `ou=People,dc=example,dc=com`.
 
 - When logging in with LDAP, you might run hit this error: `Exception while invoking method 'login'
   SizeLimitExceededError`. In our testing, this seems to occur with LDAP sites where multiple LDAP
   objects match the username. In this case, you probably need to add a custom **LDAP Search
-  Filter**. Your search filter should typically take the form of `(&(something))` so that it is
-  AND'd against the default Sandstorm LDAP query used when a user is logging in. Contact us at
-  support@sandstorm.io if you need help.
+  Filter** under "Additional LDAP filter criteria. Your search filter should typically take the form
+  of `(&(something))` so that it is AND'd against the default Sandstorm LDAP query used when a user
+  is logging in. Contact us at support@sandstorm.io if you need help.
 
 - Some LDAP servers require authentication before permitting a search. In that case, you will need
-  to configure an **LDAP Search Bind Dn** and **LDAP Search Bind Password**.
+  to configure an **Bind user DN** and **Bind user password**, a user and password for the search
+  user.
 
 - Typically LDAP servers use the `cn` field to store the name of the person who is successfully
   logging in. `cn` is short for common name. If your LDAP server is configured differently, please
-  adjust the **LDAP Name Field**.
+  adjust the **LDAP given name attribute**.
 
 ## Organization management
 
@@ -63,20 +68,19 @@ account. This feature can be enabled or disabled per login provider.
 
 To enable this feature:
 
-- Click **Admin Settings** within your Sandstorm server; this should take you to `/admin/settings`.
+- Log in to your server as an administrator.
 
-- Scroll to the bottom to find **Define organization**.
+- Click your name at the top right, then **Admin panel**; this should take you to `/admin`.
 
-- Enable and configure your organization on a per-login-provider basis.
+- Under the "Configuration" header, click "Organization settings"
+
+- Enable and configure your organization membership on a per-login-provider basis.
 
 This feature is important because, by default, when a user signs into a Sandstorm server for the
 first time, Sandstorm creates a _Visitor_ account for them. Visitors can use grains that have been
-shared with them but cannot create grains of their own. The setting **Disallow collaboration with users outside the organization** can disable the ability for users not a part of your organization to log in.
-
-At the moment, this feature does not actively synchronize status; it checks for organization
-membership at the time the user's account is created. Therefore, when a person leaves your
-organization, you will need to visit the **Users** tab within admin settings and adjust their
-account level.
+shared with them but cannot create grains of their own. The setting **Disallow collaboration with
+users outside the organization** can disable the ability for users not a part of your organization
+to log in.
 
 ### Features coming soon
 
@@ -87,13 +91,13 @@ for single sign-on. If you need this feature, please feel free to [request a fea
 today](https://sandstorm.io/business). SAML support should be compatible with Shibboleth and other
 systems.
 
-**Group Management.** This will allow you to share a grain with everyone in a group, such as the
+**Group management.** This will allow you to share a grain with everyone in a group, such as the
 marketing department, using groups from Google or LDAP.
 
-**Global Access Control.** Configure organization-wide access control policies, such as prohibiting
+**Global access control.** Configure organization-wide access control policies, such as prohibiting
 your employees from sharing grains outside of the organization.
 
-**Global Audit Logging.** Monitor data across the whole organization to keep track of who has
+**Global audit logging.** Monitor data across the whole organization to keep track of who has
 accessed what.
 
 If you're interested in these features, we'd love to hear from you. Please [contact
@@ -143,24 +147,22 @@ If you don't have Sandstorm yet, follow these steps first.
 
 - [Install Sandstorm](https://sandstorm.io/install) via the usual directions.
 
-- Obtain a feature key. At the moment, we send all feature keys by email to you. To request a key,
-  visit the [Sandstorm for Work page on our website](https://sandstorm.io/business), click **Contact
-  Us**, fill out the form, and mention that you want to unlock Sandstorm for Work.
+- Obtain a feature key from our automated [feature key generator](https://sandstorm.io/get-feature-key).
 
 Now that you have Sandstorm, enable Sandstorm for Work. These steps work properly on any up-to-date
 Sandstorm install, even if you installed before Sandstorm for Work was avaiable.
 
 - Log in as an administrator.
 
-- Click on your name, then click on **Admin Settings** to visit `/admin/settings`.
+- Click on your name at the top right of the page, then click on **Admin panel** to visit `/admin`.
 
-- Click on **For Work** to visit `/admin/features`.
+- Click on **Sandstorm for Work** to visit `/admin/feature-key`.
 
 - Click **Choose File** to upload a feature key file. You can alternatively paste a feature key into
   the text area and click Verify.
 
-Once you've done this, you will see information about your feature key on the **For Work** tab. All
-Sandstorm features enabled by your feature key will be available to you in the most
+Once you've done this, you will see information about your feature key on the **Sandstorm for Work**
+page. All Sandstorm features enabled by your feature key will be available to you in the most
 contextually-relevant location.
 
 ### Special pricing

--- a/docs/administering/guide.md
+++ b/docs/administering/guide.md
@@ -40,7 +40,7 @@ Within `/opt/sandstorm` there are a few essential files and directories.
 
 - `/opt/sandstorm/var/log/sandstorm.log` - this is the log file for Sandstorm. If you are logged in
   to a Sandstorm install as an administrator, you can view this on the web by visiting **Admin
-  Settings** then clicking **Log**.
+  panel** then clicking **System log**.
 
 - `/opt/sandstorm/var/mongo` - this is the data directory for MongoDB, the database engine that
   stores all Sandstorm data like grain names, user names, and permissions. You can query it by
@@ -103,7 +103,7 @@ available, called the **app index.** Every day, Sandstorm downloads this file. F
 app index, if a user on your Sandstorm server has an older version installed, Sandstorm creates a
 notification suggesting that the user click a button to update to the latest version.
 
-This behavior can be customized within **Admin Settings** under **Advanced**. We strongly recommend
+This behavior can be customized within the **Admin panel** under **App sources**. We strongly recommend
 keeping this enabled. You can also point your Sandstorm install at a different app market URL and
 app index URL.
 
@@ -149,7 +149,7 @@ Key concepts:
 
 - Every Sandstorm user starts by seeing no apps installed, and must install apps on their own.
 
-- Sandstorm supports multiple **login providers** which be enabled/disabled from **Admin Settings**.
+- Sandstorm supports multiple **login providers** which can be enabled/disabled from the **Admin panel**.
 
 There are three standard levels of users.
 
@@ -157,9 +157,9 @@ There are three standard levels of users.
 
 - **Users** can install apps for their own use, create grains, and share them with others. By default, these users must be invited by an Admin.
 
-- **Admins** can also see the **Admin Settings** control panel, allowing them to invite users, modify user levels, and configure server settings like login providers and email settings.
+- **Admins** can also see the **Admin panel**, allowing them to invite users, modify user levels, and configure server settings like login providers and email settings.
 
-Additionally, Sandstorm has **Demo Accounts** which are not enabled by default. See the [Demo mode](demo.md) documentation for details.
+Additionally, Sandstorm has **demo accounts** which are disabled by default. See the [Demo mode](demo.md) documentation for details.
 
 If you see a message saying your Sandstorm install has no users, read the [How do I log in, if
 there's a problem with logging in via the

--- a/docs/administering/reverse-proxy.md
+++ b/docs/administering/reverse-proxy.md
@@ -110,7 +110,7 @@ Make sure to test your Sandstorm install by visiting it on the web.
 
 **Make sure login works.** If you changed your `BASE_URL`, Sandstorm will temporarily disable any
 OAuth providers like Google or GitHub so that you can ensure they are configured correctly. Make
-sure to visit **Admin Settings** within your Sandstorm install and re-enable them. If OAuth
+sure to visit **Identity providers** in the **Admin panel** within your Sandstorm install and re-enable them. If OAuth
 providers were your only way to log in, you might need to get a [login token via the command
 line.](faq.md#how-do-i-log-in-if-theres-a-problem-with-logging-in-via-the-web)
 

--- a/docs/administering/sandcats-https.md
+++ b/docs/administering/sandcats-https.md
@@ -95,10 +95,6 @@ re-enable GitHub, Google, and any other OAuth-based login
 providers. This process will typically require visiting the Google and
 GitHub websites.
 
-Once you click **Save** at the bottom of the login configuration page,
-you should sign in however you normally sign in, perhaps with a Google
-or GitHub account, by clicking **Sign in**.
-
 **Congratulations!** You're now using HTTPS, also known as SSL and TLS.
 
 ### Technical details


### PR DESCRIPTION
A bunch of updates to the docs to bring them in line with the names of things in the new admin UI.

Open question: do we want to use "identity providers" or "login providers"?  I observe that the product uses "identity providers" throughout (and that tends to be the term we use internally), but the docs say "login providers".