### PR TITLE
Feature key update/delete forms: prefer modals to other weirdness

### DIFF
--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -96,16 +96,22 @@
 </template>
 
 <template name="adminFeatureKeyModifyForm">
-  {{#if showForm}}
-    {{> featureKeyUploadForm successCb=hideFormCb }}
-  {{else}}
-    <form class="feature-key-modify-form">
-      <div class="button-row">
-        <button type="submit" class="feature-key-upload-button">Upload new feature key...</button>
-        <button type="button" class="feature-key-delete-button">Delete feature key</button>
-      </div>
-    </form>
+  {{#if showUpdateForm}}
+    {{#modalDialogWithBackdrop onDismiss=hideFormCb }}
+      {{> featureKeyUploadForm successCb=hideFormCb }}
+    {{/modalDialogWithBackdrop}}
   {{/if}}
+  {{#if showDeleteForm}}
+    {{#modalDialogWithBackdrop onDismiss=hideFormCb }}
+      {{> featureKeyDeleteForm cancelCb=hideFormCb successCb=hideFormCb token=token }}
+    {{/modalDialogWithBackdrop}}
+  {{/if}}
+  <form class="feature-key-modify-form">
+    <div class="button-row">
+      <button type="submit" class="feature-key-upload-button">Upload new feature key...</button>
+      <button type="button" class="feature-key-delete-button">Delete feature key</button>
+    </div>
+  </form>
 </template>
 
 <template name="adminFeatureKey">
@@ -145,5 +151,18 @@
       <button type="submit" class="check-key" disabled={{disabled}}>Verify</button>
     </div>
     <label>Or select a file to upload: <input name="feature-key" type="file" /></label>
+  </form>
+</template>
+
+<template name="featureKeyDeleteForm">
+  <p>
+    Really delete feature key?  This will disable Sandstorm for Work features, like LDAP and SAML
+    login, organizational user management, and organizational controls.
+  </p>
+  <form class="feature-key-delete-form">
+    <div class="button-row">
+      <button type="submit" class="danger">Delete key</button>
+      <button type="button" class="cancel">Cancel</button>
+    </div>
   </form>
 </template>

--- a/shell/client/styles/_admin-feature-key.scss
+++ b/shell/client/styles/_admin-feature-key.scss
@@ -2,6 +2,15 @@
   @extend %standard-form;
 }
 
+.feature-key-delete-form {
+  @extend %standard-form;
+
+  button.danger {
+    @extend %button-base;
+    @extend %button-danger;
+  }
+}
+
 .feature-key-explanation-row {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Fixes #2089.

Makes "Upload new feature key..." show a modal with the form, rather than
modifying the page in-place.

Makes "Delete feature key" show a modal with two buttons, one to confirm, and
one to reject.

Tested in both the setup wizard and in the admin panel.

![feature-key-page](https://cloud.githubusercontent.com/assets/307325/16143198/1f6b15ce-3420-11e6-8007-5d83a41bf13b.png)

Click "Upload new feature key...":

![upload-feature-key-modal](https://cloud.githubusercontent.com/assets/307325/16143203/264b21ae-3420-11e6-9c65-913e91baf02a.png)

Or click "Delete feature key":

![delete-feature-key-modal](https://cloud.githubusercontent.com/assets/307325/16143210/37f4a934-3420-11e6-917b-eeb4fb6a19e5.png)