### PR TITLE
Use new Cap'n-Proto-connection-level flow control in supervisor.

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -2305,14 +2305,6 @@ ResponseStream = class ResponseStream {
         return;
       } else {
         // Write buffer is full. Don't complete until it has more space.
-        if (this.waiting.length >= 16) {
-          // Yikes, there are 16 writes in-flight already. Probably, the caller does not implement
-          // flow control, and is going to do *all* of its writes in parallel. Since the caller
-          // is ignoring returns anyway, we might as well shed load from the Cap'n Proto tables
-          // by closing out the earlier calls.
-          this.waiting.shift()();
-        }
-
         return new Promise((resolve, reject) => {
           this.waiting.push(resolve);
         });

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -2248,6 +2248,10 @@ kj::Promise<void> SupervisorMain::DefaultSystemConnector::run(
   auto server = capnp::makeRpcServer(appNetwork, kj::heap<SandstormApiImpl>(wakelockSet, grainId,
       coreCap), kj::mv(gateway));
 
+  // Limit outstanding calls from the app to 1MiW (8MiB) in order to prevent an errant or malicious
+  // app from consuming excessive RAM elsewhere in the system.
+  server.setFlowLimit(1u << 20);
+
   // Get the app's UiView by restoring a null SturdyRef from it.
   capnp::MallocMessageBuilder message;
   auto hostId = message.initRoot<capnp::rpc::twoparty::VatId>();


### PR DESCRIPTION
We limit an app to having 8MiB of outgoing calls in-flight at once. This prevents even apps that have not yet received last week's sandstorm-http-bridge update from inundating the front-end with queued writes. (However, apps with old sandstorm-http-bridge will still have the problem that the writes queue up inside sandstorm-http-bridge. Consuming RAM there is still bad, but should do less damage at least on Oasis.)

Note that we now no longer want the front-end to start prematurely closing out write()s when it detects a lack of flow control from the app, because that would prevent the connection-level flow control logic from doing its job.

This depends on a recent Cap'n Proto commit: https://github.com/sandstorm-io/capnproto/commit/538a767e04f11b8135fc086314c0250724cac148