### PR TITLE
Add word wrap to PGP key fingerprint

### DIFF
--- a/shell/client/styles/_app-details.scss
+++ b/shell/client/styles/_app-details.scss
@@ -243,6 +243,7 @@
             background-image: url("/key-m.svg");
             >span {
               padding-right: 4px;
+              overflow-wrap: break-word;
             }
           }
           >a.keybase {


### PR DESCRIPTION
Before, on narrow window:

![key-too-wide](https://cloud.githubusercontent.com/assets/25457/16164758/cb0d897e-3494-11e6-8dba-f32850d20715.png)

After, on narrow window:

![now-with-word-wrap](https://cloud.githubusercontent.com/assets/25457/16164771/d63bb60e-3494-11e6-95ee-51de276c7ef7.png)

@neynah requesting your +1; after that, review/merge by Kenton.