### PR TITLE
Use FontForge to convert SVGs to TTF

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -120,12 +120,13 @@ Please install the following:
 * `curl`
 * discount (markdown parser)
 * [Clang compiler](http://clang.llvm.org/) version 3.4 or better
+* FontForge, used by `grunt` to convert SVGs to WebFonts
 * [Meteor](http://meteor.com)
 
 On Debian or Ubuntu, you should be able to get all these with:
 
     sudo apt-get install build-essential libcap-dev xz-utils zip \
-        unzip strace curl clang-3.4 discount git
+        unzip strace curl clang-3.4 discount git fontforge
     curl https://install.meteor.com/ | sh
 
 ### Get the source code

--- a/icons/Gruntfile.js
+++ b/icons/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
         destCss: "../shell/client/styles",
         options: {
           font: "icons",
-          engine: "node",
+          engine: "fontforge",
           autoHint: false,
           htmlDemo: false,
           relativeFontPath: "/icons/",


### PR DESCRIPTION
- Also add this to `install.md`

- This fixes the "Where did the circle go?" problem in #2102