### PR TITLE
Grains hints: be reasonable on mobile

### DIFF
--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -274,12 +274,11 @@ Template.sandstormGrainListPage.events({
     }
 
     const intro = Template.instance().data.intro = introJs();
-    intro.setOptions({
+    let introOptions = {
       steps: [
         {
           element: document.querySelector(".grain-list .question-mark"),
           intro: "Each document, chat room, mail box, notebook, blog, or anything else you create is a grain. All your grains are private until you share them.",
-          position: "right",
         },
       ],
       highlightClass: "hidden-introjs-highlight",
@@ -290,7 +289,14 @@ Template.sandstormGrainListPage.events({
       overlayOpacity: 0,
       showBullets: false,
       doneLabel: "Got it",
-    });
+    };
+
+    // Detect if the window is skinner than 500px; if so, force the hint to appear vertically.
+    if (window.innerWidth < 500) {
+      introOptions.tooltipPosition = "bottom";
+    }
+
+    intro.setOptions(introOptions);
 
     // onexit gets triggered when user clicks on the overlay.
     intro.onexit(exitAndRemoveOverlayNow);


### PR DESCRIPTION
Before this diff:

![screenshot from 2016-06-17 17 10 40](https://cloud.githubusercontent.com/assets/25457/16167791/7bf7229a-34ae-11e6-8a06-003e7ae759be.png)

After this diff:

![screenshot from 2016-06-17 17 10 59](https://cloud.githubusercontent.com/assets/25457/16167793/854a32d8-34ae-11e6-8103-d53df66b0dfe.png)
