### PR TITLE
Always show table headers on app details page

### DIFF
--- a/shell/packages/sandstorm-ui-app-details/app-details.html
+++ b/shell/packages/sandstorm-ui-app-details/app-details.html
@@ -49,7 +49,7 @@
     {{#let grains=filteredSortedGrains}}
       {{>sandstormGrainTable grains=grains actions=actions
                              onGrainClicked=onGrainClicked _db=_db showHintIfEmpty=1
-                             bulkActionButtons=bulkActionButtons}}
+                             alwaysShowTableHeaders=1 bulkActionButtons=bulkActionButtons}}
       {{#unless grains}}
         {{#if isFiltering}}
           <div class="no-grains">

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -450,9 +450,9 @@ Template.sandstormGrainTable.helpers({
     }
   },
 
-  showTableHeaders: function() {
-    return !! (Template.instance().data.alwaysShowTableHeaders ||
-               Template.instance().data.grains.length);
+  showTableHeaders: function () {
+    return !!(Template.instance().data.alwaysShowTableHeaders ||
+              Template.instance().data.grains.length);
   },
 });
 

--- a/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist-client.js
@@ -449,6 +449,11 @@ Template.sandstormGrainTable.helpers({
       return Template.instance()._selectedSharedWithMeIds.get(this._id);
     }
   },
+
+  showTableHeaders: function() {
+    return !! (Template.instance().data.alwaysShowTableHeaders ||
+               Template.instance().data.grains.length);
+  },
 });
 
 Template.sandstormGrainTable.events({

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.html
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.html
@@ -84,6 +84,8 @@
       onClick: parameterless callback function
     }, and/or
   * an onGrainClicked callback function, which takes a single argument grainId as a String
+  * a showHintIfEmpty value, which if truthy, tells the JS to show a guided tour if the grains
+    list is empty.
   * an alwaysShowTableHeaders value, which if truthy, always shows table headers. By contrast,
     if empty or falsey, when the grains list is missing, we only show the action button(s).
   * a list "bulkActionButtons" containing object with shape

--- a/shell/packages/sandstorm-ui-grainlist/grainlist.html
+++ b/shell/packages/sandstorm-ui-grainlist/grainlist.html
@@ -84,6 +84,8 @@
       onClick: parameterless callback function
     }, and/or
   * an onGrainClicked callback function, which takes a single argument grainId as a String
+  * an alwaysShowTableHeaders value, which if truthy, always shows table headers. By contrast,
+    if empty or falsey, when the grains list is missing, we only show the action button(s).
   * a list "bulkActionButtons" containing object with shape
     {
       buttonClass: a string to be used in the button's class attribute
@@ -109,7 +111,7 @@
 
     <table class="grain-list-table">
       <thead>
-        {{#if grains}}
+        {{#if showTableHeaders}}
         <tr>
             <td class="select-all-grains">
               <input title={{selectAllTitle}} type="checkbox">

--- a/tests/tests/account.js
+++ b/tests/tests/account.js
@@ -41,6 +41,7 @@ module.exports["Test link identities"] = function (browser) {
     .url(browser.launch_url + "/demo")
     .waitForElementVisible(".demo-box button.start", medium_wait)
     .click(".demo-box button.start")
+    .disableGuidedTour()
     .waitForElementPresent(".main-content>.app-list", medium_wait)
     .click(".login>button.show-popup")
     .waitForElementVisible(".login-buttons-list", short_wait)


### PR DESCRIPTION
After:

![screenshot from 2016-06-17 18 33 37](https://cloud.githubusercontent.com/assets/25457/16168373/117517cc-34ba-11e6-9ccc-05c7bd18d3b5.png)

![screenshot from 2016-06-17 18 33 43](https://cloud.githubusercontent.com/assets/25457/16168376/1d234882-34ba-11e6-98e1-375eedc19276.png)

This addresses feedback from @kentonv that it's preferable to always show the table headers on the app details page, even if the user has 0 grains with that app, while staying consistent with @neynah 's request that on the overall grains list page, there is no table header.

It also adds code documentation for an existing but undocumented parameter of the grain list template.