### PR TITLE
Revert "Use FontForge to convert SVGs to TTF"

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -120,13 +120,12 @@ Please install the following:
 * `curl`
 * discount (markdown parser)
 * [Clang compiler](http://clang.llvm.org/) version 3.4 or better
-* FontForge, used by `grunt` to convert SVGs to WebFonts
 * [Meteor](http://meteor.com)
 
 On Debian or Ubuntu, you should be able to get all these with:
 
     sudo apt-get install build-essential libcap-dev xz-utils zip \
-        unzip strace curl clang-3.4 discount git fontforge
+        unzip strace curl clang-3.4 discount git
     curl https://install.meteor.com/ | sh
 
 ### Get the source code

--- a/icons/Gruntfile.js
+++ b/icons/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
         destCss: "../shell/client/styles",
         options: {
           font: "icons",
-          engine: "fontforge",
+          engine: "node",
           autoHint: false,
           htmlDemo: false,
           relativeFontPath: "/icons/",


### PR DESCRIPTION
This reverts commit c9f0899ed0004152442b8084046ea6f957a65361.

Rationale:

- It introduces an issue where the down-arrow is in a weird place,
  among other bad icon issues. See https://github.com/sandstorm-io/sandstorm/pull/2110
  for one example.

- It means the question mark will have no circular outline. I personally
  believe this should not be a show-stopper for the user onboarding changes
  being improved.