### PR TITLE
admin caps: ignore caps for grains that don't exist

### DIFF
--- a/shell/client/admin/network-capabilities-client.js
+++ b/shell/client/admin/network-capabilities-client.js
@@ -11,13 +11,16 @@ const lookupIdentityById = function (identityId) {
 };
 
 const capDetails = function (cap) {
-
   let introducer = {};
   let ownerInfo = {};
   console.log(cap);
   if (cap.owner.grain !== undefined) {
     const grainId = cap.owner.grain.grainId;
     const grain = Grains.findOne(grainId);
+    if (!grain) {
+      // Grain was deleted.  Don't show anything.
+      return undefined;
+    }
     const grainTitle = grain && grain.title;
     const packageId = grain && grain.packageId;
     const pkg = packageId && globalDb.collections.packages.findOne(packageId);
@@ -111,13 +114,15 @@ Template.newAdminNetworkCapabilities.helpers({
   ipNetworkCaps() {
     return ApiTokens.find({
       "frontendRef.ipNetwork": { $exists: true },
-    }).map(capDetails);
+    }).map(capDetails)
+      .filter((item) => !!item);
   },
 
   ipInterfaceCaps() {
     return ApiTokens.find({
       "frontendRef.ipInterface": { $exists: true },
-    }).map(capDetails);
+    }).map(capDetails)
+      .filter((item) => !!item);
   },
 });
 

--- a/shell/client/admin/network-capabilities-client.js
+++ b/shell/client/admin/network-capabilities-client.js
@@ -21,6 +21,7 @@ const capDetails = function (cap) {
       // Grain was deleted.  Don't show anything.
       return undefined;
     }
+
     const grainTitle = grain && grain.title;
     const packageId = grain && grain.packageId;
     const pkg = packageId && globalDb.collections.packages.findOne(packageId);


### PR DESCRIPTION
If you grant a grain a capability and then delete the grain, the ApiToken is
still lying around in the collection.

The Network Capabilities UI previously assumed this would not happen; now it
ignores such tokens.

Refs: #2117.