### PR TITLE
Add guided-tour hint explaining how to share access

### DIFF
--- a/shell/client/demo-client.js
+++ b/shell/client/demo-client.js
@@ -111,6 +111,12 @@ Template.appdemo.events({
           globalDb.addUserActions(packageId);
         }
 
+        // Also mark the user as needing the "How to share access" guided-tour hint.
+        const grainsCount = globalDb.currentUserGrains().count();
+        if (grainsCount === 0) {
+          Meteor._localStorage.setItem("userNeedsShareAccessHint", true);
+        }
+
         // 4. Create new grain and 5. browse to it.
         launchAndEnterGrainByPackageId(packageId);
       }
@@ -188,4 +194,3 @@ Router.map(function () {
     },
   });
 });
-

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -454,7 +454,7 @@ Template.grainShareButton.onRendered(() => {
   const activeGrain = globalGrains.getActive();
   let unsafeCurrentAppTitle = (activeGrain && activeGrain.appTitle()) || "";
 
-  /* Use DOM to escape HTML, so it is safe to pass to intro.js */
+  // Use DOM to escape HTML, so it is safe to pass to intro.js.
   let div = document.createElement("div");
   div.appendChild(document.createTextNode(unsafeCurrentAppTitle));
   let escapedCurrentAppTitle = div.innerHTML;

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -441,7 +441,7 @@ Template.shareableLinkTab.events({
 });
 
 Template.grainShareButton.onRendered(() => {
-  if (! Meteor._localStorage.getItem("userNeedsShareAccessHint")) {
+  if (!Meteor._localStorage.getItem("userNeedsShareAccessHint")) {
     return;
   }
 
@@ -452,12 +452,12 @@ Template.grainShareButton.onRendered(() => {
 
   let templateData = Template.instance();
   const activeGrain = globalGrains.getActive();
-  var unsafeCurrentAppTitle = (activeGrain && activeGrain.appTitle()) || "";
+  let unsafeCurrentAppTitle = (activeGrain && activeGrain.appTitle()) || "";
 
   /* Use DOM to escape HTML, so it is safe to pass to intro.js */
-  var div = document.createElement("div");
+  let div = document.createElement("div");
   div.appendChild(document.createTextNode(unsafeCurrentAppTitle));
-  var escapedCurrentAppTitle = div.innerHTML;
+  let escapedCurrentAppTitle = div.innerHTML;
 
   const intro = templateData.intro = introJs();
   let introOptions = {
@@ -467,7 +467,7 @@ Template.grainShareButton.onRendered(() => {
         intro: "You've created your first " + escapedCurrentAppTitle + " grain. When you're ready, you can share it with others.",
       },
     ],
-    highlightClass: 'introjs-black-helperLayer',
+    highlightClass: "introjs-black-helperLayer",
     tooltipPosition: "bottom",
     positionPrecedence: ["bottom", "top", "left", "right"],
     showStepNumbers: false,

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -454,17 +454,32 @@ Template.grainShareButton.onRendered(() => {
   const activeGrain = globalGrains.getActive();
   let unsafeCurrentAppTitle = (activeGrain && activeGrain.appTitle()) || "";
 
+  const currentPkgId = Grains.findOne({ _id: activeGrain.grainId() }).packageId;
+  const possibleUserActions = UserActions.find({ packageId: currentPkgId }).fetch();
+  let unsafeCurrentNounPhrase = "grain";
+  // Frequently there is only 1 UserAction per package. If there is more than 1, then we go with
+  // the default of "grain".
+  if (possibleUserActions.length === 1) {
+    const currentUserAction = possibleUserActions[0];
+    unsafeCurrentNounPhrase = SandstormDb.nounPhraseForActionAndAppTitle(currentUserAction, unsafeCurrentAppTitle);
+  }
+
   // Use DOM to escape HTML, so it is safe to pass to intro.js.
   let div = document.createElement("div");
   div.appendChild(document.createTextNode(unsafeCurrentAppTitle));
   let escapedCurrentAppTitle = div.innerHTML;
+
+  div = document.createElement("div");
+  div.appendChild(document.createTextNode(unsafeCurrentNounPhrase));
+  let escapedCurrentNounPhrase = div.innerHTML;
 
   const intro = templateData.intro = introJs();
   let introOptions = {
     steps: [
       {
         element: document.querySelector(".share"),
-        intro: "You've created your first " + escapedCurrentAppTitle + " grain. When you're ready, you can share it with others.",
+        intro: "You've created your first " + escapedCurrentAppTitle + " " +
+          escapedCurrentNounPhrase + ". When you're ready, you can share it with others. Enjoy!",
       },
     ],
     highlightClass: "introjs-black-helperLayer",
@@ -475,7 +490,7 @@ Template.grainShareButton.onRendered(() => {
     overlayOpacity: 0.7,
     showBullets: false,
     disableInteraction: false,
-    doneLabel: "Thanks",
+    doneLabel: "Got it",
   };
 
   intro.setOptions(introOptions);

--- a/shell/client/styles/_geometry.scss
+++ b/shell/client/styles/_geometry.scss
@@ -6,6 +6,10 @@
 // TODO(cleanup): We don't include "screen" in the query because we assume this whole stylesheet
 //   is intended for screens. For non-screens, an entirely different stylesheet would be desired,
 //   or possibly no stylesheet at all: the HTML is designed to be understandable with no style.
+//
+//
+// NOTE: If you change the definition of $mobile or $desktop, run: `git grep -F '$mobile'`
+// in order to find places in the Javascript code that hard-code this 900px breakpoint.
 $mobile: "(max-width: 900px)";
 $desktop: "(min-width: 901px)";
 

--- a/shell/client/styles/introjs-customizations.scss
+++ b/shell/client/styles/introjs-customizations.scss
@@ -10,3 +10,7 @@
 .hidden-introjs-highlight {
   display: none;
 }
+.introjs-helperLayer.introjs-black-helperLayer {
+  background: black;
+  box-shadow: 0 2px 15px rgba(255,255,255,.4);
+}

--- a/shell/packages/sandstorm-ui-applist/applist-client.js
+++ b/shell/packages/sandstorm-ui-applist/applist-client.js
@@ -239,6 +239,16 @@ Template.sandstormAppListPage.onRendered(() => {
   const db = Template.instance().data._db;
   // Set up automatically-opening hint explaining what installing is, if zero apps installed.
   if (!db.collections.userActions.find().count() && !Session.get("dismissedInstallHint")) {
+    // If the user had 0 grains (including in the trash) at the time they see this message, then
+    // when they open a grain for the first time, we want to show them our guided-tour message
+    // about how "Share access" works.
+    //
+    // Persist between reloads via localStorage.
+    const grainsCount = db.currentUserGrains().count();
+    if (grainsCount === 0) {
+      Meteor._localStorage.setItem("userNeedsShareAccessHint", true);
+    }
+
     const intro = Template.instance().intro = introJs();
     let introOptions = {
       steps: [


### PR DESCRIPTION
Close #2049

Implementation notes:

- We only show this to appdemo users and to users who see
  the hint about installing apps. Therefore, the test suite
  should be unaffected.

- We check the viewport width, and if it is less than 900px
  (aka "$mobile" for Sandstorm) then we don't show this note.