### PR TITLE
Add explanatory text to /admin/users/invite

### DIFF
--- a/shell/client/admin/user-invite.html
+++ b/shell/client/admin/user-invite.html
@@ -1,4 +1,10 @@
 <template name="newAdminUserInviteLink">
+
+  <p>You can invite others to create accounts on your server by giving them an account creation
+    link. People you invite will be granted User permission and be able to install apps and create
+    grains of their own. Alternatively, if you want to share a specific grain with someone, you can
+    do that within the grain's "Share Access" menu.</p>
+
   <h2>Create a link</h2>
 
   {{#if hasSuccess}}
@@ -13,7 +19,7 @@
     {{/focusingErrorBox}}
   {{/if}}
 
-  <p>This will create a magic link which you can send to someone.</p>
+  <p>This will create a account creation link which you can send to someone.</p>
   <form class="admin-invite-button-form">
     <button type="submit">Create link</button>
     {{#if generatedLink}}

--- a/shell/client/admin/user-invite.html
+++ b/shell/client/admin/user-invite.html
@@ -19,7 +19,7 @@
     {{/focusingErrorBox}}
   {{/if}}
 
-  <p>This will create a account creation link which you can send to someone.</p>
+  <p>This will create an account creation link which you can send to someone.</p>
   <form class="admin-invite-button-form">
     <button type="submit">Create link</button>
     {{#if generatedLink}}


### PR DESCRIPTION
Close #2076

I changed the proposed text here so that it:

- Avoids the word "just".

- Avoids all-caps "NOT".

- Avoids the word "magic", preferring a phrase specific to what kind of magic.