### PR TITLE
Test that we are on a terminal first

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2100,13 +2100,13 @@ sandcats_generate_keys() {
 
 # Now that the steps exist as functions, run them in an order that
 # would result in a working install.
+assert_on_terminal
 assert_linux_x86_64
 assert_usable_kernel
 detect_current_uid
 detect_userns_clone
 assert_userns_clone_works_or_can_be_made_to_work
 handle_args "$@"
-assert_on_terminal
 assert_dependencies
 assert_valid_bundle_file
 detect_init_system


### PR DESCRIPTION
Rationale:

- By running this assertion first, we cause the side-effect that FD#3 is
  ready.

- This happens to be important because since I enabled error reporting
  by default, and since the error reporting code assumes that FD#3 is
  ready, a horrifying infinite loop occurs instead.

- Since the installer-test suite runs with REPORT=no, it does not catch
  this error, but it is true that the "precise64" base box can be used
  to reproduce the error.

Close #2081