### PR TITLE
install.sh: Handle args before asserting on a terminal

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2100,13 +2100,13 @@ sandcats_generate_keys() {
 
 # Now that the steps exist as functions, run them in an order that
 # would result in a working install.
+handle_args "$@"
 assert_on_terminal
 assert_linux_x86_64
 assert_usable_kernel
 detect_current_uid
 detect_userns_clone
 assert_userns_clone_works_or_can_be_made_to_work
-handle_args "$@"
 assert_dependencies
 assert_valid_bundle_file
 detect_init_system


### PR DESCRIPTION
Context: assert_on_terminal needs to know if USE_DEFAULTS is set.