### PR TITLE
email config: propagate information about errors users might hit

### DIFF
--- a/shell/client/admin/email-config-client.js
+++ b/shell/client/admin/email-config-client.js
@@ -153,7 +153,7 @@ Template.newAdminEmailConfig.events({
     const formData = instance.getSmtpConfig();
     Meteor.call("setSmtpConfig", undefined, formData, (err) => {
       if (err) {
-        instance.errorMessage.set(err.toString());
+        instance.errorMessage.set(err.message);
         instance.state.set("error");
       } else {
         instance.state.set("success");


### PR DESCRIPTION
This provides more useful error messages when an exception is thrown while
attempting to send a test email.  Specific cases tested:

* hostname doesn't resolve
* hostname resolves but server isn't listening on that port
* server is listening but rejects your credentials

Fixes #2091.