### PR TITLE
Unclutter account view

### DIFF
--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -468,11 +468,10 @@ body>.main-content>.account {
   }
 
   h3.title-bar {
-    background-color: white;
     width: 660px;
     margin-bottom: 5px;
     border: none;
-    font-size: 12pt;
+    font-size: 14pt;
     padding: 5px;
   }
 
@@ -946,127 +945,64 @@ div.billing {
 div.identity-editor {
   width: 435px;
   background-color: white;
-  padding: 15px 22px;
+  padding: 22px;
 
-  .details {
-    display: block;
-    clear: right;
-    font-size: 80%;
-    color: #777777;
-  }
+  form.account-profile-editor {
+    @extend %standard-form;
+    width: 390px;
 
-  .editor .picture {
-    width: 128px;
-    position: absolute;
-    label {
-      display: block;
-      font-weight: bold;
-    }
-    button {
-      display:block;
-      border: none;
-      padding: 0;
-      width: 115px;
-      height: 115px;
-      position: relative;
-      background-color: transparent;
-
-      &:hover {
-        cursor: pointer;
-        &::before {
-          position: absolute;
-          content: " ";
-          display: block;
-          top: 0;
-          left: 0;
-          width: 100%;
-          height: 100%;
-          background-color: rgba(0, 0, 0, 0.3);
-          background-image: url("/upload.svg");
-          opacity: 0.75;
-          z-index: 1;
-        }
-      }
-
-      >img {
-        display: block;
-        max-width: 100%;
-        max-height: 100%;
-        margin: auto;
-      }
-
-      @media (max-width: 352px) {
-        width: 192px;
-        height: 192px;
-      }
-    }
-  }
-
-  .editor {
     .inline-icon {
       width: 20px;
     }
-    >ul {
-      position: relative;
-      left: 140px;
-      padding: 8px;
-      width: 250px;
 
+    ul {
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    ul.verified-email-list {
       >li {
-        list-style-type: none;
-        overflow: hidden;
-        margin-bottom: 8px;
-
-        label {
-          display: block;
-          font-weight: bold;
-        }
-
-        &.terms, &.mailingListOptin {
-          padding-left: 24px;
-          label { font-weight: inherit; text-indent: -24px; }
-        }
-
-        input[type="text"], select {
-          display: block;
-          width: 230px;
-          font-size: inherit;
-          line-height: inherit;
-          background-color: white;
-          border: 1px solid #ccc;
-          padding: 2px;
-        }
-
-        input:invalid {
-          border: 1px solid #c00;
-        }
-
-        &.handle .input-container {
-          position: relative;
-          input[type="text"] {
-            font-size: 12pt;
-            font-family: monospace;
-          }
-        }
-
-        &.save {
-          text-align: right;
-          >button {
-            @extend %button-base;
-            @extend %button-primary;
-          }
-          >button.logout{
-            @extend %button-secondary;
-          }
+        // Vertically center each email address within a 30px space.
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-start;
+        min-height: 30px;
+        border-top: 1px solid #dddddd;
+        &:last-child {
+          border-bottom: 1px solid #dddddd;
         }
       }
     }
 
-    ul.verified-email-list {
-      padding: 0;
-      li {
-        list-style-type: none;
+    .picture-row {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      justify-content: flex-start;
+      .picture-box {
+        flex: none;
+        width: 128px;
+        height: 128px;
+        margin-right: 16px;
+        img {
+          max-width: 128px;
+          max-height: 128px;
+        }
       }
+    }
+
+    .terms, .mailingListOptin {
+      padding-left: 24px;
+      label {
+        font-weight: inherit;
+        text-indent: -24px;
+      }
+    }
+
+    .handle input[type="text"] {
+      font-family: monospace;
     }
   }
 }

--- a/shell/client/styles/_colors.scss
+++ b/shell/client/styles/_colors.scss
@@ -5,7 +5,9 @@ $sandstorm-purple-color: #762F87;
 $darker-purple-color: #65468e;
 
 // The color that we use to outline focused elements, for accessibility
+// Keep $half-focus-outline-color's values in sync with the values from the outline color.
 $focus-outline-color: $sandstorm-purple-color;
+$half-focus-outline-color: rgba(118, 47, 135, 0.5);
 
 // Colors for success/error message box backgrounds.
 $error-background-color: #ffdddd;

--- a/shell/client/styles/_focus.scss
+++ b/shell/client/styles/_focus.scss
@@ -9,18 +9,7 @@ input::-moz-focus-inner {
     padding: 0;
 }
 
-a:focus {
+a:focus, button:focus, input:focus, select:focus, textarea:focus {
   outline: $focus-outline-color solid 1px;
-}
-
-button:focus {
-  outline: $focus-outline-color solid 1px;
-}
-
-input:focus {
-  outline: $focus-outline-color solid 1px;
-}
-
-textarea:focus {
-  outline: $focus-outline-color solid 1px;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.075), 0 0 5px $half-focus-outline-color;
 }

--- a/shell/client/styles/_partials.scss
+++ b/shell/client/styles/_partials.scss
@@ -147,7 +147,11 @@
     font-size: 20px;
   }
 
-  input[type=text], input[type=password], input[type=number], input[type=email], textarea {
+  input[type=text], input[type=password], input[type=number], input[type=email], select {
+    min-height: 30px;
+  }
+
+  input[type=text], input[type=password], input[type=number], input[type=email], select, textarea {
     display: block;
     width: 100%;
     color: #222;
@@ -160,6 +164,9 @@
     &:disabled {
       color: #666;
       background-color: #efefef;
+    }
+    &:invalid {
+      border: 1px solid #c00;
     }
   }
 

--- a/shell/client/styles/_partials.scss
+++ b/shell/client/styles/_partials.scss
@@ -122,8 +122,6 @@
 
 %standard-form {
   // Styles that we tend to reuse in forms, particularly in the admin panel.
-  margin-bottom: 10px;
-
   .form-group {
     margin-bottom: 10px;
   }

--- a/shell/client/styles/_setup-wizard.scss
+++ b/shell/client/styles/_setup-wizard.scss
@@ -239,7 +239,6 @@
   flex-direction: row-reverse;
   align-items: stretch;
   justify-content: flex-start;
-  margin-bottom: 15px;
 }
 
 .setup-next-button {

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -136,97 +136,102 @@ setActionCompleted: (optional) Function.  Callback triggered on profile saved or
 --}}
   <div class="identity-editor">
     <form class="account-profile-editor" data-identity-id="{{identity._id}}">
-      <div class="editor">
-        <div class="picture">
-          <label>Avatar:
-            <button type="button">
-              <img src="{{identity.profile.pictureUrl}}" alt="Upload picture">
-            </button>
+      <ul>
+        <li class="form-group">
+          <label>Profile picture:</label>
+          <div class="picture-row">
+            <div class="picture-box">
+              <img src="{{identity.profile.pictureUrl}}">
+            </div>
+            <input type="file" name="picture" style="display:none">
+            <div class="form-subtext">
+              <button type="button">Upload new picture</button>
+              <p>This picture will be shown to other users to help identify you.</p>
+              <p>512x512px, 64KiB max.</p>
+            </div>
+          </div>
+        </li>
+
+        <li class="form-group">
+          <label>
+            Full name:
+            <input type="text" name="nameInput" value="{{identity.profile.name}}"
+                   placeholder="full name" required>
           </label>
-          <input type="file" name="picture" style="display:none">
-          <span class="details">
-            <p>This picture will be shown to other users to help identify you.</p>
-            <p>512x512px, 64KiB max.</p>
+          <span class="form-subtext">Your regular first and last name, as you would like it
+            displayed to others. This does not have to be your real name.
           </span>
-        </div>
-        <ul>
-          <li class="name">
-            <label><img class="inline-icon" src="/people-m.svg" role="presentation">
-              Full name:
-              <input type="text" name="nameInput" value="{{identity.profile.name}}"
-                     placeholder="full name" required>
-            </label>
-            <span class="details">Your regular first and last name, as you would like it
-              displayed to others. This does not have to be your real name.
-            </span>
-          </li>
-          <li class="handle">
-            <label>@ Handle:
-              <div class="input-container">
-                <input type="text" name="handle" value="{{identity.profile.handle}}"
-                       placeholder="handle" pattern="^[a-z_][a-z0-9_]*$"
-                       title="Handles must start with a lower-case letter and contain only lower-case letters, digits, and underscores." required>
-              </div>
-            </label>
-            <span class="details">
-              For use in apps that use handles (often, chat apps).
-              This is only your first choice; an app may make you rename if someone has
-              already taken this name within the specific grain. Your handle must start
-              with a letter and contain only lower-case letters, digits, and underscores.
-            </span>
-          </li>
-          <li class="email">
-            <label><img class="inline-icon" src="/email-m.svg" role="presentation">
-              E-mail:
-            </label>
-            <ul class="verified-email-list">
-              {{#each verifiedEmails}}
-              <li> {{.}} </li>
-              {{/each}}
-            </ul>
-            <span class="details">{{emailDetails}}</span>
-          </li>
-          <li class="pronoun">
-            {{#with identity.profile}}
-            <label><img class="inline-icon" src="/pronoun-m.svg" role="presentation">
-              Preferred pronoun:
-              <select name="pronoun">
-                <option value="neutral" selected="{{isNeutral}}">they (unspecified)</option>
-                <option value="male" selected="{{isMale}}">he/him (male)</option>
-                <option value="female" selected="{{isFemale}}">she/her (female)</option>
-                <option value="robot" selected="{{isRobot}}">it (robot)</option>
-              </select>
-            </label>
-            {{/with}}
-          </li>
-          {{#unless hasCompletedSignup}}
+        </li>
+
+        <li class="form-group handle">
+          <label>Handle:
+            <div class="input-container">
+              <input type="text" name="handle" value="{{identity.profile.handle}}"
+                     placeholder="handle" pattern="^[a-z_][a-z0-9_]*$"
+                     title="Handles must start with a lower-case letter and contain only lower-case letters, digits, and underscores." required>
+            </div>
+          </label>
+          <span class="form-subtext">
+            To be displayed in apps that use handles. Your handle must start with a letter and
+            contain only lower-case letters, digits, and underscores.
+          </span>
+        </li>
+
+        <li class="form-group">
+          <label>
+            E-mail:
+          </label>
+          <ul class="verified-email-list">
+            {{#each verifiedEmails}}
+            <li> {{.}} </li>
+            {{/each}}
+          </ul>
+          <span class="form-subtext">{{emailDetails}}</span>
+        </li>
+
+        <li class="form-group">
+          {{#with identity.profile}}
+          <label>
+            Preferred pronoun:
+            <select name="pronoun">
+              <option value="neutral" selected="{{isNeutral}}">they (unspecified)</option>
+              <option value="male" selected="{{isMale}}">he/him (male)</option>
+              <option value="female" selected="{{isFemale}}">she/her (female)</option>
+              <option value="robot" selected="{{isRobot}}">it (robot)</option>
+            </select>
+          </label>
+          {{/with}}
+        </li>
+
+        {{#unless hasCompletedSignup}}
           {{#with termsAndPrivacy}}
-          <li class="terms">
-            <label>
-              <input type="checkbox" name="agreedToTerms" required> I have read and agree to the
-              {{#if termsUrl}}<a target="_blank" href="{{termsUrl}}">Terms of Service</a>
-              {{#if privacyUrl}} and {{/if}}{{/if}}{{#if privacyUrl}}
-              <a target="_blank" href="{{privacyUrl}}">Privacy policy</a>{{/if}}.
-            </label>
-          </li>
+            <li class="form-group">
+              <label>
+                <input type="checkbox" name="agreedToTerms" required> I have read and agree to the
+                {{#if termsUrl}}<a target="_blank" href="{{termsUrl}}">Terms of Service</a>
+                {{#if privacyUrl}} and {{/if}}{{/if}}{{#if privacyUrl}}
+                <a target="_blank" href="{{privacyUrl}}">Privacy policy</a>{{/if}}.
+              </label>
+            </li>
           {{/with}}
           {{#if isPaymentsEnabled}}
             {{> billingOptins}}
           {{/if}}
+        {{/unless}}
+
+        {{#unless hideButtons}}
+        <li class="button-row">
+          <button disabled="{{profileSaved}}" type="submit">
+            {{#if hasCompletedSignup}}Save{{else}}Continue{{/if}}
+          </button>
+          {{#unless hasCompletedSignup}}
+          <button class="logout" type="button">Cancel</button>
           {{/unless}}
-          {{#unless hideButtons}}
-          <li class="save">
-            <button disabled="{{profileSaved}}">
-              {{#if hasCompletedSignup}}Save{{else}}Continue{{/if}}
-            </button>
-            {{#unless hasCompletedSignup}}
-            <button class="logout">Cancel</button>
-            {{/unless}}
-          </li>
-          {{/unless}}
-        </ul>
-      </div>
+        </li>
+        {{/unless}}
+      </ul>
     </form>
+
     {{#if hasCompletedSignup}}
       <hr>
       {{> identityManagementButtons identityManagementButtonsData}}

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -217,20 +217,20 @@ Template._accountProfileEditor.helpers({
 });
 
 Template.sandstormAccountSettings.events({
-  "click [role='tab']": function (event, instance) {
+  "click [role='tab']": function (ev, instance) {
     instance._actionCompleted.set();
-    instance._selectedIdentityId.set(event.currentTarget.getAttribute("data-identity-id"));
+    instance._selectedIdentityId.set(ev.currentTarget.getAttribute("data-identity-id"));
   },
 
-  "click button.link-new-identity": function (event, instance) {
+  "click button.link-new-identity": function (ev, instance) {
     instance._isLinkingNewIdentity.set(true);
   },
 
-  "click button.cancel-link-new-identity": function (event, instance) {
+  "click button.cancel-link-new-identity": function (ev, instance) {
     instance._isLinkingNewIdentity.set(false);
   },
 
-  "click button.logout-other-sessions": function (event, instance) {
+  "click button.logout-other-sessions": function (ev, instance) {
     instance._logoutOtherSessionsInFlight.set(true);
     Meteor.logoutOtherClients(function (err) {
       if (err) {
@@ -249,8 +249,8 @@ Template.sandstormAccountSettings.events({
     });
   },
 
-  "click button.make-primary": function (event, instance) {
-    Meteor.call("setPrimaryEmail", event.target.getAttribute("data-email"));
+  "click button.make-primary": function (ev, instance) {
+    Meteor.call("setPrimaryEmail", ev.target.getAttribute("data-email"));
   },
 });
 
@@ -331,8 +331,8 @@ Template._accountProfileEditor.onCreated(function () {
 });
 
 Template._accountProfileEditor.events({
-  "submit form.account-profile-editor": function (event, instance) {
-    event.preventDefault();
+  "submit form.account-profile-editor": function (ev, instance) {
+    ev.preventDefault();
     const form = Template.instance().find("form");
     submitProfileForm(form, function () {
       instance._profileSaved.set(true);
@@ -340,12 +340,12 @@ Template._accountProfileEditor.events({
     });
   },
 
-  change: function (event, instance) {
+  change: function (ev, instance) {
     // Pictures get saved right away.
     //
     // TODO(someday): Upload pictures to a staging area, perhaps allowing the user to resize
     //   and crop them before saving.
-    if (event.target == instance.find("input[name='picture']")) { return; }
+    if (ev.target == instance.find("input[name='picture']")) { return; }
 
     instance._profileSaved.set(false);
   },
@@ -354,13 +354,13 @@ Template._accountProfileEditor.events({
 
   keypress: function () { Template.instance()._profileSaved.set(false); },
 
-  "click .logout": function (event, instance) {
-    event.preventDefault();
+  "click .logout": function (ev, instance) {
+    ev.preventDefault();
     Meteor.logout();
   },
 
-  "click .picture button": function (event, instance) {
-    event.preventDefault();
+  "click .picture button": function (ev, instance) {
+    ev.preventDefault();
 
     const staticHost = Template.currentData().staticHost;
     if (!staticHost) throw new Error("missing _staticHost");
@@ -392,9 +392,9 @@ Template._accountProfileEditor.events({
       }
     });
 
-    function listener(event) {
+    function listener(ev) {
       input.removeEventListener("change", listener);
-      file = event.currentTarget.files[0];
+      file = ev.currentTarget.files[0];
       if (file && token) doUpload();
     }
 


### PR DESCRIPTION
* Same total width as previous layout.
* Profile picture is no longer a separate column.
* The remaining content has more horizontal space.
* The form uses our standard form layout styles.
* Icons were removed, as suggested by @neynah.
* Page subheadings no longer have a distracting white background.
* Copy about handles was made more terse.

Longer-term, I think the account settings page should probably get split out
into multiple pages - we've already got a number of things that deserve a place
in the hierarchy:

* identities
* email addresses
* referral program
* billing

And I expect we'll wind up adding 2FA and notifications and maybe even OAuth
tokens some day.  So, we should plan to organize content and find a good way
to navigate between all these "my account" data.

Revised accounts page:
![accounts-revised](https://cloud.githubusercontent.com/assets/307325/16326383/efa5e890-397a-11e6-9456-22d3601f4e1f.png)

Confirm your profile modal:
![confirm-profile-modal](https://cloud.githubusercontent.com/assets/307325/16326428/5cfd41a4-397b-11e6-80f2-97a70cb2e0fb.png)

Closes #2065 
