### PR TITLE
Unclutter account view, v2

### DIFF
--- a/shell/client/setup-wizard/wizard.js
+++ b/shell/client/setup-wizard/wizard.js
@@ -641,6 +641,7 @@ Template.setupWizardLoginUser.helpers({
   },
 
   accountProfileEditorData() {
+    const instance = Template.instance();
     // copied from packages/sandstorm-accounts-ui/account-settings.js
     const identityId = SandstormDb.getUserIdentityIds(Meteor.user())[0];
     const identity = Meteor.users.findOne({ _id: identityId });
@@ -655,6 +656,13 @@ Template.setupWizardLoginUser.helpers({
       staticHost: window.location.protocol + "//" + makeWildcardHost("static"),
       db: globalDb,
       hideButtons: true,
+      setActionCompleted: function (result) {
+        if (result.success) {
+          instance.successMessage.set(result.success);
+        } else if (result.error) {
+          instance.errorMessage.set(result.error);
+        }
+      },
     };
   },
 

--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -468,11 +468,10 @@ body>.main-content>.account {
   }
 
   h3.title-bar {
-    background-color: white;
     width: 660px;
     margin-bottom: 5px;
     border: none;
-    font-size: 12pt;
+    font-size: 14pt;
     padding: 5px;
   }
 
@@ -946,127 +945,64 @@ div.billing {
 div.identity-editor {
   width: 435px;
   background-color: white;
-  padding: 15px 22px;
+  padding: 22px;
 
-  .details {
-    display: block;
-    clear: right;
-    font-size: 80%;
-    color: #777777;
-  }
+  form.account-profile-editor {
+    @extend %standard-form;
+    width: 390px;
 
-  .editor .picture {
-    width: 128px;
-    position: absolute;
-    label {
-      display: block;
-      font-weight: bold;
-    }
-    button {
-      display:block;
-      border: none;
-      padding: 0;
-      width: 115px;
-      height: 115px;
-      position: relative;
-      background-color: transparent;
-
-      &:hover {
-        cursor: pointer;
-        &::before {
-          position: absolute;
-          content: " ";
-          display: block;
-          top: 0;
-          left: 0;
-          width: 100%;
-          height: 100%;
-          background-color: rgba(0, 0, 0, 0.3);
-          background-image: url("/upload.svg");
-          opacity: 0.75;
-          z-index: 1;
-        }
-      }
-
-      >img {
-        display: block;
-        max-width: 100%;
-        max-height: 100%;
-        margin: auto;
-      }
-
-      @media (max-width: 352px) {
-        width: 192px;
-        height: 192px;
-      }
-    }
-  }
-
-  .editor {
     .inline-icon {
       width: 20px;
     }
-    >ul {
-      position: relative;
-      left: 140px;
-      padding: 8px;
-      width: 250px;
 
+    ul {
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    ul.verified-email-list {
       >li {
-        list-style-type: none;
-        overflow: hidden;
-        margin-bottom: 8px;
-
-        label {
-          display: block;
-          font-weight: bold;
-        }
-
-        &.terms, &.mailingListOptin {
-          padding-left: 24px;
-          label { font-weight: inherit; text-indent: -24px; }
-        }
-
-        input[type="text"], select {
-          display: block;
-          width: 230px;
-          font-size: inherit;
-          line-height: inherit;
-          background-color: white;
-          border: 1px solid #ccc;
-          padding: 2px;
-        }
-
-        input:invalid {
-          border: 1px solid #c00;
-        }
-
-        &.handle .input-container {
-          position: relative;
-          input[type="text"] {
-            font-size: 12pt;
-            font-family: monospace;
-          }
-        }
-
-        &.save {
-          text-align: right;
-          >button {
-            @extend %button-base;
-            @extend %button-primary;
-          }
-          >button.logout{
-            @extend %button-secondary;
-          }
+        // Vertically center each email address within a 30px space.
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-start;
+        min-height: 30px;
+        border-top: 1px solid #dddddd;
+        &:last-child {
+          border-bottom: 1px solid #dddddd;
         }
       }
     }
 
-    ul.verified-email-list {
-      padding: 0;
-      li {
-        list-style-type: none;
+    .picture-row {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      justify-content: flex-start;
+      .picture-box {
+        flex: none;
+        width: 128px;
+        height: 128px;
+        margin-right: 16px;
+        img {
+          max-width: 128px;
+          max-height: 128px;
+        }
       }
+    }
+
+    .terms, .mailingListOptin {
+      padding-left: 24px;
+      label {
+        font-weight: inherit;
+        text-indent: -24px;
+      }
+    }
+
+    .handle input[type="text"] {
+      font-family: monospace;
     }
   }
 }

--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -453,6 +453,7 @@ body>.main-content>.account {
   .identities-editor {
     position: relative;
     white-space: nowrap;
+    max-width: 660px;
   }
 
   h2, h3 {
@@ -940,6 +941,11 @@ div.billing {
     position: static;
     margin: auto;
   }
+}
+
+div.single-identity-editor {
+  max-width: 435px;
+  margin: auto;
 }
 
 div.identity-editor {

--- a/shell/client/styles/_colors.scss
+++ b/shell/client/styles/_colors.scss
@@ -5,7 +5,9 @@ $sandstorm-purple-color: #762F87;
 $darker-purple-color: #65468e;
 
 // The color that we use to outline focused elements, for accessibility
+// Keep $half-focus-outline-color's values in sync with the values from the outline color.
 $focus-outline-color: $sandstorm-purple-color;
+$half-focus-outline-color: rgba(118, 47, 135, 0.5);
 
 // Colors for success/error message box backgrounds.
 $error-background-color: #ffdddd;

--- a/shell/client/styles/_focus.scss
+++ b/shell/client/styles/_focus.scss
@@ -9,18 +9,7 @@ input::-moz-focus-inner {
     padding: 0;
 }
 
-a:focus {
+a:focus, button:focus, input:focus, select:focus, textarea:focus {
   outline: $focus-outline-color solid 1px;
-}
-
-button:focus {
-  outline: $focus-outline-color solid 1px;
-}
-
-input:focus {
-  outline: $focus-outline-color solid 1px;
-}
-
-textarea:focus {
-  outline: $focus-outline-color solid 1px;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.075), 0 0 5px $half-focus-outline-color;
 }

--- a/shell/client/styles/_partials.scss
+++ b/shell/client/styles/_partials.scss
@@ -122,8 +122,6 @@
 
 %standard-form {
   // Styles that we tend to reuse in forms, particularly in the admin panel.
-  margin-bottom: 10px;
-
   .form-group {
     margin-bottom: 10px;
   }
@@ -149,7 +147,11 @@
     font-size: 20px;
   }
 
-  input[type=text], input[type=password], input[type=number], input[type=email], textarea {
+  input[type=text], input[type=password], input[type=number], input[type=email], select {
+    min-height: 30px;
+  }
+
+  input[type=text], input[type=password], input[type=number], input[type=email], select, textarea {
     display: block;
     width: 100%;
     color: #222;
@@ -162,6 +164,9 @@
     &:disabled {
       color: #666;
       background-color: #efefef;
+    }
+    &:invalid {
+      border: 1px solid #c00;
     }
   }
 

--- a/shell/client/styles/_setup-wizard.scss
+++ b/shell/client/styles/_setup-wizard.scss
@@ -239,7 +239,6 @@
   flex-direction: row-reverse;
   align-items: stretch;
   justify-content: flex-start;
-  margin-bottom: 15px;
 }
 
 .setup-next-button {

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -25,7 +25,22 @@ limitations under the License.
 
   <h2>My account</h2>
   <div class="identities-editor">
+
   <h3 class="title-bar">Linked identities</h3>
+
+  {{#with actionCompleted}}
+    {{#if success}}
+      {{#focusingSuccessBox}}
+        Success: {{success}}
+      {{/focusingSuccessBox}}
+    {{/if}}
+    {{#if error}}
+      {{#focusingErrorBox}}
+        {{error}}
+      {{/focusingErrorBox}}
+    {{/if}}
+  {{/with}}
+
   <div class="identities-tabs">
   {{#unless isLinkingNewIdentity}}
   <ul role="tablist" >
@@ -65,19 +80,6 @@ limitations under the License.
     {{/each}}
   </section>
   </div>
-
-  {{#with actionCompleted}}
-  {{#with success}}
-  <div class="action-completed success">
-    Success: {{.}}
-  </div>
-  {{/with}}
-  {{#with error}}
-  <div class="action-completed error">
-    {{.}}
-  </div>
-  {{/with}}
-  {{/with}}
 
   <h3 class="title-bar">Primary e-mail address for service-related notifications</h3>
   <div class="verified-emails-editor">
@@ -120,8 +122,20 @@ limitations under the License.
 <template name="sandstormAccountsFirstSignIn">
   <h1>Confirm your profile</h1>
   <div class="single-identity-editor">
+    {{#if success}}
+      {{#focusingSuccessBox}}
+        Success: {{success}}
+      {{/focusingSuccessBox}}
+    {{/if}}
+
+    {{#if error}}
+      {{#focusingErrorBox}}
+        {{error}}
+      {{/focusingErrorBox}}
+    {{/if}}
+
     {{>_accountProfileEditor identity=identityToConfirm termsAndPrivacy=termsAndPrivacy
-                             staticHost=_staticHost db=_db}}
+                             staticHost=_staticHost db=_db setActionCompleted=onActionCompleted}}
   </div>
 </template>
 
@@ -145,7 +159,7 @@ setActionCompleted: (optional) Function.  Callback triggered on profile saved or
             </div>
             <input type="file" name="picture" style="display:none">
             <div class="form-subtext">
-              <button type="button">Upload new picture</button>
+              <button type="button" name="upload-picture">Upload new picture</button>
               <p>This picture will be shown to other users to help identify you.</p>
               <p>512x512px, 64KiB max.</p>
             </div>

--- a/shell/packages/sandstorm-accounts-ui/account-settings.html
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.html
@@ -136,97 +136,102 @@ setActionCompleted: (optional) Function.  Callback triggered on profile saved or
 --}}
   <div class="identity-editor">
     <form class="account-profile-editor" data-identity-id="{{identity._id}}">
-      <div class="editor">
-        <div class="picture">
-          <label>Avatar:
-            <button type="button">
-              <img src="{{identity.profile.pictureUrl}}" alt="Upload picture">
-            </button>
+      <ul>
+        <li class="form-group">
+          <label>Profile picture:</label>
+          <div class="picture-row">
+            <div class="picture-box">
+              <img src="{{identity.profile.pictureUrl}}">
+            </div>
+            <input type="file" name="picture" style="display:none">
+            <div class="form-subtext">
+              <button type="button">Upload new picture</button>
+              <p>This picture will be shown to other users to help identify you.</p>
+              <p>512x512px, 64KiB max.</p>
+            </div>
+          </div>
+        </li>
+
+        <li class="form-group">
+          <label>
+            Full name:
+            <input type="text" name="nameInput" value="{{identity.profile.name}}"
+                   placeholder="full name" required>
           </label>
-          <input type="file" name="picture" style="display:none">
-          <span class="details">
-            <p>This picture will be shown to other users to help identify you.</p>
-            <p>512x512px, 64KiB max.</p>
+          <span class="form-subtext">Your regular first and last name, as you would like it
+            displayed to others. This does not have to be your real name.
           </span>
-        </div>
-        <ul>
-          <li class="name">
-            <label><img class="inline-icon" src="/people-m.svg" role="presentation">
-              Full name:
-              <input type="text" name="nameInput" value="{{identity.profile.name}}"
-                     placeholder="full name" required>
-            </label>
-            <span class="details">Your regular first and last name, as you would like it
-              displayed to others. This does not have to be your real name.
-            </span>
-          </li>
-          <li class="handle">
-            <label>@ Handle:
-              <div class="input-container">
-                <input type="text" name="handle" value="{{identity.profile.handle}}"
-                       placeholder="handle" pattern="^[a-z_][a-z0-9_]*$"
-                       title="Handles must start with a lower-case letter and contain only lower-case letters, digits, and underscores." required>
-              </div>
-            </label>
-            <span class="details">
-              For use in apps that use handles (often, chat apps).
-              This is only your first choice; an app may make you rename if someone has
-              already taken this name within the specific grain. Your handle must start
-              with a letter and contain only lower-case letters, digits, and underscores.
-            </span>
-          </li>
-          <li class="email">
-            <label><img class="inline-icon" src="/email-m.svg" role="presentation">
-              E-mail:
-            </label>
-            <ul class="verified-email-list">
-              {{#each verifiedEmails}}
-              <li> {{.}} </li>
-              {{/each}}
-            </ul>
-            <span class="details">{{emailDetails}}</span>
-          </li>
-          <li class="pronoun">
-            {{#with identity.profile}}
-            <label><img class="inline-icon" src="/pronoun-m.svg" role="presentation">
-              Preferred pronoun:
-              <select name="pronoun">
-                <option value="neutral" selected="{{isNeutral}}">they (unspecified)</option>
-                <option value="male" selected="{{isMale}}">he/him (male)</option>
-                <option value="female" selected="{{isFemale}}">she/her (female)</option>
-                <option value="robot" selected="{{isRobot}}">it (robot)</option>
-              </select>
-            </label>
-            {{/with}}
-          </li>
-          {{#unless hasCompletedSignup}}
+        </li>
+
+        <li class="form-group handle">
+          <label>Handle:
+            <div class="input-container">
+              <input type="text" name="handle" value="{{identity.profile.handle}}"
+                     placeholder="handle" pattern="^[a-z_][a-z0-9_]*$"
+                     title="Handles must start with a lower-case letter and contain only lower-case letters, digits, and underscores." required>
+            </div>
+          </label>
+          <span class="form-subtext">
+            To be displayed in apps that use handles. Your handle must start with a letter and
+            contain only lower-case letters, digits, and underscores.
+          </span>
+        </li>
+
+        <li class="form-group">
+          <label>
+            E-mail:
+          </label>
+          <ul class="verified-email-list">
+            {{#each verifiedEmails}}
+            <li> {{.}} </li>
+            {{/each}}
+          </ul>
+          <span class="form-subtext">{{emailDetails}}</span>
+        </li>
+
+        <li class="form-group">
+          {{#with identity.profile}}
+          <label>
+            Preferred pronoun:
+            <select name="pronoun">
+              <option value="neutral" selected="{{isNeutral}}">they (unspecified)</option>
+              <option value="male" selected="{{isMale}}">he/him (male)</option>
+              <option value="female" selected="{{isFemale}}">she/her (female)</option>
+              <option value="robot" selected="{{isRobot}}">it (robot)</option>
+            </select>
+          </label>
+          {{/with}}
+        </li>
+
+        {{#unless hasCompletedSignup}}
           {{#with termsAndPrivacy}}
-          <li class="terms">
-            <label>
-              <input type="checkbox" name="agreedToTerms" required> I have read and agree to the
-              {{#if termsUrl}}<a target="_blank" href="{{termsUrl}}">Terms of Service</a>
-              {{#if privacyUrl}} and {{/if}}{{/if}}{{#if privacyUrl}}
-              <a target="_blank" href="{{privacyUrl}}">Privacy policy</a>{{/if}}.
-            </label>
-          </li>
+            <li class="form-group">
+              <label>
+                <input type="checkbox" name="agreedToTerms" required> I have read and agree to the
+                {{#if termsUrl}}<a target="_blank" href="{{termsUrl}}">Terms of Service</a>
+                {{#if privacyUrl}} and {{/if}}{{/if}}{{#if privacyUrl}}
+                <a target="_blank" href="{{privacyUrl}}">Privacy policy</a>{{/if}}.
+              </label>
+            </li>
           {{/with}}
           {{#if isPaymentsEnabled}}
             {{> billingOptins}}
           {{/if}}
+        {{/unless}}
+
+        {{#unless hideButtons}}
+        <li class="button-row">
+          <button disabled="{{profileSaved}}" type="submit">
+            {{#if hasCompletedSignup}}Save{{else}}Continue{{/if}}
+          </button>
+          {{#unless hasCompletedSignup}}
+          <button class="logout" type="button">Cancel</button>
           {{/unless}}
-          {{#unless hideButtons}}
-          <li class="save">
-            <button disabled="{{profileSaved}}">
-              {{#if hasCompletedSignup}}Save{{else}}Continue{{/if}}
-            </button>
-            {{#unless hasCompletedSignup}}
-            <button class="logout">Cancel</button>
-            {{/unless}}
-          </li>
-          {{/unless}}
-        </ul>
-      </div>
+        </li>
+        {{/unless}}
+      </ul>
     </form>
+
     {{#if hasCompletedSignup}}
       <hr>
       {{> identityManagementButtons identityManagementButtonsData}}

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -217,20 +217,20 @@ Template._accountProfileEditor.helpers({
 });
 
 Template.sandstormAccountSettings.events({
-  "click [role='tab']": function (event, instance) {
+  "click [role='tab']": function (ev, instance) {
     instance._actionCompleted.set();
-    instance._selectedIdentityId.set(event.currentTarget.getAttribute("data-identity-id"));
+    instance._selectedIdentityId.set(ev.currentTarget.getAttribute("data-identity-id"));
   },
 
-  "click button.link-new-identity": function (event, instance) {
+  "click button.link-new-identity": function (ev, instance) {
     instance._isLinkingNewIdentity.set(true);
   },
 
-  "click button.cancel-link-new-identity": function (event, instance) {
+  "click button.cancel-link-new-identity": function (ev, instance) {
     instance._isLinkingNewIdentity.set(false);
   },
 
-  "click button.logout-other-sessions": function (event, instance) {
+  "click button.logout-other-sessions": function (ev, instance) {
     instance._logoutOtherSessionsInFlight.set(true);
     Meteor.logoutOtherClients(function (err) {
       if (err) {
@@ -249,8 +249,8 @@ Template.sandstormAccountSettings.events({
     });
   },
 
-  "click button.make-primary": function (event, instance) {
-    Meteor.call("setPrimaryEmail", event.target.getAttribute("data-email"));
+  "click button.make-primary": function (ev, instance) {
+    Meteor.call("setPrimaryEmail", ev.target.getAttribute("data-email"));
   },
 });
 
@@ -331,8 +331,8 @@ Template._accountProfileEditor.onCreated(function () {
 });
 
 Template._accountProfileEditor.events({
-  "submit form.account-profile-editor": function (event, instance) {
-    event.preventDefault();
+  "submit form.account-profile-editor": function (ev, instance) {
+    ev.preventDefault();
     const form = Template.instance().find("form");
     submitProfileForm(form, function () {
       instance._profileSaved.set(true);
@@ -340,12 +340,12 @@ Template._accountProfileEditor.events({
     });
   },
 
-  change: function (event, instance) {
+  change: function (ev, instance) {
     // Pictures get saved right away.
     //
     // TODO(someday): Upload pictures to a staging area, perhaps allowing the user to resize
     //   and crop them before saving.
-    if (event.target == instance.find("input[name='picture']")) { return; }
+    if (ev.target == instance.find("input[name='picture']")) { return; }
 
     instance._profileSaved.set(false);
   },
@@ -354,13 +354,13 @@ Template._accountProfileEditor.events({
 
   keypress: function () { Template.instance()._profileSaved.set(false); },
 
-  "click .logout": function (event, instance) {
-    event.preventDefault();
+  "click .logout": function (ev, instance) {
+    ev.preventDefault();
     Meteor.logout();
   },
 
-  "click .picture button": function (event, instance) {
-    event.preventDefault();
+  "click .picture button": function (ev, instance) {
+    ev.preventDefault();
 
     const staticHost = Template.currentData().staticHost;
     if (!staticHost) throw new Error("missing _staticHost");
@@ -392,9 +392,9 @@ Template._accountProfileEditor.events({
       }
     });
 
-    function listener(event) {
+    function listener(ev) {
       input.removeEventListener("change", listener);
-      file = event.currentTarget.files[0];
+      file = ev.currentTarget.files[0];
       if (file && token) doUpload();
     }
 

--- a/shell/packages/sandstorm-accounts-ui/account-settings.js
+++ b/shell/packages/sandstorm-accounts-ui/account-settings.js
@@ -350,8 +350,9 @@ const submitProfileForm = function (form, cb) {
 Template._accountProfileEditor.onCreated(function () {
   this.submitProfileForm = submitProfileForm; // Stored on the object so setup wizard can call it directly.
   this._profileSaved = new ReactiveVar(true);
-  this._setActionCompleted = this.data.setActionCompleted || function () {};
   this._uploadToken = undefined;
+  this._setActionCompleted = this.data.setActionCompleted || function () {};
+
   this.doUploadIfReady = () => {
     const input = this.find("input[name='picture']");
     const file = input && input.files && input.files[0];
@@ -365,6 +366,7 @@ Template._accountProfileEditor.onCreated(function () {
       this.doUpload(token, file);
     }
   };
+
   this.doUpload = (token, file) => {
     const staticHost = this.data.staticHost;
     if (!staticHost) throw new Error("missing staticHost");

--- a/tests/tests/account.js
+++ b/tests/tests/account.js
@@ -67,8 +67,8 @@ module.exports["Test link identities"] = function (browser) {
     .waitForElementVisible("input[name=name]", short_wait)
     .setValue("input[name=name]", devName1)
     .submitForm(".login-buttons-list form.dev")
-    .waitForElementPresent(".action-completed.error", medium_wait)
-    .assert.containsText(".action-completed.error", "Error linking identity")
+    .waitForElementPresent(".flash-message.error-message", medium_wait)
+    .assert.containsText(".flash-message.error-message", "Error linking identity")
 
     // Linking a third identity to the second account should succeed.
     .click("button.link-new-identity")


### PR DESCRIPTION
In #2140 I changed a class name in a final refactoring, but this broke the event handler, which captured click events based on that class name.

I took a closer look at the upload code, and it had a number of other weird issues that I decided to fix while I was poking at that area of the codebase.

We now:

* use the focusing success/error boxes, so the message can't get lost below the fold
* avoid `window.alert()` entirely
* avoid leaking event listeners which would cause us to upload the same file multiple times if you canceled the file picker, then opened it again (which would produce multiple `alert()`s if it was too large...)
* can see upload success/failure messages from the confirm-your-profile page (and the equivalent page in the setup wizard).

![uploaded-profile-pic](https://cloud.githubusercontent.com/assets/307325/16360075/130bb100-3b03-11e6-9d7b-724f1135adfd.png)

![confirm-your-profile](https://cloud.githubusercontent.com/assets/307325/16360089/bcd8f3fa-3b03-11e6-8470-d564b7012c58.png)

![too-large](https://cloud.githubusercontent.com/assets/307325/16360095/052b8a28-3b04-11e6-9932-9e01006d1d1e.png)
