### PR TITLE
Fix regression in static web publishing.

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -2365,6 +2365,23 @@ ResponseStream = class ResponseStream {
       this.response.end();
     }
   }
+
+  sendingDirectResponse() {
+    // For internal front-end use: Indicates that the caller is going to fill in the response
+    // instead. If a response has already been started, this throws an exception.
+    //
+    // This is used in particular in pre-meteor.js, when dealing with static web publishing.
+
+    if (this.started) {
+      throw new Error("can't sendDirectResponse() because response already started");
+      this.response.end();
+    } else if (this.ended) {
+      throw new Error("can't sendDirectResponse() because response already sent");
+    } else {
+      this.started = true;
+      this.ended = true;
+    }
+  }
 };
 
 // TODO(cleanup): Node 0.12 has a `gunzipSync` but 0.10 (which Meteor still uses) does not.


### PR DESCRIPTION
This turned 404 errors into 500's. It may also have broken redirects to add a trailing '/' when the specified file is a directory.

The root of the problem is that I wrote some really terrible code in pre-meteor.js which made assumptions about ResponseStream that would not be obvious to someone changing ResponseStream, and sure enough a later change to ResponseStream broke it. So, now I did the right thing and added a method to ResponseStream for this specific case so that it's obvious that this is a requirement.