### PR TITLE
tests: disable more of the new guided tour stuff

### DIFF
--- a/tests/commands/disableGuidedTour.js
+++ b/tests/commands/disableGuidedTour.js
@@ -22,7 +22,8 @@ exports.command = function (callback) {
     .execute(function () {
       Session.set('dismissedGrainTableGuidedTour', true);
       Session.set('dismissedInstallHint', true);
-    })
+      Meteor._localStorage.removeItem("userNeedsShareAccessHint");
+    });
   if (typeof callback === "function") {
     return ret.status(callback);
   } else {

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -171,6 +171,7 @@ module.exports["Test grain not found"] = function (browser) {
     .waitForElementVisible(".grain-not-found", medium_wait)
     .assert.containsText(".grain-not-found", "No grain found")
     .loginDevAccount()
+    .disableGuidedTour()
     .url(browser.launch_url + "/grain/BogusGrainId")
     .waitForElementVisible(".grain-not-found", medium_wait)
     .assert.containsText(".grain-not-found", "No grain found")
@@ -339,6 +340,7 @@ module.exports["Test roleless sharing"] = function (browser) {
     .getText('#share-token-text', function(response) {
       browser
         .loginDevAccount()
+        .disableGuidedTour()
         .getDevName(function(result) {
           secondUserName = result.value;
         })
@@ -361,6 +363,7 @@ module.exports["Test roleless sharing"] = function (browser) {
         .getText('#share-token-text', function(response) {
           browser
             .loginDevAccount()
+            .disableGuidedTour()
             .url(response.value)
             .waitForElementVisible("button.pick-identity", short_wait)
             .click("button.pick-identity")
@@ -378,6 +381,7 @@ module.exports["Test roleless sharing"] = function (browser) {
             .waitForElementVisible('#share-token-text', medium_wait)
 
             .loginDevAccount(firstUserName)
+            .disableGuidedTour()
             .url(response.value)
             .waitForElementVisible('.grain-frame', medium_wait)
             .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
@@ -412,6 +416,7 @@ module.exports["Test role sharing"] = function (browser) {
     .getText('#share-token-text', function(response) {
       browser
         .loginDevAccount()
+        .disableGuidedTour()
         .url(response.value)
         .waitForElementVisible("button.pick-identity", short_wait)
         .click("button.pick-identity")
@@ -431,6 +436,7 @@ module.exports["Test role sharing"] = function (browser) {
         .getText('#share-token-text', function(response) {
           browser
             .loginDevAccount()
+            .disableGuidedTour()
             .url(response.value)
             .waitForElementVisible("button.pick-identity", short_wait)
             .click("button.pick-identity")
@@ -477,6 +483,7 @@ module.exports["Test grain identity chooser interstitial"] = function (browser) 
 
         // Navigate to the url as a different user
         .loginDevAccount()
+        .disableGuidedTour()
         .pause(short_wait)
         // Try incognito
         .url(shareLink.value)

--- a/tests/tests/trash.js
+++ b/tests/tests/trash.js
@@ -57,6 +57,7 @@ module.exports["Test grain trash"] = function (browser) {
       browser
         .loginDevAccount(null, false, function (secondUserName) {
           browser
+            .disableGuidedTour()
             .url(tokenResponse.value)
             .waitForElementVisible("button.pick-identity", short_wait)
             .click("button.pick-identity")
@@ -89,6 +90,7 @@ module.exports["Test grain trash"] = function (browser) {
             .frame(null)
 
             .loginDevAccount(firstUserName)
+            .disableGuidedTour()
             .url(grainUrl)
             .waitForElementVisible(".navitem-open-grain>a", short_wait)
             .click(".navitem-open-grain>a")
@@ -106,6 +108,7 @@ module.exports["Test grain trash"] = function (browser) {
             .assert.containsText(".grain-interstitial>p", "This grain is in your trash.")
 
             .loginDevAccount(secondUserName)
+            .disableGuidedTour()
             .url(grainUrl)
             .waitForElementVisible(".grain-interstitial", short_wait)
             .assert.containsText(".grain-interstitial>p",
@@ -127,6 +130,7 @@ module.exports["Test grain trash"] = function (browser) {
             .assert.elementNotPresent(grainCheckboxSelector)
 
             .loginDevAccount(firstUserName)
+            .disableGuidedTour()
             .waitForElementVisible(".navitem-open-grain>a", short_wait)
             .click(".navitem-open-grain>a")
             .waitForElementVisible("button.show-trash", medium_wait)


### PR DESCRIPTION
These were causing issues for me locally, because the guided tour backdrop
prevents click events from reaching anything else on the page.