### PR TITLE
Route/proxy non-main-host requests before sockjs's handler swallows them

### DIFF
--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -357,12 +357,6 @@ const canonicalizeShellOrWildcardUrl = (hostname, url) => {
 };
 
 const dispatchToMeteorOrStaticPublishing = (req, res, next, redirectRatherThanServeShell) => {
-  if (!req.headers.host) {
-    res.writeHead(400, { 'Content-Type': 'text/plain' });
-    res.end('Missing Host header');
-    return;
-  }
-
   const hostname = req.headers.host.split(':')[0];
   if (isSandstormShell(hostname)) {
     // Go on to Meteor, or serve a redirect.
@@ -450,6 +444,12 @@ const dispatchToMeteorOrStaticPublishing = (req, res, next, redirectRatherThanSe
 };
 
 const redirectToMeteorOrServeStaticPublishing = (req, res, next) => {
+  if (!req.headers.host) {
+    res.writeHead(400, { 'Content-Type': 'text/plain' });
+    res.end('Missing Host header');
+    return;
+  }
+
   return dispatchToMeteorOrStaticPublishing(req, res, next, true);
 };
 
@@ -493,7 +493,9 @@ Meteor.startup(() => {
   WebApp.httpServer.removeAllListeners("request");
   WebApp.httpServer.on("request", (req, res) => {
     if (!req.headers.host) {
-      throw new Meteor.Error(400, 'Missing Host header');
+      res.writeHead(400, { 'Content-Type': 'text/plain' });
+      res.end('Missing Host header');
+      return;
     }
 
     const hostname = req.headers.host.split(":")[0];
@@ -540,7 +542,7 @@ Meteor.startup(() => {
     });
   });
 
-  listenOnAlternatePorts()
+  listenOnAlternatePorts();
 });
 
 const errorTxtMapping = {};

--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -436,11 +436,14 @@ const handleNonMeteorRequestDirectly = (req, res, next) => {
   handleNonMeteorRequest(req, res, next, false);
 };
 
-// "Alternate ports" are ports other than the main HTTP or HTTPS
-// port. For requests to the shell, grains, we redirect to the main
-// port. For static publishing, we serve it.
+// "Alternate ports" are ports other than the main HTTP or HTTPS port.
+// They are handled as follows:
 //
-// They are bound to FD #5 and higher.
+// * Requests to the shell & grains, we redirect to the main port.
+// * For requests to static publishing on hosts within the wildcard, we redirect to the main port.
+// * For static publishing glued in via DNS TXT record, we serve the request as-is.
+//
+// Alternate ports are bound to FD #5 and higher.
 const getNumberOfAlternatePorts = function () {
   const numPorts = process.env.PORT.split(',').length;
   const numAlternatePorts = numPorts - 1;


### PR DESCRIPTION
This fixes the longstanding "Meteor app refresh loop" issue.

Meteor's sockjs inserts itself as the first request listener on the Meteor HTTP
handler object.  Normally, this is fine, and keeps DDP requests from
accidentally getting routed to the application handlers.  This is problematic
for programs that happen to implement a proxy, and which need to proxy requests
that use the same paths and overall protocol as Meteor does internally.

As a result of the sockjs middleware being first in the chain, XHRs to an
Meteor app's sockjs endpoint would wind up getting answered by Sandstorm's
instance of sockjs and communicating over DDP to Sandstorm itself.  So any app
that fell back to long-polling would speak DDP to Sandstorm, rather than to the
intended app's backend.

Meteor hashes all the code that goes into an app to determine if a reload is
needed to have the latest code running on the client.  It publishes the current
version of the client code in a collection over DDP.  This lead the code
running in the browser to believe that there had been a code change, since it
was now getting the hash for **Sandstorm's** shell code over DDP, which did not
match the hash for the app's code.  So the app would refresh the page, hoping
to load the new code.  Browsers would cache that websockets had failed for that
host, and so the app would load the code, learn about Sandstorm's code version
over sockjs long-polling DDP, and attempt to refresh again.

The solution here is to do Sandstorm's proxying earlier in the request dispatch
chain.  We splice our own handler in after ddp-server has installed its sockjs
handler, and now everything works as intended.

Fixes #1186.