### PR TITLE
somewhat cleaner stream management for getWwwFileHack()

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -2356,30 +2356,14 @@ ResponseStream = class ResponseStream {
     // implies `!this.ended`.
     if (!this.started) {
       this.started = true;
-      this.response.writeHead(500, "done() never called on response stream",
+      this.response.writeHead(500, "Internal Server Error",
                               { "Content-Type": "text/plain" });
+      this.response.write("Error: done() never called on response stream.");
     }
 
     if (!this.ended) {
       this.ended = true;
       this.response.end();
-    }
-  }
-
-  sendingDirectResponse() {
-    // For internal front-end use: Indicates that the caller is going to fill in the response
-    // instead. If a response has already been started, this throws an exception.
-    //
-    // This is used in particular in pre-meteor.js, when dealing with static web publishing.
-
-    if (this.started) {
-      throw new Error("can't sendDirectResponse() because response already started");
-      this.response.end();
-    } else if (this.ended) {
-      throw new Error("can't sendDirectResponse() because response already sent");
-    } else {
-      this.started = true;
-      this.ended = true;
     }
   }
 };

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -87,11 +87,13 @@ interface Supervisor {
     notFound @2;
   }
 
-  getWwwFileHack @9 (path :Text, stream :Util.ByteStream) -> (status :WwwFileStatus);
+  getWwwFileHack @9 (path :Text, stream :Util.ByteStream)
+                 -> (status :WwwFileStatus, handle :Util.Handle);
   # Reads a file from under the grain's "/var/www" directory. If the path refers to a regular
-  # file, the contents are written to `stream`, and `status` is returned as `file`. If the path
+  # file, the contents are asynchronously written to `stream`, `status` is returned as `file`, and
+  # the returned `handle` refers to the task performing the writes to `stream`. If the path
   # refers to a directory or is not found, then `stream` is NOT called at all and the method
-  # returns the corresponding status.
+  # returns the corresponding status and a null `handle`.
   #
   # Note that if a Supervisor capability is obtained and used only for `getWwwFileHack()` -- i.e.
   # `getMainView()` and `restore()` are not called -- then the supervisor will not actually start

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -458,6 +458,16 @@ private:
   void taskFailed(kj::Exception&& exception) override;
 };
 
+class TaskHandle: public Handle::Server {
+  // Holds onto a promise to ensure that it runs to completion.
+
+public:
+  template <typename F> explicit TaskHandle(kj::Promise<void>&& task, F&& errorFunc)
+    : task(task.eagerlyEvaluate(kj::mv(errorFunc))) {}
+private:
+  kj::Promise<void> task;
+};
+
 }  // namespace sandstorm
 
 #endif // SANDSTORM_UTIL_H_


### PR DESCRIPTION
This is an iteration on the bugfix in https://github.com/sandstorm-io/sandstorm/pull/2152. The idea is to provide the `stream` argument of `getWwwFileHack()` as a promise that's only fulfilled once we know it's actually needed.
