### PR TITLE
admin user accounts list: allow sorting

### DIFF
--- a/shell/client/admin/user-accounts-client.js
+++ b/shell/client/admin/user-accounts-client.js
@@ -192,6 +192,7 @@ Template.newAdminUsers.onCreated(function () {
         return identity;
       });
       return {
+        _id: account._id,
         account,
         identities,
       };

--- a/shell/client/admin/user-accounts-client.js
+++ b/shell/client/admin/user-accounts-client.js
@@ -68,6 +68,84 @@ Template.newAdminUserTableRow.events({
   },
 });
 
+Template.newAdminUserTable.onCreated(function () {
+  this.sortOrder = new ReactiveVar({
+    key: "createdAt",
+    order: "ascending",
+  });
+});
+
+Template.newAdminUserTable.helpers({
+  sortOrder() {
+    return Template.instance().sortOrder.get();
+  },
+
+  equal(a, b) {
+    return a === b;
+  },
+
+  sortUsers(users) {
+    const instance = Template.instance();
+    const sortOrder = instance.sortOrder.get();
+
+    const multiplier = sortOrder.order === "ascending" ? 1 : -1;
+    if (sortOrder.key === "createdAt") {
+      return _.sortBy(users, (user) => {
+        return multiplier * (user.account.createdAt);
+      });
+    } else if (sortOrder.key === "lastActive") {
+      return _.sortBy(users, (user) => {
+        // If the account has a lastActive time, use that.
+        if (user.account.lastActive) return multiplier * user.account.lastActive;
+        // If not, check any of the identities for a lastActive time.
+        for (let i = 0; i < user.identities.length; i++) {
+          const identity = user.identities[i];
+          if (identity.lastActive) return multiplier * identity.lastActive;
+        }
+
+        return 0;
+      });
+    }
+
+    // If we don't know about the requested sort order, just return the original set as-is.
+    return users;
+  },
+});
+
+Template.newAdminUserTable.events({
+  "click .header-row .created"(evt) {
+    const instance = Template.instance();
+    const currentSortOrder = instance.sortOrder.get();
+
+    const newSortOrder = {
+      key: "createdAt",
+      order: "ascending",
+    };
+
+    if (currentSortOrder.key === "createdAt" && currentSortOrder.order === "ascending") {
+      newSortOrder.order = "decending";
+    }
+
+    instance.sortOrder.set(newSortOrder);
+  },
+
+  "click .header-row .last-active"(evt) {
+    const instance = Template.instance();
+    const currentSortOrder = instance.sortOrder.get();
+
+    const newSortOrder = {
+      key: "lastActive",
+      order: "descending",
+    };
+
+    if (currentSortOrder.key === "lastActive" && currentSortOrder.order === "descending") {
+      newSortOrder.order = "ascending";
+    }
+
+    instance.sortOrder.set(newSortOrder);
+  },
+});
+
 Template.newAdminUsers.onCreated(function () {
   this.usersSub = this.subscribe("allUsers", undefined);
   this.searchString = new ReactiveVar("");
@@ -94,12 +172,9 @@ Template.newAdminUsers.onCreated(function () {
 
   this.allUsers = () => {
     if (!this.usersSub.ready()) return [];
+
     const accounts = Meteor.users.find({
       loginIdentities: { $exists: 1 },
-    }, {
-      $sort: {
-        createdAt: 1,
-      },
     });
 
     const users = accounts.map((account) => {

--- a/shell/client/admin/user-accounts.html
+++ b/shell/client/admin/user-accounts.html
@@ -58,11 +58,31 @@
   <div class="admin-user-table" role="grid">
     <div role="rowgroup">
       <div class="header-row" role="row">
+        {{#with sortOrder=sortOrder}}
         <div class="account-role" role="columnheader"></div>
         <div class="identities" role="columnheader">Account</div>
-        <div class="created" role="columnheader">Created</div>
-        <div class="last-active" role="columnheader">Last Active</div>
+        <div class="created" role="columnheader">
+          Created
+          {{#if equal sortOrder.key "createdAt"}}
+            {{#if equal sortOrder.order "ascending"}}
+              ▾
+            {{else}}
+              ▴
+            {{/if}}
+          {{/if}}
+        </div>
+        <div class="last-active" role="columnheader">
+          Last Active
+          {{#if equal sortOrder.key "lastActive"}}
+            {{#if equal sortOrder.order "ascending"}}
+              ▾
+            {{else}}
+              ▴
+            {{/if}}
+          {{/if}}
+        </div>
         <div class="actions" role="columnheader">Actions</div>
+        {{/with}}
       </div>
     </div>
 
@@ -76,7 +96,7 @@
 
     {{!-- for each account, look up the identities --}}
     {{#if ready}}
-      {{#each user in users }}
+      {{#each user in sortUsers users }}
         {{> newAdminUserTableRow user=user}}
       {{else}}
         <div class="no-match-row" role="row">

--- a/shell/client/styles/_admin-users.scss
+++ b/shell/client/styles/_admin-users.scss
@@ -135,6 +135,9 @@
     >div[role=columnheader]:not(:first-child) {
       border-left: 1px solid $default-table-header-border-color;
     }
+    .created, .last-active {
+      cursor: pointer;
+    }
   }
 
   .loading-row {


### PR DESCRIPTION
The ability to sort by last active is an important affordance for allowing
admins to audit which accounts are active.

Blaze's "eventually rendered" semantics make the page look downright goofy
immediately after you click on the "Created" or "Last Active" header -- those
two columns repaint with the new data immediately, whereas the "Account" column
doesn't update until a future frame.  This seems to be unavoidable given
Blaze's design - unlike React, there doesn't appear to be a `key={_id}` prop
you can pass in explicitly to help the UI layer deal better with reorderings.
At least, I'm not finding a solution for this in the docs.

![sort-by-last-active](https://cloud.githubusercontent.com/assets/307325/16536260/53910e78-3fa4-11e6-9da0-42fe924a98ff.png)