### PR TITLE
Move claimRequest() to SessionContext.

### DIFF
--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -1455,6 +1455,7 @@ SandstormPermissions.createNewApiToken = function (db, provider, grainId, petnam
   }, {
     clientPowerboxRequest: {
       grainId: String,
+      sessionId: String,
       introducerIdentity: String,
     },
   }, {

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -65,6 +65,7 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
       const fulfillingGrainTitle = fulfillingProvider.title;
       Meteor.call(
         "fulfillUiViewRequest",
+        this._requestInfo.sessionId,
         this._requestInfo.identityId,
         fulfillingProvider.grainId,
         fulfillingGrainTitle, // petname: for UiViews, just use the grain title.
@@ -378,7 +379,8 @@ Template.powerboxRequest.events({
     const saveLabel = ref._requestInfo.saveLabel;
     const identityId = ref._requestInfo.identityId;
     const grainId = ref._requestInfo.grainId;
-    Meteor.call("finishPowerboxRequest", event.target.token.value, saveLabel,
+    const sessionId = ref._requestInfo.sessionId;
+    Meteor.call("finishPowerboxRequest", sessionId, event.target.token.value, saveLabel,
                 identityId, grainId, function (err, token) {
         if (err) {
           ref._error.set(err.toString());

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -101,6 +101,7 @@ Meteor.methods({
       clientPowerboxRequest: {
         grainId: grainId,
         introducerIdentity: session.identityId,
+        sessionId: session._id,
       },
     };
 
@@ -109,8 +110,9 @@ Meteor.methods({
     return { sturdyRef, descriptor };
   },
 
-  fulfillUiViewRequest(identityId, grainId, petname, roleAssignment, ownerGrainId) {
+  fulfillUiViewRequest(sessionId, identityId, grainId, petname, roleAssignment, ownerGrainId) {
     const db = this.connection.sandstormDb;
+    check(sessionId, String);
     check(identityId, String);
     check(grainId, String);
     check(roleAssignment, db.roleAssignmentPattern);
@@ -140,6 +142,7 @@ Meteor.methods({
       clientPowerboxRequest: {
         grainId: ownerGrainId,
         introducerIdentity: identityId,
+        sessionId: sessionId,
       },
     };
 

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -30,38 +30,6 @@ class SandstormCoreImpl {
     this.grainId = grainId;
   }
 
-  claimRequest(sturdyRef, requiredPermissions) {
-    return inMeteor(() => {
-      const hashedSturdyRef = hashSturdyRef(sturdyRef);
-
-      const token = ApiTokens.findOne({
-        _id: hashedSturdyRef,
-        "owner.clientPowerboxRequest.grainId": this.grainId,
-      });
-
-      if (!token) {
-        throw new Error("no such token");
-      }
-
-      // Honor `requiredPermissions`.
-      const requirements = [];
-      if (token.owner.clientPowerboxRequest.introducerIdentity) {
-        requirements.push({
-          permissionsHeld: {
-            permissions: requiredPermissions || [],
-            identityId: token.owner.clientPowerboxRequest.introducerIdentity,
-            grainId: this.grainId,
-          },
-        });
-      }
-
-      return restoreInternal(
-          new Buffer(sturdyRef),
-          { clientPowerboxRequest: Match.ObjectIncluding({ grainId: this.grainId }) },
-          requirements, hashedSturdyRef, true);
-    });
-  }
-
   restore(sturdyRef) {
     return inMeteor(() => {
       const hashedSturdyRef = hashSturdyRef(sturdyRef);

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1818,15 +1818,6 @@ public:
     });
   }
 
-  kj::Promise<void> claimRequest(ClaimRequestContext context) override {
-    auto req = sandstormCore.claimRequestRequest();
-    req.setRequestToken(context.getParams().getRequestToken());
-    req.setRequiredPermissions(context.getParams().getRequiredPermissions());
-    return req.send().then([context](auto args) mutable -> void {
-      context.getResults().setCap(args.getCap());
-    });
-  }
-
   kj::Promise<void> drop(DropContext context) override {
     auto req = sandstormCore.dropRequest();
     req.setToken(context.getParams().getToken());

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -292,6 +292,9 @@ struct ApiTokenOwner {
       grainId @13 :Text;
       # Grain ID owning the ref.
 
+      sessionId @15 :Text;
+      # The ID of the session that created this token.
+
       introducerIdentity @14 :Text;
       # The identity ID through which a user's powerbox action caused the grain to receive this
       # token. This is the identity against which the `requiredPermissions` parameter

--- a/tests/apps/ip-networking.js
+++ b/tests/apps/ip-networking.js
@@ -32,8 +32,8 @@ module.exports = {};
 module.exports["Test Ip Networking"] = function (browser) {
   browser
     // sandstorm-test-python: David's branch that updates for the new claimRequest() flow.
-    .installApp("http://sandstorm.io/apps/david/sandstorm-test-python3.spk",
-                "ebf2504eeb495cd781ef76adf4756dd5",
+    .installApp("http://sandstorm.io/apps/david/sandstorm-test-python4.spk",
+                "874e67d3cd02486198d046909149723c",
                 "umeqc9yhncg63fjj6sahtw30nf99kfm6tgkuz8rmhn5dqtusnwah", false, true)
     .assert.containsText("#grainTitle", "Untitled Test App test page")
     .waitForElementVisible('.grain-frame', short_wait)
@@ -56,8 +56,8 @@ module.exports["Test Ip Networking"] = function (browser) {
 module.exports["Test Ip Interface"] = function (browser) {
   browser
     // sandstorm-test-python: David's branch that updates for the new claimRequest() flow.
-    .installApp("http://sandstorm.io/apps/david/sandstorm-test-python3.spk",
-                "ebf2504eeb495cd781ef76adf4756dd5",
+    .installApp("http://sandstorm.io/apps/david/sandstorm-test-python4.spk",
+                "874e67d3cd02486198d046909149723c",
                 "umeqc9yhncg63fjj6sahtw30nf99kfm6tgkuz8rmhn5dqtusnwah", false, true)
     .assert.containsText("#grainTitle", "Untitled Test App test page")
     .waitForElementVisible('.grain-frame', short_wait)

--- a/tests/apps/powerbox.js
+++ b/tests/apps/powerbox.js
@@ -32,8 +32,8 @@ module.exports = {};
 module.exports["Test Powerbox"] = function (browser) {
   browser
     .init()
-    .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app2.spk",
-                "7a2996cc34d329da6d24e37fdbaa919d",
+    .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app4.spk",
+                "f855d3c96e18e785a3a734a49919ef18",
                 "ygpudg61w49gg0x1t2gw4p7q2q7us24gxsyr1as1hf0ezn2uycth")
     .assert.containsText("#grainTitle", "Untitled PowerboxTest")
     .waitForElementVisible('.grain-frame', short_wait)
@@ -64,8 +64,8 @@ module.exports["Test PowerboxSave"] = function (browser) {
   browser
     browser
     .init()
-    .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app2.spk",
-                "7a2996cc34d329da6d24e37fdbaa919d",
+    .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app4.spk",
+                "f855d3c96e18e785a3a734a49919ef18",
                 "ygpudg61w49gg0x1t2gw4p7q2q7us24gxsyr1as1hf0ezn2uycth")
     .assert.containsText("#grainTitle", "Untitled PowerboxTest")
     .waitForElementVisible('.grain-frame', short_wait)
@@ -96,8 +96,8 @@ module.exports["Test PowerboxSave"] = function (browser) {
 module.exports["Test Powerbox with failing requirements"] = function (browser) {
   browser
     .init()
-    .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app2.spk",
-                "7a2996cc34d329da6d24e37fdbaa919d",
+    .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app4.spk",
+                "f855d3c96e18e785a3a734a49919ef18",
                 "ygpudg61w49gg0x1t2gw4p7q2q7us24gxsyr1as1hf0ezn2uycth")
     .assert.containsText("#grainTitle", "Untitled PowerboxTest")
 


### PR DESCRIPTION
Shortly after #2027 was merged, @kentonv noticed that it probably makes more sense for `claimRequest()` to go on `SessionContext` rather than `SandstormApi`.

This makes it so that you can only claim a request token that was created with your current session.