### PR TITLE
update spk init template to use Action.nounPhrase rather than Action.title

### DIFF
--- a/src/sandstorm/spk.c++
+++ b/src/sandstorm/spk.c++
@@ -726,7 +726,7 @@ private:
         "\n"
         "    actions = [\n"
         "      # Define your \"new document\" handlers here.\n"
-        "      ( title = (defaultText = \"New Instance\"),\n"
+        "      ( nounPhrase = (defaultText = \"instance\"),\n"
         "        command = .myCommand\n"
         "        # The command to run when starting for the first time. (\".myCommand\"\n"
         "        # is just a constant defined at the bottom of the file.)\n"


### PR DESCRIPTION
The `title` field [is deprecated](https://github.com/sandstorm-io/sandstorm/blob/v0.170/src/sandstorm/package.capnp#L147-L153).

See also #1885.