### PR TITLE
Add desktop notifications, triggerable from the server

### DIFF
--- a/shell/client/desktop-notifications-client.js
+++ b/shell/client/desktop-notifications-client.js
@@ -1,0 +1,238 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test if localStorage is usable.
+// We can't use Meteor._localStorage for this because we need to be able to enumerate the elements
+// in localStorage for periodic cleanup.
+let localStorageWorks = false;
+const testKey = "localstorage-test-" + Random.id();
+try {
+  if (window.localStorage) {
+    window.localStorage.setItem(testKey, testKey);
+    const readBack = window.localStorage.getItem(testKey);
+    window.localStorage.removeItem(testKey);
+    localStorageWorks = true;
+  }
+} catch (e) {
+  // localStorage doesn't work.  Most of this code will be disabled.
+}
+
+const showDesktopNotification = (notif) => {
+  const data = notif;
+  const timestamp = +notif.creationDate;
+  const handle = new Notification(notif.title, {
+    tag: notif._id, // Merge desktop notifications from other browser tabs.
+    body: notif.body,
+    icon: notif.iconUrl,
+    badge: notif.iconUrl,
+    timestamp,
+  });
+
+  handle.onclick = () => {
+    if (notif.action) {
+      // Request that the Sandstorm window receive focus.  This attempts to switch
+      // the browser's active tab and window to the Sandstorm window that created
+      // the notification.
+      window.focus();
+
+      // Now, do something based on what type of notification this was.
+      if (notif.action.grain) {
+        // For a notification about a grain, open that grain URL and path.
+        const grain = notif.action.grain;
+        Router.go(`/grain/${grain.grainId}/${grain.path}`);
+      }
+
+      handle.close();
+    }
+  };
+};
+
+Template.desktopNotifications.onCreated(function () {
+  if (!localStorageWorks) return;
+  // There's some tricky logic here to try to make sure notifications are preferentially handled by
+  // a tab that already has the associated grain open, rather than just by the first or last tab to
+  // learn about the notification.  Otherwise your odds of getting the notification in the right tab
+  // are 1 in N, and then you'll open the grain in another window, which probably isn't what the
+  // user wanted.
+  //
+  // The tabs coordinate which tab will handle notifications via localStorage and listening for
+  // storage events.  If a tab already has a grain open, then it will claim a newly discovered
+  // notification immediately.  If a notification goes unclaimed for 2 seconds, then any tab (TODO:
+  // prefer the most recently focused/visible tab? requires more activity monitoring) may claim it
+  // and display it to the user.
+  //
+  // Notifications are kept in localStorage slightly longer than they are preserved on the server,
+  // to ensure that we avoid delivering duplicate notifications if one tab's connection is laggy or
+  // otherwise gets delayed messages.
+
+  // A random ID to identify this tab.  Not strictly needed for the current coordination algorithm,
+  // but useful for debugging.
+  this.tabId = Random.id();
+  //console.log(`desktop notifications tab id is ${this.tabId}`);
+
+  this.periodicCleanupTimerHandle = window.setInterval(() => {
+    // Do a periodic cleanup: call removeItem() any localStorage items with key prefix
+    // "notification-" and value with timestamp older than 180 seconds (longer than the sum of the
+    // serverside timeout and serverside key lifetime).
+    //
+    // Collect items to remove.  Iterating over localStorage
+    const toRemove = [];
+    const expireTimestamp = Date.now() - 180000;
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key.lastIndexOf("notification-", 0) === 0) {
+        const valueString = localStorage.getItem(key);
+        const value = JSON.parse(valueString);
+        if (value.lastWrite.timestamp < expireTimestamp) {
+          toRemove.push(key);
+        }
+      }
+    }
+
+    // Actually remove items.
+    for (let i = 0; i < toRemove.length; i++) {
+      localStorage.removeItem(toRemove[i]);
+    }
+  }, 30000);
+
+  this.waiters = {}; // Map from notification id to setTimeout handle
+
+  this.maybeClaimNotification = (notif, storageValue) => {
+    if (storageValue && storageValue.state === "claimed") {
+      // Another tab has already claimed this notification.  Bail out.
+      return;
+    }
+
+    // Set storage state for this notification to "claimed".
+    const storageKey = `notification-${notif._id}`;
+    const newStorageValue = {
+      rawData: notif,
+      state: "claimed",
+      lastWrite: {
+        timestamp: Date.now(),
+        tabId: this.tabId,
+      },
+    };
+
+    localStorage.setItem(storageKey, JSON.stringify(newStorageValue));
+    // Create the actual desktop notification.
+    showDesktopNotification(notif);
+  };
+
+  this.shouldHandleNotificationImmediately = (notif) => {
+    if (notif.action && notif.action.grain) {
+      // Defer handling of grain notifications.
+      const grainId = notif.action.grain.grainId;
+      return !!(grainId ? globalGrains.getById(grainId) : undefined);
+    } else {
+      // Eagerly handle any other type of notification.
+      return true;
+    }
+  };
+
+  this.onWaitingPeriodExpired = (notif) => {
+    // 2-second waiting period probably expired.  Try claiming the notification.
+    const storageKey = `notification-${notif._id}`;
+    const storageValueString = localStorage.getItem(storageKey);
+    const storageValue = storageValueString ? JSON.parse(storageValueString) : undefined;
+    // TODO(now): check that the waiting period has actually expired since the lastWrite timestamp;
+    // if so, claim the request; if not, schedule again for later.
+    this.maybeClaimNotification(notif, storageValue);
+    delete this.waiters[notif._id];
+  };
+
+  this.handleDiscoveredNotification = (notif, storageValue) => {
+    if (this.shouldHandleNotificationImmediately(notif)) {
+      this.maybeClaimNotification(notif, storageValue);
+    } else {
+      if (!storageValue) {
+        // write it to the database with state: "discovered"
+        const storageKey = `notification-${notif._id}`;
+        const newStorageValue = {
+          rawData: notif,
+          state: "discovered",
+          lastWrite: {
+            timestamp: Date.now(),
+            tabId: this.tabId,
+          },
+        };
+        // Do one last check to narrow the window for a race condition
+        if (localStorage.getItem(storageKey) === null) {
+          localStorage.setItem(storageKey, JSON.stringify(newStorageValue));
+        }
+      }
+
+      if (this.waiters[notif._id] === undefined) {
+        // Schedule claiming the request later.  Try not to wake up tabs at the same time.
+        const delay = 2000 + Math.random() * 100;
+        this.waiters[notif._id] = window.setTimeout(this.onWaitingPeriodExpired.bind(this, notif), delay);
+      }
+    }
+  };
+
+  this.storageEventHandler = (evt) => {
+    if (evt.key && evt.key.lastIndexOf("notification-", 0) === 0 && evt.newValue) {
+      // This is a write to a notification object.
+      const notificationId = evt.key.slice("notification-".length);
+      const storageValue = JSON.parse(evt.newValue);
+
+      if (evt.oldValue === null) {
+        if (storageValue && storageValue.state === "discovered") {
+          this.handleDiscoveredNotification(storageValue.rawData, storageValue);
+        }
+      } else {
+        const oldStorageValue = JSON.parse(evt.oldValue);
+        const lastWrite = oldStorageValue && oldStorageValue.lastWrite;
+        if (lastWrite && lastWrite.tabId === this.tabId && oldStorageValue.state === "claimed" &&
+            storageValue.state !== "claimed") {
+          // Someone else clobbered our write with one that should not dominate ours.
+          // Reapply our claim so no other tabs will attempt to claim this notification.
+          localStorage.setItem(evt.key, evt.oldValue);
+          console.log("storage: observed dangerous interleaved writes");
+          console.log(evt);
+        }
+      }
+    }
+  };
+
+  window.addEventListener("storage", this.storageEventHandler);
+
+  this.dbHandle = globalDb.collections.desktopNotifications.find().observe({
+    added: (notif) => {
+      // Look this notification up by ID in localStorage.
+      const storageKey = `notification-${notif._id}`;
+      const storageValueString = localStorage.getItem(storageKey);
+      const storageValue = storageValueString ? JSON.parse(storageValueString) : undefined;
+
+      this.handleDiscoveredNotification(notif, storageValue);
+    },
+  });
+
+  this.subscribe("desktopNotifications");
+});
+
+Template.desktopNotifications.onDestroyed(function () {
+  if (!localStorageWorks) return;
+  window.removeEventListener("storage", this.storageEventHandler);
+
+  if (this.dbHandle) {
+    this.dbHandle.stop();
+  }
+
+  if (this.periodicCleanupTimerHandle) {
+    window.clearInterval(this.periodicCleanupTimerHandle);
+  }
+});

--- a/shell/client/desktop-notifications.html
+++ b/shell/client/desktop-notifications.html
@@ -1,0 +1,3 @@
+<template name="desktopNotifications">
+{{!-- Empty, we just use this to hook into component lifecycle. --}}
+</template>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -124,6 +124,7 @@ limitations under the License.
     {{#unless identityUser}}
       {{#unless firstLogin}}
         {{#unless firstTimeBillingPromptState}}
+          {{> desktopNotifications }}
           {{> yield}}
         {{/unless}}
       {{/unless}}

--- a/shell/imports/server/desktop-notifications.js
+++ b/shell/imports/server/desktop-notifications.js
@@ -1,0 +1,46 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Match } from "meteor/check";
+
+const createDesktopNotification = (options) => {
+  Match.check(options, {
+    identityId: String,
+    action: Match.OneOf({
+      grain: {
+        grainId: String,
+        path: Match.Optional(String),
+      },
+    }),
+    title: String,
+    body: Match.Optional(String),
+    iconUrl: Match.Optional(String),
+    badgeUrl: Match.Optional(String),
+  });
+
+  globalDb.collections.desktopNotifications.insert({
+    identityId: options.identityId,
+    grainId: options.grainId,
+    path: options.path,
+    title: options.title,
+    body: options.body,
+    iconUrl: options.iconUrl,
+    badgeUrl: options.badgeUrl,
+    creationDate: new Date(),
+  });
+};
+
+export { createDesktopNotification };

--- a/shell/imports/server/desktop-notifications.js
+++ b/shell/imports/server/desktop-notifications.js
@@ -18,7 +18,7 @@ import { Match } from "meteor/check";
 
 const createDesktopNotification = (options) => {
   Match.check(options, {
-    accountId: String,
+    userId: String,
     action: Match.OneOf({
       grain: {
         grainId: String,
@@ -32,7 +32,7 @@ const createDesktopNotification = (options) => {
   });
 
   globalDb.collections.desktopNotifications.insert({
-    accountId: options.accountId,
+    userId: options.userId,
     grainId: options.grainId,
     path: options.path,
     title: options.title,

--- a/shell/imports/server/desktop-notifications.js
+++ b/shell/imports/server/desktop-notifications.js
@@ -18,7 +18,7 @@ import { Match } from "meteor/check";
 
 const createDesktopNotification = (options) => {
   Match.check(options, {
-    identityId: String,
+    accountId: String,
     action: Match.OneOf({
       grain: {
         grainId: String,
@@ -32,7 +32,7 @@ const createDesktopNotification = (options) => {
   });
 
   globalDb.collections.desktopNotifications.insert({
-    identityId: options.identityId,
+    accountId: options.accountId,
     grainId: options.grainId,
     path: options.path,
     title: options.title,

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -648,7 +648,7 @@ const DesktopNotifications = new Mongo.Collection("desktopNotifications");
 //
 //   _id: String.  Used as the tag to coordinate notification merging between browser tabs.
 //   creationDate: Date object. indicating when this notification was posted.
-//   accountId: String. Account id to which this notification was published.
+//   userId: String. Account id to which this notification was published.
 //   title: String. Primary label of the notification.
 //   body: String (optional).  Additional context information to place in the notification.  May be
 //                             elided by the browser or by Sandstorm.

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -183,7 +183,7 @@ UserActions = new Mongo.Collection("userActions");
 //
 // Each contains:
 //   _id:  random
-//   userId:  User who has installed this action.
+//   userId:  Account ID of the user who has installed this action.
 //   packageId:  Package used to run this action.
 //   appId:  Same as Packages.findOne(packageId).appId; denormalized for searchability.
 //   appTitle:  Same as Packages.findOne(packageId).manifest.appTitle; denormalized so
@@ -256,7 +256,7 @@ Sessions = new Mongo.Collection("sessions");
 //       have the same `tabId` as the outer session.
 //   timestamp:  Time of last keep-alive message to this session.  Sessions time out after some
 //       period.
-//   userId:  User ID of the user who owns this session.
+//   userId:  Account ID of the user who owns this session.
 //   identityId:  Identity ID of the user who owns this session.
 //   hashedToken: If the session is owned by an anonymous user, the _id of the entry in ApiTokens
 //       that was used to open it. Note that for old-style sharing (i.e. when !grain.private),
@@ -490,7 +490,7 @@ Notifications = new Mongo.Collection("notifications");
 // Each contains:
 //   _id:          random
 //   grainId:      The grain originating this notification, if any.
-//   userId:       The user receiving the notification.
+//   userId:       Account ID of the user receiving the notification.
 //   text:         The JSON-ified LocalizedText to display in the notification.
 //   isUnread:     Boolean indicating if this notification is unread.
 //   timestamp:    Date when this notification was last updated
@@ -576,7 +576,7 @@ AssetUploadTokens = new Mongo.Collection("assetUploadTokens");
 //   _id:       Random ID.
 //   purpose:   Contains one of the following, indicating how the asset is to be used:
 //       profilePicture: Indicates that the upload is a new profile picture. Contains fields:
-//           userId: User whose picture shall be replaced.
+//           userId: Account ID of user whose picture shall be replaced.
 //           identityId: Which of the user's identities shall be updated.
 //   expires:   Time when this token will go away if unused.
 

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -639,6 +639,30 @@ SetupSession = new Mongo.Collection("setupSession");
 //   creationDate: Date object indicating when this session was created.
 //   hashedSessionId: the sha256 of the secret session id that was returned to the client
 
+const DesktopNotifications = new Mongo.Collection("desktopNotifications");
+// Responsible for very short-lived queueing of desktop notification information.
+// Entries are removed when they are ~30 seconds old.  This collection is a bit
+// odd in that it is intended primarily for edge-triggered communications, but
+// Meteor's collections aren't really designed to support that organization.
+// Fields for each :
+//
+//   _id: String.  Used as the tag to coordinate notification merging between browser tabs.
+//   creationDate: Date object. indicating when this notification was posted.
+//   identityId: String. Identity id to which this notification was published.
+//   title: String. Primary label of the notification.
+//   body: String (optional).  Additional context information to place in the notification.  May be
+//                             elided by the browser or by Sandstorm.
+//   action: Object. What to do when this desktop notification is activated.  Currently, only one
+//                   shape is supported:
+//           { grain: { grainId, path } }
+//   iconUrl: Optional String.  Primary icon to display with the notifications.
+//                              See https://notifications.spec.whatwg.org/#icon-url
+//   badgeUrl: Optional String. Secondary icon to display with the notification, used to represent
+//                              the notification if there is insufficient space to display the whole
+//                              notification.  Can also be displayed (though with less visual
+//                              priority than the primary icon) in the notification.
+//                              See https://notifications.spec.whatwg.org/#badge-url
+
 if (Meteor.isServer) {
   Meteor.publish("credentials", function () {
     // Data needed for isSignedUp() and isAdmin() to work.
@@ -946,6 +970,7 @@ SandstormDb = function () {
     featureKey: FeatureKey,
     setupSession: SetupSession,
     users: Meteor.users,
+    desktopNotifications: DesktopNotifications,
 
     // Intentionally omitted:
     // - Migrations, since it's used only within this package.

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -648,7 +648,7 @@ const DesktopNotifications = new Mongo.Collection("desktopNotifications");
 //
 //   _id: String.  Used as the tag to coordinate notification merging between browser tabs.
 //   creationDate: Date object. indicating when this notification was posted.
-//   identityId: String. Identity id to which this notification was published.
+//   accountId: String. Account id to which this notification was published.
 //   title: String. Primary label of the notification.
 //   body: String (optional).  Additional context information to place in the notification.  May be
 //                             elided by the browser or by Sandstorm.

--- a/shell/server/desktop-notifications-server.js
+++ b/shell/server/desktop-notifications-server.js
@@ -1,0 +1,132 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Meteor } from "meteor/meteor";
+
+SandstormDb.periodicCleanup(120000, () => {
+  // Remove old desktop notfications regularly.
+  // periodicCleanup doesn't like runs more frequent than once every two minutes
+  const now = Date.now();
+  const then = new Date(now - 30000); // Clear tokens older than 30 seconds.
+  globalDb.collections.desktopNotifications.find({
+    creationDate: { $lt: then },
+  }).forEach((doc) => {
+    globalDb.collections.desktopNotifications.remove({
+      _id: doc._id,
+    });
+  });
+});
+
+Meteor.publish("desktopNotifications", function () {
+  const subscribeTime = new Date();
+
+  if (!this.userId) {
+    // No desktop notifications for anonymous users.
+    return [];
+  }
+
+  // Look up all identity ids associated with this account.
+  // Watch for notifications directed at any of them.
+  const db = this.connection.sandstormDb;
+
+  const callbacks = {
+    added: (doc) => {
+      this.added("desktopNotifications", doc._id, doc);
+    },
+
+    changed: (newDoc, oldDoc) => {
+      this.changed("desktopNotifications", newDoc._id, newDoc);
+    },
+
+    removed: (doc) => {
+      this.removed("desktopNotifications", doc._id);
+    },
+  };
+
+  const identitySubs = {}; // Map from identity id to observe handle for that identity
+  const refIdentity = (identityId) => {
+    if (identitySubs[identityId]) {
+      console.log(`duplicate ref identity id ${identityId} in desktopNotifications sub for account ${this.userId}`);
+      return;
+    }
+
+    const sub = db.collections.desktopNotifications.find({
+      identityId,
+      creationDate: { $gt: subscribeTime },
+    }).observe(callbacks);
+    identitySubs[identityId] = sub;
+  };
+
+  const unrefIdentity = (identityId) => {
+    const sub = identitySubs[identityId];
+    if (!sub) {
+      console.log(`duplicate unref identity id ${identityId} in desktopNotifications sub for account ${this.userId}`);
+      return;
+    }
+
+    delete identitySubs[identityId];
+    sub.stop();
+  };
+
+  let userObserveHandle = undefined;
+
+  this.onStop(() => {
+    identities = Object.keys(identitySubs);
+    identities.forEach((identityId) => {
+      unrefIdentity(identityId);
+    });
+
+    if (userObserveHandle) {
+      userObserveHandle.stop();
+    }
+  });
+
+  userObserveHandle = db.collections.users.find({
+    _id: this.userId,
+  }).observe({
+    added(doc) {
+      // for each identity, ref identity
+      const identityIds = SandstormDb.getUserIdentityIds(doc);
+      identityIds.forEach((identityId) => {
+        refIdentity(identityId);
+      });
+    },
+
+    changed(newDoc, oldDoc) {
+      const newIdentityIds = SandstormDb.getUserIdentityIds(newDoc);
+      const oldIdentityIds = SandstormDb.getUserIdentityIds(oldDoc);
+
+      const identityIdsAdded = _.difference(newIdentityIds, oldIdentityIds);
+      identityIdsAdded.forEach((identityId) => {
+        refIdentity(identityId);
+      });
+
+      const identityIdsRemoved = _.difference(oldIdentityIds, newIdentityIds);
+      identityIdsRemoved.forEach((identityId) => {
+        unrefIdentity(identityId);
+      });
+    },
+
+    removed(doc) {
+      const identityIds = SandstormDb.getUserIdentityIds(doc);
+      identityIds.forEach((identityId) => {
+        unrefIdentity(identityId);
+      });
+    },
+  });
+
+  this.ready();
+});

--- a/shell/server/desktop-notifications-server.js
+++ b/shell/server/desktop-notifications-server.js
@@ -54,7 +54,7 @@ Meteor.publish("desktopNotifications", function () {
   };
 
   const sub = db.collections.desktopNotifications.find({
-    accountId: this.userId,
+    userId: this.userId,
     creationDate: { $gt: subscribeTime },
   }).observe(callbacks);
 


### PR DESCRIPTION
Tabs coordinate over localStorage to make desktop notifications spawn
from the most useful tab to handle them - one of the ones that already
has that grain open, or if none do, whichever one gets there first.