### PR TITLE
account for the fact that grain.cachedViewInfo might not exist

### DIFF
--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -194,7 +194,7 @@ class PersistentUiViewImpl {
       const pkg = Packages.findOne({ _id: grain.packageId });
       const manifest = pkg.manifest || {};
 
-      const viewInfo = grain.cachedViewInfo;
+      const viewInfo = grain.cachedViewInfo || {};
 
       if (!viewInfo.appTitle) {
         viewInfo.appTitle = manifest.appTitle || {};


### PR DESCRIPTION
Some apps, such as Hacker CMS, do not implement `getViewInfo()`, so we can't assume that `Grains.cachedViewInfo` gets filled in. (The filling-in happens [here](https://github.com/sandstorm-io/sandstorm/blob/5b15b6d203edde6fe005ebec32df0ffd95dcb786/shell/server/proxy.js#L1385-L1392).) As a result, currently the collections app fails to retrieve an icon and title for Hacker CMS grains. This patch fixes the problem.