### PR TITLE
Get UiView offers to work again.

### DIFF
--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -1445,6 +1445,7 @@ SandstormPermissions.createNewApiToken = function (db, provider, grainId, petnam
       title: String,
       renamed: Match.Optional(Boolean),
       upstreamTitle: Match.Optional(String),
+      seenAllActivity: Match.Optional(Boolean),
     },
   }, {
     grain: {


### PR DESCRIPTION
#2174 introduced a `ApiTokenOwner.user.seenAllActivity` field. Its absence in the input-checking of `SandstormPermissions.createNewApiToken()` is causing `UiView` offers to fail, rendering the Collections app useless.