### PR TITLE
Remove vestigial 'isSimulation' check.

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -2017,11 +2017,9 @@ if (Meteor.isServer) {
       packageId: { $ne: packageId },
     };
 
-    if (!this.isSimulation) {
-      Grains.find(selector).forEach(function (grain) {
-        backend.shutdownGrain(grain._id, grain.userId);
-      });
-    }
+    Grains.find(selector).forEach(function (grain) {
+      backend.shutdownGrain(grain._id, grain.userId);
+    });
 
     Grains.update(selector, {
       $set: { appVersion: version, packageId: packageId, packageSalt: Random.secret() },


### PR DESCRIPTION
The `SandstormDb.upgradeGrains()` method only exists on the server. The `isSimulation` check is left over from when this code used to be directly part of a Meteor method: https://github.com/sandstorm-io/sandstorm/commit/21598d55e68cc29cac0a73006797a9a7ab61ae05