### PR TITLE
Get SandstormApi.drop() to succeed on non-notification sturdyrefs.

### DIFF
--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -525,26 +525,19 @@ function dropInternal(sturdyRef, ownerPattern) {
 
   check(token.owner, ownerPattern);
 
-  if (token.frontendRef) {
-    if (token.frontendRef.notificationHandle) {
-      const notificationId = token.frontendRef.notificationHandle;
-      globalDb.removeApiTokens({ _id: hashedSturdyRef });
-      const anyToken = ApiTokens.findOne({ "frontendRef.notificationHandle": notificationId });
-      if (!anyToken) {
-        // No other tokens referencing this notification exist, so dismiss the notification
-        dismissNotification(notificationId);
-      }
-    } else {
-      throw new Error("Unknown frontend token type.");
+  if (token.frontendRef && token.frontendRef.notificationHandle) {
+    const notificationId = token.frontendRef.notificationHandle;
+    globalDb.removeApiTokens({ _id: hashedSturdyRef });
+    const anyToken = ApiTokens.findOne({ "frontendRef.notificationHandle": notificationId });
+    if (!anyToken) {
+      // No other tokens referencing this notification exist, so dismiss the notification
+      dismissNotification(notificationId);
     }
-  } else if (token.objectId) {
-    if (token.objectId.wakeLockNotification) {
-      dropWakelock(token.grainId, token.objectId.wakeLockNotification);
-    } else {
-      throw new Error("Unknown objectId token type.");
-    }
+  } else if (token.objectId && token.objectId.wakeLockNotification) {
+    dropWakelock(token.grainId, token.objectId.wakeLockNotification);
+    globalDb.removeApiTokens({ _id: hashedSturdyRef });
   } else {
-    throw new Error("Unknown token type.");
+    globalDb.removeApiTokens({ _id: hashedSturdyRef });
   }
 }
 


### PR DESCRIPTION
Currently, `SandstormApi.drop()` fails on any token that is does not represent either a wakelock notification or a notification handle. Moreover, in the wakelock case we never actually remove the token from the database, even when the grain is deleted!

The patch makes `dropInternal()` succeed by default. Some types of token require special handling on drop. For everything else, we can just remove the token from the database.
