### PR TITLE
add ETag header support for NO_CONTENT responses

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1643,7 +1643,7 @@ class Proxy {
       const noContent = rpcResponse.noContent;
       const noContentCode = noContentSuccessCodes[noContent.shouldResetForm * 1];
       if (noContent.eTag) {
-        response.setHeader('ETag', composeETag(noContent.eTag));
+        response.setHeader("ETag", composeETag(noContent.eTag));
       }
 
       response.writeHead(noContentCode.id, noContentCode.title);

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1645,6 +1645,7 @@ class Proxy {
       if (noContent.eTag) {
         response.setHeader('ETag', composeETag(noContent.eTag));
       }
+
       response.writeHead(noContentCode.id, noContentCode.title);
       response.end();
     } else if ('preconditionFailed' in rpcResponse) {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1642,6 +1642,9 @@ class Proxy {
     } else if ('noContent' in rpcResponse) {
       const noContent = rpcResponse.noContent;
       const noContentCode = noContentSuccessCodes[noContent.shouldResetForm * 1];
+      if (noContent.eTag) {
+        response.setHeader('ETag', composeETag(noContent.eTag));
+      }
       response.writeHead(noContentCode.id, noContentCode.title);
       response.end();
     } else if ('preconditionFailed' in rpcResponse) {

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -339,6 +339,9 @@ public:
       case WebSession::Response::NO_CONTENT: {
         auto noContent = builder.initNoContent();
         noContent.setShouldResetForm(statusInfo.noContent.shouldResetForm);
+        KJ_IF_MAYBE(etag, findHeader("etag")) {
+          parseETag(*etag, noContent.initETag());
+        }
         break;
       }
       case WebSession::Response::PRECONDITION_FAILED: {

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -311,6 +311,8 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
         shouldResetForm @15 :Bool;
         # If this is the response to a form submission, should the form be reset to empty?
         # Distinguishes between HTTP response 204 (False) and 205 (True)
+
+        eTag @19 :ETag;
       }
 
       preconditionFailed :group {

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -313,6 +313,8 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
         # Distinguishes between HTTP response 204 (False) and 205 (True)
 
         eTag @19 :ETag;
+        # Optional entity tag header. Server can send this in a response to a modifying request
+        # to indicate for example the new version of the modified resource.
       }
 
       preconditionFailed :group {


### PR DESCRIPTION
This resolves #2160 pretty much as hinted in the issue comments:

 * add new field `eTag` to the WebSession::noContent
 * copypaste eTag from-http-to-rpc in sandstorm-http-bridge.c++
 * copypaste eTag from-rpc-to-http-response in proxy.js

With this commit, my currently unpublished TiddlyWiki5 package started to work. TiddlyWiki5 is the only way I tested this change, in addition to building and updating my `vagrant-spk` vm to it.

I also tested by mistake using a package created by older sandstorm version with the sandstorm of this version. In that case, there were no obvious problems, but because of the old `sandstorm-http-bridge` version, the `proxy.js` always saw `noContent.eTag` as `undefined`. I believe this is to be expected feature of capnproto backwards compatibility and confirms that I managed to use correct field index 19 for the property.