### PR TITLE
Fix loading anything at all under IE10

### DIFF
--- a/shell/packages/sandstorm-accounts-packages/package.js
+++ b/shell/packages/sandstorm-accounts-packages/package.js
@@ -4,6 +4,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.use("ecmascript");
   api.use(["underscore", "random"]);
   api.use("accounts-base", ["client", "server"]);
   // Export Accounts (etc) to packages using this one.


### PR DESCRIPTION
A package was using "const" without declaring api.use("ecmascript")
in its package.js.  This resulted in it not getting passed through
the transpilation pipeline, and having its contents placed in the
bundle directly.

IE10 does not support the "const" keyword, and parse errors when it
sees this code, and stops attempting to parse JS.