### PR TITLE
Refactor sturdyref handling code

### DIFF
--- a/shell/imports/server/frontend-ref.js
+++ b/shell/imports/server/frontend-ref.js
@@ -129,6 +129,7 @@ class FrontendRefRegistry {
       if (object.frontendRefField in this._frontendRefHandlers) {
         throw new Error("frontendRef handler already registered: " + object.frontendRefField);
       }
+
       this._frontendRefHandlers[object.frontendRefField] = object;
     }
 
@@ -136,6 +137,7 @@ class FrontendRefRegistry {
       if (object.typeId in this._typeIdHandlers) {
         throw new Error("typeId handler already registered: " + object.typeId);
       }
+
       this._typeIdHandlers[object.typeId] = object;
     }
   }

--- a/shell/imports/server/frontend-ref.js
+++ b/shell/imports/server/frontend-ref.js
@@ -20,19 +20,19 @@ class FrontendRefRegistry {
     this._queryHandlers = {};
   }
 
+  create(db, frontendRef, requirements) {
+    // Construct a fresh capability based on a `frontendRef` value.
+
+    const saveTemplate = { frontendRef };
+    if (requirements) {
+      saveTemplate.requirements = requirements;
+    }
+
+    return this.restore(db, saveTemplate, frontendRef);
+  }
+
   restore(db, saveTemplate, frontendRef) {
     // Restores a frontendRef capability using the appropriate registered handler.
-
-    if (!frontendRef) {
-      // saveTemplate is optional.
-      frontendRef = saveTemplate;
-      saveTemplate = undefined;
-    }
-
-    if (!saveTemplate) {
-      // If saveTemplate not provided, infer from frontendRef.
-      saveTemplate = { frontendRef };
-    }
 
     const keys = Object.keys(frontendRef);
     if (keys.length != 1) {

--- a/shell/imports/server/frontend-ref.js
+++ b/shell/imports/server/frontend-ref.js
@@ -65,7 +65,7 @@ class FrontendRefRegistry {
     // `fieldName` is the name of the field of `ApiTokens.frontendRef` which is filled in for this
     // ref type.
     //
-    // `callback` is of type `(db, value, saveTemplate) -> capability`, where
+    // `callback` is of type `(db, saveTemplate, value) -> capability`, where
     // `value` is the value of the single field of `ApiTokens.frontendRef` for this capability, and
     // `saveTemplate` is the token template to pass to the PersistentImpl constructor. The returned
     // object is a Cap'n Proto capability implementing SystemPersistent along with whatever other

--- a/shell/imports/server/frontend-ref.js
+++ b/shell/imports/server/frontend-ref.js
@@ -14,14 +14,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { checkRequirements } from "./persistent.js";
+
 class FrontendRefRegistry {
   constructor() {
     this._restoreHandlers = {};
     this._queryHandlers = {};
+    this._validateHandlers = {};
   }
 
   create(db, frontendRef, requirements) {
     // Construct a fresh capability based on a `frontendRef` value.
+
+    checkRequirements(requirements);
 
     const saveTemplate = { frontendRef };
     if (requirements) {
@@ -59,6 +64,29 @@ class FrontendRefRegistry {
     }
   }
 
+  validate(db, session, mutableFrontendRef) {
+    // Validates a powerbox request on the given `session` (a record from the Sessions table)
+    // requesting the creation of the given frontendRef type. `mutableFrontendRef` is expected to
+    // come directly from the client; calling validate() verifies that it has a valid type, and
+    // may modify the value to add bits that need to be generated server-side. `validate()` also
+    // returns an array of MembraneRequirements that shall apply to the capability. These
+    // requirements will not yet have been checked, so the caller should check them before
+    // proceeding.
+
+    const keys = Object.keys(mutableFrontendRef);
+    if (keys.length != 1) {
+      throw new Error("invalid frontendRef: " + JSON.stringify(mutableFrontendRef));
+    }
+
+    const key = keys[0];
+    const handler = this._validateHandlers[key];
+    if (!handler) {
+      throw new Error("invalid frontendRef: " + JSON.stringify(mutableFrontendRef));
+    }
+
+    return handler(db, session, mutableFrontendRef[key]);
+  }
+
   addRestoreHandler(fieldName, callback) {
     // Registers a callback to use to restore frontendRef capabilities of this type.
     //
@@ -86,14 +114,46 @@ class FrontendRefRegistry {
     //
     // `callback` is of type `(db, userAccountId, tagValue) -> options`.
     // * `tagValue` is a Buffer of the Cap'n-Proto-encoded `PowerboxDescriptor.Tag.value`.
-    // * The returned `options` is an array of `PowerboxOption` objects representing the options
-    //   that should be offered to the user for this query.
+    // * The returned `options` is an array of objects representing the options that should be
+    //   offered to the user for this query. See the `powerboxOptions` Meteor publish in
+    //   powerbox-server.js for a full description of the fields of each option.
 
     if (typeId in this._queryHandlers) {
       throw new Error("query handler already registered: " + typeId);
     }
 
     this._queryHandlers[typeId] = callback;
+  }
+
+  addValidateHandler(fieldName, callback) {
+    // Registers a callback to validate creation of a new frontendRef of this type from a powerbox
+    // request. The callback does not actually construct the capability, validates the frontendRef
+    // (passed from the untrusted client), possibly modifying it, and also produces a list of
+    // MembraneRequirements that should apply to the new capability.
+    //
+    // `fieldName` is the name of the field of `ApiTokens.frontendRef` which is filled in for this
+    // ref type.
+    //
+    // `callback` is of type `(db, session, mutableValue) -> {descriptor, requirements}`, where:
+    //     `mutableValue` is the value of the single field of `frontendRef` for this capability.
+    //         If this is an object value, the callback may optionally modify it, e.g. adding
+    //         additional fields that need to be generated server-side. The callback *must*, at
+    //         the very least, type-check this value. It should throw an exception if the vaule is
+    //         not valid.
+    //     `session` is the record from the Sessions table of the UI session where the powerbox
+    //         request occurred.
+    //     `descriptor` (returned) is the JSON-encoded PowerboxDescriptor for the capability. Note
+    //         that if the descriptor contains any `tag.value`s, they of course need to be
+    //         presented as capnp-encoded Buffers.
+    //     `requirements` (returned) is an array of MembraneRequirements which should apply to the
+    //         new capability. Note that these requirements will be checked immediately and the
+    //         powerbox request will fail if they aren't met.
+
+    if (fieldName in this._validateHandlers) {
+      throw new Error("restore handler already registered: " + fieldName);
+    }
+
+    this._validateHandlers[fieldName] = callback;
   }
 }
 

--- a/shell/imports/server/frontend-ref.js
+++ b/shell/imports/server/frontend-ref.js
@@ -1,0 +1,101 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class FrontendRefRegistry {
+  constructor() {
+    this._restoreHandlers = {};
+    this._queryHandlers = {};
+  }
+
+  restore(db: SandstormDb, saveTemplate: ApiToken, frontendRef: ApiToken.FrontendRef): Capability {
+    // Restores a frontendRef capability using the appropriate registered handler.
+
+    if (!frontendRef) {
+      // saveTemplate is optional.
+      frontendRef = saveTemplate;
+      saveTemplate = undefined;
+    }
+
+    if (!saveTemplate) {
+      // If saveTemplate not provided, infer from frontendRef.
+      saveTemplate = { frontendRef };
+    }
+
+    const keys = Object.keys(frontendRef);
+    if (keys.length != 1) {
+      throw new Error("invalid frontendRef: " + JSON.stringify(frontendRef));
+    }
+
+    const key = keys[0];
+    const handler = this._restoreHandlers[key];
+    if (!handler) {
+      throw new Error("invalid frontendRef: " + JSON.stringify(frontendRef));
+    }
+
+    return handler(db, saveTemplate, frontendRef[key]);
+  }
+
+  query(db: SandstormDb, userAccountId: string, tag: PowerboxDescriptor.Tag): PowerboxOption[] {
+    // Performs a powerbox query using the appropriate registered handler.
+
+    const handler = this._queryHandlers[tag.id];
+    if (handler) {
+      return handler(db, userAccountId, tag.value);
+    } else {
+      return [];  // no matches
+    }
+  }
+
+  addRestoreHandler(fieldName: string,
+                    callback: (db: SandstormDb, saveTemplate: ApiToken, value: any)
+                              => Capability) {
+    // Registers a callback to use to restore frontendRef capabilities of this type.
+    //
+    // `fieldName` is the name of the field of `ApiTokens.frontendRef` which is filled in for this
+    // ref type.
+    //
+    // `callback` is of type `(db, value, saveTemplate) -> capability`, where
+    // `value` is the value of the single field of `ApiTokens.frontendRef` for this capability, and
+    // `saveTemplate` is the token template to pass to the PersistentImpl constructor. The returned
+    // object is a Cap'n Proto capability implementing SystemPersistent along with whatever other
+    // interfaces are appropriate for the ref type.
+
+    if (fieldName in this._restoreHandlers) {
+      throw new Error("restore handler already registered: " + fieldName);
+    }
+    this._restoreHandlers[fieldName] = callback;
+  }
+
+  addQueryHandler(typeId: string,
+      callback: (db: SandstormDb, userAccountId: Text, tagValue: Buffer) => PowerboxOption[]) {
+    // Registers a callback to use to interpret a powerbox query for the given type ID.
+    //
+    // `typeId` is a stringified decimal 64-bit integer. (Stringification is needed as Javascript
+    // numbers cannot represent 64-bit integers precisely.)
+    //
+    // `callback` is of type `(db, userAccountId, tagValue) -> options`.
+    // * `tagValue` is a Buffer of the Cap'n-Proto-encoded `PowerboxDescriptor.Tag.value`.
+    // * The returned `options` is an array of `PowerboxOption` objects representing the options
+    //   that should be offered to the user for this query.
+
+    if (typeId in this._queryHandlers) {
+      throw new Error("query handler already registered: " + typeId);
+    }
+    this._queryHandlers[typeId] = callback;
+  }
+}
+
+export { FrontendRefRegistry };

--- a/shell/imports/server/frontend-ref.js
+++ b/shell/imports/server/frontend-ref.js
@@ -20,7 +20,7 @@ class FrontendRefRegistry {
     this._queryHandlers = {};
   }
 
-  restore(db: SandstormDb, saveTemplate: ApiToken, frontendRef: ApiToken.FrontendRef): Capability {
+  restore(db, saveTemplate, frontendRef) {
     // Restores a frontendRef capability using the appropriate registered handler.
 
     if (!frontendRef) {
@@ -48,7 +48,7 @@ class FrontendRefRegistry {
     return handler(db, saveTemplate, frontendRef[key]);
   }
 
-  query(db: SandstormDb, userAccountId: string, tag: PowerboxDescriptor.Tag): PowerboxOption[] {
+  query(db, userAccountId, tag) {
     // Performs a powerbox query using the appropriate registered handler.
 
     const handler = this._queryHandlers[tag.id];
@@ -59,9 +59,7 @@ class FrontendRefRegistry {
     }
   }
 
-  addRestoreHandler(fieldName: string,
-                    callback: (db: SandstormDb, saveTemplate: ApiToken, value: any)
-                              => Capability) {
+  addRestoreHandler(fieldName, callback) {
     // Registers a callback to use to restore frontendRef capabilities of this type.
     //
     // `fieldName` is the name of the field of `ApiTokens.frontendRef` which is filled in for this
@@ -76,11 +74,11 @@ class FrontendRefRegistry {
     if (fieldName in this._restoreHandlers) {
       throw new Error("restore handler already registered: " + fieldName);
     }
+
     this._restoreHandlers[fieldName] = callback;
   }
 
-  addQueryHandler(typeId: string,
-      callback: (db: SandstormDb, userAccountId: Text, tagValue: Buffer) => PowerboxOption[]) {
+  addQueryHandler(typeId, callback) {
     // Registers a callback to use to interpret a powerbox query for the given type ID.
     //
     // `typeId` is a stringified decimal 64-bit integer. (Stringification is needed as Javascript
@@ -94,6 +92,7 @@ class FrontendRefRegistry {
     if (typeId in this._queryHandlers) {
       throw new Error("query handler already registered: " + typeId);
     }
+
     this._queryHandlers[typeId] = callback;
   }
 }

--- a/shell/imports/server/persistent.js
+++ b/shell/imports/server/persistent.js
@@ -1,0 +1,78 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const Crypto = Npm.require("crypto");
+
+const privateDb = Symbol("PersistentImpl.db");
+const privateTemplate = Symbol("PersistentImpl.template");
+
+class PersistentImpl {
+  constructor(db: SandstormDb, saveTemplate: ApiToken) {
+    this[privateDb] = db;
+    this[privateTemplate] = saveTemplate;
+  }
+
+  save(params) {
+    return inMeteor(() => {
+      if (!params.sealFor) {
+        throw new Error("must specify 'sealFor'");
+      }
+
+      const db = this[privateDb];
+
+      const newToken = _.clone(this[privateTemplate]);
+      newToken.owner = params.sealFor;
+      if (newToken.owner.user) {
+        if (!newToken.identityId) {
+          throw new Error("can't save non-UiView with user as owner");
+        }
+
+        // Only "identityId" and "title" are allowed to be passed to save().
+        const userOwner = _.pick(newToken.owner.user, "identityId", "title");
+
+        // Fill in denormalizedGrainMetadata and upstreamTitle ourselves.
+        userOwner.denormalizedGrainMetadata = db.getDenormalizedGrainInfo(newToken.grainId);
+
+        const grain = db.getGrain(saveTemplate.grainId);
+        if (grain && grain.title !== userOwner.title) {
+          userOwner.upstreamTitle = grain.title;
+        }
+
+        newToken.owner.user = userOwner;
+      }
+
+      const sturdyRef = generateSturdyRef();
+      newToken._id = hashSturdyRef(sturdyRef);
+
+      newToken.created = new Date();
+
+      db.collections.apiTokens.insert(newToken);
+      return { sturdyRef: new Buffer(sturdyRef) };
+    });
+  }
+
+  // TODO(someday): Implement SystemPersistent.addRequirements().
+}
+
+function hashSturdyRef(sturdyRef) {
+  return Crypto.createHash("sha256").update(sturdyRef).digest("base64");
+};
+
+function generateSturdyRef() {
+  return Random.secret();
+}
+
+export { PersistentImpl, hashSturdyRef, generateSturdyRef };

--- a/shell/imports/server/persistent.js
+++ b/shell/imports/server/persistent.js
@@ -20,7 +20,7 @@ const privateDb = Symbol("PersistentImpl.db");
 const privateTemplate = Symbol("PersistentImpl.template");
 
 class PersistentImpl {
-  constructor(db: SandstormDb, saveTemplate: ApiToken) {
+  constructor(db, saveTemplate) {
     this[privateDb] = db;
     this[privateTemplate] = saveTemplate;
   }

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -377,7 +377,9 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //                  it has been set.
 //       ipInterface: Ditto IpNetwork, except it's an IpInterface.
 //       emailVerifier: An EmailVerifier capability that is implemented by the frontend. The
-//                      value is an object containing the field `services`, which itself is a
+//                      value is an object containing the fields `id` and `services`. `id` is the
+//                      value returned by `EmailVerifier.getId()` and is used as part of a
+//                      powerbox query for matching verified emails. `services` is a
 //                      list of names of identity providers that are trusted to verify addresses.
 //                      If `services` is omitted or falsy, all configured identity providers are
 //                      trusted. Note that a malicious user could specify invalid names in the
@@ -439,6 +441,7 @@ ApiTokens = new Mongo.Collection("apiTokens");
 //       ipNetwork :Bool;
 //       ipInterface :Bool;
 //       emailVerifier :group {
+//         id :Text;
 //         services :List(String);
 //       }
 //       verifiedEmail :group {
@@ -466,6 +469,7 @@ ApiTokens = new Mongo.Collection("apiTokens");
 
 ApiTokens.ensureIndexOnServer("grainId", { sparse: 1 });
 ApiTokens.ensureIndexOnServer("owner.user.identityId", { sparse: 1 });
+ApiTokens.ensureIndexOnServer("frontendRef.emailVerifier.id", { sparse: 1 });
 
 ApiHosts = new Mongo.Collection("apiHosts");
 // Allows defining some limited static behavior for an API host when accessed unauthenticated. This

--- a/shell/packages/sandstorm-ui-powerbox/package.js
+++ b/shell/packages/sandstorm-ui-powerbox/package.js
@@ -24,5 +24,6 @@ Package.onUse(function (api) {
   api.use(["ecmascript", "check"], "server");
   api.addFiles(["powerbox.html", "powerbox-client.js"], "client");
   api.addFiles(["powerbox-server.js"], "server");
-  api.export("SandstormPowerboxRequest");
+  api.export("SandstormPowerboxRequest", "client");
+  api.export("SandstormPowerbox", "server");
 });

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -41,6 +41,7 @@ Meteor.methods({
     ));
 
     const db = this.connection.sandstormDb;
+    const frontendRefRegistry = this.connection.frontendRefRegistry;
 
     const session = db.collections.sessions.findOne(sessionId);
     if (!session) {
@@ -110,8 +111,9 @@ Meteor.methods({
       },
     };
 
-    // TODO(cleanup): refactor: reaches out into core.js
-    const sturdyRef = waitPromise(saveFrontendRef(frontendRefVariety, apiTokenOwner, requirements)).sturdyRef.toString();
+    const cap = frontendRefRegistry.create(db, frontendRefVariety, requirements);
+    const sturdyRef = waitPromise(cap.save(apiTokenOwner)).sturdyRef.toString();
+    cap.close();
     return { sturdyRef, descriptor };
   },
 

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -18,8 +18,6 @@ const Crypto = Npm.require("crypto");
 const Capnp = Npm.require("capnp");
 const Powerbox = Capnp.importSystem("sandstorm/powerbox.capnp");
 const Grain = Capnp.importSystem("sandstorm/grain.capnp");
-const Ip = Capnp.importSystem("sandstorm/ip.capnp");
-const Email = Capnp.importSystem("sandstorm/email.capnp");
 
 function encodePowerboxDescriptor(desc) {
   return Capnp.serializePacked(Powerbox.PowerboxDescriptor, desc)

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -188,21 +188,25 @@ class PowerboxOption {
 function registerUiViewQueryHandler(frontendRefRegistry) {
   // TODO(cleanup): Maybe this belongs in a different file? But where?
 
-  frontendRefRegistry.addQueryHandler(Grain.UiView.typeId, (db, userId, value) => {
-    if (!userId) return [];
+  frontendRefRegistry.register({
+    typeId: Grain.UiView.typeId,
 
-    // TODO(someday): Allow `value` to specify app IDs to filter for.
+    query(db, userId, value) {
+      if (!userId) return [];
 
-    const sharedGrainIds = db.userApiTokens(userId).map(token => token.grainId);
-    const ownedGrainIds = db.userGrains(userId).map(grain => grain._id);
+      // TODO(someday): Allow `value` to specify app IDs to filter for.
 
-    return _.uniq(sharedGrainIds.concat(ownedGrainIds)).map(grainId => {
-      return new PowerboxOption({
-        _id: "grain-" + grainId,
-        grainId: grainId,
-        uiView: {},
+      const sharedGrainIds = db.userApiTokens(userId).map(token => token.grainId);
+      const ownedGrainIds = db.userGrains(userId).map(grain => grain._id);
+
+      return _.uniq(sharedGrainIds.concat(ownedGrainIds)).map(grainId => {
+        return new PowerboxOption({
+          _id: "grain-" + grainId,
+          grainId: grainId,
+          uiView: {},
+        });
       });
-    });
+    },
   });
 }
 

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -321,7 +321,6 @@ function getVerifiedEmails(db, userId, verifierId) {
   let services = null;
 
   if (verifierId) {
-    console.log(verifierId);
     const verifier = db.collections.apiTokens.findOne(
         { "frontendRef.emailVerifier.id": verifierId });
     if (!verifier) return []; // invalid verifier

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -43,7 +43,8 @@ Meteor.methods({
     const db = this.connection.sandstormDb;
     const frontendRefRegistry = this.connection.frontendRefRegistry;
 
-    const session = db.collections.sessions.findOne(sessionId);
+    const session = db.collections.sessions.findOne(
+        { _id: sessionId, userId: this.userId || { $exists: false } });
     if (!session) {
       throw new Meteor.Error(403, "Invalid session ID");
     }

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -29,16 +29,10 @@ function encodePowerboxDescriptor(desc) {
 }
 
 Meteor.methods({
-  newFrontendRef(sessionId, frontendRefVariety) {
-    // Checks if the requester is an admin, and if so, provides a new frontendref of the desired
-    // variety, provided by the requesting user, owned by the grain for this session.
+  newFrontendRef(sessionId, frontendRef) {
+    // Completes a powerbox request for a frontendRef capability.
     check(sessionId, String);
-    check(frontendRefVariety, Match.OneOf(
-      { ipNetwork: true },
-      { ipInterface: true },
-      { emailVerifier: { services: Match.Optional([String]) } },
-      { verifiedEmail: { verifierId: Match.Optional(String), address: String } },
-    ));
+    // frontendRef is type-checked by frontendRefRegistry.validate(), below.
 
     const db = this.connection.sandstormDb;
     const frontendRefRegistry = this.connection.frontendRefRegistry;
@@ -49,59 +43,8 @@ Meteor.methods({
       throw new Meteor.Error(403, "Invalid session ID");
     }
 
-    let descriptor;
-    let requirements = [];
-    if (frontendRefVariety.ipNetwork) {
-      if (!db.isAdmin(this.userId)) {
-        throw new Meteor.Error(403, "User must be an admin to powerbox offer IpNetwork");
-      }
-
-      descriptor = encodePowerboxDescriptor({ tags: [{ id: Ip.IpNetwork.typeId }] });
-      requirements.push({ userIsAdmin: Meteor.userId() });
-    } else if (frontendRefVariety.ipInterface) {
-      if (!db.isAdmin(this.userId)) {
-        throw new Meteor.Error(403, "User must be an admin to powerbox offer IpInterface");
-      }
-
-      descriptor = encodePowerboxDescriptor({ tags: [{ id: Ip.IpInterface.typeId }] });
-      requirements.push({ userIsAdmin: Meteor.userId() });
-    } else if (frontendRefVariety.emailVerifier) {
-      const services = frontendRefVariety.emailVerifier.services;
-      if (services) {
-        services.forEach(service => {
-          if (!Accounts.identityServices[service]) {
-            throw new Error("No such identity service: " + service);
-          }
-        });
-      }
-
-      // Assign an ID to the verifier. Note that this isn't really security-sensitive but ideally
-      // will avoid collisions. Also note that various code expects this string to be base64.
-      frontendRefVariety.emailVerifier.id = Crypto.randomBytes(16).toString("base64");
-
-      descriptor = encodePowerboxDescriptor({ tags: [{ id: Email.EmailVerifier.typeId }] });
-    } else if (frontendRefVariety.verifiedEmail) {
-      // Verify that the address actually belongs to the user.
-
-      if (!_.contains(
-          getVerifiedEmails(db, this.userId, frontendRefVariety.verifiedEmail.verifierId),
-          frontendRefVariety.verifiedEmail.address)) {
-        throw new Meteor.Error(403, "User has no such verified address");
-      }
-
-      // Add the session's tabId.
-      frontendRefVariety.verifiedEmail.tabId = session.tabId;
-
-      // Build the descriptor, which contains the verifier ID.
-      const tagValue = frontendRefVariety.verifiedEmail.verifierId &&
-          Capnp.serialize(Email.VerifiedEmail.PowerboxTag,
-              { verifierId: new Buffer(frontendRefVariety.verifiedEmail.verifierId, "hex") });
-      descriptor = encodePowerboxDescriptor({
-        tags: [{ id: Email.VerifiedEmail.typeId, value: tagValue }],
-      });
-    } else {
-      throw new Meteor.Error(500, "Unimplemented frontendRef type");
-    }
+    let { descriptor, requirements } = frontendRefRegistry.validate(db, session, frontendRef);
+    descriptor = encodePowerboxDescriptor(descriptor);
 
     const grainId = session.grainId;
     const apiTokenOwner = {
@@ -112,7 +55,7 @@ Meteor.methods({
       },
     };
 
-    const cap = frontendRefRegistry.create(db, frontendRefVariety, requirements);
+    const cap = frontendRefRegistry.create(db, frontendRef, requirements);
     const sturdyRef = waitPromise(cap.save(apiTokenOwner)).sturdyRef.toString();
     cap.close();
     return { sturdyRef, descriptor };
@@ -242,109 +185,25 @@ class PowerboxOption {
   }
 }
 
-const specialCaseTypes = {};
-// This object maps tag IDs to functions which return lists of matches for that tag.
+function registerUiViewQueryHandler(frontendRefRegistry) {
+  // TODO(cleanup): Maybe this belongs in a different file? But where?
 
-specialCaseTypes[Grain.UiView.typeId] = function (db, userId, value) {
-  if (!userId) return [];
+  frontendRefRegistry.addQueryHandler(Grain.UiView.typeId, (db, userId, value) => {
+    if (!userId) return [];
 
-  // TODO(someday): Allow `value` to specify app IDs to filter for.
+    // TODO(someday): Allow `value` to specify app IDs to filter for.
 
-  const sharedGrainIds = db.userApiTokens(userId).map(token => token.grainId);
-  const ownedGrainIds = db.userGrains(userId).map(grain => grain._id);
+    const sharedGrainIds = db.userApiTokens(userId).map(token => token.grainId);
+    const ownedGrainIds = db.userGrains(userId).map(grain => grain._id);
 
-  return _.uniq(sharedGrainIds.concat(ownedGrainIds)).map(grainId => {
-    return new PowerboxOption({
-      _id: "grain-" + grainId,
-      grainId: grainId,
-      uiView: {},
+    return _.uniq(sharedGrainIds.concat(ownedGrainIds)).map(grainId => {
+      return new PowerboxOption({
+        _id: "grain-" + grainId,
+        grainId: grainId,
+        uiView: {},
+      });
     });
   });
-};
-
-specialCaseTypes[Ip.IpNetwork.typeId] = function (db, userId, value) {
-  if (Meteor.users.findOne(userId).isAdmin) {
-    return [
-      new PowerboxOption({
-        _id: "frontendref-ipnetwork",
-        frontendRef: { ipNetwork: true },
-      }),
-    ];
-  } else {
-    return [];
-  }
-};
-
-specialCaseTypes[Ip.IpInterface.typeId] = function (db, userId, value) {
-  if (Meteor.users.findOne(userId).isAdmin) {
-    return [
-      new PowerboxOption({
-        _id: "frontendref-ipinterface",
-        frontendRef: { ipInterface: true },
-      }),
-    ];
-  } else {
-    return [];
-  }
-};
-
-specialCaseTypes[Email.EmailVerifier.typeId] = function (db, userId, value) {
-  const results = [];
-
-  results.push({
-    _id: "emailverifier-all",
-    frontendRef: { emailVerifier: {} },
-  });
-
-  for (const name in Accounts.identityServices) {
-    if (Accounts.identityServices[name].isEnabled()) {
-      results.push({
-        _id: "emailverifier-" + name,
-        frontendRef: { emailVerifier: { services: [name] } },
-      });
-    }
-  };
-
-  return results;
-};
-
-specialCaseTypes[Email.VerifiedEmail.typeId] = function (db, userId, value) {
-  const verifierId = value &&
-      Capnp.parse(Email.VerifiedEmail.PowerboxTag, value).verifierId.toString("base64");
-  return getVerifiedEmails(db, userId, verifierId).map(address => ({
-    _id: "email-" + address,
-    frontendRef: { verifiedEmail: { verifierId, address } },
-  }));
-};
-
-function getVerifiedEmails(db, userId, verifierId) {
-  // Get all of the email addresses verified as belonging to the given user using the given
-  // verifier.
-
-  let services = null;
-
-  if (verifierId) {
-    const verifier = db.collections.apiTokens.findOne(
-        { "frontendRef.emailVerifier.id": verifierId });
-    if (!verifier) return []; // invalid verifier
-    const verifierInfo = verifier.frontendRef.emailVerifier;
-
-    if (verifierInfo.services) {
-      // Limit to the listed services.
-      services = {};
-      verifierInfo.services.forEach(service => services[service] = true);
-    }
-  }
-
-  const user = Meteor.users.findOne(userId);
-  const emails = {};  // map address -> true, for uniquification
-  Meteor.users.find({ _id: { $in: SandstormDb.getUserIdentityIds(user) } }).forEach(identity => {
-    if (!services || services[identity.profile.service]) {
-      SandstormDb.getVerifiedEmails(identity).forEach(email => { emails[email.email] = true; });
-    }
-  });
-
-  return Object.keys(emails);
 }
 
 Meteor.publish("powerboxOptions", function (requestId, descriptorList) {
@@ -379,6 +238,7 @@ Meteor.publish("powerboxOptions", function (requestId, descriptorList) {
 
   const results = {};
   const db = this.connection.sandstormDb;
+  const frontendRefRegistry = this.connection.frontendRefRegistry;
 
   if (descriptorList.length > 0) {
     const descriptorMatches = descriptorList.map(packedDescriptor => {
@@ -395,14 +255,11 @@ Meteor.publish("powerboxOptions", function (requestId, descriptorList) {
 
       // Expand each tag into a match map.
       const tagMatches = descriptor.tags.map(tag => {
-        const type = specialCaseTypes[tag.id];
         const result = {};
 
-        if (type) {
-          type(db, this.userId, tag.value).forEach(option => {
-            result[option._id] = option;
-          });
-        }
+        frontendRefRegistry.query(db, this.userId, tag).forEach(option => {
+          result[option._id] = new PowerboxOption(option);
+        });
 
         return result;
       });
@@ -478,3 +335,5 @@ Meteor.publish("powerboxOptions", function (requestId, descriptorList) {
 
   this.ready();
 });
+
+SandstormPowerbox = { registerUiViewQueryHandler };

--- a/shell/server/00-startup.js
+++ b/shell/server/00-startup.js
@@ -17,12 +17,15 @@
 import "/imports/db-deprecated.js";
 import { FrontendRefRegistry } from "/imports/server/frontend-ref.js";
 
+globalFrontendRefRegistry = new FrontendRefRegistry();
+
 getWildcardOrigin = globalDb.getWildcardOrigin.bind(globalDb);
 
 Meteor.onConnection((connection) => {
   // TODO(cleanup): This is the best way I've thought of so far to allow methods declared in
   //   packages to actually use the DB, but it's pretty sad.
   connection.sandstormDb = globalDb;
+  connection.frontendRefRegistry = globalFrontendRefRegistry;
 });
 SandstormDb.periodicCleanup(5 * 60 * 1000, SandstormPermissions.cleanupSelfDestructing(globalDb));
 SandstormDb.periodicCleanup(10 * 60 * 1000,
@@ -34,5 +37,3 @@ SandstormDb.periodicCleanup(24 * 60 * 60 * 1000, () => {
 Meteor.startup(() => { globalDb.migrateToLatest(); });
 LDAP_DEFAULTS.url = globalDb.getLdapUrl();
 LDAP_DEFAULTS.base = globalDb.getLdapBase();
-
-globalFrontendRefRegistry = new FrontendRefRegistry();

--- a/shell/server/00-startup.js
+++ b/shell/server/00-startup.js
@@ -19,6 +19,8 @@ import { FrontendRefRegistry } from "/imports/server/frontend-ref.js";
 
 globalFrontendRefRegistry = new FrontendRefRegistry();
 
+SandstormPowerbox.registerUiViewQueryHandler(globalFrontendRefRegistry);
+
 getWildcardOrigin = globalDb.getWildcardOrigin.bind(globalDb);
 
 Meteor.onConnection((connection) => {

--- a/shell/server/00-startup.js
+++ b/shell/server/00-startup.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import "/imports/db-deprecated.js";
+import { FrontendRefRegistry } from "/imports/server/frontend-ref.js";
 
 getWildcardOrigin = globalDb.getWildcardOrigin.bind(globalDb);
 
@@ -33,3 +34,5 @@ SandstormDb.periodicCleanup(24 * 60 * 60 * 1000, () => {
 Meteor.startup(() => { globalDb.migrateToLatest(); });
 LDAP_DEFAULTS.url = globalDb.getLdapUrl();
 LDAP_DEFAULTS.base = globalDb.getLdapBase();
+
+globalFrontendRefRegistry = new FrontendRefRegistry();

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -298,38 +298,6 @@ Meteor.methods({
     return { sent: true };
   },
 
-  offerIpNetwork: function (token) {
-    checkAuth(token);
-    if (!isAdmin()) {
-      throw new Meteor.Error(403, "Offering IpNetwork is only allowed for logged in users " +
-        "(a token is not sufficient). Please sign in with an admin account");
-    }
-
-    const requirements = [
-      { userIsAdmin: Meteor.userId() },
-    ];
-    const sturdyRef = waitPromise(
-      saveFrontendRef({ ipNetwork: true }, { webkey: null }, requirements)
-    ).sturdyRef;
-    return ROOT_URL.protocol + "//" + globalDb.makeApiHost(sturdyRef) + "#" + sturdyRef;
-  },
-
-  offerIpInterface: function (token) {
-    checkAuth(token);
-    if (!isAdmin()) {
-      throw new Meteor.Error(403, "Offering IpInterface is only allowed for logged in users " +
-        "(a token is not sufficient). Please sign in with an admin account");
-    }
-
-    const requirements = [
-      { userIsAdmin: Meteor.userId() },
-    ];
-    const sturdyRef = waitPromise(
-      saveFrontendRef({ ipInterface: true }, { webkey: null }, requirements)
-    ).sturdyRef;
-    return ROOT_URL.protocol + "//" + globalDb.makeApiHost(sturdyRef) + "#" + sturdyRef;
-  },
-
   adminToggleDisableCap: function (token, capId, value) {
     checkAuth(token);
     check(capId, String);

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -432,7 +432,7 @@ const makeSaveTemplateForChild = function (parentToken, requirements, parentToke
   }
 
   return saveTemplate;
-}
+};
 
 restoreInternal = (originalToken, ownerPattern, requirements, originalTokenInfo,
                    currentTokenId) => {

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -249,10 +249,13 @@ const makePersistentUiView = function (db, saveTemplate, grainId) {
                               PersistentUiView);
 };
 
-globalFrontendRefRegistry.addRestoreHandler("notificationHandle",
-    (db, saveTemplate, notificationId) => {
-  return new Capnp.Capability(new NotificationHandle(db, saveTemplate, notificationId),
-                              PersistentHandle);
+globalFrontendRefRegistry.register({
+  frontendRefField: "notificationHandle",
+
+  restore(db, saveTemplate, notificationId) {
+    return new Capnp.Capability(new NotificationHandle(db, saveTemplate, notificationId),
+                                PersistentHandle);
+  },
 });
 
 function dismissNotification(notificationId, callCancel) {

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -518,7 +518,7 @@ restoreInternal = (originalToken, ownerPattern, requirements, originalTokenInfo,
     // Ensure the grain is running, then restore the capability.
     return waitPromise(globalBackend.useGrain(token.grainId, (supervisor) => {
       // Note that in this case it is the supervisor's job to implement SystemPersistent, so we
-      // discard persistentMethods.
+      // don't generate a saveTemplate here.
       return supervisor.restore(token.objectId, requirements, originalToken);
     }));
   } else {

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -14,9 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const Crypto = Npm.require("crypto");
 const Capnp = Npm.require("capnp");
 const Url = Npm.require("url");
+import { PersistentImpl, hashSturdyRef, generateSturdyRef } from "/imports/server/persistent.js";
 
 const PersistentHandle = Capnp.importSystem("sandstorm/supervisor.capnp").PersistentHandle;
 const SandstormCore = Capnp.importSystem("sandstorm/supervisor.capnp").SandstormCore;
@@ -50,7 +50,7 @@ class SandstormCoreImpl {
 
       return restoreInternal(sturdyRef,
                              { grain: Match.ObjectIncluding({ grainId: this.grainId }) },
-                             [], hashedSturdyRef);
+                             [], token);
     });
   }
 
@@ -81,11 +81,15 @@ class SandstormCoreImpl {
   }
 
   makeChildToken(parent, owner, requirements) {
-    const _this = this;
     return inMeteor(() => {
-      return {
-        token: new Buffer(makeChildTokenInternal(parent, owner, requirements)),
-      };
+      // Compute the save ApiToken template.
+      return makeSaveTemplateForChild(parent.toString(), requirements);
+    }).then(saveTemplate => {
+      // Create a dummy PersistentImpl and invoke its own save() method.
+      return new PersistentImpl(globalDb, saveTemplate).save({ sealFor: owner });
+    }).then(saveResult => {
+      // Transform to expected result structure.
+      return { token: saveResult.sturdyRef };
     });
   }
 
@@ -116,13 +120,10 @@ class SandstormCoreImpl {
               isUnread: true,
             });
 
-            const persistentMethods = {
-              save(params) {
-                return saveFrontendRef({ notificationHandle: notificationId }, params.sealFor);
-              },
+            return {
+              handle: globalFrontendRefRegistry.restore(globalDb,
+                  { notificationHandle: notificationId }),
             };
-
-            return { handle: makeNotificationHandle(notificationId, false, persistentMethods) };
           });
         },
       },
@@ -140,11 +141,13 @@ const makeSandstormCore = (grainId) => {
   return new Capnp.Capability(new SandstormCoreImpl(grainId), SandstormCore);
 };
 
-class NotificationHandle {
-  constructor(notificationId, saved, persistentMethods) {
+class NotificationHandle extends PersistentImpl {
+  // TODO(cleanup): Move to a different file.
+
+  constructor(db, saveTemplate, notificationId) {
+    super(db, saveTemplate);
     this.notificationId = notificationId;
-    this.saved = saved;
-    _.extend(this, persistentMethods);
+    this.saved = !!saveTemplate.parentToken;  // TODO(cleanup): ugly
   }
 
   close() {
@@ -184,21 +187,24 @@ class IdenticonStaticAssetImpl {
   }
 }
 
-class PersistentUiViewImpl {
-  constructor(persistentMethods, grainId) {
+class PersistentUiViewImpl extends PersistentImpl {
+  // TODO(cleanup): Move out of core.js.
+
+  constructor(db, saveTemplate, grainId) {
+    super(db, saveTemplate);
     check(grainId, String);
+    this._db = db;
     this._grainId = grainId;
-    _.extend(this, persistentMethods);
   }
 
   getViewInfo() {
     return inMeteor(() => {
-      const grain = Grains.findOne({ _id: this._grainId, trashed: { $exists: false }, });
-      if (!grain) {
+      const grain = this._db.getGrain(this._grainId);
+      if (!grain || grain.trashed) {
         throw new Error("grain no longer exists");
       }
 
-      let pkg = Packages.findOne({ _id: grain.packageId }) ||
+      let pkg = this._db.getPackage(grain.packageId) ||
         DevPackages.findOne({ appId: grain.appId }) ||
         {};
 
@@ -231,20 +237,24 @@ class PersistentUiViewImpl {
   // and grains can't call methods on UiViews because they lack the "is human" pseudopermission.
 }
 
-const makePersistentUiView = function (persistentMethods, grainId) {
+const makePersistentUiView = function (db, saveTemplate, grainId) {
   check(grainId, String);
-  if (!Grains.findOne({ _id: grainId, trashed: { $exists: false }, })) {
+
+  // Verify that the grain exists and hasn't been trashed.
+  const grain = db.getGrain(grainId);
+  if (!grain || grain.trashed) {
     throw new Meteor.Error(404, "grain not found");
   }
 
-  return new Capnp.Capability(new PersistentUiViewImpl(persistentMethods, grainId),
+  return new Capnp.Capability(new PersistentUiViewImpl(db, saveTemplate, grainId),
                               PersistentUiView);
 };
 
-function makeNotificationHandle(notificationId, saved, persistentMethods) {
-  return new Capnp.Capability(new NotificationHandle(notificationId, saved, persistentMethods),
+globalFrontendRefRegistry.addRestoreHandler("notificationHandle",
+    (db, saveTemplate, notificationId) => {
+  return new Capnp.Capability(new NotificationHandle(db, saveTemplate, notificationId),
                               PersistentHandle);
-}
+});
 
 function dismissNotification(notificationId, callCancel) {
   const notification = Notifications.findOne({ _id: notificationId });
@@ -281,14 +291,6 @@ function dismissNotification(notificationId, callCancel) {
   }
 }
 
-hashSturdyRef = (sturdyRef) => {
-  return Crypto.createHash("sha256").update(sturdyRef).digest("base64");
-};
-
-function generateSturdyRef() {
-  return Random.secret();
-}
-
 Meteor.methods({
   dismissNotification(notificationId) {
     // This will remove notifications from the database and from view of the user.
@@ -317,6 +319,7 @@ Meteor.methods({
   },
 });
 
+// TODO(now): Get rid of this maybe?
 saveFrontendRef = (frontendRef, owner, requirements) => {
   return inMeteor(() => {
     const sturdyRef = new Buffer(generateSturdyRef());
@@ -377,7 +380,62 @@ checkRequirements = (requirements) => {
   return true;
 };
 
-restoreInternal = (originalToken, ownerPattern, requirements, tokenId, saveByCopy) => {
+const makeSaveTemplateForChild = function (parentToken, requirements, parentTokenInfo) {
+  // Constructs (part of) an ApiToken record appropriate to be used when save()ing a capability
+  // that was originally created by restore()ing `parentToken`. This fills in everything that is
+  // appropriate to fill in based only on the parent. Some fields -- especially `owner`, `created`,
+  // and `_id` -- obviously cannot be filled in until `save()` is called.
+  //
+  // `parentToken` is the raw SturdyRef of the parent.
+  //
+  // `requirements` is a list of MembraneRequirements that should be added to any children.
+  //
+  // `parentTokenInfo` is the ApiToken record for `parentToken`. Provide this only if you have
+  // it handy; if omitted it will be looked up.
+
+  parentTokenInfo = parentTokenInfo || ApiTokens.findOne(hashSturdyRef(parentToken));
+  if (!parentTokenInfo) {
+    throw new Error("no such token");
+  }
+
+  let saveTemplate;
+  if ((parentTokenInfo.owner || {}).clientPowerboxRequest) {
+    // Saving this token should make a copy of the restored token, rather than make a child
+    // token.
+
+    saveTemplate = _.clone(parentTokenInfo);
+
+    // Don't copy over fields that should be determined at save() time.
+    delete saveTemplate._id;
+    delete saveTemplate.owner;
+    delete saveTemplate.created;
+  } else {
+    if (parentTokenInfo.identityId) {
+      // A UiView token. Need to denormalize some fields from the parent.
+      saveTemplate = _.pick(parentTokenInfo, "grainId", "identityId", "accountId");
+
+      // By default, a save()d copy should have the same permissions, so set an allAccess role
+      // assignment.
+      saveTemplate.roleAssignment = { allAccess: null };
+    } else {
+      // A non-UiView child token.
+      saveTemplate = {};
+    }
+
+    // Saved token should be a child of the restored token.
+    saveTemplate.parentToken = parentTokenInfo._id;
+  }
+
+  if (requirements) {
+    // Append additional requirements requested by caller.
+    saveTemplate.requirements = (saveTemplate.requirements || []).concat(requirements);
+  }
+
+  return saveTemplate;
+}
+
+restoreInternal = (originalToken, ownerPattern, requirements, originalTokenInfo,
+                   currentTokenId) => {
   // Restores the token `originalToken`, which is a Buffer.
   //
   // `ownerPattern` is a match pattern (i.e. used with check()) that the token's owner must match.
@@ -386,25 +444,28 @@ restoreInternal = (originalToken, ownerPattern, requirements, tokenId, saveByCop
   // `requirements` is a list of additional MembraneRequirements to add to the returned capability,
   // beyond what's already stored in ApiTokens. This is often an empty list.
   //
-  // `tokenId` is optional. If specified, it should be hashSturdyRef(originalToken); only specify
-  // it if you happen to have computed this already.
+  // `originalTokenInfo` is optional. If specified, it should be the ApiToken record associated
+  // with `originalToken`. Provide this if you happen to have looked it up already.
   //
-  // By default, saving the returned capability will create a child of `originalToken`. However,
-  // if the optional `saveByCopy` parameter is set to `true`, then saving will yield a sibling
-  // of `originalToken`, with all fields other than `_id`, `owner`, and `created` copied, and with
-  // the new `requirements` appended.
-  //
-  // (When the token turns out to have a parent, this function will call itself recursively. When
-  // it does, `originalToken` stays the same, but `tokenId` is replaced with the parent. This is
-  // because the capability we ultimately restore needs to become a child of the token that is
-  // being restored.)
+  // `currentTokenId` is only provided when this function calls itself recursively. It is the
+  // _id (hashed token) of an ancestor of originalToken. The function recurses until it gets to
+  // the top-level token.
 
-  tokenId = tokenId || hashSturdyRef(originalToken);
   requirements = requirements || [];
 
-  const token = ApiTokens.findOne(tokenId);
+  if (!originalTokenInfo) {
+    originalTokenInfo = ApiTokens.findOne(hashSturdyRef(originalToken));
+    if (!originalTokenInfo) {
+      throw new Meteor.Error(403, "No token found to restore");
+    }
+  }
+
+  const token = currentTokenId ?
+      ApiTokens.findOne(currentTokenId) : originalTokenInfo;
   if (!token) {
-    throw new Meteor.Error(403, "No token found to restore");
+    if (!originalTokenInfo) {
+      throw new Meteor.Error(403, "Couldn't restore token because parent token has been deleted");
+    }
   }
 
   if (token.revoked) {
@@ -437,7 +498,8 @@ restoreInternal = (originalToken, ownerPattern, requirements, tokenId, saveByCop
   if (token.parentToken) {
     // A token which chains to some parent token.  Restore the parent token (possibly recursively),
     // checking requirements on the way up.
-    return restoreInternal(originalToken, Match.Any, requirements, token.parentToken, saveByCopy);
+    return restoreInternal(originalToken, Match.Any, requirements,
+                           originalTokenInfo, token.parentToken);
   }
 
   // Check the passed-in `requirements`.
@@ -445,46 +507,7 @@ restoreInternal = (originalToken, ownerPattern, requirements, tokenId, saveByCop
     throw new Meteor.Error(403, "Requirements not satisfied.");
   }
 
-  // The capability we restore must implement SystemPersistent, and we already know what the
-  // implementation will look like. So, construct it here.
-  //
-  // TODO(cleanup): It would probably be a lot cleaner to have a common base class that these
-  //   inherit, and to pass down some common parameters to the constructor.
-  const persistentMethods = {
-    save(params) {
-      return inMeteor(() => {
-        const sturdyRefString = saveByCopy
-            ? saveByCopyInternal(originalToken, params.sealFor, requirements, token)
-            : makeChildTokenInternal(originalToken, params.sealFor, requirements, token);
-        const sturdyRef = new Buffer(sturdyRefString);
-        return { sturdyRef };
-      });
-    },
-
-    // TODO(someday): Implement SystemPersistent.addRequirements().
-  };
-
-  if (token.frontendRef) {
-    // A token which represents a capability implemented by a pseudo-driver.
-
-    if (token.frontendRef.identity) {
-      return { cap: makeIdentity(token.frontendRef.identity, persistentMethods) };
-    } else if (token.frontendRef.notificationHandle) {
-      const notificationId = token.frontendRef.notificationHandle;
-      return { cap: makeNotificationHandle(notificationId, true, persistentMethods) };
-    } else if (token.frontendRef.ipNetwork) {
-      return { cap: makeIpNetwork(persistentMethods) };
-    } else if (token.frontendRef.ipInterface) {
-      return { cap: makeIpInterface(persistentMethods) };
-    } else if (token.frontendRef.emailVerifier) {
-      return { cap: makeEmailVerifier(
-          persistentMethods, tokenId, token.frontendRef.emailVerifier), };
-    } else if (token.frontendRef.verifiedEmail) {
-      return { cap: makeVerifiedEmail(persistentMethods) };
-    } else {
-      throw new Meteor.Error(500, "Unknown frontend token type.");
-    }
-  } else if (token.objectId) {
+  if (token.objectId) {
     // A token which represents a specific capability exported by a grain.
 
     // Fix Mongo converting Buffers to Uint8Arrays.
@@ -498,16 +521,27 @@ restoreInternal = (originalToken, ownerPattern, requirements, tokenId, saveByCop
       // discard persistentMethods.
       return supervisor.restore(token.objectId, requirements, originalToken);
     }));
-  } else if (token.grainId) {
-    // It's a UiView.
-
-    // If a grain is attempting to restore a UiView, it gets a UiView which filters out all
-    // the method calls.  In the future, we may allow grains to restore UiViews that pass along the
-    // "is human" pseudopermission (say, to allow an app to proxy all requests to some grain and
-    // do some transformation), which will return a different capability.
-    return { cap: makePersistentUiView(persistentMethods, token.grainId) };
   } else {
-    throw new Meteor.Error(500, "Unknown token type. ID: " + token._id);
+    // Construct a template ApiToken for use if the restored capability is save()d later.
+    const saveTemplate = makeSaveTemplateForChild(originalToken, requirements, originalTokenInfo);
+
+    if (token.frontendRef) {
+      // A token which represents a capability implemented by a pseudo-driver.
+
+      const cap = globalFrontendRefRegistry.restore(globalDb, saveTemplate, token.frontendRef);
+      return { cap };
+    } else if (token.grainId) {
+      // It's a UiView.
+
+      // If a grain is attempting to restore a UiView, it gets a UiView which filters out all
+      // the method calls.  In the future, we may allow grains to restore UiViews that pass along the
+      // "is human" pseudopermission (say, to allow an app to proxy all requests to some grain and
+      // do some transformation), which will return a different capability.
+      return { cap: makePersistentUiView(globalDb, saveTemplate, token.grainId) };
+    } else {
+      console.log(token);
+      throw new Meteor.Error(500, "Unknown token type. ID: " + token._id);
+    }
   }
 };
 
@@ -540,91 +574,6 @@ function dropInternal(sturdyRef, ownerPattern) {
     globalDb.removeApiTokens({ _id: hashedSturdyRef });
   }
 }
-
-function saveByCopyInternal(rawOriginalToken, owner, requirements, tokenInfo) {
-  const hashedOriginal = hashSturdyRef(rawOriginalToken);
-  tokenInfo = tokenInfo || ApiTokens.findOne(hashedOriginal);
-  if (!tokenInfo) {
-    throw new Error("parent token doesn't exist");
-  }
-
-  const sturdyRef = generateSturdyRef();
-  const hashedSturdyRef = hashSturdyRef(sturdyRef);
-
-  const newTokenInfo = _.clone(tokenInfo);
-  newTokenInfo._id = hashedSturdyRef;
-  newTokenInfo.owner = owner;
-  newTokenInfo.created = new Date();
-  newTokenInfo.requirements = (tokenInfo.requirements || []).concat(requirements);
-
-  ApiTokens.insert(newTokenInfo);
-
-  return sturdyRef;
-}
-
-function makeChildTokenInternal(rawParentToken, owner, requirements, tokenInfo) {
-  const hashedParent = hashSturdyRef(rawParentToken);
-
-  // If we don't have tokenInfo (we were called from SandstormCore.makeChildToken()), look up
-  // the parent token now and use that.
-  // TODO(someday): I think this makeChildToken() will lose titles because of this.
-  //   Option 1: Somehow pass info through the supervisor for it to pass back through
-  //       makeChildToken().
-  //   Option 2: Follow the chain of parentTokens here.
-  //   Option 3: Maybe the title should actually be passed in a PowerboxDescriptor which the app
-  //       is expected to thread through to offer(). This is analogous to how file transfers
-  //       work: the file name is not normally stored in the content. Our petname system for
-  //       grains already matches that model better -- and if we decide to get rid of said petname
-  //       system and instead have everyone see the author's title, then we'd presumably stop
-  //       storing it in the token `owner` field altogether, so this becomes moot.
-  tokenInfo = tokenInfo || ApiTokens.findOne(hashedParent);
-  if (!tokenInfo) {
-    throw new Error("parent token doesn't exist");
-  }
-
-  if (tokenInfo.identityId) {
-    // This is a UiView capability. We need to use SandstormPermissions to create it in order
-    // to properly denormalize fields.
-
-    if (owner.user) {
-      // Initialize the grain's title to a copy of the title set by the human user closest in the
-      // sharing graph. It turns out that the "root token" is actually the token representing that
-      // user, not the grain owner, because user-to-user sharing relationships are not parent-child
-      // token relationships.
-      const rootTitle = globalDb.userGrainTitle(tokenInfo.grainId, tokenInfo.accountId,
-                                                tokenInfo.identityId);
-
-      if (!owner.user.title && rootTitle) {
-        owner.user.title = rootTitle;
-      }
-    }
-
-    return SandstormPermissions.createNewApiToken(globalDb, { rawParentToken },
-        tokenInfo.grainId, tokenInfo.petname, { allAccess: null }, owner).token;
-  }
-
-  if (owner.user) {
-    throw new Error("can't save non-UiView with user as owner");
-  }
-
-  const sturdyRef = generateSturdyRef();
-  const hashedSturdyRef = hashSturdyRef(sturdyRef);
-
-  const newTokenInfo = {
-    _id: hashedSturdyRef,
-    parentToken: hashedParent,
-    owner: owner,
-    created: new Date(),
-    requirements: requirements,
-  };
-
-  // For non-UiView capabilities, we need not denormalize grainId, identityId, etc. into the child
-  // token.
-
-  ApiTokens.insert(newTokenInfo);
-
-  return sturdyRef;
-};
 
 function SandstormCoreFactoryImpl() {
 }

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -147,13 +147,11 @@ class NotificationHandle extends PersistentImpl {
   constructor(db, saveTemplate, notificationId) {
     super(db, saveTemplate);
     this.notificationId = notificationId;
-    this.saved = !!saveTemplate.parentToken;  // TODO(cleanup): ugly
   }
 
   close() {
-    const _this = this;
     return inMeteor(() => {
-      if (!_this.saved) {
+      if (!this.isSaved()) {
         dismissNotification(_this.notificationId);
       }
     });

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -539,7 +539,6 @@ restoreInternal = (originalToken, ownerPattern, requirements, originalTokenInfo,
       // do some transformation), which will return a different capability.
       return { cap: makePersistentUiView(globalDb, saveTemplate, token.grainId) };
     } else {
-      console.log(token);
       throw new Meteor.Error(500, "Unknown token type. ID: " + token._id);
     }
   }

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -153,7 +153,7 @@ class NotificationHandle extends PersistentImpl {
   close() {
     return inMeteor(() => {
       if (!this.isSaved()) {
-        dismissNotification(_this.notificationId);
+        dismissNotification(this.notificationId);
       }
     });
   }

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -121,7 +121,7 @@ class SandstormCoreImpl {
             });
 
             return {
-              handle: globalFrontendRefRegistry.restore(globalDb,
+              handle: globalFrontendRefRegistry.create(globalDb,
                   { notificationHandle: notificationId }),
             };
           });
@@ -316,22 +316,6 @@ Meteor.methods({
     Notifications.update({ userId: Meteor.userId() }, { $set: { isUnread: false } }, { multi: true });
   },
 });
-
-// TODO(now): Get rid of this maybe?
-saveFrontendRef = (frontendRef, owner, requirements) => {
-  return inMeteor(() => {
-    const sturdyRef = new Buffer(generateSturdyRef());
-    const hashedSturdyRef = hashSturdyRef(sturdyRef);
-    ApiTokens.insert({
-      _id: hashedSturdyRef,
-      frontendRef: frontendRef,
-      owner: owner,
-      created: new Date(),
-      requirements: requirements,
-    });
-    return { sturdyRef: sturdyRef };
-  });
-};
 
 checkRequirements = (requirements) => {
   if (!requirements) {

--- a/shell/server/drivers/ip.js
+++ b/shell/server/drivers/ip.js
@@ -149,10 +149,12 @@ Meteor.startup(() => {
 
     query(db, userId, value) {
       if (Meteor.users.findOne(userId).isAdmin) {
-        return [{
-          _id: "frontendref-ipinterface",
-          frontendRef: { ipInterface: true },
-        }];
+        return [
+          {
+            _id: "frontendref-ipinterface",
+            frontendRef: { ipInterface: true },
+          },
+        ];
       } else {
         return [];
       }
@@ -271,14 +273,16 @@ Meteor.startup(() => {
 
     query(db, userId, value) {
       if (Meteor.users.findOne(userId).isAdmin) {
-        return [{
-          _id: "frontendref-ipnetwork",
-          frontendRef: { ipNetwork: true },
-        }];
+        return [
+          {
+            _id: "frontendref-ipnetwork",
+            frontendRef: { ipNetwork: true },
+          },
+        ];
       } else {
         return [];
       }
-    }
+    },
   });
 });
 

--- a/shell/server/drivers/ip.js
+++ b/shell/server/drivers/ip.js
@@ -129,6 +129,30 @@ Meteor.startup(() => {
     return new Capnp.Capability(new IpInterfaceImpl(db, saveTemplate),
                                 IpRpc.PersistentIpInterface);
   });
+
+  globalFrontendRefRegistry.addValidateHandler("ipInterface", (db, session, value) => {
+    check(value, true);
+
+    if (!session.userId) {
+      throw new Meteor.Error(403, "Not logged in.");
+    }
+
+    return {
+      descriptor: { tags: [{ id: IpRpc.IpInterface.typeId }] },
+      requirements: [{ userIsAdmin: session.userId }],
+    };
+  });
+
+  globalFrontendRefRegistry.addQueryHandler(IpRpc.IpInterface.typeId, (db, userId, value) => {
+    if (Meteor.users.findOne(userId).isAdmin) {
+      return [{
+        _id: "frontendref-ipinterface",
+        frontendRef: { ipInterface: true },
+      }];
+    } else {
+      return [];
+    }
+  });
 });
 
 BoundUdpPortImpl = class BoundUdpPortImpl {
@@ -221,6 +245,30 @@ Meteor.startup(() => {
   globalFrontendRefRegistry.addRestoreHandler("ipNetwork", (db, saveTemplate) => {
     return new Capnp.Capability(new IpNetworkImpl(db, saveTemplate),
                                 IpRpc.PersistentIpNetwork);
+  });
+
+  globalFrontendRefRegistry.addValidateHandler("ipNetwork", (db, session, value) => {
+    check(value, true);
+
+    if (!session.userId) {
+      throw new Meteor.Error(403, "Not logged in.");
+    }
+
+    return {
+      descriptor: { tags: [{ id: IpRpc.IpNetwork.typeId }] },
+      requirements: [{ userIsAdmin: session.userId }],
+    };
+  });
+
+  globalFrontendRefRegistry.addQueryHandler(IpRpc.IpNetwork.typeId, (db, userId, value) => {
+    if (Meteor.users.findOne(userId).isAdmin) {
+      return [{
+        _id: "frontendref-ipnetwork",
+        frontendRef: { ipNetwork: true },
+      }];
+    } else {
+      return [];
+    }
   });
 });
 

--- a/shell/server/drivers/ip.js
+++ b/shell/server/drivers/ip.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import Bignum from "bignum";
+import { PersistentImpl } from "/imports/server/persistent.js";
 const Future = Npm.require("fibers/future");
 const Net = Npm.require("net");
 const Dgram = Npm.require("dgram");
@@ -40,9 +41,9 @@ ByteStreamConnection = class ByteStreamConnection{
   // expectSize(size) { }
 };
 
-IpInterfaceImpl = class IpInterfaceImpl {
-  constructor(persistentMethods) {
-    _.extend(this, persistentMethods);
+class IpInterfaceImpl extends PersistentImpl {
+  constructor(db, saveTemplate) {
+    super(db, saveTemplate);
   }
 
   listenTcp(portNum, port) {
@@ -121,9 +122,14 @@ IpInterfaceImpl = class IpInterfaceImpl {
   }
 };
 
-makeIpInterface = (persistentMethods) => {
-  return new Capnp.Capability(new IpInterfaceImpl(persistentMethods), IpRpc.PersistentIpInterface);
-};
+// TODO(cleanup): Meteor.startup() needed because 00-startup.js runs *after* code in subdirectories
+//   (ugh).
+Meteor.startup(() => {
+  globalFrontendRefRegistry.addRestoreHandler("ipInterface", (db, saveTemplate) => {
+    return new Capnp.Capability(new IpInterfaceImpl(db, saveTemplate),
+                                IpRpc.PersistentIpInterface);
+  });
+});
 
 BoundUdpPortImpl = class BoundUdpPortImpl {
   constructor(server, address, port) {
@@ -195,9 +201,9 @@ const addressType = (address) => {
   return type;
 };
 
-IpNetworkImpl = class IpNetworkImpl {
-  constructor(persistentMethods) {
-    _.extend(this, persistentMethods);
+class IpNetworkImpl extends PersistentImpl {
+  constructor(db, saveTemplate) {
+    super(db, saveTemplate);
   }
 
   getRemoteHost(address) {
@@ -209,9 +215,14 @@ IpNetworkImpl = class IpNetworkImpl {
   }
 };
 
-makeIpNetwork = (persistentMethods) => {
-  return new Capnp.Capability(new IpNetworkImpl(persistentMethods), IpRpc.PersistentIpNetwork);
-};
+// TODO(cleanup): Meteor.startup() needed because 00-startup.js runs *after* code in subdirectories
+//   (ugh).
+Meteor.startup(() => {
+  globalFrontendRefRegistry.addRestoreHandler("ipNetwork", (db, saveTemplate) => {
+    return new Capnp.Capability(new IpNetworkImpl(db, saveTemplate),
+                                IpRpc.PersistentIpNetwork);
+  });
+});
 
 IpRemoteHostImpl = class IpRemoteHostImpl {
   constructor(address) {

--- a/shell/server/drivers/ip.js
+++ b/shell/server/drivers/ip.js
@@ -125,33 +125,38 @@ class IpInterfaceImpl extends PersistentImpl {
 // TODO(cleanup): Meteor.startup() needed because 00-startup.js runs *after* code in subdirectories
 //   (ugh).
 Meteor.startup(() => {
-  globalFrontendRefRegistry.addRestoreHandler("ipInterface", (db, saveTemplate) => {
-    return new Capnp.Capability(new IpInterfaceImpl(db, saveTemplate),
-                                IpRpc.PersistentIpInterface);
-  });
+  globalFrontendRefRegistry.register({
+    frontendRefField: "ipInterface",
+    typeId: IpRpc.IpInterface.typeId,
 
-  globalFrontendRefRegistry.addValidateHandler("ipInterface", (db, session, value) => {
-    check(value, true);
+    restore(db, saveTemplate) {
+      return new Capnp.Capability(new IpInterfaceImpl(db, saveTemplate),
+                                  IpRpc.PersistentIpInterface);
+    },
 
-    if (!session.userId) {
-      throw new Meteor.Error(403, "Not logged in.");
-    }
+    validate(db, session, value) {
+      check(value, true);
 
-    return {
-      descriptor: { tags: [{ id: IpRpc.IpInterface.typeId }] },
-      requirements: [{ userIsAdmin: session.userId }],
-    };
-  });
+      if (!session.userId) {
+        throw new Meteor.Error(403, "Not logged in.");
+      }
 
-  globalFrontendRefRegistry.addQueryHandler(IpRpc.IpInterface.typeId, (db, userId, value) => {
-    if (Meteor.users.findOne(userId).isAdmin) {
-      return [{
-        _id: "frontendref-ipinterface",
-        frontendRef: { ipInterface: true },
-      }];
-    } else {
-      return [];
-    }
+      return {
+        descriptor: { tags: [{ id: IpRpc.IpInterface.typeId }] },
+        requirements: [{ userIsAdmin: session.userId }],
+      };
+    },
+
+    query(db, userId, value) {
+      if (Meteor.users.findOne(userId).isAdmin) {
+        return [{
+          _id: "frontendref-ipinterface",
+          frontendRef: { ipInterface: true },
+        }];
+      } else {
+        return [];
+      }
+    },
   });
 });
 
@@ -242,32 +247,37 @@ class IpNetworkImpl extends PersistentImpl {
 // TODO(cleanup): Meteor.startup() needed because 00-startup.js runs *after* code in subdirectories
 //   (ugh).
 Meteor.startup(() => {
-  globalFrontendRefRegistry.addRestoreHandler("ipNetwork", (db, saveTemplate) => {
-    return new Capnp.Capability(new IpNetworkImpl(db, saveTemplate),
-                                IpRpc.PersistentIpNetwork);
-  });
+  globalFrontendRefRegistry.register({
+    frontendRefField: "ipNetwork",
+    typeId: IpRpc.IpNetwork.typeId,
 
-  globalFrontendRefRegistry.addValidateHandler("ipNetwork", (db, session, value) => {
-    check(value, true);
+    restore(db, saveTemplate) {
+      return new Capnp.Capability(new IpNetworkImpl(db, saveTemplate),
+                                  IpRpc.PersistentIpNetwork);
+    },
 
-    if (!session.userId) {
-      throw new Meteor.Error(403, "Not logged in.");
-    }
+    validate(db, session, value) {
+      check(value, true);
 
-    return {
-      descriptor: { tags: [{ id: IpRpc.IpNetwork.typeId }] },
-      requirements: [{ userIsAdmin: session.userId }],
-    };
-  });
+      if (!session.userId) {
+        throw new Meteor.Error(403, "Not logged in.");
+      }
 
-  globalFrontendRefRegistry.addQueryHandler(IpRpc.IpNetwork.typeId, (db, userId, value) => {
-    if (Meteor.users.findOne(userId).isAdmin) {
-      return [{
-        _id: "frontendref-ipnetwork",
-        frontendRef: { ipNetwork: true },
-      }];
-    } else {
-      return [];
+      return {
+        descriptor: { tags: [{ id: IpRpc.IpNetwork.typeId }] },
+        requirements: [{ userIsAdmin: session.userId }],
+      };
+    },
+
+    query(db, userId, value) {
+      if (Meteor.users.findOne(userId).isAdmin) {
+        return [{
+          _id: "frontendref-ipnetwork",
+          frontendRef: { ipNetwork: true },
+        }];
+      } else {
+        return [];
+      }
     }
   });
 });

--- a/shell/server/drivers/mail.js
+++ b/shell/server/drivers/mail.js
@@ -331,6 +331,36 @@ class VerifiedEmailImpl extends PersistentImpl {
   }
 }
 
+function getVerifiedEmails(db, userId, verifierId) {
+  // Get all of the email addresses verified as belonging to the given user using the given
+  // verifier.
+
+  let services = null;
+
+  if (verifierId) {
+    const verifier = db.collections.apiTokens.findOne(
+        { "frontendRef.emailVerifier.id": verifierId });
+    if (!verifier) return []; // invalid verifier
+    const verifierInfo = verifier.frontendRef.emailVerifier;
+
+    if (verifierInfo.services) {
+      // Limit to the listed services.
+      services = {};
+      verifierInfo.services.forEach(service => services[service] = true);
+    }
+  }
+
+  const user = Meteor.users.findOne(userId);
+  const emails = {};  // map address -> true, for uniquification
+  Meteor.users.find({ _id: { $in: SandstormDb.getUserIdentityIds(user) } }).forEach(identity => {
+    if (!services || services[identity.profile.service]) {
+      SandstormDb.getVerifiedEmails(identity).forEach(email => { emails[email.email] = true; });
+    }
+  });
+
+  return Object.keys(emails);
+}
+
 // TODO(cleanup): Meteor.startup() needed because 00-startup.js runs *after* code in subdirectories
 //   (ugh).
 Meteor.startup(() => {
@@ -339,8 +369,86 @@ Meteor.startup(() => {
                                 EmailImpl.PersistentEmailVerifier);
   });
 
+  globalFrontendRefRegistry.addValidateHandler("emailVerifier", (db, session, value) => {
+    check(value, { services: Match.Optional([String]) });
+
+    const services = value.services;
+    if (services) {
+      services.forEach(service => {
+        if (!Accounts.identityServices[service]) {
+          throw new Error("No such identity service: " + service);
+        }
+      });
+    }
+
+    value.id = Crypto.randomBytes(16).toString("base64");
+
+    return {
+      descriptor: { tags: [{ id: EmailRpc.EmailVerifier.typeId }] },
+      requirements: [],
+    };
+  });
+
+  globalFrontendRefRegistry.addQueryHandler(
+      EmailRpc.EmailVerifier.typeId, (db, userId, value) => {
+    const results = [];
+
+    results.push({
+      _id: "emailverifier-all",
+      frontendRef: { emailVerifier: {} },
+    });
+
+    for (const name in Accounts.identityServices) {
+      if (Accounts.identityServices[name].isEnabled()) {
+        results.push({
+          _id: "emailverifier-" + name,
+          frontendRef: { emailVerifier: { services: [name] } },
+        });
+      }
+    };
+
+    return results;
+  });
+
   globalFrontendRefRegistry.addRestoreHandler("verifiedEmail", (db, saveTemplate) => {
     return new Capnp.Capability(new VerifiedEmailImpl(db, saveTemplate),
                                 EmailImpl.PersistentVerifiedEmail);
+  });
+
+  globalFrontendRefRegistry.addValidateHandler("verifiedEmail", (db, session, value) => {
+    check(value, { verifierId: Match.Optional(String), address: String });
+
+    if (!session.userId) {
+      throw new Meteor.Error(403, "Not logged in.");
+    }
+
+    // Verify that the address actually belongs to the user.
+
+    if (!_.contains(getVerifiedEmails(db, session.userId, value.verifierId), value.address)) {
+      throw new Meteor.Error(403, "User has no such verified address");
+    }
+
+    // Add the session's tabId.
+    value.tabId = session.tabId;
+
+    // Build the descriptor, which contains the verifier ID.
+    const tagValue = value.verifierId &&
+        Capnp.serialize(EmailRpc.VerifiedEmail.PowerboxTag,
+            { verifierId: new Buffer(value.verifierId, "hex") });
+
+    return {
+      descriptor: { tags: [{ id: EmailRpc.VerifiedEmail.typeId, value: tagValue }] },
+      requirements: [],
+    };
+  });
+
+  globalFrontendRefRegistry.addQueryHandler(
+      EmailRpc.VerifiedEmail.typeId, (db, userId, value) => {
+    const verifierId = value &&
+        Capnp.parse(EmailRpc.VerifiedEmail.PowerboxTag, value).verifierId.toString("base64");
+    return getVerifiedEmails(db, userId, verifierId).map(address => ({
+      _id: "email-" + address,
+      frontendRef: { verifiedEmail: { verifierId, address } },
+    }));
   });
 });

--- a/shell/server/drivers/mail.js
+++ b/shell/server/drivers/mail.js
@@ -297,7 +297,7 @@ hackSendEmail = (session, email) => {
 class EmailVerifierImpl extends PersistentImpl {
   constructor(db, saveTemplate, params) {
     super(db, saveTemplate);
-    this._id = saveTemplate.parentToken;  // TODO(now): Fix.
+    this._id = params.id;
     this._services = params.services;
   }
 

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -22,7 +22,7 @@ const Net = Npm.require("net");
 const Dgram = Npm.require("dgram");
 const Promise = Npm.require("es6-promise").Promise;
 const Capnp = Npm.require("capnp");
-import { hashSturdyRef } from "/imports/server/persistent.js";
+import { hashSturdyRef, checkRequirements } from "/imports/server/persistent.js";
 
 const EmailRpc = Capnp.importSystem("sandstorm/email.capnp");
 const HackSessionContext = Capnp.importSystem("sandstorm/hack-session.capnp").HackSessionContext;
@@ -112,9 +112,7 @@ SessionContextImpl = class SessionContextImpl {
         },
       };
 
-      if (!checkRequirements([requirement])) {
-        throw new Meteor.Error(403, "Permissions not satisfied.");
-      }
+      checkRequirements(globalDb, [requirement]);
 
       const save = castedCap.save(apiTokenOwner);
       const sturdyRef = waitPromise(save).sturdyRef;

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -22,6 +22,7 @@ const Net = Npm.require("net");
 const Dgram = Npm.require("dgram");
 const Promise = Npm.require("es6-promise").Promise;
 const Capnp = Npm.require("capnp");
+import { hashSturdyRef } from "/imports/server/persistent.js";
 
 const EmailRpc = Capnp.importSystem("sandstorm/email.capnp");
 const HackSessionContext = Capnp.importSystem("sandstorm/hack-session.capnp").HackSessionContext;
@@ -73,7 +74,7 @@ SessionContextImpl = class SessionContextImpl {
       return restoreInternal(
           new Buffer(sturdyRef),
           { clientPowerboxRequest: Match.ObjectIncluding({ grainId: this.grainId }) },
-          requirements, hashedSturdyRef, true);
+          requirements, token);
     });
   }
 

--- a/shell/server/identity.js
+++ b/shell/server/identity.js
@@ -26,7 +26,7 @@ class IdentityImpl extends PersistentImpl {
 };
 
 makeIdentity = (identityId, requriements) => {
-  var saveTemplate = { frontendRef: { identity: identityId } };
+  const saveTemplate = { frontendRef: { identity: identityId } };
   return new Capnp.Capability(new IdentityImpl(globalDb, saveTemplate, identityId),
                               IdentityRpc.PersistentIdentity);
 };

--- a/shell/server/identity.js
+++ b/shell/server/identity.js
@@ -31,8 +31,11 @@ makeIdentity = (identityId, requriements) => {
                               IdentityRpc.PersistentIdentity);
 };
 
-globalFrontendRefRegistry.addRestoreHandler("identity",
-    (db, saveTemplate, identityId) => {
-  return new Capnp.Capability(new IdentityImpl(db, saveTemplate, identityId),
-                              IdentityRpc.PersistentIdentity);
+globalFrontendRefRegistry.register({
+  frontendRefField: "identity",
+
+  restore(db, saveTemplate, identityId) {
+    return new Capnp.Capability(new IdentityImpl(db, saveTemplate, identityId),
+                                IdentityRpc.PersistentIdentity);
+  },
 });

--- a/shell/server/identity.js
+++ b/shell/server/identity.js
@@ -16,23 +16,23 @@
 
 const Capnp = Npm.require("capnp");
 const IdentityRpc = Capnp.importSystem("sandstorm/identity-impl.capnp");
+import { PersistentImpl } from "/imports/server/persistent.js";
 
-class IdentityImpl {
-  constructor(identityId, persistentMethods) {
-    _.extend(this, persistentMethods);
+class IdentityImpl extends PersistentImpl {
+  constructor(db, saveTemplate, identityId) {
+    super(db, saveTemplate);
     this.identityId = identityId;
   }
 };
 
-makeIdentity = (identityId, persistentMethods, requriements) => {
-  if (!persistentMethods) {
-    persistentMethods = {
-      save(params) {
-        return saveFrontendRef({ identity: identityId }, params.sealFor, requriements || []);
-      },
-    };
-  }
-
-  return new Capnp.Capability(new IdentityImpl(identityId, persistentMethods),
+makeIdentity = (identityId, requriements) => {
+  var saveTemplate = { frontendRef: { identity: identityId } };
+  return new Capnp.Capability(new IdentityImpl(globalDb, saveTemplate, identityId),
                               IdentityRpc.PersistentIdentity);
 };
+
+globalFrontendRefRegistry.addRestoreHandler("identity",
+    (db, saveTemplate, identityId) => {
+  return new Capnp.Capability(new IdentityImpl(db, saveTemplate, identityId),
+                              IdentityRpc.PersistentIdentity);
+});

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1173,7 +1173,7 @@ class Proxy {
         displayName: { defaultText: identity.profile.name },
         preferredHandle: identity.profile.handle,
         identityId: new Buffer(identity._id, "hex"),
-        identity: makeIdentity(identity._id, null, [idCapRequirement]),
+        identity: makeIdentity(identity._id, [idCapRequirement]),
       };
       if (identity.profile.pictureUrl) this.userInfo.pictureUrl = identity.profile.pictureUrl;
       if (identity.profile.pronoun) this.userInfo.pronouns = identity.profile.pronoun;

--- a/tests/apps/powerbox.js
+++ b/tests/apps/powerbox.js
@@ -127,7 +127,7 @@ module.exports["Test Powerbox with failing requirements"] = function (browser) {
           browser
             .switchWindow(windows.value[1])
             .waitForElementVisible(".grainlog-contents > pre", short_wait)
-            .assert.containsText(".grainlog-contents > pre", "Error: Requirements not satisfied")
+            .assert.containsText(".grainlog-contents > pre", "Error: Capability revoked because a user involved in introducing it no longer has the necessary permissions")
         });
     })
     .end();


### PR DESCRIPTION
A few things going on here:
* Creating a registry for FrontendRef types, so that it's easy to add new ones in a self-contained way.
* Getting rid of the ugly `persistentMethods` hack and instead having capability classes inherit from a common PersistentImpl class.
* Simplifying all the different code paths around save(). These turned out to have way more interlocking branches than were really needed. Note that save() no longer delegates to SandstormPermissions.createNewApiToken() -- it seemed that most of the complication of that function doesn't actually apply to the child token case anyhow. It may also be possible to simplify that function now that it's not used for this code ptah.
* Moving messy code into clean imports. @zarvox will like this.

Note that there is some unfinished work here:
* FrontendRefRegistry can register powerbox query handlers in addition to regular handlers, but I'm not actually using that functionality yet. This change only uses the registry for restore handlers.
* The various pseudo-driver implementations ought to be moved into import modules, where the main export is a function which registers the driver with some given FrontendRefRegistry. Then, 00-startup should call all the registration functions.
* core.js still contains a lot of stuff that doesn't really belong there. Again, should be refactored into imports.

I recommend reading the commits separately, though at present the middle commit contains most of the changes.