### PR TITLE
Open offered UiView immediately and dismiss the offer asynchronously

### DIFF
--- a/shell/packages/sandstorm-ui-grainview/grainview.js
+++ b/shell/packages/sandstorm-ui-grainview/grainview.js
@@ -807,9 +807,9 @@ GrainView = class GrainView {
           if (err) {
             console.error(err);
           }
-
-          Router.go("grain", { grainId: apiToken.grainId });
         });
+
+        Router.go("grain", { grainId: apiToken.grainId });
       }
     }
 


### PR DESCRIPTION
By the time we have the grainId in the offered UiView, we can open the grain
immediately.  We don't need to wait for the dismiss RPC roundtrip to complete
to open the grain, and we're unlikely to do anything in particular if the
dismiss call produces an error.