### PR TITLE
Add test for Collections app.

### DIFF
--- a/docs/administering/self-signed.md
+++ b/docs/administering/self-signed.md
@@ -107,7 +107,7 @@ You can attempt to find out if this is the problem by taking the following steps
 
 - Right-click on the grain area, where the page is not loading, and click ***Inspect** in your browser.
 
-- Look for an **IFRAME** tag, whose `id` is `grain-frame`.
+- Look for an **IFRAME** tag, whose `class` is `grain-frame`.
 
 - Attempt to load that URL in a separate tab, outside of Sandstorm.
 

--- a/shell/client/grain.html
+++ b/shell/client/grain.html
@@ -31,9 +31,9 @@
       {{/if}}
     {{else}}
     {{#if appOrigin}}
-      {{!-- Selenium requires iframes to have an id in order to select them. id="grain-frame" is only
+      {{!-- Selenium requires iframes to have an id in order to select them. `id` is only
             used for testing purposes. --}}
-      <iframe data-grainid="{{grainId}}" id="grain-frame" class="grain-frame" src="{{appOrigin}}/_sandstorm-init?sessionid={{sessionId}}&path={{originalPath}}"></iframe>
+      <iframe data-grainid="{{grainId}}" id="grain-frame-{{grainId}}" class="grain-frame" src="{{appOrigin}}/_sandstorm-init?sessionid={{sessionId}}&path={{originalPath}}"></iframe>
       {{#if hasNotLoaded}}
         {{> _grainSpinner}}
       {{/if}}

--- a/tests/apps/backgrounding.js
+++ b/tests/apps/backgrounding.js
@@ -32,6 +32,7 @@ module.exports = {};
 module.exports["Install"] = function (browser) {
   browser
     .init()
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/jparyani/background-test-0.spk", "dbed78d1ef5ed4a4f8193e829672623e", "duvq9t519fdcpetkk2s1axe1hdy91zc5svhzas2yfqpn8df9cd40")
     .assert.containsText("#grainTitle", "Untitled SandstormTest");
 };
@@ -60,6 +61,7 @@ module.exports["Test Notification"] = function (browser) {
 module.exports["Install Wakelock Dropper"] = function (browser) {
   browser
     .init()
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/jparyani/background-test-drop-wakelock-1.spk", "963745fa41d602dfc7467cac2e1597b5", "duvq9t519fdcpetkk2s1axe1hdy91zc5svhzas2yfqpn8df9cd40")
     .assert.containsText("#grainTitle", "Untitled SandstormTest");
 };

--- a/tests/apps/collections.js
+++ b/tests/apps/collections.js
@@ -1,0 +1,243 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+"use strict";
+
+var crypto = require("crypto");
+var utils = require("../utils"),
+    short_wait = utils.short_wait,
+    medium_wait = utils.medium_wait,
+    long_wait = utils.long_wait;
+
+var COLLECTIONS_APP_ID = "s3u2xgmqwznz2n3apf30sm3gw1d85y029enw5pymx734cnk5n78h";
+var COLLECTIONS_PACKAGE_ID = "f636f1239d9bd0eace4de2f7e238b633";
+var COLLECTIONS_PACKAGE_URL = "https://sandstorm.io/apps/david/collections1.spk";
+
+module.exports = {};
+
+function setGrainTitle(browser, collectionTitle) {
+  return browser
+    .waitForElementVisible("#grainTitle", short_wait)
+    .click("#grainTitle")
+    .setAlertText(collectionTitle)
+    .acceptAlert()
+    .grainFrame()
+    .waitForElementVisible("button[title='add description']", short_wait)
+    .click("button[title='add description']")
+    .waitForElementVisible("form.description-row>textarea", short_wait)
+    .setValue("form.description-row>textarea", "This is " + collectionTitle)
+    .click("form.description-row>button")
+    .frame(null)
+}
+
+function powerboxCardSelector(grainId) {
+  return ".popup.request .candidate-cards .powerbox-card button[data-card-id=grain-" + grainId + "]";
+}
+
+module.exports["Test Collections"] = function (browser) {
+  // Prepend 'A' so that the default handle is valid.
+  var devNameAlice = "A" + crypto.randomBytes(10).toString("hex");
+  var devNameBob = "A" + crypto.randomBytes(10).toString("hex");
+  var devNameCarol = "A" + crypto.randomBytes(10).toString("hex");
+  var devIdentityAlice = crypto.createHash("sha256").update("dev:" + devNameAlice).digest("hex");
+  var devIdentityBob = crypto.createHash("sha256").update("dev:" + devNameBob).digest("hex");
+  var devIdentityCarol = crypto.createHash("sha256").update("dev:" + devNameCarol).digest("hex");
+
+  browser = browser
+    .init()
+    .loginDevAccount(devNameAlice)
+    .installApp(COLLECTIONS_PACKAGE_URL, COLLECTIONS_PACKAGE_ID, COLLECTIONS_APP_ID);
+  browser = setGrainTitle(browser, "Collection A");
+
+  browser.executeAsync(function (bobIdentityId, done) {
+    // Share Collection A to Bob.
+    var grainId = Grains.findOne()._id;
+    Meteor.call("newApiToken", { identityId: Meteor.user().loginIdentities[0].id },
+                grainId, "petname", { allAccess: null },
+                { user: { identityId: bobIdentityId, title: "Collection A", } },
+                function(error, result) {
+                  done({ error: error, grainId: grainId, });
+                });
+  }, [devIdentityBob], function (result) {
+    var grainIdA = result.value.grainId;
+    browser.assert.equal(!result.value.error, true);
+    browser.newGrain(COLLECTIONS_APP_ID, function (grainIdB) {
+      browser = setGrainTitle(browser, "Collection B");
+
+      browser.newGrain(COLLECTIONS_APP_ID, function (grainIdC) {
+        browser = setGrainTitle(browser, "Collection C");
+
+        browser = browser
+          .url(browser.launch_url + "/grain/" + grainIdA)
+          .grainFrame()
+          .waitForElementVisible("table.grain-list-table>tbody>tr.add-grain>td>button", medium_wait)
+          .click("table.grain-list-table>tbody>tr.add-grain>td>button")
+          .frame(null)
+          .waitForElementVisible(powerboxCardSelector(grainIdB), short_wait)
+          .click(powerboxCardSelector(grainIdB))
+          // Add with 'editor' permissions.
+          .waitForElementVisible(".popup.request .selected-card>form input[value='0']", short_wait)
+          .click(".popup.request .selected-card>form input[value='0']")
+          .click(".popup.request .selected-card>form button.connect-button")
+
+          .grainFrame()
+          .waitForElementVisible("table.grain-list-table>tbody>tr.add-grain>td>button", short_wait)
+          .click("table.grain-list-table>tbody>tr.add-grain>td>button")
+          .frame(null)
+          .waitForElementVisible(powerboxCardSelector(grainIdC), short_wait)
+          .click(powerboxCardSelector(grainIdC))
+          // Add with 'viewer' permissions.
+          .waitForElementVisible(".popup.request .selected-card>form input[value='1']", short_wait)
+          .click(".popup.request .selected-card>form input[value='1']")
+          .click(".popup.request .selected-card>form button.connect-button")
+
+          .grainFrame()
+          .waitForElementVisible("table.grain-list-table>tbody tr:nth-child(3).grain", short_wait)
+          .click("table.grain-list-table>tbody tr:nth-child(3).grain .click-to-go")
+          .frame(null)
+
+          .grainFrame(grainIdC)
+          .waitForElementVisible(".description-row p", short_wait)
+          .assert.containsText(".description-row p", "This is Collection C")
+          .waitForElementVisible(".description-row button.description-button", short_wait)
+          .frame(null)
+
+          .execute("window.Meteor.logout()")
+
+          // Log in as Bob
+          .loginDevAccount(devNameBob)
+          .url(browser.launch_url + "/grain/" + grainIdA)
+          .grainFrame()
+          .waitForElementVisible(".description-row p", short_wait)
+          .assert.containsText(".description-row p", "This is Collection A")
+          .waitForElementVisible(".description-row button.description-button", short_wait)
+
+          .waitForElementVisible("table.grain-list-table>tbody>tr.add-grain>td>button", short_wait)
+          .waitForElementVisible("table.grain-list-table>tbody tr:nth-child(2).grain", short_wait)
+          .assert.containsText("table.grain-list-table>tbody tr:nth-child(2).grain td>a",
+                               "Collection B")
+          .click("table.grain-list-table>tbody tr:nth-child(2).grain .click-to-go")
+          .frame(null)
+
+          .grainFrame(grainIdB)
+          .waitForElementVisible(".description-row p", short_wait)
+          .assert.containsText(".description-row p", "This is Collection B")
+          .waitForElementVisible(".description-row button.description-button", short_wait)
+
+          // As Bob, add collection A to collection B, creating a cycle of references.
+          .waitForElementVisible("table.grain-list-table>tbody>tr.add-grain>td>button", short_wait)
+          .click("table.grain-list-table>tbody>tr.add-grain>td>button")
+          .frame(null)
+          .waitForElementVisible(powerboxCardSelector(grainIdA), short_wait)
+          .click(powerboxCardSelector(grainIdA))
+          // Add with 'viewer' permissions.
+          .waitForElementVisible(".popup.request .selected-card>form input[value='1']", short_wait)
+          .click(".popup.request .selected-card>form input[value='1']")
+          .click(".popup.request .selected-card>form button.connect-button")
+
+          // Navigate back to collection A by clicking on it in collection B.
+          .grainFrame()
+          .waitForElementVisible("table.grain-list-table>tbody tr:nth-child(2).grain", short_wait)
+          .click("table.grain-list-table>tbody tr:nth-child(2).grain .click-to-go")
+          .frame(null)
+
+          .grainFrame(grainIdA)
+          .waitForElementVisible("table.grain-list-table>tbody>tr.add-grain>td>button", short_wait)
+          .waitForElementVisible("table.grain-list-table>tbody tr:nth-child(3).grain", short_wait)
+          .assert.containsText("table.grain-list-table>tbody tr:nth-child(3).grain td>a",
+                               "Collection C")
+          .click("table.grain-list-table>tbody tr:nth-child(3).grain .click-to-go")
+          .frame(null)
+
+          .grainFrame(grainIdC)
+          .waitForElementVisible(".description-row p", short_wait)
+          .assert.containsText(".description-row p", "This is Collection C")
+          .assert.elementNotPresent(".description-row button.description-button")
+
+          .frame(null)
+          .executeAsync(function (carolIdentityId, grainIdB, done) {
+            // As Bob, share Collection B to Carol.
+            Meteor.call("newApiToken", { identityId: Meteor.user().loginIdentities[0].id },
+                grainIdB, "petname", { allAccess: null },
+                { user: { identityId: carolIdentityId, title: "Collection B", } },
+                function(error, result) {
+                  done({ error: error });
+                });
+          }, [devIdentityCarol, grainIdB], function (result) {
+            browser.assert.equal(!result.value.error, true);
+            browser
+              .execute("window.Meteor.logout()")
+
+              // Log in as Carol
+              .loginDevAccount(devNameCarol)
+              .url(browser.launch_url + "/grain/" + grainIdB)
+              .grainFrame()
+              .waitForElementVisible(".description-row p", short_wait)
+              .assert.containsText(".description-row p", "This is Collection B")
+              .waitForElementVisible(".description-row button.description-button", short_wait)
+
+              .waitForElementVisible("table.grain-list-table>tbody tr:nth-child(2).grain",
+                                     short_wait)
+              .assert.containsText("table.grain-list-table>tbody tr:nth-child(2).grain td>a",
+                                   "Collection A")
+              .click("table.grain-list-table>tbody tr:nth-child(2).grain .click-to-go")
+
+              .grainFrame(grainIdA)
+
+              .waitForElementVisible(".description-row p", short_wait)
+              .assert.containsText(".description-row p", "This is Collection A")
+
+              // Carol does not have edit permissions.
+              .assert.elementNotPresent(".description-row button.description-button")
+              .frame(null)
+
+              .execute("window.Meteor.logout()")
+
+              // Log back in as Alice
+              .loginDevAccount(devNameAlice)
+              .url(browser.launch_url + "/grain/" + grainIdA)
+              .disableGuidedTour()
+              .grainFrame()
+
+              // Unlink collection B from collection A.
+              .waitForElementVisible("table.grain-list-table>tbody tr:nth-child(3).grain",
+                                     short_wait)
+              .waitForElementVisible("table.grain-list-table>tbody tr:nth-child(2).grain",
+                                     short_wait)
+              .assert.containsText("table.grain-list-table>tbody tr:nth-child(2).grain td>a",
+                                   "Collection B")
+              .click("table.grain-list-table>tbody tr:nth-child(2).grain td>input[type=checkbox]")
+              .waitForElementVisible(".bulk-action-buttons>button[title='unlink selected grains']",
+                                     short_wait)
+              .click(".bulk-action-buttons>button[title='unlink selected grains']")
+
+              .frame(null)
+              .execute("window.Meteor.logout()")
+
+              // Log back in as Carol. Check that she can no longer access collection A.
+              .loginDevAccount(devNameCarol)
+
+              // Add some characters onto the end of the URL because otherwise we trigger
+              // the grain-tab restore logic and tabs open for both Collection A and Collection B.
+              .url(browser.launch_url + "/grain/" + grainIdA + "/#")
+
+              .waitForElementVisible(".grain-interstitial.request-access", medium_wait)
+              .end();
+          });
+      });
+    });
+  });
+};

--- a/tests/apps/ip-networking.js
+++ b/tests/apps/ip-networking.js
@@ -31,19 +31,20 @@ module.exports = {};
 
 module.exports["Test Ip Networking"] = function (browser) {
   browser
+    .loginDevAccount(null, true)
     // sandstorm-test-python: David's branch that updates for the new claimRequest() flow.
     .installApp("http://sandstorm.io/apps/david/sandstorm-test-python4.spk",
                 "874e67d3cd02486198d046909149723c",
-                "umeqc9yhncg63fjj6sahtw30nf99kfm6tgkuz8rmhn5dqtusnwah", false, true)
+                "umeqc9yhncg63fjj6sahtw30nf99kfm6tgkuz8rmhn5dqtusnwah")
     .assert.containsText("#grainTitle", "Untitled Test App test page")
     .waitForElementVisible('.grain-frame', short_wait)
-    .frame("grain-frame")
+    .grainFrame()
       .waitForElementVisible("#powerbox-request-ipnetwork", short_wait)
       .click("#powerbox-request-ipnetwork")
     .frameParent()
     .waitForElementVisible(".popup.request .candidate-cards .powerbox-card button[data-card-id=frontendref-ipnetwork]", short_wait)
     .click(".popup.request .candidate-cards .powerbox-card button[data-card-id=frontendref-ipnetwork]")
-    .frame("grain-frame")
+    .grainFrame()
       .waitForElementVisible("span.token", short_wait)
       .waitForElementVisible("form.test-ip-network input[type=text]", short_wait)
       .setValue("form.test-ip-network input[type=text]", "http://build.sandstorm.io")
@@ -55,19 +56,20 @@ module.exports["Test Ip Networking"] = function (browser) {
 
 module.exports["Test Ip Interface"] = function (browser) {
   browser
+    .loginDevAccount(null, true)
     // sandstorm-test-python: David's branch that updates for the new claimRequest() flow.
     .installApp("http://sandstorm.io/apps/david/sandstorm-test-python4.spk",
                 "874e67d3cd02486198d046909149723c",
-                "umeqc9yhncg63fjj6sahtw30nf99kfm6tgkuz8rmhn5dqtusnwah", false, true)
+                "umeqc9yhncg63fjj6sahtw30nf99kfm6tgkuz8rmhn5dqtusnwah")
     .assert.containsText("#grainTitle", "Untitled Test App test page")
     .waitForElementVisible('.grain-frame', short_wait)
-    .frame("grain-frame")
+    .grainFrame()
       .waitForElementVisible("#powerbox-request-ipinterface", short_wait)
       .click("#powerbox-request-ipinterface")
     .frameParent()
     .waitForElementVisible(".popup.request .candidate-cards .powerbox-card button[data-card-id=frontendref-ipinterface]", short_wait)
     .click(".popup.request .candidate-cards .powerbox-card button[data-card-id=frontendref-ipinterface]")
-    .frame("grain-frame")
+    .grainFrame()
       .waitForElementVisible("span.token", short_wait)
       .waitForElementVisible("form.test-ip-interface input[type=number]", short_wait)
       .setValue("form.test-ip-interface input[type=number]", IP_INTERFACE_TEST_PORT)

--- a/tests/apps/powerbox.js
+++ b/tests/apps/powerbox.js
@@ -32,12 +32,13 @@ module.exports = {};
 module.exports["Test Powerbox"] = function (browser) {
   browser
     .init()
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app4.spk",
                 "f855d3c96e18e785a3a734a49919ef18",
                 "ygpudg61w49gg0x1t2gw4p7q2q7us24gxsyr1as1hf0ezn2uycth")
     .assert.containsText("#grainTitle", "Untitled PowerboxTest")
     .waitForElementVisible('.grain-frame', short_wait)
-    .frame("grain-frame")
+    .grainFrame()
     .waitForElementVisible("#offer", short_wait)
     .click("#offer")
     .waitForElementVisible("#offer-result", short_wait)
@@ -47,13 +48,13 @@ module.exports["Test Powerbox"] = function (browser) {
     .getText("#powerbox-offer-url", function (result) {
         browser
           .click(".popup.offer .frame button.dismiss")
-          .frame("grain-frame")
+          .grainFrame()
           .click("#request")
           .frameParent()
           .waitForElementVisible("#powerbox-request-input", short_wait)
           .setValue("#powerbox-request-input", result.value)
           .click("#powerbox-request-form button")
-          .frame("grain-frame")
+          .grainFrame()
           .waitForElementVisible("#request-result", short_wait)
           .assert.containsText("#request-result", "request: footest");
     });
@@ -64,12 +65,13 @@ module.exports["Test PowerboxSave"] = function (browser) {
   browser
     browser
     .init()
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app4.spk",
                 "f855d3c96e18e785a3a734a49919ef18",
                 "ygpudg61w49gg0x1t2gw4p7q2q7us24gxsyr1as1hf0ezn2uycth")
     .assert.containsText("#grainTitle", "Untitled PowerboxTest")
     .waitForElementVisible('.grain-frame', short_wait)
-    .frame("grain-frame")
+    .grainFrame()
     .waitForElementVisible("#offer", short_wait)
     .click("#offer")
     .waitForElementVisible("#offer-result", short_wait)
@@ -79,13 +81,13 @@ module.exports["Test PowerboxSave"] = function (browser) {
     .getText("#powerbox-offer-url", function (result) {
         browser
           .click(".popup.offer .frame button.dismiss")
-          .frame("grain-frame")
+          .grainFrame()
           .click("#request-save-restore")
           .frameParent()
           .waitForElementVisible("#powerbox-request-input", short_wait)
           .setValue("#powerbox-request-input", result.value)
           .click("#powerbox-request-form button")
-          .frame("grain-frame")
+          .grainFrame()
           .waitForElementVisible("#request-result", short_wait)
           .assert.containsText("#request-result", "request: footest");
     });
@@ -96,6 +98,7 @@ module.exports["Test PowerboxSave"] = function (browser) {
 module.exports["Test Powerbox with failing requirements"] = function (browser) {
   browser
     .init()
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app4.spk",
                 "f855d3c96e18e785a3a734a49919ef18",
                 "ygpudg61w49gg0x1t2gw4p7q2q7us24gxsyr1as1hf0ezn2uycth")
@@ -104,7 +107,7 @@ module.exports["Test Powerbox with failing requirements"] = function (browser) {
     // We'll use the debugLog at the bottom of the test, but it's nice to open it early and give it time to load.
     .click("#openDebugLog")
     .waitForElementVisible('.grain-frame', short_wait)
-    .frame("grain-frame")
+    .grainFrame()
     .waitForElementVisible("#offer", short_wait)
     .click("#offer")
     .waitForElementVisible("#offer-result", short_wait)
@@ -114,13 +117,13 @@ module.exports["Test Powerbox with failing requirements"] = function (browser) {
     .getText("#powerbox-offer-url", function (result) {
        browser
         .click(".popup.offer .frame button.dismiss")
-        .frame("grain-frame")
+        .grainFrame()
         .click("#request-failing-requirements")
         .frame()
         .waitForElementVisible("#powerbox-request-input", short_wait)
         .setValue("#powerbox-request-input", result.value)
         .click("#powerbox-request-form button")
-        .frame("grain-frame")
+        .grainFrame()
         .waitForElementVisible("#request-result", short_wait)
         .assert.containsText("#request-result", "request:")
         .windowHandles(function (windows) {

--- a/tests/apps/roundcube.js
+++ b/tests/apps/roundcube.js
@@ -26,6 +26,7 @@ module.exports = {};
 
 module.exports["Install"] = function (browser) {
   browser
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/jparyani/roundcube-6.spk", "373a821a7a9cde5b13258922046fe217", "0qhha1v9ne1p42s5jw7r6qq6rt5tcx80zpg1f5ptsg7ryr4hws1h")
     .assert.containsText("#grainTitle", "Untitled Roundcube mailbox");
 };
@@ -34,7 +35,7 @@ module.exports["Install"] = function (browser) {
 module.exports["Incoming Mail"] = function (browser) {
   browser
     .waitForElementVisible('.grain-frame', short_wait)
-    .frame("grain-frame")
+    .grainFrame()
     .waitForElementVisible(".button-settings", short_wait)
     .pause(short_wait) // Roundcube seems to swallow the click if you click while it's doing the initial mailbox load AJAX, sadly.
     .click(".button-settings")
@@ -57,7 +58,6 @@ module.exports["Incoming Mail"] = function (browser) {
             .waitForElementVisible(".mailbox.inbox > a", medium_wait)
             .click(".mailbox.inbox > a") // Make sure we have the inbox selected
             .pause(short_wait) // It's sad, but there's no good way to wait for the mail to be delivered other than pausing
-            .frame("grain-frame")
             .click(".mailbox.inbox > a") // This is equivalent to refreshing the inbox
             .waitForElementVisible("#messagelist tbody tr:nth-child(1)", short_wait)
             .assert.containsText("#messagelist tbody tr:nth-child(1) .subject", "Hello world email");

--- a/tests/apps/web-publishing.js
+++ b/tests/apps/web-publishing.js
@@ -33,11 +33,12 @@ module.exports = {};
 module.exports["Basic web publishing"] = function (browser) {
   browser
     .init()
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/jparyani/web-publishing-1.spk",
       "ea3ef5ac80af4fb8041c635185b2a10f", "qkag0k1ta3guun74g4rxx4xfqun8a3d7vsagh3843cvvxhh6n8s0")
     .assert.containsText("#grainTitle", "Untitled WebPublishingTest grain")
     .waitForElementVisible(".grain-frame", short_wait)
-    .frame("grain-frame")
+    .grainFrame()
     .waitForElementVisible("#public-address", short_wait)
     .getText("#public-address", function (result) {
       this
@@ -52,11 +53,12 @@ module.exports["Basic web publishing"] = function (browser) {
 module.exports["Web publishing with grain shutdown"] = function (browser) {
   browser
     .init()
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/jparyani/web-publishing-1.spk",
       "ea3ef5ac80af4fb8041c635185b2a10f", "qkag0k1ta3guun74g4rxx4xfqun8a3d7vsagh3843cvvxhh6n8s0")
     .assert.containsText("#grainTitle", "Untitled WebPublishingTest grain")
     .waitForElementVisible(".grain-frame", short_wait)
-    .frame("grain-frame")
+    .grainFrame()
     .waitForElementVisible("#public-address", short_wait)
     .getText("#public-address", function (result) {
       this

--- a/tests/commands/grainFrame.js
+++ b/tests/commands/grainFrame.js
@@ -1,0 +1,45 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+"use strict";
+
+var utils = require("../utils"),
+    short_wait = utils.short_wait,
+    medium_wait = utils.medium_wait,
+    long_wait = utils.long_wait,
+    very_long_wait = utils.very_long_wait;
+
+exports.command = function(grainId) {
+  // Focuses on the iframe for `grainId`. If `grainId` is null, uses the currently-active grain.
+
+  var self = this
+      .frame()
+      .waitForElementPresent("iframe.grain-frame", short_wait);
+
+  if (grainId) {
+    return self.waitForElementVisible("#grain-frame-" + grainId, medium_wait)
+      .frame("grain-frame-" + grainId);
+  } else {
+    return self.execute(function () {
+      return window.globalGrains.getActive().grainId();
+    }, [], function (result) {
+      var grainId = result.value;
+      self
+        .waitForElementVisible("#grain-frame-" + grainId, short_wait)
+        .frame("grain-frame-" + grainId);
+    });
+  }
+};

--- a/tests/tests/apihost.js
+++ b/tests/tests/apihost.js
@@ -30,11 +30,12 @@ module.exports = {
 module.exports['Install and launch test app'] = function (browser) {
   browser
     .init()
+    .loginDevAccount()
     // Test app code: https://github.com/kentonv/apihost-testapp
     .installApp("https://alpha-qkhxczi7kki1x49pfakw.sandstorm.io/apihost-testapp.spk", "1c3b4825b0f383c0641c01fdbc47dc07", "w304h9n5rjx1pzfa8e4guheue5mq3dkwv63aajy1rscupw6e38mh")
     .assert.containsText('#grainTitle', 'Untitled ApiHost test app instance')
-    .frame('grain-frame')
-      .waitForElementPresent('iframe', medium_wait)
+    .grainFrame()
+    .waitForElementPresent('iframe', medium_wait)
     .frameParent()
     .url(undefined, function (response) {
       var grainUrl = response.value;
@@ -48,7 +49,7 @@ var grainId = undefined;
 
 module.exports['Test renderTemplate with static host info'] = function (browser) {
   browser
-    .frame('grain-frame')
+    .grainFrame()
       .waitForElementVisible('iframe[src]', short_wait)
       .frame('offer-template')
         .waitForElementPresent('#text', short_wait)

--- a/tests/tests/appdemo.js
+++ b/tests/tests/appdemo.js
@@ -27,6 +27,7 @@ module.exports = {};
 
 module.exports["Test appdemo link"] = function (browser) {
   browser
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk",
                 "ca690ad886bf920026f8b876c19539c1",
                 "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh",
@@ -39,7 +40,7 @@ module.exports["Test appdemo link"] = function (browser) {
     .assert.containsText(".start", "Hacker CMS")
     .click(".start")
     .waitForElementPresent("iframe.grain-frame", short_wait)
-    .frame("grain-frame")
+    .grainFrame()
     .waitForElementPresent("#publish", medium_wait)
     .assert.containsText("#publish", "Publish")
     .end();

--- a/tests/tests/autoupdate.js
+++ b/tests/tests/autoupdate.js
@@ -28,6 +28,7 @@ module.exports = {};
 module.exports["Test autoupdates"] = function (browser) {
   var appId = "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh";
   browser
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk",
                 "ca690ad886bf920026f8b876c19539c1",
                 appId,

--- a/tests/tests/backup-restore.js
+++ b/tests/tests/backup-restore.js
@@ -93,11 +93,12 @@ module.exports["Test backup and restore"] = function(browser) {
   //v0: /install/9111a8c70938276d28a00468a18a25c7?url=https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-0.spk
   //v1: /install/f5fe6aa9fcbccc690fd36a86efe02b8a?url=https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-1.spk
   browser
+    .loginDevAccount()
     // sandstorm-test-python, v0
     .installApp("https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-0.spk", "9111a8c70938276d28a00468a18a25c7", "rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh")
     .assert.containsText('#grainTitle', 'Untitled Test App test page')
     .waitForElementVisible('.grain-frame', short_wait)
-    .frame('grain-frame')
+    .grainFrame()
     .waitForElementPresent('#randomId', medium_wait)
     .assert.containsText('#randomId', 'initial state')
     .setValue("#state", [randomValue, browser.Keys.ENTER])
@@ -174,7 +175,7 @@ module.exports["Test backup and restore"] = function(browser) {
     .waitForElementVisible('#grainTitle', medium_wait)
     .assert.containsText('#grainTitle', 'Untitled Test App test page')
     .waitForElementVisible('.grain-frame', short_wait)
-    .frame('grain-frame')
+    .grainFrame()
     .waitForElementPresent('#randomId', medium_wait)
     .assert.containsText('#randomId', randomValue)
     .frame(null)

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -134,10 +134,9 @@ module.exports = utils.testAllLogins({
 
   "Test grain frame" : function (browser) {
     browser
-      .waitForElementPresent('iframe.grain-frame', short_wait)
-      .frame('grain-frame')
-        .waitForElementPresent('#publish', medium_wait)
-        .assert.containsText('#publish', 'Publish')
+      .grainFrame()
+      .waitForElementPresent('#publish', medium_wait)
+      .assert.containsText('#publish', 'Publish')
       .frameParent();
   },
 
@@ -145,9 +144,9 @@ module.exports = utils.testAllLogins({
     browser
       .click('#restartGrain')
       .pause(short_wait)
-      .frame('grain-frame')
-        .waitForElementPresent('#publish', medium_wait)
-        .assert.containsText('#publish', 'Publish')
+      .grainFrame()
+      .waitForElementPresent('#publish', medium_wait)
+      .assert.containsText('#publish', 'Publish')
       .frameParent();
   },
 
@@ -180,6 +179,7 @@ module.exports["Test grain not found"] = function (browser) {
 
 module.exports["Sign in at grain URL"] = function (browser) {
   browser
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
     .waitForElementVisible("#grainTitle", medium_wait)
     .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
@@ -193,10 +193,10 @@ module.exports["Sign in at grain URL"] = function (browser) {
             .waitForElementVisible(".request-access", medium_wait)
             .assert.containsText(".request-access", "Please sign in to request access.")
             .execute(function (name) { window.loginDevAccount(name) }, [devName.value])
-            .waitForElementVisible("#grain-frame", medium_wait)
+            .waitForElementVisible("iframe.grain-frame", medium_wait)
             .waitForElementVisible("#grainTitle", medium_wait)
             .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
-            .frame("grain-frame")
+            .grainFrame()
             .waitForElementPresent("#publish", medium_wait)
             .assert.containsText("#publish", "Publish")
             .frame(null)
@@ -215,7 +215,7 @@ module.exports["Sign in at grain URL"] = function (browser) {
                     .execute("window.Meteor.logout()")
                     .url(browser.launch_url)
                     .url(response.value)
-                    .waitForElementVisible("#grain-frame", medium_wait)
+                    .waitForElementVisible("iframe.grain-frame", medium_wait)
                     .waitForElementVisible("#grainTitle", medium_wait)
                     .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
                     .execute(function (name) { window.loginDevAccount(name) }, [otherName])
@@ -229,9 +229,9 @@ module.exports["Sign in at grain URL"] = function (browser) {
                     // The forget grain button only appears once we've logged in.
                     .waitForElementVisible("#deleteGrain", medium_wait)
                     .waitForElementVisible("#grainTitle", medium_wait)
-                    .waitForElementVisible("#grain-frame", medium_wait)
+                    .waitForElementVisible("iframe.grain-frame", medium_wait)
                     .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
-                    .frame("grain-frame")
+                    .grainFrame()
                     .waitForElementPresent("#publish", medium_wait)
                     .assert.containsText("#publish", "Publish")
                     .frame(null)
@@ -242,7 +242,7 @@ module.exports["Sign in at grain URL"] = function (browser) {
                     .execute("window.Meteor.logout()")
                     .url(browser.launch_url)
                     .url(response.value)
-                    .waitForElementVisible("#grain-frame", medium_wait)
+                    .waitForElementVisible("iframe.grain-frame", medium_wait)
                     .waitForElementVisible("#grainTitle", medium_wait)
                     .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
                     .execute(function (name) { window.loginDevAccount(name) }, [otherName])
@@ -250,9 +250,9 @@ module.exports["Sign in at grain URL"] = function (browser) {
                     // The forget grain button only appears once we've logged in.
                     .waitForElementVisible("#deleteGrain", medium_wait)
                     .waitForElementVisible("#grainTitle", medium_wait)
-                    .waitForElementVisible("#grain-frame", medium_wait)
+                    .waitForElementVisible("iframe.grain-frame", medium_wait)
                     .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
-                    .frame("grain-frame")
+                    .grainFrame()
                     .waitForElementPresent("#publish", medium_wait)
                     .assert.containsText("#publish", "Publish")
                     .frame(null)
@@ -266,6 +266,7 @@ module.exports["Sign in at grain URL"] = function (browser) {
 
 module.exports["Logging out closes grain"] = function (browser) {
   browser
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
     .waitForElementVisible("#grainTitle", medium_wait)
     .assert.containsText("#grainTitle", expectedHackerCMSGrainTitle)
@@ -284,6 +285,7 @@ module.exports["Logging out closes grain"] = function (browser) {
 module.exports["Test grain anonymous user"] = function (browser) {
   browser
     // Upload app as normal user
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
     .waitForElementVisible('#grainTitle', medium_wait)
     .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
@@ -310,7 +312,7 @@ module.exports["Test grain anonymous user"] = function (browser) {
         .url(response.value)
         .waitForElementVisible('#grainTitle', medium_wait)
         .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
-        .frame('grain-frame')
+        .grainFrame()
         .waitForElementPresent('#publish', medium_wait)
         .assert.containsText('#publish', 'Publish')
         .frame(null)
@@ -324,6 +326,7 @@ module.exports["Test roleless sharing"] = function (browser) {
   var secondUserName;
   browser
   // Upload app as 1st user
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
     .getDevName(function (result) {
       firstUserName = result.value;
@@ -349,7 +352,7 @@ module.exports["Test roleless sharing"] = function (browser) {
         .click("button.pick-identity")
         .waitForElementVisible('.grain-frame', medium_wait)
         .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
-        .frame('grain-frame')
+        .grainFrame()
         .waitForElementPresent('#publish', medium_wait)
         .assert.containsText('#publish', 'Publish')
         .frame(null)
@@ -369,7 +372,7 @@ module.exports["Test roleless sharing"] = function (browser) {
             .click("button.pick-identity")
             .waitForElementVisible('.grain-frame', medium_wait)
             .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
-            .frame('grain-frame')
+            .grainFrame()
             .waitForElementPresent('#publish', medium_wait)
             .assert.containsText('#publish', 'Publish')
             .frame(null)
@@ -400,6 +403,7 @@ module.exports["Test roleless sharing"] = function (browser) {
 module.exports["Test role sharing"] = function (browser) {
   browser
     // Upload app as 1st user
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/david/gitweb5.spk",
                 "26eb486a44085512a678c543fc7c1fdd",
                 "6va4cjamc21j0znf5h5rrgnv0rpyvh1vaxurkrgknefvj0x63ash")
@@ -422,7 +426,7 @@ module.exports["Test role sharing"] = function (browser) {
         .click("button.pick-identity")
         .waitForElementVisible('.grain-frame', medium_wait)
         .assert.containsText('#grainTitle', expectedGitWebGrainTitle)
-        .frame('grain-frame')
+        .grainFrame()
         .waitForElementPresent('#offer-iframe', medium_wait) // Wait for GitWeb's offer iframe.
         .frame(null)
         .click('.topbar .share > .show-popup')
@@ -442,7 +446,7 @@ module.exports["Test role sharing"] = function (browser) {
             .click("button.pick-identity")
             .waitForElementVisible('.grain-frame', medium_wait)
             .assert.containsText('#grainTitle', expectedGitWebGrainTitle)
-            .frame('grain-frame')
+            .grainFrame()
             .waitForElementPresent('#offer-iframe', medium_wait) // Wait for GitWeb's offer iframe.
             .frame(null)
             .click('.topbar .share > .show-popup')
@@ -459,7 +463,8 @@ module.exports["Test role sharing"] = function (browser) {
 
 module.exports["Test grain identity chooser interstitial"] = function (browser) {
   browser
-    // Upload app as normal user
+     // Upload app as normal user
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
     .waitForElementVisible('.grain-frame', medium_wait)
     .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
@@ -476,7 +481,7 @@ module.exports["Test grain identity chooser interstitial"] = function (browser) 
         .url(shareLink.value)
         .waitForElementVisible('.grain-frame', medium_wait)
         .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
-        .frame('grain-frame')
+        .grainFrame()
         .waitForElementPresent('#publish', medium_wait)
         .assert.containsText('#publish', 'Publish')
         .frame(null)
@@ -496,7 +501,7 @@ module.exports["Test grain identity chooser interstitial"] = function (browser) 
         }, [], function (response) {
           browser.assert.equal(response.value, null);
         })
-        .frame('grain-frame')
+        .grainFrame()
         .waitForElementPresent('#publish', medium_wait)
         .assert.containsText('#publish', 'Publish')
         // Try redeeming as current user
@@ -509,7 +514,7 @@ module.exports["Test grain identity chooser interstitial"] = function (browser) 
         .click("button.pick-identity")
         .waitForElementVisible('.grain-frame', medium_wait)
         .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
-        .frame('grain-frame')
+        .grainFrame()
         .waitForElementPresent('#publish', medium_wait)
         .assert.containsText('#publish', 'Publish')
         .frame(null)
@@ -523,7 +528,7 @@ module.exports["Test grain identity chooser interstitial"] = function (browser) 
         }, [], function (response) {
           browser.assert.equal(!!response.value, true);
         })
-        .frame('grain-frame')
+        .grainFrame()
         .waitForElementPresent('#publish', medium_wait)
         .assert.containsText('#publish', 'Publish')
         .frame(null)
@@ -541,7 +546,7 @@ module.exports["Test grain identity chooser interstitial"] = function (browser) 
             .url(shareLink.value)
             .waitForElementVisible('.grain-frame', medium_wait)
             .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
-            .frame('grain-frame')
+            .grainFrame()
             .waitForElementPresent('#publish', medium_wait)
             .assert.containsText('#publish', 'Publish')
             .frame(null)

--- a/tests/tests/postmessage-api.js
+++ b/tests/tests/postmessage-api.js
@@ -31,10 +31,11 @@ module.exports['Install and launch test app'] = function (browser) {
   browser
     .init()
     // test-3 introduces the JSON-formatted renderTemplate output
+    .loginDevAccount()
     .installApp("https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-7.spk", "281d3ffbc93933001d6b28e44ffac615", "rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh")
 
     .assert.containsText('#grainTitle', 'Untitled Test App test page')
-    .frame('grain-frame')
+    .grainFrame()
       .waitForElementPresent('#randomId', medium_wait)
       .assert.containsText('#randomId', 'initial state')
     .frameParent()
@@ -51,7 +52,7 @@ var grainId = undefined;
 module.exports['Test setPath'] = function (browser) {
   var expectedUrl = browser.launch_url + '/grain/' + grainId + '/#setpath';
   browser
-    .frame('grain-frame')
+    .grainFrame()
       .click('#setPath')
       .pause(very_short_wait)
     .frameParent()
@@ -69,7 +70,7 @@ module.exports['Test setTitle'] = function (browser) {
     .getTitle(function (title) {
       origTitle = title;
     })
-    .frame('grain-frame')
+    .grainFrame()
       .setValue('#title', [ randomValue ] )
       .click('#setTitle')
       .pause(very_short_wait)
@@ -86,7 +87,7 @@ module.exports['Test setTitle to blank'] = function (browser) {
     .getTitle(function (title) {
       origTitle = title;
     })
-    .frame('grain-frame')
+    .grainFrame()
       .clearValue('#title')
       .click('#setTitle')
       .pause(very_short_wait)
@@ -100,7 +101,7 @@ module.exports['Test setTitle to blank'] = function (browser) {
 
 module.exports['Test startSharing'] = function (browser) {
   browser
-    .frame('grain-frame')
+    .grainFrame()
       .click('#startSharing')
     .frameParent()
     .waitForElementVisible('.popup.share', short_wait)
@@ -110,7 +111,7 @@ module.exports['Test startSharing'] = function (browser) {
 
 module.exports['Test showConnectionGraph'] = function (browser) {
   browser
-    .frame('grain-frame')
+    .grainFrame()
       .click('#showConnectionGraph')
     .frameParent()
     .waitForElementVisible('.popup.who-has-access', short_wait)
@@ -120,7 +121,7 @@ module.exports['Test showConnectionGraph'] = function (browser) {
 
 module.exports['Test renderTemplate'] = function (browser) {
   browser
-    .frame('grain-frame')
+    .grainFrame()
       .click('#renderTemplate')
       .waitForElementVisible('#template-frame[data-rendered=true]', short_wait)
       .frame('template-frame')

--- a/tests/tests/restore-open-grains.js
+++ b/tests/tests/restore-open-grains.js
@@ -34,6 +34,7 @@ var hackerCmsAppId = "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh";
 
 module.exports["Test restore open grains"] = function (browser) {
   browser
+    .loginDevAccount()
     // Create three Hacker CMS grains.
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk",
                 "ca690ad886bf920026f8b876c19539c1",

--- a/tests/tests/sharing.js
+++ b/tests/tests/sharing.js
@@ -32,6 +32,7 @@ module.exports["Test open direct share link"] = function (browser) {
   var devName2 = "A" + crypto.randomBytes(10).toString("hex");
   var devIdentityId2 = crypto.createHash("sha256").update("dev:" + devName2).digest("hex");
   browser
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
                 hackerCmsAppId)
     .waitForElementVisible("#grainTitle", medium_wait)
@@ -53,13 +54,13 @@ module.exports["Test open direct share link"] = function (browser) {
          // First, try visiting the link while already logged in.
         .loginDevAccount(devName2)
         .url(browser.launch_url + "/shared/" + result.value.result.token)
-        .waitForElementVisible("#grain-frame", medium_wait)
+        .waitForElementVisible("iframe.grain-frame", medium_wait)
         .waitForElementVisible("#grainTitle", medium_wait)
         .assert.containsText("#grainTitle", "user2 title")
         .url(function(grainUrl) {
           browser.assert.equal(0, grainUrl.value.indexOf(browser.launch_url + "/grain/"));
         })
-        .frame("grain-frame")
+        .grainFrame()
         .waitForElementPresent("#publish", medium_wait)
         .assert.containsText("#publish", "Publish")
         .frame(null)
@@ -71,13 +72,13 @@ module.exports["Test open direct share link"] = function (browser) {
         .assert.containsText(".grain-interstitial",
                              "Access through this URL is restricted to the identity:")
         .click(".grain-interstitial button.sign-in")
-        .waitForElementVisible("#grain-frame", medium_wait)
+        .waitForElementVisible("iframe.grain-frame", medium_wait)
         .waitForElementVisible("#grainTitle", medium_wait)
         .assert.containsText("#grainTitle", "user2 title")
         .url(function(grainUrl) {
           browser.assert.equal(0, grainUrl.value.indexOf(browser.launch_url + "/grain/"));
         })
-        .frame("grain-frame")
+        .grainFrame()
         .waitForElementPresent("#publish", medium_wait)
         .assert.containsText("#publish", "Publish")
         .frame(null)
@@ -90,13 +91,13 @@ module.exports["Test open direct share link"] = function (browser) {
         .assert.containsText(".grain-interstitial",
                              "Access through this URL is restricted to the identity:")
         .click(".grain-interstitial button.sign-in")
-        .waitForElementVisible("#grain-frame", medium_wait)
+        .waitForElementVisible("iframe.grain-frame", medium_wait)
         .waitForElementVisible("#grainTitle", medium_wait)
         .assert.containsText("#grainTitle", "user2 title")
         .url(function(grainUrl) {
           browser.assert.equal(0, grainUrl.value.indexOf(browser.launch_url + "/grain/"));
         })
-        .frame("grain-frame")
+        .grainFrame()
         .waitForElementPresent("#publish", medium_wait)
         .assert.containsText("#publish", "Publish")
         .frame(null)
@@ -105,6 +106,7 @@ module.exports["Test open direct share link"] = function (browser) {
 
 module.exports["Test revoked share link"] = function (browser) {
   browser
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
                 hackerCmsAppId)
     .waitForElementVisible("#grainTitle", medium_wait)
@@ -142,6 +144,7 @@ module.exports["Test revoked share link"] = function (browser) {
 module.exports["Test share popup no permission"] = function (browser) {
   var sharePopupSelector = ".topbar .share > .show-popup";
   browser
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
                 hackerCmsAppId)
     .waitForElementVisible("#grainTitle", medium_wait)

--- a/tests/tests/trash.js
+++ b/tests/tests/trash.js
@@ -33,6 +33,7 @@ module.exports["Test grain trash"] = function (browser) {
   var grainCheckboxSelector;
 
   browser
+    .loginDevAccount()
     .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
                 hackerCmsAppId)
     .getDevName(function (result) {
@@ -63,7 +64,7 @@ module.exports["Test grain trash"] = function (browser) {
             .click("button.pick-identity")
             .waitForElementVisible('.grain-frame', medium_wait)
             .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
-            .frame('grain-frame')
+            .grainFrame()
             .waitForElementPresent('#publish', medium_wait)
             .assert.containsText('#publish', 'Publish')
             .frame(null)
@@ -84,7 +85,7 @@ module.exports["Test grain trash"] = function (browser) {
             .click("button.restore-from-trash")
             .waitForElementVisible('.grain-frame', medium_wait)
             .assert.containsText('#grainTitle', expectedHackerCMSGrainTitle)
-            .frame('grain-frame')
+            .grainFrame()
             .waitForElementPresent('#publish', medium_wait)
             .assert.containsText('#publish', 'Publish')
             .frame(null)


### PR DESCRIPTION
Fixes #2225. Adds `newGrain()` and `grainFrame()` testing commands. Decouples `loginDevAccount()` from `installApp()`, because sometimes it's useful to install an app on an existing account.
