### PR TITLE
empty string fallback for termsUrl and privacyUrl

### DIFF
--- a/shell/client/admin/personalization-client.js
+++ b/shell/client/admin/personalization-client.js
@@ -4,8 +4,8 @@ Template.newAdminPersonalization.onCreated(function () {
   this.serverTitle = new ReactiveVar(globalDb.getSettingWithFallback("serverTitle", ""));
   this.splashUrl = new ReactiveVar(globalDb.getSettingWithFallback("splashUrl", ""));
   this.signupDialog = new ReactiveVar(globalDb.getSettingWithFallback("signupDialog", DEFAULT_SIGNUP_DIALOG));
-  this.termsOfServiceUrl = new ReactiveVar(globalDb.getSetting("termsUrl"));
-  this.privacyPolicyUrl = new ReactiveVar(globalDb.getSetting("privacyUrl"));
+  this.termsOfServiceUrl = new ReactiveVar(globalDb.getSettingWithFallback("termsUrl", ""));
+  this.privacyPolicyUrl = new ReactiveVar(globalDb.getSettingWithFallback("privacyUrl", ""));
 
   this.formState = new ReactiveVar("default");
   this.message = new ReactiveVar("");


### PR DESCRIPTION
Fixes #2229. 

This follows the pattern used for other settings such as [`appMarketUrl`](https://github.com/sandstorm-io/sandstorm/blob/cc2b028e607715f3f2e9119438326a9b73e525ce/shell/client/admin/app-sources-client.js#L6).