### PR TITLE
Give top bar a z-index of 0

### DIFF
--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -75,6 +75,9 @@ body>.topbar {
   background-color: $topbar-background-color;
   color: #ccc;
 
+  // Using 0 rather than CSS default ("auto") allows introjs to highlight elements in the topbar.
+  z-index: 0;
+
   @media #{$mobile} {
     line-height: 48px;
     height: 48px;


### PR DESCRIPTION
Using 0 rather than CSS default ("auto") allows introjs to highlight elements in the topbar.
Interestingly, at runtime, Chrome reports the z-index of the topbar element as "0" before
this change; Firefox reports it as "auto." By setting it to 0 explicitly, we cause Firefox
and Chrome to have the same behavior when queried by introjs about the top bar's z-index.

Close #2163