### PR TITLE
admin user details: show non-login identities

### DIFF
--- a/shell/client/admin/user-details-client.js
+++ b/shell/client/admin/user-details-client.js
@@ -55,8 +55,8 @@ Template.newAdminUserDetailsIdentityTable.helpers({
     return identities;
   },
 
-  nonLoginIdentities(account) {
-    const identityIds = account.nonLoginIdentities || [];
+  nonloginIdentities(account) {
+    const identityIds = account.nonloginIdentities || [];
     const identities = identityIds.map(lookupIdentity);
     return identities;
   },

--- a/shell/client/admin/user-details.html
+++ b/shell/client/admin/user-details.html
@@ -169,7 +169,7 @@
           {{> newAdminUserDetailsIdentityMIATableRow }}
         {{/if}}
       {{/each}}
-      {{#each identity in (nonLoginIdentities account) }}
+      {{#each identity in (nonloginIdentities account) }}
         {{#if identity}}
           {{> newAdminUserDetailsIdentityTableRow
                 identity=identity


### PR DESCRIPTION
I miscapitalized nonloginIdentities, which resulted in the admin UI never
showing non-login identities in the list of identities for an account.