### PR TITLE
Display warning when backing up a grain that holds capabilities.

### DIFF
--- a/shell/client/grain.html
+++ b/shell/client/grain.html
@@ -148,9 +148,30 @@
 <template name="grainDebugLogButton">
   <button class="grain-button" title="Show Debug Log" id="openDebugLog">Log</button>
 </template>
+
 <template name="grainBackupButton">
   <button class="grain-button {{#if isLoading}}loading{{/if}}" title="Download Backup" id="backupGrain" disabled="{{#if isLoading}}true{{/if}}">Backup</button>
+  {{#if state.confirming }}
+    {{#modalDialogWithBackdrop onDismiss=cancelBackup}}
+      <form name="confirm">
+        <p>
+         Warning: this grain has access to the following objects.
+         A restored backup might not work correctly until you re-grant it access to these objects.
+        </p>
+        <ul class="token-list">
+        {{#each state.confirming}}
+          <li>{{.}}</li>
+        {{/each}}
+       </ul>
+       <div class="align-buttons">
+         <button name="cancel">Cancel</button>
+         <button name="confirm">Download backup</button>
+       </div>
+      </form>
+    {{/modalDialogWithBackdrop}}
+  {{/if}}
 </template>
+
 <template name="grainRestartButton">
   <button class="grain-button" title="Restart App" id="restartGrain">Restart</button>
 </template>

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -75,8 +75,7 @@ body>.topbar {
   background-color: $topbar-background-color;
   color: #ccc;
 
-  // Using 0 rather than CSS default ("auto") allows introjs to highlight elements in the topbar.
-  z-index: 0;
+  z-index: 1;
 
   @media #{$mobile} {
     line-height: 48px;
@@ -367,12 +366,34 @@ body>.topbar {
     }
     >.delete>button    { background-image: url("/trash.svg"); }
     >.debug-log>button { background-image: url("/debug.svg"); }
-    >.backup>button    {
-      background-image: url("/download.svg");
+    >.backup {
+      >button    {
+        background-image: url("/download.svg");
+        &.loading {
+          background-image: url("/spinner_96.gif");
+          cursor: auto;
+        }
+      }
+      form[name=confirm] {
+        line-height: 22px;
+        >ul {
+          max-height: 300px;
+          overflow: auto;
+          margin-bottom: 15px;
+        }
+        .align-buttons {
+          display: flex;
+          justify-content: flex-end;
 
-      &.loading {
-        background-image: url("/spinner_96.gif");
-        cursor: auto;
+          button[name=confirm] {
+            @extend %button-base;
+            @extend %button-primary;
+          }
+          button[name=cancel] {
+            @extend %button-base;
+            @extend %button-secondary;
+          }
+        }
       }
     }
     >.restart>button   { background-image: url("/restart.svg"); }

--- a/shell/client/styles/_widgets.scss
+++ b/shell/client/styles/_widgets.scss
@@ -103,6 +103,7 @@
 .modal-content {
   min-height: 32px;
   background-color: #fff;
+  color: $default-content-foreground-color;
   opacity: 1;
   padding: 24px;
   >h2 {

--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -56,6 +56,23 @@ Meteor.publish("grainTopBar", function (grainId) {
   return result;
 });
 
+Meteor.publish("tokensOwnedByGrain", function (grainId) {
+  check(grainId, String);
+  const result = [];
+
+  if (this.userId) {
+    if (Grains.findOne({ _id: grainId, userId: this.userId })) {
+      // Only the grain owner is allowed to see these.
+      result.push(ApiTokens.find(
+        { "owner.grain.grainId": grainId },
+        { fields: { owner: 1 }, }
+      ));
+    }
+  }
+
+  return result;
+});
+
 // We allow users to learn package information about a grain they own.
 // This is used for obtaining icon and app title information for grains
 // you own, which is used in the sidebar. It is not a security/privacy


### PR DESCRIPTION
One potentially confusing aspect of the Collections app is that `UiView` capabilites held by it do not survive a grain backup/restore cycle. We need some way to teach the user about what to expect in such situations.

This patch proposes to display a warning when the user requests a backup of a grain that holds any capabilities other than the "user identity" capabilities saved by sandstorm-http-bridge. The warning looks like this:

![backup-modal](https://cloud.githubusercontent.com/assets/495768/17000479/bac6332a-4e90-11e6-842a-1693e25b9016.png)

To get the warning to display properly, I needed to give the topbar a `z-index` greater than 0, because otherwise the grain iframe gets drawn above the modal.

