### PR TITLE
Add backup warning for Collections app grains.

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -191,7 +191,12 @@ Template.grainBackupPopup.onCreated(function () {
   const grain = Grains.findOne({ _id: this._grainId });
 
   if (grain.appId === "s3u2xgmqwznz2n3apf30sm3gw1d85y029enw5pymx734cnk5n78h") {
-    // HACK: Display a warning if this is the Collections app.
+    // HACK: Display a warning if this is a Collections grain.
+    //
+    // TODO(soon): Figure out how to avoid special-casing here. Ideally, we would have some
+    // kind of machinery for rewiring the capabilities of restored backups, so that backup/restore
+    // would not result in a completely broken collection. Alternatively, we could add a field
+    // `Manifest.backupWarning` that we would display here if present.
     this._state.set({
       showWarning:
         "Backing up a collection does not back up any of its linked grains, " +

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -189,12 +189,16 @@ Template.grainBackupPopup.onCreated(function () {
   };
 
   const grain = Grains.findOne({ _id: this._grainId });
-  let pkg = Packages.findOne({ _id: grain.packageId }) ||
-      DevPackages.findOne({ appId: grain.appId }) || {};
 
-  const manifest = pkg.manifest || {};
-  if (manifest.backupWarning) {
-    this._state.set({ showWarning: manifest.backupWarning.defaultText });
+  if (grain.appId === "s3u2xgmqwznz2n3apf30sm3gw1d85y029enw5pymx734cnk5n78h") {
+    // HACK: Display a warning if this is the Collections app.
+    this._state.set({
+      showWarning:
+        "Backing up a collection does not back up any of its linked grains, " +
+        "and restoring a collection does not automatically restore its links to grains. " +
+        "Unless your goal is to debug a problem with this collection, downloading " +
+        "a backup will not be very useful.",
+    });
   } else {
     this._doBackup();
   }

--- a/shell/client/grain.html
+++ b/shell/client/grain.html
@@ -149,8 +149,40 @@
   <button class="grain-button" title="Show Debug Log" id="openDebugLog">Log</button>
 </template>
 <template name="grainBackupButton">
-  <button class="grain-button {{#if isLoading}}loading{{/if}}" title="Download Backup" id="backupGrain" disabled="{{#if isLoading}}true{{/if}}">Backup</button>
+  <button class="grain-button" title="Download Backup" id="backupGrain">Backup</button>
 </template>
+
+<template name="grainBackupPopup">
+  <h4>Download Backup</h4>
+  {{#if state.showWarning }}
+    <p class="warning-intro"> Warning! Restoring this backup might not work how you expect it to.
+    </p>
+    <p class="warning-body">
+      {{ state.showWarning }}
+     </p>
+   {{/if}}
+     {{#if state.processing}}
+    <p> Preparing backup... </p>
+   {{/if}}
+   {{#if state.error}}
+     <p class="error"> Error </p>
+     {{/if}}
+
+
+     <div class="button-row">
+       <button name="cancel" title="cancel">Cancel</button>
+        {{#if state.processing}}
+          <div class="spinner"></div>
+         {{/if}}
+
+
+         {{#if state.showWarning }}
+         <button name="confirm" title="download backup">Download backup</button>
+         {{/if}}
+    </div>
+
+</template>
+
 <template name="grainRestartButton">
   <button class="grain-button" title="Restart App" id="restartGrain">Restart</button>
 </template>
@@ -485,7 +517,8 @@
 
   {{#if isOwner}}
     {{>sandstormTopbarItem name="debug-log" topbar=globalTopbar template="grainDebugLogButton" data=globalTopbar}}
-    {{>sandstormTopbarItem name="backup" topbar=globalTopbar template="grainBackupButton" data=globalTopbar}}
+    {{>sandstormTopbarItem name="backup" topbar=globalTopbar template="grainBackupButton"
+                           data=globalTopbar popupTemplate="grainBackupPopup"}}
     {{>sandstormTopbarItem name="restart" topbar=globalTopbar template="grainRestartButton" data=globalTopbar}}
   {{/if}}
 

--- a/shell/client/grain.html
+++ b/shell/client/grain.html
@@ -155,32 +155,30 @@
 <template name="grainBackupPopup">
   <h4>Download Backup</h4>
   {{#if state.showWarning }}
-    <p class="warning-intro"> Warning! Restoring this backup might not work how you expect it to.
+    <p class="warning-intro">
+      Warning! Restoring this backup might not work how you expect it to.
     </p>
     <p class="warning-body">
       {{ state.showWarning }}
-     </p>
-   {{/if}}
-     {{#if state.processing}}
+    </p>
+  {{/if}}
+  {{#if state.processing}}
     <p> Preparing backup... </p>
-   {{/if}}
-   {{#if state.error}}
-     <p class="error"> Error </p>
-     {{/if}}
+  {{/if}}
+  {{#if state.error}}
+    <p class="error">Error: {{ state.error }}</p>
+  {{/if}}
 
+  <div class="button-row">
+    <button name="cancel" title="cancel">Cancel</button>
+    {{#if state.processing}}
+      <div class="spinner"></div>
+    {{/if}}
 
-     <div class="button-row">
-       <button name="cancel" title="cancel">Cancel</button>
-        {{#if state.processing}}
-          <div class="spinner"></div>
-         {{/if}}
-
-
-         {{#if state.showWarning }}
-         <button name="confirm" title="download backup">Download backup</button>
-         {{/if}}
-    </div>
-
+    {{#if state.showWarning}}
+      <button name="confirm" title="download backup">Download backup</button>
+    {{/if}}
+  </div>
 </template>
 
 <template name="grainRestartButton">

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -367,14 +367,7 @@ body>.topbar {
     }
     >.delete>button    { background-image: url("/trash.svg"); }
     >.debug-log>button { background-image: url("/debug.svg"); }
-    >.backup>button    {
-      background-image: url("/download.svg");
-
-      &.loading {
-        background-image: url("/spinner_96.gif");
-        cursor: auto;
-      }
-    }
+    >.backup>button    { background-image: url("/download.svg"); }
     >.restart>button   { background-image: url("/restart.svg"); }
     >.webkey>button    { background-image: url("/key.svg"); }
     >.who-has-access img { width: 20px; }
@@ -1323,4 +1316,40 @@ body>.popup {
       margin-bottom: 14px;
     }
   }
+
+  &.backup {
+    >.frame-container {
+      width: 400px;
+    }
+
+    .warning-intro, .error {
+      color: #a94442;
+      background-color: #f2dede;
+      border-color: #ebccd1;
+      padding: 5px;
+    }
+
+    .button-row {
+      display: flex;
+      justify-content: flex-end;
+
+      button {
+        @extend %button-base;
+        &[name=confirm] {
+          @extend %button-primary;
+        }
+        &[name=cancel] {
+          @extend %button-secondary;
+        }
+      }
+
+      .spinner {
+        width: 32px;
+        height: 32px;
+        background-image: url("/spinner_96.gif");
+        background-size: 32px 32px;
+      }
+    }
+  }
+
 }

--- a/src/sandstorm/package.capnp
+++ b/src/sandstorm/package.capnp
@@ -161,10 +161,6 @@ struct Manifest {
 
   continueCommand @3 :Command;
   # Command to run to restart an already-created grain.
-
-  backupWarning @9 :Util.LocalizedText;
-  # If present, a warning to display to the user when clicking the "download backup" button.
-  # Useful if backup/restore might not work as the user expects, e.g. as with the Collections app.
 }
 
 struct SourceMap {

--- a/src/sandstorm/package.capnp
+++ b/src/sandstorm/package.capnp
@@ -161,6 +161,10 @@ struct Manifest {
 
   continueCommand @3 :Command;
   # Command to run to restart an already-created grain.
+
+  backupWarning @9 :Util.LocalizedText;
+  # If present, a warning to display to the user when clicking the "download backup" button.
+  # Useful if backup/restore might not work as the user expects, e.g. as with the Collections app.
 }
 
 struct SourceMap {


### PR DESCRIPTION
This allows the Collections app to alert the user that backup/restore do not work as might be expected. 

![backupwarning](https://cloud.githubusercontent.com/assets/495768/17041953/dfa93380-4f77-11e6-944e-d12ce7b4bd0d.png)

After this change, a topbar popup always appears when you download a backup. If the app does not specify a warning, it goes straight to the "in progress" state, where there is a new "cancel" button. 

![downloading](https://cloud.githubusercontent.com/assets/495768/17041955/e2cd0c6c-4f77-11e6-83db-3126fbb34119.png)
