### PR TITLE
Add basic whitelabeling

### DIFF
--- a/shell/client/accounts/login-buttons.html
+++ b/shell/client/accounts/login-buttons.html
@@ -132,7 +132,10 @@ licenses, included in the LICENSES directory.
     {{!-- There's no actual difference between signing "up" and "in", but people expect there to
           be a difference, so humor them by making the front-page login say "sign up". (But for a
           private server, don't offer "sign up".) --}}
-    <h4>{{#if allowUninvited}}Create account{{else}}Sign in{{/if}}</h4>
+    <h4>
+      <span class="logo" style="background-image: url('{{logoUrl}}')"></span>
+      {{#if allowUninvited}}Create account{{else}}Sign in{{/if}}
+    </h4>
 
     {{> loginButtonsList}}
   </div>

--- a/shell/client/accounts/login-buttons.html
+++ b/shell/client/accounts/login-buttons.html
@@ -238,7 +238,7 @@ licenses, included in the LICENSES directory.
 
 <template name="ldapLoginForm">
   <form class="ldap">
-    with LDAP
+    {{loginProviderLabel}}
 
     <label class="username">username
       <span title="This is your LDAP username. It will be the name that you normally use to log in to other internal services at your company." class="info">i</span>
@@ -257,7 +257,7 @@ licenses, included in the LICENSES directory.
 
 <template name="samlLoginForm">
   <button class="login oneclick saml">
-    with SAML
+    {{loginProviderLabel}}
   </button>
 </template>
 

--- a/shell/client/accounts/login-buttons.html
+++ b/shell/client/accounts/login-buttons.html
@@ -84,7 +84,11 @@ licenses, included in the LICENSES directory.
     {{#if isAdmin}}
       {{#linkTo route="newAdminRoot" role="menuitem"}}Admin panel{{/linkTo}}
     {{/if}}
-    <a href="mailto:support@sandstorm.io" target="_blank" role="menuitem">Send feedback</a>
+
+    {{#if showSendFeedback}}
+      <a href="mailto:support@sandstorm.io" target="_blank" role="menuitem">Send feedback</a>
+    {{/if}}
+
     {{#if quotaEnabled }}
       {{#linkTo route="referrals" role="menuitem"}}Referral program{{/linkTo}}
     {{/if}}

--- a/shell/client/accounts/login-buttons.js
+++ b/shell/client/accounts/login-buttons.js
@@ -317,6 +317,18 @@ Template.emailAuthenticationForm.helpers({
   },
 });
 
+Template.ldapLoginForm.helpers({
+  loginProviderLabel() {
+    const defaultLabel = "with LDAP";
+    if (globalDb.isFeatureKeyValid()) {
+      const override = globalDb.getSettingWithFallback("whitelabelCustomLoginProviderName", "");
+      return override || defaultLabel;
+    }
+
+    return defaultLabel;
+  },
+});
+
 Template.ldapLoginForm.events({
   "submit form": function (event, instance) {
     event.preventDefault();
@@ -378,6 +390,18 @@ Template.devLoginForm.events({
     event.preventDefault();
     const form = instance.find("form");
     loginDevHelper(form.name.value, false, instance.data.linkingNewIdentity);
+  },
+});
+
+Template.samlLoginForm.helpers({
+  loginProviderLabel() {
+    const defaultLabel = "with LDAP";
+    if (globalDb.isFeatureKeyValid()) {
+      const override = globalDb.getSettingWithFallback("whitelabelCustomLoginProviderName", "");
+      return override || defaultLabel;
+    }
+
+    return defaultLabel;
   },
 });
 

--- a/shell/client/accounts/login-buttons.js
+++ b/shell/client/accounts/login-buttons.js
@@ -265,8 +265,11 @@ Template.loginButtonsList.helpers({
   services: getServices,
 
   showTroubleshooting: function () {
-    return !(Meteor.settings && Meteor.settings.public &&
+    const hiddenByConfFile = (Meteor.settings && Meteor.settings.public &&
       Meteor.settings.public.hideTroubleshooting);
+    const hiddenByDbSetting = (this._db.isFeatureKeyValid() &&
+      this._db.getSettingWithFallback("whitelabelHideTroubleshooting", false));
+    return !hiddenByConfFile && !hiddenByDbSetting;
   },
 
   linkingNewIdentity: function () {

--- a/shell/client/accounts/login-buttons.js
+++ b/shell/client/accounts/login-buttons.js
@@ -229,6 +229,18 @@ Template.loginButtonsDialog.helpers({
   allowUninvited: function () {
     return Meteor.settings.public.allowUninvited;
   },
+
+  logoUrl() {
+    const defaultLogoUrl = "/sandstorm-gradient-logo.svg";
+    if (globalDb.isFeatureKeyValid()) {
+      const assetId = globalDb.getSettingWithFallback("whitelabelCustomLogoAssetId", "");
+      if (assetId) {
+        return `${window.location.protocol}//${globalDb.makeWildcardHost("static")}/${assetId}`;
+      }
+    }
+
+    return defaultLogoUrl;
+  },
 });
 
 Template.loginButtonsList.onCreated(function () {

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -10,6 +10,26 @@
     <h2>Current feature key</h2>
     {{> adminFeatureKeyDetails featureKey=currentFeatureKey }}
     {{> adminFeatureKeyModifyForm }}
+
+    <p>Looking to configure Sandstorm for Work-exclusive features?</p>
+    <ul>
+      <li>Enable LDAP and/or SAML login under
+        {{#linkTo route="newAdminIdentity"}}
+          Identity providers
+        {{/linkTo}}
+      </li>
+      <li>Manage organization membership under
+        {{#linkTo route="newAdminOrganization"}}
+          Organization settings
+        {{/linkTo}}
+      </li>
+      <li>Configure whitelabeling under
+        {{#linkTo route="newAdminPersonalization"}}
+          Personalization
+        {{/linkTo}}
+      </li>
+    </ul>
+
   {{else}}
     <div class="feature-key-explanation-row">
       <div class="lanyard-image" role="presentation"></div>

--- a/shell/client/admin/personalization-client.js
+++ b/shell/client/admin/personalization-client.js
@@ -7,8 +7,43 @@ Template.newAdminPersonalization.onCreated(function () {
   this.termsOfServiceUrl = new ReactiveVar(globalDb.getSettingWithFallback("termsUrl", ""));
   this.privacyPolicyUrl = new ReactiveVar(globalDb.getSettingWithFallback("privacyUrl", ""));
 
+  // While these whitelabeling features are only for Sandstorm for Work users, it's simpler to just
+  // always populate these fields in the DB and in RPC shapes and only make use of their values if
+  // the server has a valid feature key.
+  this.whitelabelCustomLoginProviderName =
+    new ReactiveVar(globalDb.getSettingWithFallback("whitelabelCustomLoginProviderName", ""));
+  this.whitelabelHideSendFeedback =
+    new ReactiveVar(globalDb.getSettingWithFallback("whitelabelHideSendFeedback", false));
+  this.whitelabelHideTroubleshooting =
+    new ReactiveVar(globalDb.getSettingWithFallback("whitelabelHideTroubleshooting", false));
+  this.whitelabelUseServerTitleForHomeText =
+    new ReactiveVar(globalDb.getSettingWithFallback("whitelabelUseServerTitleForHomeText", false));
+
   this.formState = new ReactiveVar("default");
   this.message = new ReactiveVar("");
+
+  this.logoError = new ReactiveVar(undefined);
+  this._uploadToken = undefined;
+  this.doUpload = (token, file) => {
+    const staticHost = globalDb.makeWildcardHost("static");
+    const path = `${window.location.protocol}//${staticHost}/${token}`;
+    HTTP.post(path, { content: file, }, (err, result) => {
+      if (err) {
+        this.logoError.set(err.message);
+      }
+    });
+  };
+
+  this.doUploadIfReady = () => {
+    const input = this.find("input[name='upload-file']");
+    const file = input && input.files && input.files[0];
+    const token = this._uploadToken;
+    if (token && file) {
+      input.value = "";
+      this._uploadToken = undefined;
+      this.doUpload(token, file);
+    }
+  };
 });
 
 Template.newAdminPersonalization.helpers({
@@ -44,6 +79,47 @@ Template.newAdminPersonalization.helpers({
   privacyPolicyUrl() {
     const instance = Template.instance();
     return instance.privacyPolicyUrl.get();
+  },
+
+  hasFeatureKey() {
+    return globalDb.isFeatureKeyValid();
+  },
+
+  logoError() {
+    const instance = Template.instance();
+    return instance.logoError.get();
+  },
+
+  logoUrl() {
+    const defaultLogoUrl = "/sandstorm-gradient-logo.svg";
+    if (globalDb.isFeatureKeyValid()) {
+      const assetId = globalDb.getSettingWithFallback("whitelabelCustomLogoAssetId", "");
+      if (assetId) {
+        return `${window.location.protocol}//${globalDb.makeWildcardHost("static")}/${assetId}`;
+      }
+    }
+
+    return defaultLogoUrl;
+  },
+
+  hideTroubleshootingChecked() {
+    const instance = Template.instance();
+    return instance.whitelabelHideTroubleshooting.get();
+  },
+
+  hideSendFeedbackChecked() {
+    const instance = Template.instance();
+    return instance.whitelabelHideSendFeedback.get();
+  },
+
+  useServerTitleForHomeTextChecked() {
+    const instance = Template.instance();
+    return instance.whitelabelUseServerTitleForHomeText.get();
+  },
+
+  customLoginProviderName() {
+    const instance = Template.instance();
+    return instance.whitelabelCustomLoginProviderName.get();
   },
 
   hasError() {
@@ -88,6 +164,62 @@ Template.newAdminPersonalization.events({
     instance.privacyPolicyUrl.set(evt.currentTarget.value);
   },
 
+  "click button[name=reset-logo]"(evt) {
+    const instance = Template.instance();
+    Meteor.call("resetWhitelabelLogo", (err) => {
+      if (err) {
+        instance.logoError.set(err.message);
+      } else {
+        instance.logoError.set(undefined);
+      }
+    });
+  },
+
+  "click button[name=upload-logo]"(evt) {
+    const instance = Template.instance();
+    const input = instance.find("input[name=upload-file]");
+    // Clear any file that was already selected.
+    input.value = "";
+
+    // Request an upload token from the server.
+    Meteor.call("getWhitelabelLogoUploadToken", (err, result) => {
+      if (err) {
+        instance.logoError.set(err.message);
+      } else {
+        instance._uploadToken = result;
+        instance.doUploadIfReady();
+      }
+    });
+
+    // Open the file picker.
+    input.click();
+  },
+
+  "change input[name=upload-file]"(evt) {
+    const instance = Template.instance();
+    instance.doUploadIfReady();
+  },
+
+  "click input[name=hide-troubleshooting]"(evt) {
+    const instance = Template.instance();
+    instance.whitelabelHideTroubleshooting.set(evt.currentTarget.checked);
+  },
+
+  "click input[name=hide-send-feedback]"(evt) {
+    const instance = Template.instance();
+    instance.whitelabelHideSendFeedback.set(evt.currentTarget.checked);
+  },
+
+  "click input[name=use-server-title-for-home-text]"(evt) {
+    const instance = Template.instance();
+    instance.whitelabelUseServerTitleForHomeText.set(evt.currentTarget.checked);
+  },
+
+  "input input[name=custom-login-provider-name]"(evt) {
+    const instance = Template.instance();
+    instance.whitelabelCustomLoginProviderName.set(evt.currentTarget.value);
+  },
+
   "submit form.admin-personalization-form"(evt) {
     evt.preventDefault();
     evt.stopPropagation();
@@ -99,6 +231,10 @@ Template.newAdminPersonalization.events({
       signupDialog: instance.signupDialog.get(),
       termsOfServiceUrl: instance.termsOfServiceUrl.get(),
       privacyPolicyUrl: instance.privacyPolicyUrl.get(),
+      whitelabelCustomLoginProviderName: instance.whitelabelCustomLoginProviderName.get(),
+      whitelabelHideSendFeedback: !!instance.whitelabelHideSendFeedback.get(),
+      whitelabelHideTroubleshooting: !!instance.whitelabelHideTroubleshooting.get(),
+      whitelabelUseServerTitleForHomeText: !!instance.whitelabelUseServerTitleForHomeText.get(),
     };
 
     instance.formState.set("submitting");

--- a/shell/client/admin/personalization.html
+++ b/shell/client/admin/personalization.html
@@ -85,6 +85,86 @@
       </span>
     </div>
 
+    {{#if hasFeatureKey}}
+    <h2>Whitelabeling</h2>
+
+    <div class="form-group">
+      <label>
+        Custom logo on sign-in dialog
+      </label>
+      {{#if logoError}}
+        {{#focusingErrorBox}}
+          {{logoError}}
+        {{/focusingErrorBox}}
+      {{/if}}
+      <div class="logo" style="background-image: url('{{ logoUrl }}')"></div>
+      {{#if customLogo }}
+        <!-- show custom logo -->
+      {{else}}
+        <!-- show default -->
+      {{/if}}
+      <button type="button" name="reset-logo" disabled={{logoResetDisabled}}>Use default</button>
+      <button type="button" name="upload-logo">Upload logo</button>
+      <input type="file" name="upload-file" style="display:none;" />
+    </div>
+
+    <div class="checkbox-group">
+      <label>
+        <input
+          type="checkbox"
+          name="hide-troubleshooting"
+          checked="{{hideTroubleshootingChecked}}"
+          disabled="{{formDisabled}}"
+        />
+        Hide troubleshooting button
+      </label>
+    </div>
+
+    <div class="checkbox-group">
+      <label>
+        <input
+          type="checkbox"
+          name="hide-send-feedback"
+          checked="{{hideSendFeedbackChecked}}"
+          disabled="{{formDisabled}}"
+        />
+        Hide "Send feedback" link
+      </label>
+    </div>
+
+    <div class="checkbox-group">
+      <label>
+        <input
+          type="checkbox"
+          name="use-server-title-for-home-text"
+          checked="{{useServerTitleForHomeTextChecked}}"
+          disabled="{{formDisabled}}"
+        />
+        Use server title (above) for home link
+      </label>
+      <span class="form-subtext">
+        If enabled, changes the default label "Sandstorm" on the link at the very top left to match
+        whatever you specified for the Server title above.
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label>
+        Custom login button text
+        <input
+          type="text"
+          name="custom-login-provider-name"
+          value="{{customLoginProviderName}}"
+          disabled="{{formDisabled}}"
+        />
+      </label>
+      <span class="form-subtext">
+        Replaces the text "with LDAP" and "with SAML" on the login page with
+        the specified text.
+      </span>
+    </div>
+    {{/if}}
+
     <div class="button-row">
       <button type="submit" disabled="{{formDisabled}}">Save</button>
     </div>

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -519,7 +519,15 @@ Template.layout.helpers({
   },
 
   accountButtonsData: function () {
-    return { isAdmin: globalDb.isAdmin(), grains: globalGrains };
+    const hasFeatureKey = globalDb.isFeatureKeyValid();
+    const showSendFeedback = hasFeatureKey ?
+        !globalDb.getSettingWithFallback("whitelabelHideSendFeedback", false) :
+        true;
+    return {
+      isAdmin: globalDb.isAdmin(),
+      grains: globalGrains,
+      showSendFeedback,
+    };
   },
 
   firstLogin: function () {

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -409,6 +409,13 @@ Template.referrals.helpers({
 });
 
 Template.layout.helpers({
+  effectiveServerTitle() {
+    const useServerTitle = globalDb.isFeatureKeyValid() &&
+        globalDb.getSettingWithFallback("whitelabelUseServerTitleForHomeText", false);
+    return useServerTitle ? globalDb.getSettingWithFallback("serverTitle", "Sandstorm") :
+        "Sandstorm";
+  },
+
   adminAlertIsTooLarge: function () {
     Template.instance().resizeTracker.depend();
     const setting = Settings.findOne({ _id: "adminAlert" });

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -60,7 +60,7 @@ limitations under the License.
 
   {{!-- standard topbar items --}}
   {{#sandstormTopbarItem name="home-button" topbar=globalTopbar}}
-    <a href="/">Sandstorm</a>
+  <a href="/">{{effectiveServerTitle}}</a>
   {{/sandstormTopbarItem}}
   {{#if showAccountButtons}}
     {{>sandstormTopbarItem name="account" topbar=globalTopbar data=accountButtonsData

--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -360,14 +360,12 @@ body>.popup.account>.frame-container {
     padding-right: 20px;
     margin: 0;
 
-    &::before {
-      content: " ";
+    .logo {
+      @extend %pseudo-img-tag;
       display: inline-block;
       width: 64px;
       height: 64px;
       vertical-align: bottom;
-      background-image: url("/sandstorm-gradient-logo.svg");
-      background-repeat: no-repeat;
     }
   }
 

--- a/shell/client/styles/_admin-personalization.scss
+++ b/shell/client/styles/_admin-personalization.scss
@@ -1,3 +1,12 @@
 form.admin-personalization-form {
   @extend %standard-form;
+
+  .logo {
+    @extend %pseudo-img-tag;
+    display: inline-block;
+    width: 64px;
+    height: 64px;
+    vertical-align: bottom;
+    margin-right: 32px;
+  }
 }

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -228,7 +228,7 @@ body>.topbar {
         overflow: hidden;
 
         >a {
-          display: block;
+          @extend %overflow-ellipsis;
           color: inherit;
           margin: 0px;
           text-decoration: none;

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1880,7 +1880,10 @@ if (Meteor.isServer) {
   };
 
   SandstormDb.prototype.newAssetUpload = function (purpose) {
-    check(purpose, { profilePicture: { userId: DatabaseId, identityId: DatabaseId } });
+    check(purpose, Match.OneOf(
+      { profilePicture: { userId: DatabaseId, identityId: DatabaseId } },
+      { loginLogo: {} },
+    ));
 
     return AssetUploadTokens.insert({
       purpose: purpose,

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -26,6 +26,7 @@ const publicAdminSettings = [
   "privacyUrl", "appMarketUrl", "appIndexUrl", "appUpdatesEnabled",
   "serverTitle", "returnAddress", "ldapNameField", "organizationMembership",
   "organizationSettings",
+  "whitelabelCustomLoginProviderName",
   "whitelabelHideSendFeedback",
   "whitelabelHideTroubleshooting",
   "whitelabelUseServerTitleForHomeText",

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -26,6 +26,7 @@ const publicAdminSettings = [
   "privacyUrl", "appMarketUrl", "appIndexUrl", "appUpdatesEnabled",
   "serverTitle", "returnAddress", "ldapNameField", "organizationMembership",
   "organizationSettings",
+  "whitelabelHideSendFeedback",
   "whitelabelHideTroubleshooting",
   "whitelabelUseServerTitleForHomeText",
 ];

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -27,6 +27,7 @@ const publicAdminSettings = [
   "serverTitle", "returnAddress", "ldapNameField", "organizationMembership",
   "organizationSettings",
   "whitelabelCustomLoginProviderName",
+  "whitelabelCustomLogoAssetId",
   "whitelabelHideSendFeedback",
   "whitelabelHideTroubleshooting",
   "whitelabelUseServerTitleForHomeText",

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -27,6 +27,7 @@ const publicAdminSettings = [
   "serverTitle", "returnAddress", "ldapNameField", "organizationMembership",
   "organizationSettings",
   "whitelabelHideTroubleshooting",
+  "whitelabelUseServerTitleForHomeText",
 ];
 
 const FEATURE_KEY_FIELDS_PUBLISHED_TO_ADMINS = [

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -26,6 +26,7 @@ const publicAdminSettings = [
   "privacyUrl", "appMarketUrl", "appIndexUrl", "appUpdatesEnabled",
   "serverTitle", "returnAddress", "ldapNameField", "organizationMembership",
   "organizationSettings",
+  "whitelabelHideTroubleshooting",
 ];
 
 const FEATURE_KEY_FIELDS_PUBLISHED_TO_ADMINS = [

--- a/shell/server/admin/personalization-server.js
+++ b/shell/server/admin/personalization-server.js
@@ -8,6 +8,11 @@ const personalizationMessageShape = {
   signupDialog: String,
   termsOfServiceUrl: String,
   privacyPolicyUrl: String,
+
+  whitelabelCustomLoginProviderName: String,
+  whitelabelHideSendFeedback: Boolean,
+  whitelabelHideTroubleshooting: Boolean,
+  whitelabelUseServerTitleForHomeText: Boolean,
 };
 
 Meteor.methods({
@@ -21,6 +26,15 @@ Meteor.methods({
     db.collections.settings.upsert({ _id: "signupDialog" }, { value: params.signupDialog });
     db.collections.settings.upsert({ _id: "termsUrl" }, { value: params.termsOfServiceUrl });
     db.collections.settings.upsert({ _id: "privacyUrl" }, { value: params.privacyPolicyUrl });
+
+    db.collections.settings.upsert({ _id: "whitelabelCustomLoginProviderName" },
+      { value: params.whitelabelCustomLoginProviderName });
+    db.collections.settings.upsert({ _id: "whitelabelHideSendFeedback" },
+      { value: params.whitelabelHideSendFeedback });
+    db.collections.settings.upsert({ _id: "whitelabelHideTroubleshooting" },
+      { value: params.whitelabelHideTroubleshooting });
+    db.collections.settings.upsert({ _id: "whitelabelUseServerTitleForHomeText" },
+      { value: params.whitelabelUseServerTitleForHomeText });
   },
 
   getWhitelabelLogoUploadToken() {

--- a/shell/server/admin/personalization-server.js
+++ b/shell/server/admin/personalization-server.js
@@ -22,4 +22,24 @@ Meteor.methods({
     db.collections.settings.upsert({ _id: "termsUrl" }, { value: params.termsOfServiceUrl });
     db.collections.settings.upsert({ _id: "privacyUrl" }, { value: params.privacyPolicyUrl });
   },
+
+  getWhitelabelLogoUploadToken() {
+    checkAuth(undefined);
+    const db = this.connection.sandstormDb;
+    return db.newAssetUpload({ loginLogo: {} });
+  },
+
+  resetWhitelabelLogo() {
+    checkAuth(undefined);
+    const db = this.connection.sandstormDb;
+    const old = globalDb.collections.settings.findAndModify({
+      query: { _id: "whitelabelCustomLogoAssetId" },
+      remove: true,
+      fields: { value: 1 },
+    });
+
+    if (old) {
+      db.unrefStaticAsset(old.value);
+    }
+  },
 });


### PR DESCRIPTION
New options for Sandstorm for Work users:

* Custom logo on sign-in dialog
* Custom text on LDAP/SAML sign-in buttons.
* Hide troubleshooting button.
* Hide "send feedback" button.
* Use server title in top left.

Example with all features enabled:

![example](https://cloud.githubusercontent.com/assets/307325/17074339/60895e14-502f-11e6-95e8-bde31ab5e745.png)

I added the configuration options to the Personalization page.  It's possible we'll want to rename that page, now that it's got some not-very-personal features.

![settings-page](https://cloud.githubusercontent.com/assets/307325/17074396/d8d133ce-502f-11e6-9347-1fcdb38899a0.png)

I also added this paragraph to help you find the features you're looking for at the bottom of the Sandstorm for Work settings page, if you have a valid key:

![sfw-guidance](https://cloud.githubusercontent.com/assets/307325/17074356/7e79c5f8-502f-11e6-8b75-99e84f8020c5.png)

Closes #2241.