### PR TITLE
better centering in identicon rendering

### DIFF
--- a/shell/packages/sandstorm-identicons/identicon.js
+++ b/shell/packages/sandstorm-identicons/identicon.js
@@ -27,8 +27,8 @@ Identicon.prototype = {
     render: function(){
         var hash    = this.hash,
             size    = this.size,
-            margin  = Math.floor(size * this.margin),
-            cell    = Math.floor((size - (margin * 2)) / 5),
+            cell    = Math.floor((size - (size * this.margin * 2)) / 5),
+            margin  = Math.floor((size - 5 * cell) / 2);
             image   = new PNGlib(size, size, 256);
 
         // light-grey background


### PR DESCRIPTION
Currently, our identicons can be up to two pixels off-center, due to sloppy rounding in identicon.js. With this patch, we reduce the error to at most 1/2 pixel, which is the best we can do if we want the cells to have constant size.

Before:
![old-identicon](https://cloud.githubusercontent.com/assets/495768/17078482/5ecb56e8-50c2-11e6-9afe-b2577bbdbd3a.png)

After:
![new-identicon](https://cloud.githubusercontent.com/assets/495768/17078488/72a0a0d8-50c2-11e6-99d5-c9d2a6c1ab41.png)

