### PR TITLE
Response header whitelist and X-Sandstorm-App- prefix

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1582,6 +1582,26 @@ class Proxy {
       response.setHeader("Content-Security-Policy", "default-src 'none'; sandbox");
     }
 
+    if (rpcResponse.additionalHeaders && rpcResponse.additionalHeaders.length > 0) {
+      // Build object for whitelisted header lookup
+      var whitelisted = {};
+      WebSession.Response.headerWhitelist.forEach(function(header) {
+        whitelisted[header] = 1;
+      });
+
+      // Add any additional prefixed/whitelisted headers to the response.
+      // We cannot trust that the headers in the RPC response are actually
+      // allowed, so we check if they are prefixed or whitelisted.
+      rpcResponse.additionalHeaders.forEach(function(header) {
+        if (header.name.startsWith(WebSession.appHeaderPrefix) ||
+            whitelisted[header.name]) {
+          // If header is prefixed with appHeaderPrefix,
+          // or if the header name is in whitelist, set it.
+          response.setHeader(header.name,  header.value);
+        }
+      });
+    }
+
     // On first response, update the session to have hasLoaded=true
     this.setHasLoaded();
 

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -123,6 +123,37 @@ function referralProgramLogSharingTokenUse(db, bobAccountId) {
   });
 }
 
+class HeaderWhitelist {
+  constructor(list) {
+    this._headers = {};
+    this._prefixes = [];
+
+    list.forEach(pattern => {
+      if (pattern.endsWith("*")) {
+        this._prefixes.push(pattern.slice(0, -1));
+      } else {
+        this._headers[pattern] = true;
+      }
+    });
+  }
+
+  matches(header) {
+    header = header.toLowerCase();
+    if (this._headers[header]) return true;
+
+    for (const i in this._prefixes) {
+      if (header.startsWith(this._prefixes[i])) {
+        return true;
+      }
+    };
+
+    return false;
+  }
+}
+
+const REQUEST_HEADER_WHITELIST = new HeaderWhitelist(WebSession.Context.headerWhitelist);
+const RESPONSE_HEADER_WHITELIST = new HeaderWhitelist(WebSession.Response.headerWhitelist);
+
 // User-agent strings that should be allowed to use http basic authentication.
 // These are regex matches, so ensure they are escaped properly with double
 // backslashes. For security reasons, we MUST NOT whitelist any user-agents
@@ -1516,26 +1547,14 @@ class Proxy {
     context.eTagPrecondition = parsePreconditionHeader(request);
 
     context.additionalHeaders = [];
-    WebSession.Context.headerWhitelist.forEach((headerName) => {
-      if (headerName.endsWith("*")) {
-        const prefix = headerName.substr(0, headerName.length - 1);
-        for (const h in request.headers) {
-          if (!h.startsWith(prefix)) {
-            continue;
-          }
-
-          context.additionalHeaders.push({
-            name: h,
-            value: request.headers[h],
-          });
-        }
-      } else if (request.headers[headerName]) {
+    for (const headerName in request.headers) {
+      if (REQUEST_HEADER_WHITELIST.matches(headerName)) {
         context.additionalHeaders.push({
           name: headerName,
           value: request.headers[headerName],
         });
-      };
-    });
+      }
+    }
 
     if (response) {
       const promise = new Promise((resolve, reject) => {
@@ -1583,18 +1602,11 @@ class Proxy {
     }
 
     if (rpcResponse.additionalHeaders && rpcResponse.additionalHeaders.length > 0) {
-      // Build object for whitelisted header lookup
-      var whitelisted = {};
-      WebSession.Response.headerWhitelist.forEach(function(header) {
-        whitelisted[header] = 1;
-      });
-
       // Add any additional prefixed/whitelisted headers to the response.
       // We cannot trust that the headers in the RPC response are actually
       // allowed, so we check if they are prefixed or whitelisted.
-      rpcResponse.additionalHeaders.forEach(function(header) {
-        if (header.name.startsWith(WebSession.appHeaderPrefix) ||
-            whitelisted[header.name]) {
+      rpcResponse.additionalHeaders.forEach(function (header) {
+        if (RESPONSE_HEADER_WHITELIST.matches(header.name)) {
           // If header is prefixed with appHeaderPrefix,
           // or if the header name is in whitelist, set it.
           response.setHeader(header.name,  header.value);

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -276,20 +276,20 @@ public:
     // Add whitelisted headers, and headers matching the app prefix, to a
     // temporary vector of headers. It is possible for a header name to appear
     // more than once.
-    kj::Vector<Header> headersMatching;
+    kj::Vector<Header*> headersMatching;
     for (auto& header: headers) {
       if (RESPONSE_HEADER_WHITELIST.matches(header.first)) {
-        headersMatching.add(kj::mv(header.second));
+        headersMatching.add(&header.second);
       }
     }
     // Initialize additionalHeaders once we know how many headers to include.
     auto headerList = builder.initAdditionalHeaders(headersMatching.size());
     // Add the headers matching the whitelist
     int i = 0;
-    for (auto const &header : headersMatching) {
+    for (auto header: headersMatching) {
       auto respHeader = headerList[i];
-      respHeader.setName(header.name);
-      respHeader.setValue(header.value);
+      respHeader.setName(header->name);
+      respHeader.setValue(header->value);
       i++;
     }
 

--- a/src/sandstorm/util-test.c++
+++ b/src/sandstorm/util-test.c++
@@ -83,6 +83,28 @@ KJ_TEST("percent encoding/decoding") {
   KJ_EXPECT(kj::str(percentDecode("%ab%BA").asChars()) == "\xab\xba");
 }
 
+KJ_TEST("HeaderWhitelist") {
+  const char* WHITELIST[] = {
+    "bar-baz",
+    "corge",
+    "foo-*",
+    "grault",
+    "qux-*",
+  };
+
+  HeaderWhitelist whitelist((kj::ArrayPtr<const char*>(WHITELIST)));
+
+  KJ_ASSERT(whitelist.matches("bar-baz"));
+  KJ_ASSERT(whitelist.matches("bar-BAZ"));
+  KJ_ASSERT(!whitelist.matches("bar-qux"));
+  KJ_ASSERT(whitelist.matches("foo-abcd"));
+  KJ_ASSERT(whitelist.matches("grault"));
+  KJ_ASSERT(whitelist.matches("Grault"));
+  KJ_ASSERT(!whitelist.matches("grault-abcd"));
+  KJ_ASSERT(whitelist.matches("QUX-abcd"));
+  KJ_ASSERT(!whitelist.matches("quxqux"));
+}
+
 struct Pipe {
   kj::AutoCloseFd readEnd;
   kj::AutoCloseFd writeEnd;

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -31,6 +31,7 @@
 #include <kj/async.h>
 #include <capnp/rpc-twoparty.h>
 #include <sandstorm/util.capnp.h>
+#include <set>
 
 namespace kj {
   class UnixEventPort;
@@ -232,6 +233,21 @@ kj::String percentEncode(kj::StringPtr text);
 kj::String percentEncode(kj::ArrayPtr<const byte> bytes);
 kj::Array<byte> percentDecode(kj::StringPtr text);
 // URL-safe encode using % escapes.
+
+class HeaderWhitelist {
+  // Given a list of strings, some of which end in '*', create an efficient whitelist matcher,
+  // where the *'s are wildcards. The input whitelist must be all-lowercase, but the matching is
+  // case-insensitive.
+
+public:
+  template <typename T>
+  HeaderWhitelist(T&& list): patterns(list.begin(), list.end()) {}
+
+  bool matches(kj::StringPtr header) const;
+
+private:
+  std::set<kj::StringPtr> patterns;
+};
 
 class SubprocessSet;
 

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -38,6 +38,11 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   # application's storage was written and may automatically implement etags based on hashing the
   # content.
 
+  const appHeaderPrefix :Text = "x-sandstorm-app-";
+  # Headers with this prefix will always be allowed in both the request and response.
+  # They represent custom HTTP headers that an app is intentionally exposing through
+  # Sandstorm.
+
   struct Params {
     # Startup params for web sessions.  See `UiView.newSession()`.
 

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -38,11 +38,6 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   # application's storage was written and may automatically implement etags based on hashing the
   # content.
 
-  const appHeaderPrefix :Text = "x-sandstorm-app-";
-  # Headers with this prefix will always be allowed in both the request and response.
-  # They represent custom HTTP headers that an app is intentionally exposing through
-  # Sandstorm.
-
   struct Params {
     # Startup params for web sessions.  See `UiView.newSession()`.
 
@@ -155,6 +150,8 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       # without Sandstorm in mind -- especially to avoid modifying client apps. Feel free
       # to send us pull requests adding additional headers.
       # Values in this list that end with '*' whitelist a prefix.
+
+      "x-sandstorm-app-*",     # For new headers introduced by Sandstorm apps.
 
       "oc-total-length",       # Owncloud client
       "oc-chunk-size",         # Owncloud client
@@ -381,7 +378,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       #   the app?
     }
 
-    additionalHeaders @19 :List(Header);
+    additionalHeaders @20 :List(Header);
     # Additional headers present in the reponse. Only whitelisted headers are
     # permitted.
 
@@ -395,6 +392,10 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       # purposes. This whitelist exists to help avoid the need to modify code originally written
       # without Sandstorm in mind -- especially to avoid modifying client apps.
       # Feel free to send us pull requests adding additional headers.
+      # Values in this list that end with '*' whitelist a prefix.
+
+      "x-sandstorm-app-*",     # For new headers introduced by Sandstorm apps.
+
       "x-oc-mtime",            # Owncloud protocol
     ];
 

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -380,6 +380,23 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       # TODO(someday):  Return blob directly from storage, so data doesn't have to stream through
       #   the app?
     }
+
+    additionalHeaders @19 :List(Header);
+    # Additional headers present in the reponse. Only whitelisted headers are
+    # permitted.
+
+    struct Header {
+      name @0 :Text;  # lower-cased name
+      value @1 :Text;
+    }
+
+    const headerWhitelist :List(Text) = [
+      # Non-standard response headers which are whitelisted for backwards-compatibility
+      # purposes. This whitelist exists to help avoid the need to modify code originally written
+      # without Sandstorm in mind -- especially to avoid modifying client apps.
+      # Feel free to send us pull requests adding additional headers.
+    ];
+
   }
 
   interface RequestStream extends(Util.ByteStream) {

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -395,6 +395,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       # purposes. This whitelist exists to help avoid the need to modify code originally written
       # without Sandstorm in mind -- especially to avoid modifying client apps.
       # Feel free to send us pull requests adding additional headers.
+      "x-oc-mtime",            # Owncloud protocol
     ];
 
   }


### PR DESCRIPTION
This is mostly @sprin's https://github.com/sandstorm-io/sandstorm/pull/1202 with some additional changes:

* While @sprin was working on the change, @zombiezen independently added header prefix whitelisting using a trailing '*' to indicate that the whitelist entry is a prefix. @sprin reconciled this with his changes by instead creating a separate list for prefixes. I feel, though, that having one list with wildcards is easier to read and understand, so I went back to this model. (This involved removing a couple of @sprin's commits that weren't relevant, and then adding some code of my own.)
* I prematurely optimized the header matching by introducing a `HeaderWhitelist` class in both C++ and Javascript which sort of "precompiles" the whitelist for efficiency. This probably wasn't necessary -- linear scans would have been fine since the whitelist is not huge.
* I changed the approach to preventing HTTP injections. Instead of applying regexes on the additionalHeaders only, I changed the code at a higher level to simply detect if any of the HTTP lines ended up containing newline characters. This approach solves not only injections in additionalHeaders but also across other headers that are represented as arbitrary strings in the capnp.

I will probably merge this later today for release.