### PR TITLE
installer-tests: Wait a little bit before asserting it has bound the …

### DIFF
--- a/installer-tests/full-server-install-say-y.t
+++ b/installer-tests/full-server-install-say-y.t
@@ -43,5 +43,5 @@ $[veryslow]Visit this link to start using it:
 To learn how to control the server, run:
   sandstorm help
 $[exitcode]0
-$[run]nc -z localhost 6080 && echo yay
+$[run]for i in `seq 0 20`; do nc -z localhost 6080 && { echo yay; break; } || sleep 1 ; done
 $[slow]yay

--- a/installer-tests/full-server-install-with-sandcats-https-invalid-domain-first.t
+++ b/installer-tests/full-server-install-with-sandcats-https-invalid-domain-first.t
@@ -45,5 +45,5 @@ $[veryslow]Visit this link to start using it:
 To learn how to control the server, run:
   sandstorm help
 $[exitcode]0
-$[run]nc -z localhost 6080 && echo yay
+$[run]for i in `seq 0 20`; do nc -z localhost 6080 && { echo yay; break; } || sleep 1 ; done
 $[slow]yay

--- a/installer-tests/full-server-install-with-sandcats-https.t
+++ b/installer-tests/full-server-install-with-sandcats-https.t
@@ -41,5 +41,5 @@ $[veryslow]Visit this link to start using it:
 To learn how to control the server, run:
   sandstorm help
 $[exitcode]0
-$[run]nc -z localhost 6080 && echo yay
+$[run]for i in `seq 0 20`; do nc -z localhost 6080 && { echo yay; break; } || sleep 1 ; done
 $[slow]yay


### PR DESCRIPTION
…ports

This should be fixed by adding a wait-loop to install.sh rather than doing the
wait-loop in a test, but life is short for now.