### PR TITLE
Update packaging-tutorial.md

### DIFF
--- a/docs/vagrant-spk/packaging-tutorial.md
+++ b/docs/vagrant-spk/packaging-tutorial.md
@@ -79,8 +79,8 @@ create the package.
 We'll use the `vagrant-spk` tool to create this directory.
 
 The purpose of `vagrant-spk` is to create a Linux system where Sandstorm and
-your app run successfully. It acts differently based on which [platform stack]
-(https://docs.sandstorm.io/en/latest/vagrant-spk/platform-stacks/)
+your app run successfully. It acts differently based on which 
+[platform stack](https://docs.sandstorm.io/en/latest/vagrant-spk/platform-stacks/)
 you want to use. In our case, we'll use the _lemp_ platform: Linux, nginx, MySQL,
 and PHP.
 


### PR DESCRIPTION
* Fix  wrongly rendered link.


-----------------------------------------------

@paulproteus It seems that the newline between the link text and the URL caused the issue in the first place.