### PR TITLE
Makefile: force usage of node/npm from the proper meteor bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,10 +249,10 @@ shell-env: tmp/.shell-env
 # the dependency on tmp/.ekam-run.
 tmp/.shell-env: tmp/.ekam-run $(IMAGES) shell/client/changelog.html shell/client/styles/_icons.scss shell/package.json shell/npm-shrinkwrap.json
 	@mkdir -p tmp
-	@touch tmp/.shell-env
 	@mkdir -p node_modules/capnp
 	@bash -O extglob -c 'cp src/capnp/!(*test*).capnp node_modules/capnp'
-	@cd shell/ && meteor npm install
+	@cd shell/ && PATH=$(METEOR_DEV_BUNDLE)/bin:$$PATH $(METEOR_DEV_BUNDLE)/bin/npm install
+	@touch tmp/.shell-env
 
 icons/node_modules: icons/package.json
 	cd icons && PATH=$(METEOR_DEV_BUNDLE)/bin:$$PATH $(METEOR_DEV_BUNDLE)/bin/npm install


### PR DESCRIPTION
Invoking "meteor npm" appears to sometimes still have issues with calling
node-gyp with the wrong node version.  In particular, if you have a more
up-to-date meteor-tool on your system, it will attempt to compile against
that tool, even if you have an older .meteor/release file.  I was getting
compile failures for bignum, and node-gyp was trying to build with node 4.
Which seems wrong.

Setting PATH and the precise npm invoked appears to fix this.

Separately: we shouldn't be touching tmp/.shell-env until after we've finished
the work for which that file marks successful completion.