### PR TITLE
Allow anonymous users to be offered capabilities.

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1802,7 +1802,7 @@ Router.map(function () {
                 grainToOpen.revealIdentity(identityChosenByLogin);
               }
 
-              if (!Meteor.userId()) {
+              if (!Meteor.userId() && globalGrains.getAll().length <= 1) {
                 // Suggest to the user that they log in by opening the login menu.
                 globalTopbar.openPopup("login");
               }

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1274,6 +1274,11 @@ Template.emailInviteTab.events({
 });
 
 Template.grainPowerboxOfferPopup.onCreated(function () {
+  let sessionToken = null;
+  if (Router.current().route.getName() === "shared") {
+    sessionToken = Router.current().params.token;
+  }
+
   this._state = new ReactiveVar({ waiting: true });
   const offer = this.data.offer;
   const sessionId = this.data.sessionId;
@@ -1291,7 +1296,8 @@ Template.grainPowerboxOfferPopup.onCreated(function () {
       Router.go("grain", { grainId: apiToken.grainId });
     }
   } else if (offer && offer.uiView && offer.uiView.token) {
-    Meteor.call("acceptPowerboxOffer", sessionId, offer.uiView.token, (err, result) => {
+    Meteor.call("acceptPowerboxOffer", sessionId, offer.uiView.token, sessionToken,
+                (err, result) => {
       if (err) {
         this._state.set({ error: err });
       } else {
@@ -1305,7 +1311,7 @@ Template.grainPowerboxOfferPopup.onCreated(function () {
       }
     });
   } else if (offer && offer.token) {
-    Meteor.call("acceptPowerboxOffer", sessionId, offer.token, (err, result) => {
+    Meteor.call("acceptPowerboxOffer", sessionId, offer.token, sessionToken, (err, result) => {
       if (err) {
         this._state.set({ error: err });
       } else {

--- a/shell/client/grain.html
+++ b/shell/client/grain.html
@@ -488,10 +488,17 @@
 </template>
 <template name="grainPowerboxOfferPopup">
   <h4>Powerbox Offer</h4>
+  {{#if state.webkey}}
   <div>
-    <a class="copy-me" href="{{powerboxOfferUrl}}" id="powerbox-offer-url">{{powerboxOfferUrl}}</a>
+    <a class="copy-me" href="{{state.webkey}}" id="powerbox-offer-url">{{state.webkey}}</a>
     <button class="dismiss">Dismiss</button>
   </div>
+  {{/if}}
+  {{#if state.error}}
+  <div>
+     Error: {{state.error}}
+  </div>
+  {{/if}}
 </template>
 
 <template name="grain">

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -605,7 +605,7 @@ credentialsSubscription = Meteor.subscribe("credentials");
 Template.registerHelper("dateString", makeDateString);
 Template.registerHelper("hideNavbar", function () {
   // Hide navbar if user is not logged in, since they can't go anywhere with it.
-  return !Meteor.userId() || isDemoExpired();
+  return (!Meteor.userId() && globalGrains.getAll().length <= 1) || isDemoExpired();
 });
 
 Template.registerHelper("shrinkNavbar", function () {

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -634,8 +634,6 @@ body>.topbar {
     >ul.navbar-grains {
       margin: 0;
       padding: 0;
-      position: absolute;
-      top: (96px + $navbar-shrink-button-height);
       bottom: 0px;
       left: 0px;
       width: 100%;

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -799,33 +799,17 @@ class GrainView {
     });
 
     const offer = session && session.powerboxView && session.powerboxView.offer;
-    if (offer && offer.uiView) {
-      // If this is an offer of a UiView, immediately dismiss the popup and open the grain.
-      const apiToken = this._db.collections.apiTokens.findOne(offer.uiView.tokenId);
-      if (apiToken && apiToken.grainId) {
+
+    return {
+      sessionId,
+      offer,
+      onDismiss: () => {
         Meteor.call("finishPowerboxOffer", sessionId, function (err) {
+          // TODO(someday): display the error nicely to the user
           if (err) {
             console.error(err);
           }
         });
-
-        Router.go("grain", { grainId: apiToken.grainId });
-      }
-    }
-
-    return {
-      get: function () {
-        return {
-          offer: offer,
-          onDismiss: () => {
-            Meteor.call("finishPowerboxOffer", sessionId, function (err) {
-              // TODO(someday): display the error nicely to the user
-              if (err) {
-                console.error(err);
-              }
-            });
-          },
-        };
       },
     };
   }

--- a/shell/imports/server/persistent.js
+++ b/shell/imports/server/persistent.js
@@ -125,8 +125,15 @@ function checkRequirements(db, requirements) {
       const p = requirement.permissionsHeld;
       const viewInfo = db.collections.grains.findOne(
           p.grainId, { fields: { cachedViewInfo: 1 } }).cachedViewInfo;
+      let vertex;
+      if (p.identityId) {
+        vertex = { grain: { _id: p.grainId, identityId: p.identityId } };
+      } else {
+        vertex = { token: { _id: p.tokenId, grainId: p.grainId } };
+      }
+
       const currentPermissions = SandstormPermissions.grainPermissions(db,
-          { grain: { _id: p.grainId, identityId: p.identityId } }, viewInfo || {}).permissions;
+          vertex, viewInfo || {}).permissions;
       if (!currentPermissions) {
         throw new Meteor.Error(403,
             "Capability revoked because a user involved in introducing it no longer has " +

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -33,8 +33,10 @@ limitations under the License.
       {{/each}}
     </ul>
     <ul class="navbar {{#if hideNavbar}}hide-desktop{{else}}{{#if shrinkNavbar}}shrink-desktop{{/if}}{{/if}}">
+      {{#if currentUser}}
       <li class="navitem-create-grain {{#if isCurrentRoute 'apps'}}current{{/if}}"><a href="{{pathFor route='apps'}}">Apps</a></li>
       <li class="navitem-open-grain {{#if isCurrentRoute 'grains'}}current{{/if}}"><a href="{{pathFor route='grains'}}"><span>Grains</span></a></li>
+      {{/if}}
 
       <li class="navbar-shrink-item">
         <button class="navbar-shrink icon icon-arrow {{#if shrinkNavbar}}shrunk{{/if}}"

--- a/shell/server/00-startup.js
+++ b/shell/server/00-startup.js
@@ -41,7 +41,7 @@ Meteor.onConnection((connection) => {
 });
 SandstormDb.periodicCleanup(5 * 60 * 1000, SandstormPermissions.cleanupSelfDestructing(globalDb));
 SandstormDb.periodicCleanup(10 * 60 * 1000,
-                            SandstormPermissions.cleanupClientPowerboxRequests(globalDb));
+                            SandstormPermissions.cleanupClientPowerboxTokens(globalDb));
 SandstormDb.periodicCleanup(24 * 60 * 60 * 1000, () => {
   SandstormAutoupdateApps.updateAppIndex(globalDb);
 });

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 const Capnp = Npm.require("capnp");
+const Crypto = Npm.require("crypto");
 const Url = Npm.require("url");
 import { PersistentImpl, hashSturdyRef, generateSturdyRef, checkRequirements }
     from "/imports/server/persistent.js";
@@ -320,15 +321,22 @@ Meteor.methods({
     Notifications.update({ userId: Meteor.userId() }, { $set: { isUnread: false } }, { multi: true });
   },
 
-  acceptPowerboxOffer(sessionId, sturdyRef) {
+  acceptPowerboxOffer(sessionId, sturdyRef, sessionToken) {
     const db = this.connection.sandstormDb;
     check(sessionId, String);
     check(sturdyRef, String);
+    check(sessionToken, Match.OneOf(String, null, undefined));
 
-    const session = db.collections.sessions.findOne(
-        { _id: sessionId, userId: this.userId || { $exists: false } });
+    const sessionQuery = { _id: sessionId };
+    if (sessionToken) {
+      sessionQuery.hashedToken = hashSturdyRef(sessionToken);
+    } else {
+      sessionQuery.userId = this.userId;
+    }
+
+    const session = db.collections.sessions.findOne(sessionQuery);
     if (!session) {
-      throw new Meteor.Error(403, "Invalid session ID");
+      throw new Meteor.Error(404, "No matching session found.");
     }
 
     const tokenId = hashSturdyRef(sturdyRef);
@@ -341,18 +349,43 @@ Meteor.methods({
       throw new Meteor.Error(404, "No such token.");
     }
 
-    const cap = restoreInternal(
-      new Buffer(sturdyRef),
-      { clientPowerboxOffer: { sessionId } },
-      [],
-      apiToken).cap;
+    let newSturdyRef;
+    let hashedNewSturdyRef;
+    if (sessionToken && apiToken.parentToken) {
+      // An anonymous user is being offered a child token. To avoid bloating the database,
+      // we deterministically derive the sturdyref from the session token and the hashed parent
+      // token.
+      //
+      // Note that an attacker with read access to the database might be able to derive
+      // `newSturdyRef` from `sessionToken` and gain access to the capability without ever having
+      // been explicitly offered it by the grain. Therefore, grains must assume that offering
+      // a capability to an anonymous user can possibly make that capability accessible to any
+      // other anonymous user who has connected through the same URL.
 
-    const owner = { webkey: null };
+      newSturdyRef = Crypto.createHash("sha256")
+        .update(sessionToken)
+        .update(apiToken.parentToken)
+        .digest("base64")
+        .slice(0, -1)                             // removing trailing "="
+        .replace(/\+/g, "-").replace(/\//g, "_"); // make URL-safe
 
-    const castedCap = cap.castAs(SystemPersistent);
-    const result = waitPromise(castedCap.save(owner)).sturdyRef.toString();
+      hashedNewSturdyRef = hashSturdyRef(newSturdyRef);
+      if (db.collections.apiTokens.findOne({ _id: hashedNewSturdyRef })) {
+        // We have already generated this token.
+        db.removeApiTokens({ _id: tokenId });
+        return newSturdyRef;
+      }
+    } else {
+      newSturdyRef = generateSturdyRef();
+      hashedNewSturdyRef = hashSturdyRef(newSturdyRef);
+    }
+
+    apiToken._id = hashedNewSturdyRef;
+    apiToken.owner = { webkey: null };
+
+    db.collections.apiTokens.insert(apiToken);
     db.removeApiTokens({ _id: tokenId });
-    return result;
+    return newSturdyRef;
   },
 
 });

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -80,13 +80,15 @@ SessionContextImpl = class SessionContextImpl {
 
   offer(cap, requiredPermissions, descriptor, displayInfo) {
     return inMeteor(() => {
-      if (!this.identityId) {
-        // TODO(soon): allow non logged in users?
-        throw new Meteor.Error(400, "Only logged in users can offer capabilities.");
+
+      const session = Sessions.findOne({ _id: this.sessionId });
+
+      if (!session.identityId && !session.hashedToken) {
+        throw new Meteor.Error(400, "");
       }
 
       const castedCap = cap.castAs(SystemPersistent);
-      let apiTokenOwner = { webkey: null };
+      let apiTokenOwner = { clientPowerboxOffer: { sessionId: this.sessionId, }, };
       const isUiView = descriptor && descriptor.tags && descriptor.tags.length === 1 &&
           descriptor.tags[0] && descriptor.tags[0].id &&
           descriptor.tags[0].id === Grain.UiView.typeId;
@@ -102,23 +104,32 @@ SessionContextImpl = class SessionContextImpl {
           tagValue.title = "offer()ed grain had no title";
         }
 
-        apiTokenOwner = {
-          user: {
-            identityId: this.identityId,
-            title: tagValue.title,
-          },
-        };
+        if (session.identityId) {
+          apiTokenOwner = {
+            user: {
+              identityId: this.identityId,
+              title: tagValue.title,
+            },
+          };
+        }
       }
 
       // TODO(soon): This will eventually use SystemPersistent.addRequirements when membranes
       // are fully implemented for supervisors.
-      const requirement = {
-        permissionsHeld: {
-          grainId: this.grainId,
-          identityId: this.identityId,
-          permissions: requiredPermissions,
-        },
+      const permissionsHeld = {
+        grainId: this.grainId,
+        permissions: requiredPermissions,
       };
+
+      if (session.identityId) {
+        permissionsHeld.identityId = session.identityId;
+      } else if (session.hashedToken) {
+        permissionsHeld.tokenId = session.hashedToken;
+      } else {
+        throw new Error("Cannot offer to anonymous session that does not have a token.");
+      }
+
+      const requirement = { permissionsHeld };
 
       checkRequirements(globalDb, [requirement]);
 
@@ -128,27 +139,31 @@ SessionContextImpl = class SessionContextImpl {
 
       let powerboxView;
       if (isUiView) {
-        // Deduplicate.
-        let tokenId = hashSturdyRef(sturdyRef.toString());
-        const newApiToken = ApiTokens.findOne({ _id: tokenId });
-        const dupeQuery = _.pick(newApiToken, "grainId", "roleAssignment", "requirements",
-                                 "parentToken", "identityId", "accountId");
-        dupeQuery._id = { $ne: newApiToken._id };
-        dupeQuery["owner.user.identityId"] = this.identityId;
-        dupeQuery.trashed = { $exists: false };
-        dupeQuery.revoked = { $exists: false };
+        if (session.identityId) {
+          // Deduplicate.
+          let tokenId = hashSturdyRef(sturdyRef.toString());
+          const newApiToken = ApiTokens.findOne({ _id: tokenId });
+          const dupeQuery = _.pick(newApiToken, "grainId", "roleAssignment", "requirements",
+                                   "parentToken", "identityId", "accountId");
+          dupeQuery._id = { $ne: newApiToken._id };
+          dupeQuery["owner.user.identityId"] = this.identityId;
+          dupeQuery.trashed = { $exists: false };
+          dupeQuery.revoked = { $exists: false };
 
-        const dupeToken = ApiTokens.findOne(dupeQuery);
-        if (dupeToken) {
-          globalDb.removeApiTokens({ _id: tokenId });
-          tokenId = dupeToken._id;
+          const dupeToken = ApiTokens.findOne(dupeQuery);
+          if (dupeToken) {
+            globalDb.removeApiTokens({ _id: tokenId });
+            tokenId = dupeToken._id;
+          }
+
+          powerboxView = { offer: { uiView: { tokenId } } };
+        } else {
+          powerboxView = { offer: { uiView: { token: sturdyRef.toString() } } };
         }
-
-        powerboxView = { offer: { uiView: { tokenId } } };
       } else {
         powerboxView = {
           offer: {
-            url: ROOT_URL.protocol + "//" + globalDb.makeApiHost(sturdyRef) + "#" + sturdyRef,
+            token: sturdyRef.toString(),
           },
         };
       }

--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -84,7 +84,7 @@ SessionContextImpl = class SessionContextImpl {
       const session = Sessions.findOne({ _id: this.sessionId });
 
       if (!session.identityId && !session.hashedToken) {
-        throw new Meteor.Error(400, "");
+        throw new Error("Session has neither an identityId nor a hashedToken.");
       }
 
       const castedCap = cap.castAs(SystemPersistent);

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -410,7 +410,9 @@ Meteor.methods({
 
         // Create a new API token for the identity redeeming this token.
         const result = SandstormPermissions.createNewApiToken(
-          globalDb, { rawParentToken: token }, apiToken.grainId, apiToken.petname, { allAccess: null }, owner);
+          globalDb, { rawParentToken: token }, apiToken.grainId,
+          apiToken.petname || "redeemed webkey",
+          { allAccess: null }, owner);
         globalDb.addContact(apiToken.accountId, identityId);
 
         // If the parent API token is forSharing and it has an accountId, then the logged-in user (call

--- a/tests/apps/collections.js
+++ b/tests/apps/collections.js
@@ -294,10 +294,6 @@ module.exports["Test collections anonymous user"] = function (browser) {
         .click("table.grain-list-table>tbody tr:nth-child(1).grain .click-to-go")
         .frame(null)
 
-        // We get another login nag here.
-        .waitForElementVisible(".popup.login button.close-popup", short_wait)
-        .click(".popup.login button.close-popup")
-
         .grainFrame(grainIdB)
         .waitForElementVisible(".description-row p", short_wait)
         .assert.containsText(".description-row p", "This is Collection B")

--- a/tests/apps/collections.js
+++ b/tests/apps/collections.js
@@ -23,8 +23,8 @@ var utils = require("../utils"),
     long_wait = utils.long_wait;
 
 var COLLECTIONS_APP_ID = "s3u2xgmqwznz2n3apf30sm3gw1d85y029enw5pymx734cnk5n78h";
-var COLLECTIONS_PACKAGE_ID = "f636f1239d9bd0eace4de2f7e238b633";
-var COLLECTIONS_PACKAGE_URL = "https://sandstorm.io/apps/david/collections1.spk";
+var COLLECTIONS_PACKAGE_ID = "e9408a7c077f7a9baeb9c02f0437ae40";
+var COLLECTIONS_PACKAGE_URL = "https://sandstorm.io/apps/david/collections3.spk";
 
 module.exports = {};
 
@@ -37,8 +37,8 @@ function setGrainTitle(browser, collectionTitle) {
     .grainFrame()
     .waitForElementVisible("button[title='add description']", short_wait)
     .click("button[title='add description']")
-    .waitForElementVisible("form.description-row>textarea", short_wait)
-    .setValue("form.description-row>textarea", "This is " + collectionTitle)
+    .waitForElementVisible("form.description-row>input[type=text]", short_wait)
+    .setValue("form.description-row>input[type=text]", "This is " + collectionTitle)
     .click("form.description-row>button")
     .frame(null)
 }
@@ -127,7 +127,7 @@ module.exports["Test Collections"] = function (browser) {
 
           .waitForElementVisible("table.grain-list-table>tbody>tr.add-grain>td>button", short_wait)
           .waitForElementVisible("table.grain-list-table>tbody tr:nth-child(2).grain", short_wait)
-          .assert.containsText("table.grain-list-table>tbody tr:nth-child(2).grain td>a",
+          .assert.containsText("table.grain-list-table>tbody tr:nth-child(2).grain td>button",
                                "Collection B")
           .click("table.grain-list-table>tbody tr:nth-child(2).grain .click-to-go")
           .frame(null)
@@ -157,7 +157,7 @@ module.exports["Test Collections"] = function (browser) {
           .grainFrame(grainIdA)
           .waitForElementVisible("table.grain-list-table>tbody>tr.add-grain>td>button", short_wait)
           .waitForElementVisible("table.grain-list-table>tbody tr:nth-child(3).grain", short_wait)
-          .assert.containsText("table.grain-list-table>tbody tr:nth-child(3).grain td>a",
+          .assert.containsText("table.grain-list-table>tbody tr:nth-child(3).grain td>button",
                                "Collection C")
           .click("table.grain-list-table>tbody tr:nth-child(3).grain .click-to-go")
           .frame(null)
@@ -191,7 +191,7 @@ module.exports["Test Collections"] = function (browser) {
 
               .waitForElementVisible("table.grain-list-table>tbody tr:nth-child(2).grain",
                                      short_wait)
-              .assert.containsText("table.grain-list-table>tbody tr:nth-child(2).grain td>a",
+              .assert.containsText("table.grain-list-table>tbody tr:nth-child(2).grain td>button",
                                    "Collection A")
               .click("table.grain-list-table>tbody tr:nth-child(2).grain .click-to-go")
 
@@ -217,7 +217,7 @@ module.exports["Test Collections"] = function (browser) {
                                      short_wait)
               .waitForElementVisible("table.grain-list-table>tbody tr:nth-child(2).grain",
                                      short_wait)
-              .assert.containsText("table.grain-list-table>tbody tr:nth-child(2).grain td>a",
+              .assert.containsText("table.grain-list-table>tbody tr:nth-child(2).grain td>button",
                                    "Collection B")
               .click("table.grain-list-table>tbody tr:nth-child(2).grain td>input[type=checkbox]")
               .waitForElementVisible(".bulk-action-buttons>button[title='unlink selected grains']",
@@ -241,3 +241,77 @@ module.exports["Test Collections"] = function (browser) {
     });
   });
 };
+
+module.exports["Test collections anonymous user"] = function (browser) {
+  browser = browser
+    .init()
+    .loginDevAccount()
+    .installApp(COLLECTIONS_PACKAGE_URL, COLLECTIONS_PACKAGE_ID, COLLECTIONS_APP_ID);
+  browser = setGrainTitle(browser, "Collection A");
+  browser.executeAsync(function (done) {
+    var grainId = Grains.findOne()._id;
+    Meteor.call("newApiToken", { identityId: Meteor.user().loginIdentities[0].id },
+                grainId, "petname", { allAccess: null },
+                { webkey: { forSharing: true }, },
+                function(error, result) {
+                  done({ error: error, grainId: grainId, token: (result || {}).token });
+                });
+  }, [], function (result) {
+    var grainIdA = result.value.grainId;
+    var tokenA = result.value.token;
+    browser.assert.equal(!result.value.error, true);
+    browser.newGrain(COLLECTIONS_APP_ID, function (grainIdB) {
+      browser = setGrainTitle(browser, "Collection B");
+
+      browser
+        .url(browser.launch_url + "/grain/" + grainIdA)
+        .grainFrame()
+        .waitForElementVisible("table.grain-list-table>tbody>tr.add-grain>td>button", medium_wait)
+        .click("table.grain-list-table>tbody>tr.add-grain>td>button")
+        .frame(null)
+        .waitForElementVisible(powerboxCardSelector(grainIdB), short_wait)
+        .click(powerboxCardSelector(grainIdB))
+
+        // Add with 'editor' permissions.
+        .waitForElementVisible(".popup.request .selected-card>form input[value='0']", short_wait)
+        .click(".popup.request .selected-card>form input[value='0']")
+        .click(".popup.request .selected-card>form button.connect-button")
+
+        // Visit token A anonymously. The link should still work.
+        .frame(null)
+        .execute("window.Meteor.logout()")
+
+        .url(browser.launch_url + "/shared/" + tokenA)
+        .waitForElementVisible(".popup.login button.close-popup", short_wait)
+        .click(".popup.login button.close-popup")
+        .grainFrame()
+        .waitForElementVisible(".description-row p", short_wait)
+        .assert.containsText(".description-row p", "This is Collection A")
+        .waitForElementVisible(".description-row button.description-button", short_wait)
+        .waitForElementVisible("table.grain-list-table>tbody tr:nth-child(1).grain", short_wait)
+        .assert.containsText("table.grain-list-table>tbody tr:nth-child(1).grain td>button",
+                             "Collection B")
+        .click("table.grain-list-table>tbody tr:nth-child(1).grain .click-to-go")
+        .frame(null)
+
+        // We get another login nag here.
+        .waitForElementVisible(".popup.login button.close-popup", short_wait)
+        .click(".popup.login button.close-popup")
+
+        .grainFrame(grainIdB)
+        .waitForElementVisible(".description-row p", short_wait)
+        .assert.containsText(".description-row p", "This is Collection B")
+        .waitForElementVisible(".description-row button.description-button", short_wait)
+
+        .frame(null)
+        .url(function (sharedUrlGrainB) {
+          browser.loginDevAccount()
+            .url(sharedUrlGrainB.value)
+            .waitForElementVisible(".grain-interstitial button.pick-identity", short_wait)
+            .click(".grain-interstitial button.pick-identity")
+            .grainFrame(grainIdB)
+            .end();
+        });
+    });
+  });
+}


### PR DESCRIPTION
The two big changes here are:
  1. `MembraneRequirement.permissionsHeld.identityId` is now part of a union, the other variant being `MembraneRequirement.permissionsHeld.tokenId`.
  2. `ApiTokenOwner` has a new variant `clientPowerboxOffer` whose purpose is to allow `SessionContext.offer()` to push a webkey to the client without ever actually writing the webkey to the database (as we currently do in the copy/paste powerbox). In principle, we should be able to avoid the need for this owner variant (probably by using a pseudo-collection), but that seems at least somewhat tricky, and we already have machinery in place for doing it the way proposed here.

Fixes #2190.

This does *not* dedupe webkeys offered to anonymous users, as had been suggested in #2190. Deduping seems less important in this case than in the owned-by-a-logged-in-user case, because:
  1. There are no grain-renaming issues.
  2. The "duplicate" tokens are likely to be pruned early in the permissions computation; they will typically be dead-ends in the sharing graph and easy to prove to be irrelevant to most computations.