### PR TITLE
Prevent error that could happen on reloading account-settings page.

### DIFF
--- a/shell/client/accounts/account-settings.js
+++ b/shell/client/accounts/account-settings.js
@@ -59,15 +59,15 @@ const helpers = {
   },
 
   identities: function () {
-    return SandstormDb.getUserIdentityIds(Meteor.user()).map(function (id) {
-      const identity = Meteor.users.findOne({ _id: id });
-      if (identity) {
+    return _.chain(SandstormDb.getUserIdentityIds(Meteor.user()))
+      .map((id) => Meteor.users.findOne({ _id: id }))
+      .filter((identity) => !!identity)
+      .map((identity) => {
         SandstormDb.fillInProfileDefaults(identity);
         SandstormDb.fillInIntrinsicName(identity);
         SandstormDb.fillInPictureUrl(identity);
         return identity;
-      }
-    });
+      }).value();
   },
 
   isNeutral: function () {


### PR DESCRIPTION
Currently, if I visit account-settings and then refresh the page, my debug console display a bunch of errors like: `Exception in template helper: TypeError: Cannot read property 'privateIntrinsicName' of undefined`. This patch prevents those errors.