### PR TITLE
Add single-quote marks to get identicons to work in powerbox cards.

### DIFF
--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -13,7 +13,7 @@
     {{#with selectedProvider}}
       <div class="selected-card">
         <div class="powerbox-card" data-card-id="{{ option._id }}"
-             style="background-image: url({{ iconSrc }});">
+             style="background-image: url('{{ iconSrc }}');">
           {{>cardTemplate}}
         </div>
         {{>configureTemplate}}
@@ -29,7 +29,7 @@
       {{#each cards}}
         <li class="powerbox-card">
           <button class="card-button" data-card-id="{{ option._id }}"
-                  style="background-image: url({{ iconSrc }});">
+                  style="background-image: url('{{ iconSrc }}');">
             {{>cardTemplate}}
           </button>
         </li>


### PR DESCRIPTION
If these quotes are not present, then our data-url svgs fail to render. Other similar usages of `background-image` in our code also use single quotes, e.g. https://github.com/sandstorm-io/sandstorm/blob/7ead9c71c9bbd2932df6b1ba31f3397d96a571bf/shell/client/grain/grainlist.html#L150