### PR TITLE
Refactor/prettify notification templates

### DIFF
--- a/shell/client/notifications-client.js
+++ b/shell/client/notifications-client.js
@@ -181,6 +181,7 @@ Template.mailingListBonusNotificationItem.helpers({
       size = size / 1000;
       suffix = "kB";
     }
+
     return Math.floor(size) + suffix;
   },
 
@@ -190,14 +191,14 @@ Template.mailingListBonusNotificationItem.helpers({
     } else {
       return 0;
     }
-  }
+  },
 });
 
 Template.mailingListBonusNotificationItem.events({
   "submit form"(evt) {
     evt.preventDefault();
     evt.stopPropagation();
-    Meteor.call("subscribeMailingList", function(err) {
+    Meteor.call("subscribeMailingList", (err) => {
       if (err) {
         window.alert("Error subscribing to list: " + err.message);
       } else {

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -162,72 +162,175 @@ limitations under the License.
   </ul>
 </template>
 
-<template name="notificationItem">
-  <a class="notification-item {{#if hasIcon}}has-icon{{/if}}" href="{{notificationUrl}}">
-    {{#if hasIcon}}
-      <div class="notification-icon">
-        {{#if senderIcon}}<img src="{{senderIcon}}">{{/if}}
-        {{#if grainIcon}}<img src="{{grainIcon}}">{{/if}}
-      </div>
-    {{/if}}
+<template name="appUpdateNotificationItem">
+  <div class="notification-item">
+    <div class="notification-icon">
+      <img src="/apps.svg">
+      {{#if senderIcon}}<img src="{{senderIcon}}">{{/if}}
+      {{#if grainIcon}}<img src="{{grainIcon}}">{{/if}}
+    </div>
 
-    {{#if senderName}}
-      <div class="notification-title">
-        <strong>{{senderName}}</strong> in <strong>{{grainTitle}}</strong>:
-      </div>
-    {{else}}
-      {{#if notificationTitle}}
-        <div class="notification-title">
-          {{notificationTitle}}:
-        </div>
-      {{/if}}
-    {{/if}}
+    <div class="notification-title">
+      App updates are available:
+    </div>
 
-    {{#if isAppUpdates}}
-      <ul class="app-updates">
-      {{#each appUpdatesList}}
-        <li><b>{{name}}</b>: version {{marketingVersion}} is available</li>
-      {{/each}}
-      </ul>
-    {{else}}
-      {{#if adminLink}}
-        <a href="{{adminLink}}">{{text.defaultText}}</a>
-      {{else}}
-        {{#if referral}}
-          {{#if paidUser}}
-            Get up to 30 GB bonus with the
-          {{else}}
-            Unlimited grains &amp; up to 2 GB bonus with the
-          {{/if}}
-          {{#linkTo route="referrals"}}
-            referral program &raquo;
-          {{/linkTo}}
-        {{else}}
-          {{#if mailingListBonus}}
-            {{> mailingListBonusNotification}}
-          {{else}}
-            {{text.defaultText}}
-            {{#if multiple}}x{{count}}{{/if}}
-          {{/if}}
-        {{/if}}
-      {{/if}}
-    {{/if}}
+    <ul class="app-updates">
+    {{#each appUpdatesList}}
+      <li><strong>{{name}}</strong>: version {{marketingVersion}} is available</li>
+    {{/each}}
+    </ul>
+
     <div class="notification-footer">
       <span title="{{timestamp}}" class="notification-timestamp">{{dateString timestamp}}</span>
-      {{#if isAppUpdates}}
-        <button title="Ignore the above updates" class="cancel-notification">Dismiss</button>
-        <button title="Update all of the above apps" class="accept-notification">Apply Updates</button>
-      {{else}}
-        {{#if mailingListBonus}}
-          {{> mailingListBonusNotificationButtons}}
-        {{else}}
-          {{#if dismissText}}
-            <button title="{{titleHelperText}}" class="cancel-notification">{{dismissText}}</button>
-          {{/if}}
-        {{/if}}
-      {{/if}}
+      <form class="standard-form">
+        <div class="button-row">
+          <button type="submit" title="Update all of the above apps">Apply updates</button>
+          <button type="button" name="dismissUpdates" title="Ignore the above updates">Dismiss</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<template name="mailingListBonusNotificationItem">
+{{!-- This template is only instantiated in the Blackrock deployment, but it's easier
+      to all the notification templates together, since it's not really sensitive. --}}
+  <div class="notification-item">
+    <div class="notification-icon">
+      <img src="/email.svg">
+    </div>
+
+    Subscribe to our announcement list and get <strong>{{renderStorage MAILING_LIST_BONUS}} bonus
+    storage</strong> (1-2 emails per month).
+
+    <div class="notification-footer">
+      <span title="{{timestamp}}" class="notification-timestamp">{{dateString timestamp}}</span>
+      <form class="standard-form">
+        <div class="button-row">
+          <button type="submit">Subscribe</button>
+          <button type="button">No thanks</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<template name="referralNotificationItem">
+  {{#linkTo route="referrals" class="notification-item"}}
+    <div class="notification-icon">
+    </div>
+
+    {{#if paidUser}}
+      Get up to 30 GB bonus with the
+    {{else}}
+      Unlimited grains &amp; up to 2 GB bonus with the
+    {{/if}}
+    {{#linkTo route="referrals"}}
+      referral program &raquo;
+    {{/linkTo}}
+
+    <div class="notification-footer">
+      <span title="{{timestamp}}" class="notification-timestamp">{{dateString timestamp}}</span>
+      <form class="standard-form">
+        <div class="button-row">
+          <button type="button">Dismiss</button>
+        </div>
+      </form>
+    </div>
+  {{/linkTo}}
+</template>
+
+<template name="adminNotificationItem">
+{{!-- The only admin notification type that exists is the stats notification.
+      If there wind up being more types, extract those into separate
+      notification items --}}
+  {{#if isStatsNotification}}
+    {{#linkTo route="newAdminStats" class="notification-item"}}
+      <div class="notification-title">
+        Notification from system:
+      </div>
+
+      You can help Sandstorm by sending us some anonymous usage stats.
+      Click here for more info.
+
+      <div class="notification-footer">
+        <span title="{{timestamp}}" class="notification-timestamp">{{dateString timestamp}}</span>
+      </div>
+    {{/linkTo}}
+  {{/if}}
+</template>
+
+<template name="backgroundedGrainNotificationItem">
+  {{#linkTo route="grain" class="notification-item"}}
+    <div class="notification-icon">
+      <img src="{{grainIcon}}">
+    </div>
+
+    <div class="notification-title">
+      <strong>{{grainTitle}}</strong> is backgrounded:
+    </div>
+
+    {{text.defaultText}}
+
+    <div class="notification-footer">
+      <span title="{{timestamp}}" class="notification-timestamp">{{dateString timestamp}}</span>
+      <form class="standard-form">
+        <div class="button-row">
+          <button title="Stop the background app" type="button">Cancel</button>
+        </div>
+      </form>
+    </div>
+  {{/linkTo}}
+</template>
+
+<template name="grainActivityNotificationItem">
+  <a class="notification-item" href="{{notificationUrl}}">
+    <div class="notification-icon">
+      {{#if senderIcon}}<img src="{{senderIcon}}">{{/if}}
+      {{#if grainIcon}}<img src="{{grainIcon}}">{{/if}}
+    </div>
+
+    <div class="notification-title">
+      <strong>{{senderName}}</strong> in <strong>{{grainTitle}}</strong>:
+    </div>
+
+    {{text.defaultText}} {{#if multiple}}x{{count}}{{/if}}
+
+    <div class="notification-footer">
+      <span title="{{timestamp}}" class="notification-timestamp">{{dateString timestamp}}</span>
+      <form class="standard-form">
+        <div class="button-row">
+          <button type="button" title="Dismiss this notification">Dismiss</button>
+        </div>
+      </form>
     </div>
   </a>
+</template>
+
+<template name="notificationItem">
+  {{!-- TODO(someday): make these be more explicitly typed, and dispatch on type.
+        Ideally, allow dynamic registration of types --}}
+  {{#if isAppUpdates}}
+    {{> appUpdateNotificationItem . }}
+  {{else}}
+  {{#if isMailingListBonus }}
+    {{> mailingListBonusNotificationItem . }}
+  {{else}}
+  {{#if isReferral}}
+    {{> referralNotificationItem . }}
+  {{else}}
+  {{#if isAdminNotification}}
+    {{> adminNotificationItem . }}
+  {{else}}
+  {{#if isOngoing }}
+    {{> backgroundedGrainNotificationItem . }}
+  {{else}}
+    {{> grainActivityNotificationItem . }}
+  {{/if}}
+  {{/if}}
+  {{/if}}
+  {{/if}}
+  {{/if}}
 </template>
 
 <template name="title">

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -1236,23 +1236,27 @@ body>.popup {
         text-decoration: inherit;
         font-weight: inherit;
         color: inherit;
-        padding: $topbar-popup-padding;
+
+        padding-left: $topbar-popup-padding + $topbar-popup-padding + 64px;
+        padding-right: $topbar-popup-padding;
+        padding-top: $topbar-popup-padding;
+        padding-bottom: $topbar-popup-padding;
+
         position: relative;
 
-        &.has-icon {
-          padding-left: $topbar-popup-padding + 96px;
-        }
+        // Guarantee position-absolute icons don't get cut off
+        min-height: $topbar-popup-padding + $topbar-popup-padding + 64px;
 
         &[href]:hover {
           background-color: #eee;
         }
 
         >.notification-icon {
-          width: 96px;
-          height: 96px;
+          width: 64px;
+          height: 64px;
           position: absolute;
-          top: 0;
-          left: 0;
+          top: $topbar-popup-padding;
+          left: $topbar-popup-padding;
 
           >img {
             display: block;
@@ -1279,22 +1283,16 @@ body>.popup {
         }
 
         .notification-footer {
-          margin: 12px 0px;
-          height: 26px;
-          >button {
-            @extend %button-base;
+          position: relative;
+          margin-top: 12px;
+          min-height: 18px;
 
-            &.accept-notification {
-              @extend %button-primary;
-              float: right;
-              margin-left: 5px;
-            }
-
-            &.cancel-notification {
-              @extend %button-secondary;
-              float: right;
-              margin-left: 5px;
-            }
+          .notification-timestamp {
+            position: absolute;
+            left: 0px;
+            top: 0px;
+            text-align: left;
+            color: #aaa;
           }
         }
       }
@@ -1302,11 +1300,6 @@ body>.popup {
 
     .notification-selected button {
       background-color: #666;
-    }
-
-    .notification-timestamp {
-      text-align: left;
-      color: #ccc;
     }
 
     .notification-title {

--- a/tests/apps/backgrounding.js
+++ b/tests/apps/backgrounding.js
@@ -45,7 +45,7 @@ module.exports["Test Notification"] = function (browser) {
     .assert.containsText(".topbar .notifications .count", "1")
     .click(".topbar .notifications>.show-popup")
     .waitForElementNotPresent(".topbar .notifications .count", short_wait)
-    .click(".cancel-notification")
+    .click(".notification-list .notification-item button")
     .pause(short_wait)
     .windowHandles(function (windows) {
       browser

--- a/tests/tests/autoupdate.js
+++ b/tests/tests/autoupdate.js
@@ -41,7 +41,7 @@ module.exports["Test autoupdates"] = function (browser) {
     .assert.containsText(".package-info > .version > .content", "<unknown>")
     .click(".topbar .notifications>.show-popup")
     .waitForElementVisible(".app-updates", short_wait)
-    .click('.accept-notification')
+    .click('.notification-list .notification-item button[type=submit]')
     .waitForElementNotPresent(".app-updates", short_wait)
     .init()
     .url(browser.launch_url + "/apps/" + appId)


### PR DESCRIPTION
This pulls apart the six types of notifications into separate templates
and helpers, which makes it much easier to modify each without.

All notifications leave space for an icon, because having the notification text
aligned to a consistent grid makes the design look much cleaner.  If we want to
add icons for the referral program and the request to send us statistics, we
can do that pretty easily in the appropriate templates.

We also switch to using the standard-form styling for buttons, and the
default-action-on-right style.

I ran the designs by @neynah in person, and made a couple tweaks she recommended around icon size/padding.

Example of all six notification types shown below.

![example-notifications](https://cloud.githubusercontent.com/assets/307325/17450889/c57e4170-5b17-11e6-88eb-c58b21226c94.png)
