### PR TITLE
Remove PYTHONPATH override that worked around a Meteor bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,7 @@ shell/public/%-m.svg: icons/%.svg
 shell-build: shell/imports/* shell/imports/*/* shell/client/* shell/server/* shell/shared/* shell/public/* shell/packages/* shell/packages/*/* shell/.meteor/packages shell/.meteor/release shell/.meteor/versions tmp/.shell-env
 	@$(call color,meteor frontend)
 	@test -z "$$(find -L shell/* -type l)" || (echo "error: broken symlinks in shell: $$(find -L shell/* -type l)" >&2 && exit 1)
-	@OLD=`pwd` && cd shell && PYTHONPATH=$$HOME/.meteor/tools/latest/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib meteor build --directory "$$OLD/shell-build"
+	@OLD=`pwd` && cd shell && meteor build --directory "$$OLD/shell-build"
 
 # ====================================================================
 # Bundle

--- a/shell/run-dev.sh
+++ b/shell/run-dev.sh
@@ -94,8 +94,4 @@ cat > $SETTINGS << __EOF__
 }
 __EOF__
 
-# Work-around for problem where Meteor's bundled npm prefers the system gyp
-# over its own bundled version, and the system gyp doesn't work.
-export PYTHONPATH=$("$SCRIPT_DIR/../find-meteor-dev-bundle.sh")/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib
-
 exec meteor run --port=$BIND_IP:$PORT --settings $SETTINGS


### PR DESCRIPTION
Meteor has long since fixed their node-gyp path bug, and the code in the
Makefile can't possibly be right because `$HOME/.meteor/tools` doesn't exist
anymore.