### PR TITLE
Avoid mixing @include and @extends on the same properties

### DIFF
--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -1103,8 +1103,8 @@ body>.popup {
       margin-top: 10px;
     }
     .share-tabs form button {
-      @include unstyled-button();
       @extend %button-primary;
+      height: 32px;
       border: 1px solid #ccc;
       border-radius: 4px;
       padding: 5px 16px;


### PR DESCRIPTION
Fixes the background-color regression in the share menu buttons.

I grepped (but not very hard) for other instances of the same element having
both an `@include` and an `@extend`, and this seemed to be the only instance.