### PR TITLE
Temporarily restore SandstormEmail to global scope to fix Blackrock invoices.

### DIFF
--- a/shell/imports/server/email.js
+++ b/shell/imports/server/email.js
@@ -191,3 +191,6 @@ const send = function (options) {
 };
 
 export { send, rawSend };
+
+// TODO(cleanup): Remove this once BlackrockPayments code finds a better way to import it.
+global.SandstormEmail = { send };


### PR DESCRIPTION
We can come up with a cleaner fix later.