### PR TITLE
setup wizard email step: make self-test dialog "Close" button work

### DIFF
--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -459,7 +459,7 @@
 
   {{#if showTestSendEmailPopup}}
     {{#modalDialogWithBackdrop onDismiss=closePopupCallback}}
-      {{> emailTestPopup token=token smtpConfig=getSmtpConfig }}
+      {{> emailTestPopup token=token smtpConfig=getSmtpConfig onDismiss=closePopupCallback }}
     {{/modalDialogWithBackdrop}}
   {{/if}}
 


### PR DESCRIPTION
A template was missing a callback hook.

Fixes #2340.