### PR TITLE
Show errors in powerbox request dialog

### DIFF
--- a/shell/client/styles/_powerbox.scss
+++ b/shell/client/styles/_powerbox.scss
@@ -1,7 +1,7 @@
 body>.popup.request>.frame-container>.frame {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: stretch;
   justify-content: flex-start;
   max-height: inherit;
 

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -303,6 +303,11 @@ Template.powerboxRequest.helpers({
     return ref && ref._error.get();
   },
 
+  error() {
+    const ref = Template.instance().data.get();
+    return ref && ref._error.get();
+  },
+
   iconSrc() {
     // data context is a card here
     return this.cardTemplate.powerboxIconSrc && this.cardTemplate.powerboxIconSrc(this);

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -179,14 +179,7 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
         if (err) {
           this.failRequest(err);
         } else {
-          this._completed = true;
-          this._requestInfo.source.postMessage({
-            rpcId: this._requestInfo.rpcId,
-            token: result.sturdyRef,
-            descriptor: result.descriptor,
-          }, this._requestInfo.origin);
-          // Completion event closes popup.
-          this._requestInfo.onCompleted();
+          this.completeRequest(result.sturdyRef, result.descriptor);
         }
       }
     );

--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -9,6 +9,12 @@
     <div class="error">{{webkeyError}}</div>
     {{/if}}
   {{else}}
+    {{#if error}}
+      {{#focusingErrorBox}}
+        {{error}}
+      {{/focusingErrorBox}}
+    {{/if}}
+
     <h4>Select one:</h4>
     {{#with selectedProvider}}
       <div class="selected-card">


### PR DESCRIPTION
This should make `failRequest()` more useful, since error messages can go somewhere other than just the console.