### PR TITLE
Add cancelRequest() for powerbox plugins to call

### DIFF
--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -70,6 +70,11 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
     this._requestInfo.onCompleted();
   }
 
+  cancelRequest() {
+    this.finalize();
+    this._requestInfo.onCompleted();
+  }
+
   failRequest(err) {
     console.error(err);
     this._error.set(err.toString());


### PR DESCRIPTION
This allows powerbox plugins to dismiss the dialog entirely, marking the request as canceled by the user.