### PR TITLE
Don't navigate when dismissing a grain notification

### DIFF
--- a/shell/client/notifications-client.js
+++ b/shell/client/notifications-client.js
@@ -263,6 +263,8 @@ Template.grainActivityNotificationItem.helpers({
 
 Template.grainActivityNotificationItem.events({
   "click button[type=button]"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
     Meteor.call("dismissNotification", this._id);
   },
 });


### PR DESCRIPTION
Complements #2342, which did the same for the referral program button.