### PR TITLE
use replaceState when navigating away from `/upload` or `/uploadBackup`

### DIFF
--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -729,7 +729,7 @@ restoreBackup = function (file) {
               statusText: err.message,
             });
           } else {
-            Router.go("grain", { grainId: grainId });
+            Router.go("grain", { grainId: grainId }, { replaceState: true });
           }
         });
       });
@@ -750,7 +750,7 @@ uploadApp = function (file) {
     } else {
       startUpload(file, "/upload/" + token, function (response) {
         Session.set("uploadStatus", undefined);
-        Router.go("install", { packageId: response });
+        Router.go("install", { packageId: response }, { replaceState: true });
       });
     }
   });


### PR DESCRIPTION
Longer-term, we should probably make uploading not be an application-modal
action, perhaps by displaying the upload progress in the notification area.

Fixes #2354.