### PR TITLE
Pin bundled mongo to 2.6 to avoid in-place upgrade woes

### DIFF
--- a/hack/.gitignore
+++ b/hack/.gitignore
@@ -1,0 +1,1 @@
+sandstorm-171.tar.xz

--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -110,16 +110,17 @@ cp $METEOR_DEV_BUNDLE/bin/node bundle/bin
 # Pull mongo v2.6 out of a previous Sandstorm package.
 OLD_BUNDLE_BASE=sandstorm-171
 OLD_BUNDLE_FILENAME=$OLD_BUNDLE_BASE.tar.xz
+OLD_BUNDLE_PATH=hack/$OLD_BUNDLE_FILENAME
 OLD_BUNDLE_SHA256=ebffd643dffeba349f139bee34e4ce33fd9b1298fafc1d6a31eb35a191059a99
 OLD_MONGO_FILES="$OLD_BUNDLE_BASE/bin/mongo $OLD_BUNDLE_BASE/bin/mongod"
-if [ ! -e "$OLD_BUNDLE_FILENAME" ] ; then
+if [ ! -e "$OLD_BUNDLE_PATH" ] ; then
   echo "Fetching $OLD_BUNDLE_FILENAME to extract a mongo 2.6..."
-  curl --output "$OLD_BUNDLE_FILENAME" https://dl.sandstorm.io/$OLD_BUNDLE_FILENAME
+  curl --output "$OLD_BUNDLE_PATH" https://dl.sandstorm.io/$OLD_BUNDLE_FILENAME
 fi
 
 # Always check the checksum to guard against corrupted downloads.
 sha256sum --check <<EOF
-$OLD_BUNDLE_SHA256  $OLD_BUNDLE_FILENAME
+$OLD_BUNDLE_SHA256  $OLD_BUNDLE_PATH
 EOF
 # set -e should ensure we don't continue past here, but let's be doubly sure
 rc=$?
@@ -129,7 +130,7 @@ if [ $rc -ne 0 ]; then
 fi
 
 # Extract bin/mongo and bin/mongod from the old sandstorm bundle, and place them in bundle/.
-tar xf $OLD_BUNDLE_FILENAME --transform=s/^${OLD_BUNDLE_BASE}/bundle/ $OLD_MONGO_FILES
+tar xf $OLD_BUNDLE_PATH --transform=s/^${OLD_BUNDLE_BASE}/bundle/ $OLD_MONGO_FILES
 
 cp $(which zip unzip xz gpg) bundle/bin
 


### PR DESCRIPTION
sandstorm-84 and earlier shipped mongo 2.4, which creates its auth schema in a
different way than mongo 2.6 and above.  While mongo 2.6 is able to read said
schema, mongo 3.2 is not.

To avoid breaking servers that were originally installed with mongo 2.4, we
can't jump to mongo 3.2 just yet.  Mongo 2.6 is still fine, and Meteor remains
backwards-compatible with Mongo 2.6, so we can continue shipping this for a while.

This change makes make-bundle.sh cache a copy of sandstorm-171 (the latest
release as of this writing) and copy its mongo/mongod into the new bundle,
rather than pulling those binaries from the current Meteor dev bundle.

Additional notes on mongo upgrades:

* https://jira.mongodb.org/browse/SERVER-22004
* https://docs.mongodb.com/manual/release-notes/2.6-upgrade-authorization/
* https://docs.mongodb.com/manual/release-notes/3.2-upgrade/