### PR TITLE
Remove some now-obsolete mentions of 'es6-promise'.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -58,13 +58,6 @@ shell/client/vendor/ansi-up.js
     License URL: https://github.com/drudru/ansi_up/blob/master/Readme.md
                  (at bottom)
 
-shell/client/vendor/es6-promise.js
-    What: ES6 Promise polyfill
-    Source URL: https://github.com/stefanpenner/es6-promise
-    Copyright: Yehuda Katz, Tom Dale, Stefan Penner and contributors
-    License: MIT
-    License URL: https://github.com/stefanpenner/es6-promise/blob/master/LICENSE
-
 shell/packages/sandstorm-identicons/identicon.js
     What: identicon.js
     Source URL: https://github.com/stewartlord/identicon.js

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -678,7 +678,6 @@ limitations under the License.
         <li><a href="https://github.com/EventedMind/iron-router">Iron Router</a> (MIT license)</li>
         <li><a href="http://underscorejs.org/">Underscore.js</a> (MIT license)</li>
         <li><a href="http://www.senchalabs.org/connect/">Connect middleware</a> (MIT license)</li>
-        <li><a href="https://www.npmjs.org/package/es6-promises">ES6-Promise polyfill by Dmitry Korobkin</a> (MIT license)</li>
         <li><a href="https://www.google.com/fonts/specimen/Source+Sans+Pro">Source Sans Pro font</a> (SIL OFL)</li>
         <li><a href="https://github.com/joyent/http-parser">Node/nginx HTTP parser library</a> (MIT license)</li>
         <li><a href="https://github.com/andris9/simplesmtp">Simple SMTP by Andris Reinman</a> (MIT license)</li>


### PR DESCRIPTION
... and it appears that we've been linking to the wrong package on npm all along.  We used `es6-promise` (singular), not `es6-promises` (plural).