### PR TITLE
Save inotify-derived grain sizes to database

### DIFF
--- a/shell/client/grain/grainlist-client.js
+++ b/shell/client/grain/grainlist-client.js
@@ -23,6 +23,7 @@ SandstormGrainListPage.mapGrainsToTemplateObject = function (grains, db) {
       isOwnedByMe: true,
       trashed: grain.trashed,
       unread: !grain.ownerSeenAllActivity,
+      size: grain.size,
     };
   });
 };
@@ -462,6 +463,12 @@ Template.sandstormGrainTable.helpers({
   showTableHeaders: function () {
     return !!(Template.instance().data.alwaysShowTableHeaders ||
               Template.instance().data.grains.length);
+  },
+
+  grainSize: function () {
+    // TODO(cleanup): extract prettySize and other similar helpers from globals into a package
+    // TODO(cleanup): access Meteor.user() through db object
+    return this.size && prettySize(this.size);
   },
 });
 

--- a/shell/client/grain/grainlist.html
+++ b/shell/client/grain/grainlist.html
@@ -122,6 +122,7 @@
             </td>
             <td class="td-app-icon"></td>
             <td class="grain-name">Name</td>
+            <td class="grain-size">Size</td>
             <td class="last-used">Last activity</td>
             <td class="shared-or-owned">Mine/Shared</td>
             {{!-- Collaborators, size TODO
@@ -136,7 +137,7 @@
         <tr class="action">
           <td class="select-grain"></td>
           <td class="td-app-icon"><div class="new-grain-icon"></div></td>
-          <td class="action-button" colspan="3"><button class="action">{{buttonText}}</button></td>
+          <td class="action-button" colspan="4"><button class="action">{{buttonText}}</button></td>
         </tr>
         {{/each}}
         {{#each grains}}
@@ -159,6 +160,7 @@
               (renamed from: {{.}})
             {{/with}}
           </td>
+          <td class="grain-size click-to-go">{{grainSize}}</td>
           <td class="last-used click-to-go">{{dateString lastUsed}}</td>
           <td class="shared-or-owned click-to-go">{{#if isOwnedByMe }}My grain{{else}}Shared with me{{/if}}</td>
           {{!-- Collaborators, size TODO

--- a/shell/client/styles/_grainlist.scss
+++ b/shell/client/styles/_grainlist.scss
@@ -176,6 +176,13 @@
         background-color: $grainlist-table-header-background-color-hover;
       }
       */
+      &.grain-size {
+        width: 80px;
+        // The mobile viewport is too small to display this much text
+        @media #{$mobile} {
+          display: none;
+        }
+      }
       &.shared-or-owned {
         width: 110px;
         // The mobile viewport is too small to display this much text
@@ -226,6 +233,13 @@
             font-size: 20px;
             @extend .icon;
           }
+        }
+      }
+      &.grain-size {
+        width: 80px;
+        // The mobile viewport is too small to display this much text
+        @media #{$mobile} {
+          display: none;
         }
       }
       &.last-used {

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -16,9 +16,6 @@
 
 let counter = 0;
 
-// Pseudo-collection, published in shell/server/grain-server.js.
-const GrainSizes = new Mongo.Collection("grainSizes");
-
 class GrainView {
   constructor(grains, db, grainId, path, tokenInfo, parentElement) {
     // `path` starts with a slash and includes the query and fragment.
@@ -135,7 +132,6 @@ class GrainView {
     this._sessionSalt = null;
     this._permissions = undefined;
 
-    this._grainSizeSub = undefined;
     this._sessionObserver = undefined;
     this._sessionSub = undefined;
 
@@ -214,9 +210,6 @@ class GrainView {
     // rendering the iframe forever, even if it is no longer linked into the page DOM.
 
     Blaze.remove(this._blazeView);
-    if (this._grainSizeSub) {
-      this._grainSizeSub.stop();
-    }
 
     if (this._sessionObserver) {
       this._sessionObserver.stop();
@@ -271,8 +264,9 @@ class GrainView {
   }
 
   size() {
-    const size = GrainSizes.findOne(this._grainId);
-    return size && size.size;
+    // Note that only a user's own grains are found in the Grains collection.
+    const grain = this._db.getGrain(this._grainId);
+    return grain && grain.size;
   }
 
   title() {
@@ -601,8 +595,6 @@ class GrainView {
 
           _this._addSessionObserver(result.sessionId);
 
-          if (_this._grainSizeSub) _this._grainSizeSub.stop();
-          _this._grainSizeSub = Meteor.subscribe("grainSize", result.grainId);
           _this._dep.changed();
         }
       });

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -2176,6 +2176,10 @@ if (Meteor.isServer) {
       }
 
       this.deleteUnusedPackages(grain.appId);
+
+      if (grain.size) {
+        Meteor.users.update(grain.userId, { $inc: { storageUsage: -grain.size } });
+      }
     });
     return numDeleted;
   };

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -219,6 +219,7 @@ Grains = new Mongo.Collection("grains");
 //            this date, the grain will be automatically deleted.
 //   ownerSeenAllActivity: True if the owner has viewed the grain since the last activity event
 //       occurred. See also ApiTokenOwner.user.seenAllActivity.
+//   size: On-disk size of the grain in bytes.
 //
 // The following fields *might* also exist. These are temporary hacks used to implement e-mail and
 // web publishing functionality without powerbox support; they will be replaced once the powerbox

--- a/shell/server/backup.js
+++ b/shell/server/backup.js
@@ -158,6 +158,7 @@ Meteor.methods({
         identityId: identityId,
         title: grainInfo.title,
         private: true,
+        size: 0,
       });
     } finally {
       cleanupToken(tokenId);

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -137,6 +137,10 @@ class SandstormCoreImpl {
       logActivity(this.grainId, null, event);
     });
   }
+
+  reportGrainSize(bytes) {
+    Grains.update(this.grainId, {$set: {size: bytes}});
+  }
 }
 
 const makeSandstormCore = (grainId) => {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -306,6 +306,7 @@ Meteor.methods({
       identityId: identityId,
       title: title,
       private: true,
+      size: 0,
     });
 
     globalBackend.startGrainInternal(packageId, grainId, this.userId, command, true, isDev);

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -537,22 +537,6 @@ const validateWebkey = (apiToken, refreshedExpiration) => {
   }
 };
 
-// Used by shared/grain.js (which sounds like a broken dependency, since this code is only available
-// on the server)
-getGrainSize = (supervisor, oldSize) => {
-  let promise;
-  if (oldSize === undefined) {
-    promise = supervisor.getGrainSize();
-  } else {
-    promise = supervisor.getGrainSizeWhenDifferent(oldSize);
-  }
-
-  const promise2 = promise.then((result) => { return parseInt(result.size); });
-  promise2.cancel = () => { promise.cancel(); };
-
-  return promise2;
-};
-
 Meteor.startup(() => {
   const shutdownApp = (appId) => {
     Grains.find({ appId: appId }).forEach((grain) => {

--- a/shell/server/shell-server.js
+++ b/shell/server/shell-server.js
@@ -58,7 +58,13 @@ Meteor.publish("grainsMenu", function () {
           Meteor.users.update(userId, { $set: { storageUsage: parseInt(results.size) } });
         });
       }).catch(function (err) {
-        if (err.kjType !== "unimplemented") {
+        if (err.kjType === "unimplemented") {
+          // Compute based on sum of grain sizes instead.
+          let total = 0;
+          Grains.find({ userId: userId }, { fields: { size: 1 } })
+              .forEach(grain => total += (grain.size || 0));
+          Meteor.users.update(userId, { $set: { storageUsage: total } });
+        } else {
           console.error(err.stack);
         }
       });

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -50,12 +50,10 @@ interface Supervisor {
   # Shut down the grain immediately.  Useful e.g. when upgrading to a newer app version.  This
   # call will never return successfully because the process kills itself.
 
-  getGrainSize @3 () -> (size :UInt64);
-  # Get the total storage size of the grain.
-
-  getGrainSizeWhenDifferent @4 (oldSize :UInt64) -> (size :UInt64);
-  # Wait until the storage size of the grain is different from `oldSize` and then return the new
-  # size. May occasionally return prematurely, with `size` equal to `oldSize`.
+  obsoleteGetGrainSize @3 () -> (size :UInt64);
+  obsoloteGetGrainSizeWhenDifferent @4 (oldSize :UInt64) -> (size :UInt64);
+  # OBSOLETE: We used to pull the grain size from the supervisor. Now the supervisor pushes the
+  #   size through SandstormCore.
 
   restore @5 (ref :SupervisorObjectId, requirements :List(MembraneRequirement), parentToken :Data)
           -> (cap :Capability);
@@ -181,6 +179,11 @@ interface SandstormCore {
 
   backgroundActivity @7 (event :Activity.ActivityEvent);
   # Implements SandstormApi.backgroundActivity().
+
+  reportGrainSize @8 (bytes :UInt64);
+  # Reports the current disk storage usage of the grain. The supervisor monitors storage usage
+  # while the grain runs and calls this method periodically. In order to avoid unnecessary traffic,
+  # the supervisor may choose not to report insignificant changes.
 }
 
 struct MembraneRequirement {


### PR DESCRIPTION
After this change:

* Storage quota can be enforced on single-machine Sandstorm. (However, the UI needs to be detangled from the Oasis payments code -- @jparyani is working on that.)
* The size of each grain is shown in the grain list. (However, preexisting grains won't show a size until they are next opened.)