### PR TITLE
Get new supervisor code to typecheck in (buggy) clang v3.8.

### DIFF
--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -412,7 +412,7 @@ private:
       uint64_t sizeBeingReported = totalSize;
       req.setBytes(sizeBeingReported);
 
-      return req.send().then([this,sizeBeingReported](auto) {
+      return req.send().then([this,sizeBeingReported](auto) -> void {
         reportInFlight = false;
         reportedSize = sizeBeingReported;
 


### PR DESCRIPTION
```
  In file included from /ekam-provider/canonical/sandstorm/supervisor.c++:17:
  In file included from /ekam-provider/canonical/sandstorm/supervisor.h:21:
  In file included from /ekam-provider/canonical/sandstorm/util.h:31:
  In file included from /ekam-provider/c++header/kj/async.h:675:
  /ekam-provider/c++header/kj/async-inl.h:319:12: error: no matching function for call to 'from'
      return PtmfHelper::from<ReturnType, Decay<Func>, ParamTypes...>(
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /ekam-provider/c++header/kj/async-inl.h:358:45: note: in instantiation of function template specialization 'kj::_::GetFunctorStartAddress<capnp::
    Response<sandstorm::SandstormCore::ReportGrainSizeResults> &&>::apply<(lambda at /ekam-provider/canonical/sandstorm/supervisor.c++:415:30) &>' 
    requested here
              GetFunctorStartAddress<DepT&&>::apply(func)),
                                              ^
  /ekam-provider/c++header/kj/memory.h:339:21: note: in instantiation of member function 'kj::_::TransformPromiseNode<kj::_::Void, capnp::Response<
    sandstorm::SandstormCore::ReportGrainSizeResults>, (lambda at /ekam-provider/canonical/sandstorm/supervisor.c++:415:30), (lambda at /ekam-
    provider/canonical/sandstorm/supervisor.c++:421:10)>::TransformPromiseNode' requested here
    return Own<T>(new T(kj::fwd<Params>(params)...), _::HeapDisposer<T>::instance);
                      ^
  /ekam-provider/c++header/kj/async-inl.h:762:7: note: in instantiation of function template specialization 'kj::heap<kj::_::TransformPromiseNode<kj
    ::_::Void, capnp::Response<sandstorm::SandstormCore::ReportGrainSizeResults>, (lambda at /ekam-provider/canonical/sandstorm/supervisor.c++:415:
    30), (lambda at /ekam-provider/canonical/sandstorm/supervisor.c++:421:10)>, kj::Own<kj::_::PromiseNode>, (lambda at /ekam-provider/canonical/
    sandstorm/supervisor.c++:415:30), (lambda at /ekam-provider/canonical/sandstorm/supervisor.c++:421:10)>' requested here
        heap<_::TransformPromiseNode<ResultT, _::FixVoid<T>, Func, ErrorFunc>>(
        ^
  /ekam-provider/canonical/sandstorm/supervisor.c++:415:25: note: in instantiation of function template specialization 'kj::Promise<capnp::Response<
    sandstorm::SandstormCore::ReportGrainSizeResults> >::then<(lambda at /ekam-provider/canonical/sandstorm/supervisor.c++:415:30), (lambda at /ekam
    -provider/canonical/sandstorm/supervisor.c++:421:10)>' requested here
        return req.send().then([this,sizeBeingReported](auto) {
                          ^

```