### PR TITLE
Call Notification.requestPermission() to make notifications work

### DIFF
--- a/shell/client/desktop-notifications-client.js
+++ b/shell/client/desktop-notifications-client.js
@@ -173,7 +173,11 @@ const showActivityDesktopNotification = (notif) => {
 };
 
 Template.desktopNotifications.onCreated(function () {
+  // Don't bother with any of this if we don't have both Notification support and localStorage.
   if (!localStorageWorks) return;
+  if (!window.Notification) return;
+  this.enabled = true;
+
   // There's some tricky logic here to try to make sure notifications are preferentially handled by
   // a tab that already has the associated grain open, rather than just by the first or last tab to
   // learn about the notification.  Otherwise your odds of getting the notification in the right tab
@@ -339,7 +343,7 @@ Template.desktopNotifications.onCreated(function () {
 });
 
 Template.desktopNotifications.onDestroyed(function () {
-  if (!localStorageWorks) return;
+  if (!this.enabled) return;
   window.removeEventListener("storage", this.storageEventHandler);
 
   if (this.dbHandle) {

--- a/shell/client/desktop-notifications-client.js
+++ b/shell/client/desktop-notifications-client.js
@@ -137,23 +137,38 @@ const showActivityDesktopNotification = (notif) => {
       timestamp,
     };
 
-    const handle = new Notification(title, notificationOptions);
+    const showNotification = () => {
+      const handle = new Notification(title, notificationOptions);
 
-    handle.onclick = () => {
-      // Request that the Sandstorm window receive focus.  This attempts to switch
-      // the browser's active tab and window to the Sandstorm window that created
-      // the notification.
-      window.focus();
+      handle.onclick = () => {
+        // Request that the Sandstorm window receive focus.  This attempts to switch
+        // the browser's active tab and window to the Sandstorm window that created
+        // the notification.
+        window.focus();
 
-      // For a notification about a grain, open that grain URL and path.
-      Router.go(`/grain/${grainId}/${path || ""}`);
+        // For a notification about a grain, open that grain URL and path.
+        Router.go(`/grain/${grainId}/${path || ""}`);
 
-      // Close this notification.
-      handle.close();
+        // Close this notification.
+        handle.close();
 
-      // Dismiss the associated notification, ignoring errors and without blocking.
-      Meteor.call("dismissNotification", notif.notificationId, (err) => {});
+        // Dismiss the associated notification, ignoring errors and without blocking.
+        Meteor.call("dismissNotification", notif.notificationId, (err) => {});
+      };
     };
+
+    const currentPerm = Notification.permission;
+    if (currentPerm === "granted") {
+      showNotification();
+    } else if (currentPerm === "default") {
+      Notification.requestPermission().then((perm) => {
+        if (perm === "granted") {
+          showNotification();
+        }
+      });
+    } else {
+      // User explicitly denied desktop notifications.  Do nothing.
+    }
   });
 };
 


### PR DESCRIPTION
I had tested with a browser that had cached the permission grant, and incognito windows blanket-deny desktop notifications entirely, and I mistakenly thought that creating the first `new Notification()` would trigger the browser to prompt you to show notifications.  Oops.

This change requests permissions to show notifications the first time Sandstorm would want to show a desktop notification.  This obviously isn't perfect, but this at least avoids the problem of "user is asked for permission when they don't have the context to understand why that permission is being asked for" and makes notifications available to users that would clearly benefit from them.  I am very strongly against dropping a permission request on users first thing when they e.g. log in or refresh their browser window.

With this PR, you'll see the bell notification go red and increment the number at the same time your browser asks for permission to show notifications, so hopefully users will connect the two and make the right choice.

I'm open to alternate/additional design proposals, but I want to close the feature gap this release if at all possible, especially now that Rocket.Chat is exclusively using the activity events API.