### PR TITLE
docs: Use vagrant-spk vm provision

### DIFF
--- a/docs/developing/web-publishing.md
+++ b/docs/developing/web-publishing.md
@@ -78,9 +78,7 @@ fi
 Now, run the improved `.sandstorm/setup.sh` script by doing:
 
 ```bash
-cd .sandstorm
-vagrant provision
-cd ..
+vagrant-spk vm provision
 ```
 
 This should result in a
@@ -94,7 +92,7 @@ inspiration. If you prefer to call Sandstorm's RPC directly, keep
 reading.
 
 **Note**: At the time of writing, some vagrant-spk stacks crash if you
-run `vagrant provision` a second time. We're [working on fixing
+run `vagrant-spk vm provision` a second time. We're [working on fixing
 that.](https://github.com/sandstorm-io/vagrant-spk/issues/87)
 
 ## Show DNS instructions to the user

--- a/docs/vagrant-spk/customizing.md
+++ b/docs/vagrant-spk/customizing.md
@@ -37,9 +37,7 @@ via `curl|bash` etc. Use this file to install:
 When you **modify this script, you must manually re-provision the Vagrant box** as follows.
 
 ```bash
-cd .sandstorm
-vagrant provision
-cd ..
+vagrant-spk vm provision
 ```
 
 This is because `vagrant-spk` currently has no way to auto-detect that the `setup.sh` script needs


### PR DESCRIPTION
In some places, we used to write:

```bash
cd .sandstorm
vagrant provision
cd ..
```

But this is no longer needed due to https://github.com/sandstorm-io/vagrant-spk/pull/145
by @zarvox. Therefore, we say this instead:

```bash
vagrant-spk vm provision
```