### PR TITLE
Fix grain title in desktop notifications on shared grains (sometimes?)

### DIFF
--- a/shell/client/desktop-notifications-client.js
+++ b/shell/client/desktop-notifications-client.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
+
 // Test if localStorage is usable.
 // We can't use Meteor._localStorage for this because we need to be able to enumerate the elements
 // in localStorage for periodic cleanup.
@@ -103,15 +105,8 @@ const showActivityDesktopNotification = (notif) => {
         appIcon = Identicon.identiconForApp((meta && meta.appId) || "00000000000000000000000000000000");
       }
 
-      if (tokenOwnerUser.upstreamTitle) {
-        if (tokenOwnerUser.renamed) {
-          grainTitle = tokenOwnerUser.title;
-        } else {
-          grainTitle = tokenOwnerUser.upstreamTitle;
-        }
-      } else if (tokenOwnerUser.title) {
-        grainTitle = tokenOwnerUser.title;
-      }
+      const titleObj = computeTitleFromTokenOwnerUser(tokenOwnerUser);
+      grainTitle = titleObj.title;
     }
   }
 

--- a/shell/client/desktop-notifications-client.js
+++ b/shell/client/desktop-notifications-client.js
@@ -95,19 +95,22 @@ const showActivityDesktopNotification = (notif) => {
     });
 
     if (apiToken) {
-      const meta = apiToken.owner.user.denormalizedGrainMetadata;
+      const tokenOwnerUser = apiToken.owner.user;
+      const meta = tokenOwnerUser.denormalizedGrainMetadata;
       if (meta && meta.icon && meta.icon.assetId) {
         appIcon = staticPrefix + "/" + meta.icon.assetId;
       } else {
         appIcon = Identicon.identiconForApp((meta && meta.appId) || "00000000000000000000000000000000");
       }
 
-      if (meta.upstreamTitle) {
-        if (meta.renamed) {
-          grainTitle = meta.title;
+      if (tokenOwnerUser.upstreamTitle) {
+        if (tokenOwnerUser.renamed) {
+          grainTitle = tokenOwnerUser.title;
         } else {
-          grainTitle = meta.upstreamTitle;
+          grainTitle = tokenOwnerUser.upstreamTitle;
         }
+      } else if (tokenOwnerUser.title) {
+        grainTitle = tokenOwnerUser.title;
       }
     }
   }

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
+
 let counter = 0;
 
 class GrainView {
@@ -298,13 +300,7 @@ class GrainView {
       }
 
       const info = apiToken.owner.user;
-      if (!info.upstreamTitle) {
-        return { title: info.title };
-      } else if (info.renamed) {
-        return { title: info.title, renamedFrom: info.upstreamTitle };
-      } else {
-        return { title: info.upstreamTitle, was: info.title };
-      }
+      return computeTitleFromTokenOwnerUser(info);
     } else {
       // Case 3.
       // TODO(someday): We don't show info about renames in this case, but we probably should.

--- a/shell/imports/client/model-helpers.js
+++ b/shell/imports/client/model-helpers.js
@@ -1,0 +1,12 @@
+const computeTitleFromTokenOwnerUser = function (apiTokenOwnerUser) {
+  // Given an apiToken.owner.user, return a struct with the effective grain title.
+  if (!apiTokenOwnerUser.upstreamTitle) {
+    return { title: apiTokenOwnerUser.title };
+  } else if (apiTokenOwnerUser.renamed) {
+    return { title: apiTokenOwnerUser.title, renamedFrom: apiTokenOwnerUser.upstreamTitle };
+  } else {
+    return { title: apiTokenOwnerUser.upstreamTitle, was: apiTokenOwnerUser.title };
+  }
+};
+
+export { computeTitleFromTokenOwnerUser };

--- a/shell/server/notifications-server.js
+++ b/shell/server/notifications-server.js
@@ -260,7 +260,6 @@ Meteor.publish("notificationGrains", function (notificationIds) {
   }).filter(x => x);
 
   return [
-    Grains.find({ _id: { $in: grainIds } }, { fields: { title: 1 } }),
     Meteor.users.find({ _id: { $in: identities } }, { fields: { profile: 1 } }),
   ];
 });


### PR DESCRIPTION
The `.title` field canonically lives on `ApiTokenOwner`, not on
`.denormalizedGrainMetadata.title`.  Ditto `.upstreamTitle`.

While debugging this with @jparyani, we discovered that sometimes you can wind up with a stub object in your `Grains` collection with only the fields `_id` and `title`, even if you don't own that grain.  This causes the grain lookup logic to get confused and think that you own the grain, which breaks my expectations.