### PR TITLE
Don't check that mail server certs are signed by any CA in particular

### DIFF
--- a/shell/imports/server/email.js
+++ b/shell/imports/server/email.js
@@ -15,12 +15,20 @@ const makePool = function (mailConfig) {
     auth = mailConfig.auth;
   }
 
+  const secure = (mailConfig.port === 465);
+  const tlsOptions = {
+    // Previously, node 0.10 did not attempt to validate certificates received when connecting
+    // with STARTTLS, so to avoid regressing we need to preserve that behavior here for now.
+    rejectUnauthorized: false,
+  };
+
   const pool = nodemailer.createTransport(smtpPool({
     host: mailConfig.hostname,
     port: mailConfig.port,
-    secure: (mailConfig.port === 465),
-    // XXX allow maxConnections to be configured?
+    secure,
+    tls: tlsOptions,
     auth,
+    // TODO(someday): allow maxConnections to be configured?
   }));
 
   pool._futureWrappedSendMail = _.bind(Future.wrap(pool.sendMail), pool);

--- a/tests/commands/assertReceiveEmail.js
+++ b/tests/commands/assertReceiveEmail.js
@@ -34,7 +34,7 @@ ReceiveEmail.prototype.command = function(selector, expectedMessage, timeout, cb
     self.emit("complete");
   }, timeout);
 
-  var options = { SMTPBanner:"Sandstorm Testing Mail Server", timeout: 10000, disableSTARTTLS: true };
+  var options = { SMTPBanner:"Sandstorm Testing Mail Server", timeout: 10000 };
   server = simplesmtp.createSimpleServer(options, function (req) {
     var mailparser = new MailParser();
 


### PR DESCRIPTION
This is restoring the behavior that existed before #2362.  Several users have
reported that the most recent upgrade has broken mail delivery on their systems
due to attempting to perform STARTTLS, then aborting when the cert provided by
the mailserver didn't validate.  This appears to be a fairly common configuration.

Node 0.10 did not validate certs at all before now, so I'm disabling cert
validation to undo the breakage.  Longer-term, we should add UI for admins to
specify one of the following behaviors:

* "none" use STARTTLS if available, but don't validate the cert
* "starttls" require STARTTLS, and validate the certificate
* "smtps" connect on port 465 and validate the cert