### PR TITLE
Relocate migrations

### DIFF
--- a/shell/imports/server/accounts/picture.js
+++ b/shell/imports/server/accounts/picture.js
@@ -1,0 +1,50 @@
+import { HTTP } from "meteor/http";
+
+const userPictureUrl = function (user) {
+  if (user.services && !(user.profile && user.profile.picture)) {
+    // Try to determine user's avatar URL from login service.
+
+    const google = user.services.google;
+    if (google && google.picture) {
+      return google.picture;
+    }
+
+    const github = user.services.github;
+    if (github && github.id) {
+      return "https://avatars.githubusercontent.com/u/" + github.id;
+    }
+
+    // Note that we do NOT support Gravatar for email addresses because pinging Gravatar would be
+    // a data leak, revealing that the user has logged into this Sandstorm server. Google and
+    // Github are different because they are actually the identity providers, so they already know
+    // the user logged in.
+  }
+};
+
+const fetchPicture = function (db, url) {
+  try {
+    const result = HTTP.get(url, {
+      npmRequestOptions: { encoding: null },
+      timeout: 5000,
+    });
+
+    const metadata = {};
+
+    metadata.mimeType = result.headers["content-type"];
+    if (metadata.mimeType.lastIndexOf("image/png", 0) === -1 &&
+        metadata.mimeType.lastIndexOf("image/jpeg", 0) === -1) {
+      throw new Error("unexpected Content-Type:", metadata.mimeType);
+    }
+
+    const enc = result.headers["content-encoding"];
+    if (enc && enc !== "identity") {
+      metadata.encoding = enc;
+    }
+
+    return db.addStaticAsset(metadata, result.content);
+  } catch (err) {
+    console.error("failed to fetch user profile picture:", url, err.stack);
+  }
+};
+
+export { userPictureUrl, fetchPicture };

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -13,7 +13,7 @@ const Future = Npm.require("fibers/future");
 const Url = Npm.require("url");
 const Crypto = Npm.require("crypto");
 
-const updateLoginStyleToRedirect = function (db) {
+const updateLoginStyleToRedirect = function(db, backend) {
   const configurations = Package["service-configuration"].ServiceConfiguration.configurations;
   ["google", "github"].forEach(function (serviceName) {
     const config = configurations.findOne({ service: serviceName });
@@ -23,7 +23,7 @@ const updateLoginStyleToRedirect = function (db) {
   });
 };
 
-const enableLegacyOAuthProvidersIfNotInSettings = function (db) {
+const enableLegacyOAuthProvidersIfNotInSettings = function(db, backend) {
   // In the before time, Google and Github login were enabled by default.
   //
   // This actually didn't make much sense, required the first user to configure
@@ -54,7 +54,7 @@ const enableLegacyOAuthProvidersIfNotInSettings = function (db) {
   });
 };
 
-const denormalizeInviteInfo = function (db) {
+const denormalizeInviteInfo = function(db, backend) {
   // When a user is invited via a signup token, the `signupKey` field of their user table entry
   // has always been populated to indicate the key they used. This points into the SignupKeys table
   // which has more information about the key, namely a freeform note entered by the admin when
@@ -84,7 +84,7 @@ const denormalizeInviteInfo = function (db) {
   });
 };
 
-const mergeRoleAssignmentsIntoApiTokens = function (db) {
+const mergeRoleAssignmentsIntoApiTokens = function(db, backend) {
   db.collections.roleAssignments.find().forEach(function (roleAssignment) {
     db.collections.apiTokens.insert({
       grainId: roleAssignment.grainId,
@@ -102,12 +102,12 @@ const mergeRoleAssignmentsIntoApiTokens = function (db) {
   });
 };
 
-const fixOasisStorageUsageStats = function (db) {};
+const fixOasisStorageUsageStats = function(db, backend) {};
 // This migration only pertained to Oasis and it was successfully applied there. Since it referred
 // to some global variables that we later wanted to remove and/or rename, we've since replaced it
 // with a no-op.
 
-const fetchProfilePictures = function (db) {
+const fetchProfilePictures = function(db, backend) {
   db.collections.users.find({}).forEach(function (user) {
     const url = userPictureUrl(user);
     if (url) {
@@ -120,13 +120,13 @@ const fetchProfilePictures = function (db) {
   });
 };
 
-const assignPlans = function (db) {
+const assignPlans = function(db, backend) {
   if (db.isReferralEnabled() && SandstormDb.paymentsMigrationHook) {
     SandstormDb.paymentsMigrationHook(db.collections.signupKeys, db.collections.plans.find().fetch());
   }
 };
 
-const removeKeyrings = function (db) {
+const removeKeyrings = function(db, backend) {
   // These blobs full of public keys were not intended to find their way into mongo and while
   // harmless they slow things down because they're huge. Remove them.
   db.collections.packages.update({ "manifest.metadata.pgpKeyring": { $exists: true } },
@@ -134,7 +134,7 @@ const removeKeyrings = function (db) {
       { multi: true });
 };
 
-const useLocalizedTextInUserActions = function (db) {
+const useLocalizedTextInUserActions = function(db, backend) {
   function toLocalizedText(newObj, oldObj, field) {
     if (field in oldObj) {
       if (typeof oldObj[field] === "string") {
@@ -154,12 +154,11 @@ const useLocalizedTextInUserActions = function (db) {
   });
 };
 
-const verifyAllPgpSignatures = function (db) {
+const verifyAllPgpSignatures = function (db, backend) {
   db.collections.packages.find({}).forEach(function (pkg) {
     try {
       console.log("checking PGP signature for package:", pkg._id);
-      // TODO(someday): inject globalBackend dependency
-      const info = waitPromise(globalBackend.cap().tryGetPackage(pkg._id));
+      const info = waitPromise(backend.cap().tryGetPackage(pkg._id));
       if (info.authorPgpKeyFingerprint) {
         console.log("  " + info.authorPgpKeyFingerprint);
         db.collections.packages.update(pkg._id,
@@ -173,7 +172,7 @@ const verifyAllPgpSignatures = function (db) {
   });
 };
 
-const splitUserIdsIntoAccountIdsAndIdentityIds = function (db) {
+const splitUserIdsIntoAccountIdsAndIdentityIds = function(db, backend) {
   db.collections.users.find().forEach(function (user) {
     const identity = {};
     let serviceUserId;
@@ -260,13 +259,13 @@ const splitUserIdsIntoAccountIdsAndIdentityIds = function (db) {
   // form of API token.
 };
 
-const appUpdateSettings = function (db) {
+const appUpdateSettings = function(db, backend) {
   db.collections.settings.insert({ _id: "appMarketUrl", value: "https://apps.sandstorm.io" });
   db.collections.settings.insert({ _id: "appIndexUrl", value: "https://app-index.sandstorm.io" });
   db.collections.settings.insert({ _id: "appUpdatesEnabled", value: true });
 };
 
-const moveDevAndEmailLoginDataIntoIdentities = function (db) {
+const moveDevAndEmailLoginDataIntoIdentities = function(db, backend) {
   db.collections.users.find().forEach(function (user) {
     if (user.identities.length !== 1) {
       throw new Error("User does not have exactly one identity: ", user);
@@ -302,7 +301,7 @@ const moveDevAndEmailLoginDataIntoIdentities = function (db) {
   });
 };
 
-const repairEmailIdentityIds = function (db) {
+const repairEmailIdentityIds = function(db, backend) {
   db.collections.users.find({ "identities.service.emailToken": { $exists: 1 } }).forEach(function (user) {
     if (user.identities.length !== 1) {
       throw new Error("User does not have exactly one identity: ", user);
@@ -335,7 +334,7 @@ const repairEmailIdentityIds = function (db) {
   });
 };
 
-const splitAccountUsersAndIdentityUsers = function (db) {
+const splitAccountUsersAndIdentityUsers = function(db, backend) {
   db.collections.users.find({ identities: { $exists: true } }).forEach(function (user) {
     if (user.identities.length !== 1) {
       throw new Error("User does not have exactly one identity: ", user);
@@ -386,7 +385,7 @@ const splitAccountUsersAndIdentityUsers = function (db) {
   });
 };
 
-const populateContactsFromApiTokens = function (db) {
+const populateContactsFromApiTokens = function(db, backend) {
   db.collections.apiTokens.find({
     "owner.user.identityId": { $exists: 1 },
     accountId: { $exists: 1 },
@@ -406,7 +405,7 @@ const populateContactsFromApiTokens = function (db) {
   });
 };
 
-const cleanUpApiTokens = function (db) {
+const cleanUpApiTokens = function(db, backend) {
   // The `splitUserIdsIntoAccountIdsAndIdentityIds()` migration only added `identityId` in cases
   // where the user still existed in the database.
   db.collections.apiTokens.remove({
@@ -448,13 +447,13 @@ const cleanUpApiTokens = function (db) {
   }).forEach(repairChain);
 };
 
-const initServerTitleAndReturnAddress = function (db) {
+const initServerTitleAndReturnAddress = function(db, backend) {
   const hostname = Url.parse(process.env.ROOT_URL).hostname;
   db.collections.settings.insert({ _id: "serverTitle", value: hostname });
   db.collections.settings.insert({ _id: "returnAddress", value: "no-reply@" + hostname });
 };
 
-const sendReferralNotifications = function (db) {
+const sendReferralNotifications = function(db, backend) {
   if (db.isReferralEnabled()) {
     db.collections.users.find({
       loginIdentities: { $exists: true },
@@ -465,13 +464,13 @@ const sendReferralNotifications = function (db) {
   }
 };
 
-const assignBonuses = function (db) {
+const assignBonuses = function(db, backend) {
   if (db.isReferralEnabled() && SandstormDb.bonusesMigrationHook) {
     SandstormDb.bonusesMigrationHook();
   }
 };
 
-const splitSmtpUrl = function (db) {
+const splitSmtpUrl = function(db, backend) {
   const smtpUrlSetting = db.collections.settings.findOne({ _id: "smtpUrl" });
   const smtpUrl = smtpUrlSetting ? smtpUrlSetting.value : process.env.MAIL_URL;
   const returnAddress = db.collections.settings.findOne({ _id: "returnAddress" });
@@ -518,7 +517,7 @@ const splitSmtpUrl = function (db) {
   db.collections.settings.remove({ _id: "smtpUrl" });
 };
 
-const smtpPortShouldBeNumber = function (db) {
+const smtpPortShouldBeNumber = function(db, backend) {
   const entry = db.collections.settings.findOne({ _id: "smtpConfig" });
   if (entry) {
     const setting = entry.value;
@@ -529,7 +528,7 @@ const smtpPortShouldBeNumber = function (db) {
   }
 };
 
-const consolidateOrgSettings = function (db) {
+const consolidateOrgSettings = function(db, backend) {
   const settings = db.collections.settings;
   const orgGoogleDomain = settings.findOne({ _id: "organizationGoogle" });
   const orgEmailDomain = settings.findOne({ _id: "organizationEmail" });
@@ -560,7 +559,7 @@ const consolidateOrgSettings = function (db) {
   settings.remove({ _id: "organizationSaml" });
 };
 
-const unsetSmtpDefaultHostnameIfNoUsersExist = function (db) {
+const unsetSmtpDefaultHostnameIfNoUsersExist = function(db, backend) {
   // We don't actually want to have the default hostname "localhost" set.
   // If the user has already finished configuring their server, then this migration should do
   // nothing (since we might break their deployment), but for new installs (which will have no users
@@ -577,7 +576,7 @@ const unsetSmtpDefaultHostnameIfNoUsersExist = function (db) {
   }
 };
 
-const extractLastUsedFromApiTokenOwner = function (db) {
+const extractLastUsedFromApiTokenOwner = function(db, backend) {
   // We used to store lastUsed as a field on owner.user.  It makes more sense to store lastUsed on
   // the apiToken as a whole.  This migration hoists such values from owner.user onto the apiToken
   // itself.
@@ -590,7 +589,7 @@ const extractLastUsedFromApiTokenOwner = function (db) {
   });
 };
 
-const setUpstreamTitles = function (db) {
+const setUpstreamTitles = function(db, backend) {
   // Initializes the `upstreamTitle` and `renamed` fields of `ApiToken.owner.user`.
 
   const apiTokensRaw = db.collections.apiTokens.rawCollection();
@@ -629,7 +628,7 @@ const setUpstreamTitles = function (db) {
   });
 };
 
-const markAllRead = function (db) {
+const markAllRead = function(db, backend) {
   // Mark as "read" all grains and tokens that predate the creation of read/unread status.
   // Otherwise it's pretty annoying to see all your old grains look like they have activity.
 
@@ -639,7 +638,7 @@ const markAllRead = function (db) {
       { multi: true });
 };
 
-const clearAppIndex = function (db) {
+const clearAppIndex = function(db, backend) {
   // Due to a bug in the app update code, some app update notifications that the user accepted
   // around July 9-16, 2016 may not have applied. We have no way of knowing exactly which updates
   // the user accepted but didn't receive. Instead, to recover, we are clearing the local cache of
@@ -651,7 +650,7 @@ const clearAppIndex = function (db) {
   db.collections.appIndex.remove({});
 };
 
-const assignEmailVerifierIds = function (db) {
+const assignEmailVerifierIds = function(db, backend) {
   // Originally, the ID of an EmailVerifier was actually the _id of the root token from which it
   // was restored. This was broken, though: Conceptually, it meant that you couldn't have a working
   // EmailVerifier that had not been restore()d from disk. In practice, that wasn't a problem due
@@ -667,7 +666,7 @@ const assignEmailVerifierIds = function (db) {
   });
 };
 
-const startPreinstallingApps = function (db) {
+const startPreinstallingApps = function (db, backend) {
   // This isn't really a normal migration. It will run only on brand new servers, and it has to
   // run after the `clearAppIndex` migration because it relies on populating AppIndex.
 
@@ -693,7 +692,7 @@ const startPreinstallingApps = function (db) {
   }
 };
 
-const setNewServer = function (db) {
+const setNewServer = function(db, backend) {
   // This migration only applies to "old" servers. New servers will set
   // new_server_migrations_applied to false before any migrations run.
   if (!db.collections.migrations.findOne({ _id: "new_server_migrations_applied" })) {
@@ -701,7 +700,7 @@ const setNewServer = function (db) {
   }
 };
 
-function backgroundFillInGrainSizes(db) {
+function backgroundFillInGrainSizes(db, backend) {
   // Fill in sizes for all grains that don't have them. Since computing a grain size requires a
   // directory walk, we don't want to do them all at once. Instead, we compute one a second until
   // all grains have sizes.
@@ -712,7 +711,7 @@ function backgroundFillInGrainSizes(db) {
     if (grain) {
       // Compute size!
       try {
-        const result = waitPromise(globalBackend.cap().getGrainStorageUsage(
+        const result = waitPromise(backend.cap().getGrainStorageUsage(
             grain.userId, grain._id));
         db.collections.grains.update({ _id: grain._id, size: { $exists: false } },
             { $set: { size: parseInt(result.size) } });
@@ -729,7 +728,7 @@ function backgroundFillInGrainSizes(db) {
       }
 
       // Do another one in a second.
-      Meteor.setTimeout(backgroundFillInGrainSizes.bind(this, db), 1000);
+      Meteor.setTimeout(backgroundFillInGrainSizes.bind(this, db, backend), 1000);
     }
   } catch (err) {
     // We'll just stop for now, to avoid spamming logs if this error persists. Next time the server
@@ -778,7 +777,7 @@ const NEW_SERVER_STARTUP = [
   startPreinstallingApps,
 ];
 
-const migrateToLatest = function (db) {
+const migrateToLatest = function (db, backend) {
   if (Meteor.settings.replicaNumber) {
     // This is a replica. Wait for the first replica to perform migrations.
 
@@ -833,7 +832,7 @@ const migrateToLatest = function (db) {
     for (let i = start; i < MIGRATIONS.length; i++) {
       // Apply migration i, then record that migration i was successfully run.
       console.log("Applying migration " + (i + 1));
-      MIGRATIONS[i](db);
+      MIGRATIONS[i](db, backend);
       db.collections.migrations.update({ _id: "migrations_applied" }, { $set: { value: i + 1 } });
       console.log("Applied migration " + (i + 1));
     }
@@ -843,7 +842,7 @@ const migrateToLatest = function (db) {
       // ensures it.
       for (let i = 0; i < NEW_SERVER_STARTUP.length; i++) {
         console.log("Running new server startup function " + (i + 1));
-        NEW_SERVER_STARTUP[i](db);
+        NEW_SERVER_STARTUP[i](db, backend);
         console.log("Running new server startup function " + (i + 1));
       }
 
@@ -851,7 +850,7 @@ const migrateToLatest = function (db) {
     }
 
     // Start background migrations.
-    backgroundFillInGrainSizes(db);
+    backgroundFillInGrainSizes(db, backend);
   }
 };
 

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -13,7 +13,7 @@ const Future = Npm.require("fibers/future");
 const Url = Npm.require("url");
 const Crypto = Npm.require("crypto");
 
-const updateLoginStyleToRedirect = function(db, backend) {
+const updateLoginStyleToRedirect = function (db, backend) {
   const configurations = Package["service-configuration"].ServiceConfiguration.configurations;
   ["google", "github"].forEach(function (serviceName) {
     const config = configurations.findOne({ service: serviceName });
@@ -23,7 +23,7 @@ const updateLoginStyleToRedirect = function(db, backend) {
   });
 };
 
-const enableLegacyOAuthProvidersIfNotInSettings = function(db, backend) {
+const enableLegacyOAuthProvidersIfNotInSettings = function (db, backend) {
   // In the before time, Google and Github login were enabled by default.
   //
   // This actually didn't make much sense, required the first user to configure
@@ -54,7 +54,7 @@ const enableLegacyOAuthProvidersIfNotInSettings = function(db, backend) {
   });
 };
 
-const denormalizeInviteInfo = function(db, backend) {
+const denormalizeInviteInfo = function (db, backend) {
   // When a user is invited via a signup token, the `signupKey` field of their user table entry
   // has always been populated to indicate the key they used. This points into the SignupKeys table
   // which has more information about the key, namely a freeform note entered by the admin when
@@ -84,7 +84,7 @@ const denormalizeInviteInfo = function(db, backend) {
   });
 };
 
-const mergeRoleAssignmentsIntoApiTokens = function(db, backend) {
+const mergeRoleAssignmentsIntoApiTokens = function (db, backend) {
   db.collections.roleAssignments.find().forEach(function (roleAssignment) {
     db.collections.apiTokens.insert({
       grainId: roleAssignment.grainId,
@@ -102,12 +102,12 @@ const mergeRoleAssignmentsIntoApiTokens = function(db, backend) {
   });
 };
 
-const fixOasisStorageUsageStats = function(db, backend) {};
+const fixOasisStorageUsageStats = function (db, backend) {};
 // This migration only pertained to Oasis and it was successfully applied there. Since it referred
 // to some global variables that we later wanted to remove and/or rename, we've since replaced it
 // with a no-op.
 
-const fetchProfilePictures = function(db, backend) {
+const fetchProfilePictures = function (db, backend) {
   db.collections.users.find({}).forEach(function (user) {
     const url = userPictureUrl(user);
     if (url) {
@@ -120,13 +120,13 @@ const fetchProfilePictures = function(db, backend) {
   });
 };
 
-const assignPlans = function(db, backend) {
+const assignPlans = function (db, backend) {
   if (db.isReferralEnabled() && SandstormDb.paymentsMigrationHook) {
     SandstormDb.paymentsMigrationHook(db.collections.signupKeys, db.collections.plans.find().fetch());
   }
 };
 
-const removeKeyrings = function(db, backend) {
+const removeKeyrings = function (db, backend) {
   // These blobs full of public keys were not intended to find their way into mongo and while
   // harmless they slow things down because they're huge. Remove them.
   db.collections.packages.update({ "manifest.metadata.pgpKeyring": { $exists: true } },
@@ -134,7 +134,7 @@ const removeKeyrings = function(db, backend) {
       { multi: true });
 };
 
-const useLocalizedTextInUserActions = function(db, backend) {
+const useLocalizedTextInUserActions = function (db, backend) {
   function toLocalizedText(newObj, oldObj, field) {
     if (field in oldObj) {
       if (typeof oldObj[field] === "string") {
@@ -172,7 +172,7 @@ const verifyAllPgpSignatures = function (db, backend) {
   });
 };
 
-const splitUserIdsIntoAccountIdsAndIdentityIds = function(db, backend) {
+const splitUserIdsIntoAccountIdsAndIdentityIds = function (db, backend) {
   db.collections.users.find().forEach(function (user) {
     const identity = {};
     let serviceUserId;
@@ -259,13 +259,13 @@ const splitUserIdsIntoAccountIdsAndIdentityIds = function(db, backend) {
   // form of API token.
 };
 
-const appUpdateSettings = function(db, backend) {
+const appUpdateSettings = function (db, backend) {
   db.collections.settings.insert({ _id: "appMarketUrl", value: "https://apps.sandstorm.io" });
   db.collections.settings.insert({ _id: "appIndexUrl", value: "https://app-index.sandstorm.io" });
   db.collections.settings.insert({ _id: "appUpdatesEnabled", value: true });
 };
 
-const moveDevAndEmailLoginDataIntoIdentities = function(db, backend) {
+const moveDevAndEmailLoginDataIntoIdentities = function (db, backend) {
   db.collections.users.find().forEach(function (user) {
     if (user.identities.length !== 1) {
       throw new Error("User does not have exactly one identity: ", user);
@@ -301,7 +301,7 @@ const moveDevAndEmailLoginDataIntoIdentities = function(db, backend) {
   });
 };
 
-const repairEmailIdentityIds = function(db, backend) {
+const repairEmailIdentityIds = function (db, backend) {
   db.collections.users.find({ "identities.service.emailToken": { $exists: 1 } }).forEach(function (user) {
     if (user.identities.length !== 1) {
       throw new Error("User does not have exactly one identity: ", user);
@@ -334,7 +334,7 @@ const repairEmailIdentityIds = function(db, backend) {
   });
 };
 
-const splitAccountUsersAndIdentityUsers = function(db, backend) {
+const splitAccountUsersAndIdentityUsers = function (db, backend) {
   db.collections.users.find({ identities: { $exists: true } }).forEach(function (user) {
     if (user.identities.length !== 1) {
       throw new Error("User does not have exactly one identity: ", user);
@@ -385,7 +385,7 @@ const splitAccountUsersAndIdentityUsers = function(db, backend) {
   });
 };
 
-const populateContactsFromApiTokens = function(db, backend) {
+const populateContactsFromApiTokens = function (db, backend) {
   db.collections.apiTokens.find({
     "owner.user.identityId": { $exists: 1 },
     accountId: { $exists: 1 },
@@ -405,7 +405,7 @@ const populateContactsFromApiTokens = function(db, backend) {
   });
 };
 
-const cleanUpApiTokens = function(db, backend) {
+const cleanUpApiTokens = function (db, backend) {
   // The `splitUserIdsIntoAccountIdsAndIdentityIds()` migration only added `identityId` in cases
   // where the user still existed in the database.
   db.collections.apiTokens.remove({
@@ -447,13 +447,13 @@ const cleanUpApiTokens = function(db, backend) {
   }).forEach(repairChain);
 };
 
-const initServerTitleAndReturnAddress = function(db, backend) {
+const initServerTitleAndReturnAddress = function (db, backend) {
   const hostname = Url.parse(process.env.ROOT_URL).hostname;
   db.collections.settings.insert({ _id: "serverTitle", value: hostname });
   db.collections.settings.insert({ _id: "returnAddress", value: "no-reply@" + hostname });
 };
 
-const sendReferralNotifications = function(db, backend) {
+const sendReferralNotifications = function (db, backend) {
   if (db.isReferralEnabled()) {
     db.collections.users.find({
       loginIdentities: { $exists: true },
@@ -464,13 +464,13 @@ const sendReferralNotifications = function(db, backend) {
   }
 };
 
-const assignBonuses = function(db, backend) {
+const assignBonuses = function (db, backend) {
   if (db.isReferralEnabled() && SandstormDb.bonusesMigrationHook) {
     SandstormDb.bonusesMigrationHook();
   }
 };
 
-const splitSmtpUrl = function(db, backend) {
+const splitSmtpUrl = function (db, backend) {
   const smtpUrlSetting = db.collections.settings.findOne({ _id: "smtpUrl" });
   const smtpUrl = smtpUrlSetting ? smtpUrlSetting.value : process.env.MAIL_URL;
   const returnAddress = db.collections.settings.findOne({ _id: "returnAddress" });
@@ -517,7 +517,7 @@ const splitSmtpUrl = function(db, backend) {
   db.collections.settings.remove({ _id: "smtpUrl" });
 };
 
-const smtpPortShouldBeNumber = function(db, backend) {
+const smtpPortShouldBeNumber = function (db, backend) {
   const entry = db.collections.settings.findOne({ _id: "smtpConfig" });
   if (entry) {
     const setting = entry.value;
@@ -528,7 +528,7 @@ const smtpPortShouldBeNumber = function(db, backend) {
   }
 };
 
-const consolidateOrgSettings = function(db, backend) {
+const consolidateOrgSettings = function (db, backend) {
   const settings = db.collections.settings;
   const orgGoogleDomain = settings.findOne({ _id: "organizationGoogle" });
   const orgEmailDomain = settings.findOne({ _id: "organizationEmail" });
@@ -559,7 +559,7 @@ const consolidateOrgSettings = function(db, backend) {
   settings.remove({ _id: "organizationSaml" });
 };
 
-const unsetSmtpDefaultHostnameIfNoUsersExist = function(db, backend) {
+const unsetSmtpDefaultHostnameIfNoUsersExist = function (db, backend) {
   // We don't actually want to have the default hostname "localhost" set.
   // If the user has already finished configuring their server, then this migration should do
   // nothing (since we might break their deployment), but for new installs (which will have no users
@@ -576,7 +576,7 @@ const unsetSmtpDefaultHostnameIfNoUsersExist = function(db, backend) {
   }
 };
 
-const extractLastUsedFromApiTokenOwner = function(db, backend) {
+const extractLastUsedFromApiTokenOwner = function (db, backend) {
   // We used to store lastUsed as a field on owner.user.  It makes more sense to store lastUsed on
   // the apiToken as a whole.  This migration hoists such values from owner.user onto the apiToken
   // itself.
@@ -589,7 +589,7 @@ const extractLastUsedFromApiTokenOwner = function(db, backend) {
   });
 };
 
-const setUpstreamTitles = function(db, backend) {
+const setUpstreamTitles = function (db, backend) {
   // Initializes the `upstreamTitle` and `renamed` fields of `ApiToken.owner.user`.
 
   const apiTokensRaw = db.collections.apiTokens.rawCollection();
@@ -628,7 +628,7 @@ const setUpstreamTitles = function(db, backend) {
   });
 };
 
-const markAllRead = function(db, backend) {
+const markAllRead = function (db, backend) {
   // Mark as "read" all grains and tokens that predate the creation of read/unread status.
   // Otherwise it's pretty annoying to see all your old grains look like they have activity.
 
@@ -638,7 +638,7 @@ const markAllRead = function(db, backend) {
       { multi: true });
 };
 
-const clearAppIndex = function(db, backend) {
+const clearAppIndex = function (db, backend) {
   // Due to a bug in the app update code, some app update notifications that the user accepted
   // around July 9-16, 2016 may not have applied. We have no way of knowing exactly which updates
   // the user accepted but didn't receive. Instead, to recover, we are clearing the local cache of
@@ -650,7 +650,7 @@ const clearAppIndex = function(db, backend) {
   db.collections.appIndex.remove({});
 };
 
-const assignEmailVerifierIds = function(db, backend) {
+const assignEmailVerifierIds = function (db, backend) {
   // Originally, the ID of an EmailVerifier was actually the _id of the root token from which it
   // was restored. This was broken, though: Conceptually, it meant that you couldn't have a working
   // EmailVerifier that had not been restore()d from disk. In practice, that wasn't a problem due
@@ -692,7 +692,7 @@ const startPreinstallingApps = function (db, backend) {
   }
 };
 
-const setNewServer = function(db, backend) {
+const setNewServer = function (db, backend) {
   // This migration only applies to "old" servers. New servers will set
   // new_server_migrations_applied to false before any migrations run.
   if (!db.collections.migrations.findOne({ _id: "new_server_migrations_applied" })) {

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -4,14 +4,16 @@
 // side-effects, we should be careful to make sure all migrations are
 // idempotent and safe to accidentally run multiple times.
 
+import { Meteor } from "meteor/meteor";
+import { _ } from "meteor/underscore";
+import { Match } from "meteor/check";
+import { userPictureUrl, fetchPicture } from "/imports/server/accounts/picture.js";
+
 const Future = Npm.require("fibers/future");
 const Url = Npm.require("url");
 const Crypto = Npm.require("crypto");
 
-const localSandstormDb = new SandstormDb();
-// TODO(someday): fix this when SandstormDb actually stores meaningful state on the object.
-
-const updateLoginStyleToRedirect = function () {
+const updateLoginStyleToRedirect = function (db) {
   const configurations = Package["service-configuration"].ServiceConfiguration.configurations;
   ["google", "github"].forEach(function (serviceName) {
     const config = configurations.findOne({ service: serviceName });
@@ -21,7 +23,7 @@ const updateLoginStyleToRedirect = function () {
   });
 };
 
-const enableLegacyOAuthProvidersIfNotInSettings = function () {
+const enableLegacyOAuthProvidersIfNotInSettings = function (db) {
   // In the before time, Google and Github login were enabled by default.
   //
   // This actually didn't make much sense, required the first user to configure
@@ -41,18 +43,18 @@ const enableLegacyOAuthProvidersIfNotInSettings = function () {
   const configurations = Package["service-configuration"].ServiceConfiguration.configurations;
   ["google", "github"].forEach(function (serviceName) {
     const config = configurations.findOne({ service: serviceName });
-    const serviceConfig = Settings.findOne({ _id: serviceName });
+    const serviceConfig = db.collections.settings.findOne({ _id: serviceName });
     if (config && !serviceConfig) {
       // Only explicitly enable the login service if:
       // 1) the service is already configured
       // 2) there is no sandstorm configuration already present (the user was
       //    using the previous default behavior).
-      Settings.insert({ _id: serviceName, value: true });
+      db.collections.settings.insert({ _id: serviceName, value: true });
     }
   });
 };
 
-const denormalizeInviteInfo = function () {
+const denormalizeInviteInfo = function (db) {
   // When a user is invited via a signup token, the `signupKey` field of their user table entry
   // has always been populated to indicate the key they used. This points into the SignupKeys table
   // which has more information about the key, namely a freeform note entered by the admin when
@@ -65,9 +67,9 @@ const denormalizeInviteInfo = function () {
   // `signupEmail` were added to the users table. We can backfill these values by denormalizing
   // from the SignupKeys table.
 
-  Meteor.users.find().forEach(function (user) {
+  db.collections.users.find().forEach(function (user) {
     if (user.signupKey && (typeof user.signupKey) === "string" && user.signupKey !== "admin") {
-      const signupInfo = SignupKeys.findOne(user.signupKey);
+      const signupInfo = db.collections.signupKeys.findOne(user.signupKey);
       if (signupInfo && signupInfo.note) {
         const newFields = { signupNote: signupInfo.note };
 
@@ -76,15 +78,15 @@ const denormalizeInviteInfo = function () {
           newFields.signupEmail = signupInfo.note.slice(prefix.length);
         }
 
-        Meteor.users.update(user._id, { $set: newFields });
+        db.collections.users.update(user._id, { $set: newFields });
       }
     }
   });
 };
 
-const mergeRoleAssignmentsIntoApiTokens = function () {
-  RoleAssignments.find().forEach(function (roleAssignment) {
-    ApiTokens.insert({
+const mergeRoleAssignmentsIntoApiTokens = function (db) {
+  db.collections.roleAssignments.find().forEach(function (roleAssignment) {
+    db.collections.apiTokens.insert({
       grainId: roleAssignment.grainId,
       userId: roleAssignment.sharer,
       roleAssignment: roleAssignment.roleAssignment,
@@ -100,39 +102,39 @@ const mergeRoleAssignmentsIntoApiTokens = function () {
   });
 };
 
-const fixOasisStorageUsageStats = function () {};
+const fixOasisStorageUsageStats = function (db) {};
 // This migration only pertained to Oasis and it was successfully applied there. Since it referred
 // to some global variables that we later wanted to remove and/or rename, we've since replaced it
 // with a no-op.
 
-const fetchProfilePictures = function () {
-  Meteor.users.find({}).forEach(function (user) {
+const fetchProfilePictures = function (db) {
+  db.collections.users.find({}).forEach(function (user) {
     const url = userPictureUrl(user);
     if (url) {
       console.log("Fetching user picture:", url);
-      const assetId = fetchPicture(url);
+      const assetId = fetchPicture(db, url);
       if (assetId) {
-        Meteor.users.update(user._id, { $set: { "profile.picture": assetId } });
+        db.collections.users.update(user._id, { $set: { "profile.picture": assetId } });
       }
     }
   });
 };
 
-const assignPlans = function () {
-  if (localSandstormDb.isReferralEnabled() && SandstormDb.paymentsMigrationHook) {
-    SandstormDb.paymentsMigrationHook(SignupKeys, Plans.find().fetch());
+const assignPlans = function (db) {
+  if (db.isReferralEnabled() && SandstormDb.paymentsMigrationHook) {
+    SandstormDb.paymentsMigrationHook(db.collections.signupKeys, db.collections.plans.find().fetch());
   }
 };
 
-const removeKeyrings = function () {
+const removeKeyrings = function (db) {
   // These blobs full of public keys were not intended to find their way into mongo and while
   // harmless they slow things down because they're huge. Remove them.
-  Packages.update({ "manifest.metadata.pgpKeyring": { $exists: true } },
+  db.collections.packages.update({ "manifest.metadata.pgpKeyring": { $exists: true } },
       { $unset: { "manifest.metadata.pgpKeyring": "" } },
       { multi: true });
 };
 
-const useLocalizedTextInUserActions = function () {
+const useLocalizedTextInUserActions = function (db) {
   function toLocalizedText(newObj, oldObj, field) {
     if (field in oldObj) {
       if (typeof oldObj[field] === "string") {
@@ -143,23 +145,24 @@ const useLocalizedTextInUserActions = function () {
     }
   }
 
-  UserActions.find({}).forEach(function (userAction) {
+  db.collections.userActions.find({}).forEach(function (userAction) {
     const fields = {};
     toLocalizedText(fields, userAction, "appTitle");
     toLocalizedText(fields, userAction, "title");
     toLocalizedText(fields, userAction, "nounPhrase");
-    UserActions.update(userAction._id, { $set: fields });
+    db.collections.userActions.update(userAction._id, { $set: fields });
   });
 };
 
-const verifyAllPgpSignatures = function () {
-  Packages.find({}).forEach(function (pkg) {
+const verifyAllPgpSignatures = function (db) {
+  db.collections.packages.find({}).forEach(function (pkg) {
     try {
       console.log("checking PGP signature for package:", pkg._id);
+      // TODO(someday): inject globalBackend dependency
       const info = waitPromise(globalBackend.cap().tryGetPackage(pkg._id));
       if (info.authorPgpKeyFingerprint) {
         console.log("  " + info.authorPgpKeyFingerprint);
-        Packages.update(pkg._id,
+        db.collections.packages.update(pkg._id,
             { $set: { authorPgpKeyFingerprint: info.authorPgpKeyFingerprint } });
       } else {
         console.log("  no signature");
@@ -170,8 +173,8 @@ const verifyAllPgpSignatures = function () {
   });
 };
 
-const splitUserIdsIntoAccountIdsAndIdentityIds = function () {
-  Meteor.users.find().forEach(function (user) {
+const splitUserIdsIntoAccountIdsAndIdentityIds = function (db) {
+  db.collections.users.find().forEach(function (user) {
     const identity = {};
     let serviceUserId;
     if ("devName" in user) {
@@ -224,44 +227,48 @@ const splitUserIdsIntoAccountIdsAndIdentityIds = function () {
 
     identity.main = true;
 
-    Meteor.users.update(user._id, { $set: { identities: [identity] } });
+    db.collections.users.update(user._id, { $set: { identities: [identity] } });
 
-    Grains.update({ userId: user._id }, { $set: { identityId: identity.id } }, { multi: true });
-    Sessions.update({ userId: user._id }, { $set: { identityId: identity.id } }, { multi: true });
-    ApiTokens.update({ userId: user._id },
-                     { $set: { identityId: identity.id } },
-                     { multi: true });
-    ApiTokens.update({ "owner.user.userId": user._id },
-                     { $set: { "owner.user.identityId": identity.id } },
-                     { multi: true });
-    ApiTokens.update({ "owner.grain.introducerUser": user._id },
-                     { $set: { "owner.grain.introducerIdentity": identity.id } },
-                     { multi: true });
+    db.collections.grains.update({ userId: user._id }, { $set: { identityId: identity.id } }, { multi: true });
+    db.collections.sessions.update({ userId: user._id }, { $set: { identityId: identity.id } }, { multi: true });
+    db.collections.apiTokens.update({ userId: user._id },
+        { $set: { identityId: identity.id } },
+        { multi: true });
+    db.collections.apiTokens.update({ "owner.user.userId": user._id },
+        { $set: { "owner.user.identityId": identity.id } },
+        { multi: true });
+    db.collections.apiTokens.update({ "owner.grain.introducerUser": user._id },
+        { $set: { "owner.grain.introducerIdentity": identity.id } },
+        { multi: true });
 
-    while (ApiTokens.update({ "requirements.permissionsHeld.userId": user._id },
-                            { $set: { "requirements.$.permissionsHeld.identityId": identity.id },
-                              $unset: { "requirements.$.permissionsHeld.userId": 1 }, },
-                            { multi: true }) > 0);
-    // The `$` operatorer modifies the first element in the array that matches the query. Since
+    while (db.collections.apiTokens.update({
+        "requirements.permissionsHeld.userId": user._id,
+      }, {
+        $set: { "requirements.$.permissionsHeld.identityId": identity.id },
+        $unset: { "requirements.$.permissionsHeld.userId": 1 },
+      }, {
+        multi: true,
+      }) > 0);
+    // The `$` operator modifies the first element in the array that matches the query. Since
     // there may be many matches, we need to repeat until no documents are modified.
 
   });
 
-  ApiTokens.remove({ userInfo: { $exists: true } });
+  db.collections.apiTokens.remove({ userInfo: { $exists: true } });
   // We've renamed `Grain.UserInfo.userId` to `Grain.userInfo.identityId`. The only place
   // that this field could show up in the database was in this deprecated, no-longer-functional
   // form of API token.
 };
 
-const appUpdateSettings = function () {
-  Settings.insert({ _id: "appMarketUrl", value: "https://apps.sandstorm.io" });
-  Settings.insert({ _id: "appIndexUrl", value: "https://app-index.sandstorm.io" });
-  Settings.insert({ _id: "appUpdatesEnabled", value: true });
+const appUpdateSettings = function (db) {
+  db.collections.settings.insert({ _id: "appMarketUrl", value: "https://apps.sandstorm.io" });
+  db.collections.settings.insert({ _id: "appIndexUrl", value: "https://app-index.sandstorm.io" });
+  db.collections.settings.insert({ _id: "appUpdatesEnabled", value: true });
 };
 
-const moveDevAndEmailLoginDataIntoIdentities = function () {
-  Meteor.users.find().forEach(function (user) {
-    if (user.identities.length != 1) {
+const moveDevAndEmailLoginDataIntoIdentities = function (db) {
+  db.collections.users.find().forEach(function (user) {
+    if (user.identities.length !== 1) {
       throw new Error("User does not have exactly one identity: ", user);
     }
 
@@ -291,13 +298,13 @@ const moveDevAndEmailLoginDataIntoIdentities = function () {
       modifier.$unset = fieldsToUnset;
     }
 
-    Meteor.users.update({ _id: user._id }, modifier);
+    db.collections.users.update({ _id: user._id }, modifier);
   });
 };
 
-const repairEmailIdentityIds = function () {
-  Meteor.users.find({ "identities.service.emailToken": { $exists: 1 } }).forEach(function (user) {
-    if (user.identities.length != 1) {
+const repairEmailIdentityIds = function (db) {
+  db.collections.users.find({ "identities.service.emailToken": { $exists: 1 } }).forEach(function (user) {
+    if (user.identities.length !== 1) {
       throw new Error("User does not have exactly one identity: ", user);
     }
 
@@ -308,29 +315,29 @@ const repairEmailIdentityIds = function () {
     newIdentity.id = Crypto.createHash("sha256")
       .update("email:" + identity.service.emailToken.email).digest("hex");
 
-    Grains.update({ identityId: identity.id }, { $set: { identityId: newIdentity.id } }, { multi: true });
-    Sessions.update({ identityId: identity.id }, { $set: { identityId: newIdentity.id } }, { multi: true });
-    ApiTokens.update({ identityId: identity.id },
-                     { $set: { identityId: newIdentity.id } },
-                     { multi: true });
-    ApiTokens.update({ "owner.user.identityId": identity.id },
-                     { $set: { "owner.user.identityId": newIdentity.id } },
-                     { multi: true });
-    ApiTokens.update({ "owner.grain.introducerIdentity": identity.id },
-                     { $set: { "owner.grain.introducerIdentity": newIdentity.id } },
-                     { multi: true });
+    db.collections.grains.update({ identityId: identity.id }, { $set: { identityId: newIdentity.id } }, { multi: true });
+    db.collections.sessions.update({ identityId: identity.id }, { $set: { identityId: newIdentity.id } }, { multi: true });
+    db.collections.apiTokens.update({ identityId: identity.id },
+        { $set: { identityId: newIdentity.id } },
+        { multi: true });
+    db.collections.apiTokens.update({ "owner.user.identityId": identity.id },
+        { $set: { "owner.user.identityId": newIdentity.id } },
+        { multi: true });
+    db.collections.apiTokens.update({ "owner.grain.introducerIdentity": identity.id },
+        { $set: { "owner.grain.introducerIdentity": newIdentity.id } },
+        { multi: true });
 
-    while (ApiTokens.update({ "requirements.permissionsHeld.identityId": identity.id },
-                            { $set: { "requirements.$.permissionsHeld.identityId": newIdentity.id } },
-                            { multi: true }) > 0);
+    while (db.collections.apiTokens.update({ "requirements.permissionsHeld.identityId": identity.id },
+        { $set: { "requirements.$.permissionsHeld.identityId": newIdentity.id } },
+        { multi: true }) > 0);
 
-    Meteor.users.update({ _id: user._id }, { $set: { identities: [newIdentity] } });
+    db.collections.users.update({ _id: user._id }, { $set: { identities: [newIdentity] } });
   });
 };
 
-const splitAccountUsersAndIdentityUsers = function () {
-  Meteor.users.find({ identities: { $exists: true } }).forEach(function (user) {
-    if (user.identities.length != 1) {
+const splitAccountUsersAndIdentityUsers = function (db) {
+  db.collections.users.find({ identities: { $exists: true } }).forEach(function (user) {
+    if (user.identities.length !== 1) {
       throw new Error("User does not have exactly one identity: ", user);
     }
 
@@ -362,27 +369,33 @@ const splitAccountUsersAndIdentityUsers = function () {
 
     accountUser.stashedOldUser = user;
 
-    ApiTokens.update({ identityId: identityUser._id }, { $set: { accountId: user._id } },
-                     { multi: true });
+    db.collections.apiTokens.update(
+      { identityId: identityUser._id },
+      { $set: { accountId: user._id } },
+      { multi: true });
 
-    Meteor.users.upsert({ _id: identityUser._id }, identityUser);
-    Meteor.users.update({ _id: user._id }, accountUser);
+    db.collections.users.upsert({ _id: identityUser._id }, identityUser);
+    db.collections.users.update({ _id: user._id }, accountUser);
   });
 
-  Meteor.users.find({ stagedServices: { $exists: true } }).forEach(function (identity) {
-    Meteor.users.update({ _id: identity._id }, { $unset: { stagedServices: 1 },
-                                              $set: { services: identity.stagedServices }, });
+  db.collections.users.find({ stagedServices: { $exists: true } }).forEach(function (identity) {
+    db.collections.users.update({ _id: identity._id }, {
+      $unset: { stagedServices: 1 },
+      $set: { services: identity.stagedServices },
+    });
   });
 };
 
-const populateContactsFromApiTokens = function () {
-  ApiTokens.find({ "owner.user.identityId": { $exists: 1 },
-                  accountId: { $exists: 1 }, }).forEach(function (token) {
+const populateContactsFromApiTokens = function (db) {
+  db.collections.apiTokens.find({
+    "owner.user.identityId": { $exists: 1 },
+    accountId: { $exists: 1 },
+  }).forEach(function (token) {
     const identityId = token.owner.user.identityId;
-    const identity = SandstormDb.prototype.getIdentity(identityId);
+    const identity = db.getIdentity(identityId);
     if (identity) {
       const profile = identity.profile;
-      Contacts.upsert({ ownerId: token.accountId, identityId: identityId }, {
+      db.collections.contacts.upsert({ ownerId: token.accountId, identityId: identityId }, {
         ownerId: token.accountId,
         petname: profile && profile.name,
         created: new Date(),
@@ -393,62 +406,75 @@ const populateContactsFromApiTokens = function () {
   });
 };
 
-const cleanUpApiTokens = function () {
+const cleanUpApiTokens = function (db) {
   // The `splitUserIdsIntoAccountIdsAndIdentityIds()` migration only added `identityId` in cases
   // where the user still existed in the database.
-  ApiTokens.remove({ userId: { $exists: true }, identityId: { $exists: false } });
-  ApiTokens.remove({ "owner.user.userId": { $exists: true },
-                    "owner.user.identityId": { $exists: false }, });
+  db.collections.apiTokens.remove({
+    userId: { $exists: true },
+    identityId: { $exists: false },
+  });
+  db.collections.apiTokens.remove({
+    "owner.user.userId": { $exists: true },
+    "owner.user.identityId": { $exists: false },
+  });
 
   // For a while we were accidentally setting `appIcon` instead of `icon`.
-  ApiTokens.find({ "owner.user.denormalizedGrainMetadata.appIcon": { $exists: true } }).forEach(
-      function (apiToken) {
+  db.collections.apiTokens.find({
+    "owner.user.denormalizedGrainMetadata.appIcon": { $exists: true },
+  }).forEach(function (apiToken) {
     const icon = apiToken.owner.user.denormalizedGrainMetadata.appIcon;
-    ApiTokens.update({ _id: apiToken._id },
-                     { $set: { "owner.user.denormalizedGrainMetadata.icon": icon },
-                      $unset: { "owner.user.denormalizedGrainMetadata.appIcon": true }, });
+    db.collections.apiTokens.update({ _id: apiToken._id }, {
+      $set: { "owner.user.denormalizedGrainMetadata.icon": icon },
+      $unset: { "owner.user.denormalizedGrainMetadata.appIcon": true },
+    });
   });
 
   // For a while the `identityId` field of child UiView tokens was not getting set.
   function repairChain(parentToken) {
-    ApiTokens.find({ parentToken: parentToken._id, grainId: { $exists: true },
-                    identityId: { $exists: false }, }).forEach(function (childToken) {
-      ApiTokens.update({ _id: childToken._id }, { $set: { identityId: parentToken.identityId } });
+    db.collections.apiTokens.find({
+      parentToken: parentToken._id,
+      grainId: { $exists: true },
+      identityId: { $exists: false },
+    }).forEach(function (childToken) {
+      db.collections.apiTokens.update({ _id: childToken._id }, { $set: { identityId: parentToken.identityId } });
       repairChain(childToken);
     });
   }
 
-  ApiTokens.find({ grainId: { $exists: true }, identityId: { $exists: true },
-                  parentToken: { $exists: false }, }).forEach(repairChain);
+  db.collections.apiTokens.find({
+    grainId: { $exists: true },
+    identityId: { $exists: true },
+    parentToken: { $exists: false },
+  }).forEach(repairChain);
 };
 
-const initServerTitleAndReturnAddress = function () {
+const initServerTitleAndReturnAddress = function (db) {
   const hostname = Url.parse(process.env.ROOT_URL).hostname;
-  Settings.insert({ _id: "serverTitle", value: hostname });
-  Settings.insert({ _id: "returnAddress", value: "no-reply@" + hostname });
+  db.collections.settings.insert({ _id: "serverTitle", value: hostname });
+  db.collections.settings.insert({ _id: "returnAddress", value: "no-reply@" + hostname });
 };
 
-const sendReferralNotifications = function () {
-  if (localSandstormDb.isReferralEnabled()) {
-    Meteor.users.find({
+const sendReferralNotifications = function (db) {
+  if (db.isReferralEnabled()) {
+    db.collections.users.find({
       loginIdentities: { $exists: true },
       expires: { $exists: false },
     }, { fields: { _id: 1 } }).forEach(function (user) {
-      sendReferralProgramNotification(user._id);
+      db.sendReferralProgramNotification(user._id);
     });
   }
 };
 
-const assignBonuses = function () {
-  if (localSandstormDb.isReferralEnabled() && SandstormDb.bonusesMigrationHook) {
+const assignBonuses = function (db) {
+  if (db.isReferralEnabled() && SandstormDb.bonusesMigrationHook) {
     SandstormDb.bonusesMigrationHook();
   }
 };
 
-const splitSmtpUrl = function () {
-  const smtpUrlSetting = Settings.findOne({ _id: "smtpUrl" });
+const splitSmtpUrl = function (db) {
+  const smtpUrlSetting = db.collections.settings.findOne({ _id: "smtpUrl" });
   const smtpUrl = smtpUrlSetting ? smtpUrlSetting.value : process.env.MAIL_URL;
-  const returnAddress = Settings.findOne({ _id: "returnAddress" });
+  const returnAddress = db.collections.settings.findOne({ _id: "returnAddress" });
 
   // Default values.
   const smtpConfig = {
@@ -487,27 +513,28 @@ const splitSmtpUrl = function () {
     smtpConfig.auth = auth;
   }
 
-  Settings.upsert({ _id: "smtpConfig" }, { value: smtpConfig });
-  Settings.remove({ _id: "returnAddress" });
-  Settings.remove({ _id: "smtpUrl" });
+  db.collections.settings.upsert({ _id: "smtpConfig" }, { value: smtpConfig });
+  db.collections.settings.remove({ _id: "returnAddress" });
+  db.collections.settings.remove({ _id: "smtpUrl" });
 };
 
-const smtpPortShouldBeNumber = function () {
-  const entry = Settings.findOne({ _id: "smtpConfig" });
+const smtpPortShouldBeNumber = function (db) {
+  const entry = db.collections.settings.findOne({ _id: "smtpConfig" });
   if (entry) {
     const setting = entry.value;
     if (setting.port) {
       setting.port = _.isNumber(setting.port) ? setting.port : parseInt(setting.port);
-      Settings.upsert({ _id: "smtpConfig" }, { value: setting });
+      db.collections.settings.upsert({ _id: "smtpConfig" }, { value: setting });
     }
   }
 };
 
-const consolidateOrgSettings = function () {
-  const orgGoogleDomain = Settings.findOne({ _id: "organizationGoogle" });
-  const orgEmailDomain = Settings.findOne({ _id: "organizationEmail" });
-  const orgLdap = Settings.findOne({ _id: "organizationLdap" });
-  const orgSaml = Settings.findOne({ _id: "organizationSaml" });
+const consolidateOrgSettings = function (db) {
+  const settings = db.collections.settings;
+  const orgGoogleDomain = settings.findOne({ _id: "organizationGoogle" });
+  const orgEmailDomain = settings.findOne({ _id: "organizationEmail" });
+  const orgLdap = settings.findOne({ _id: "organizationLdap" });
+  const orgSaml = settings.findOne({ _id: "organizationSaml" });
 
   const orgMembership = {
     google: {
@@ -526,47 +553,47 @@ const consolidateOrgSettings = function () {
     },
   };
 
-  Settings.upsert({ _id: "organizationMembership" }, { value: orgMembership });
-  Settings.remove({ _id: "organizationGoogle" });
-  Settings.remove({ _id: "organizationEmail" });
-  Settings.remove({ _id: "organizationLdap" });
-  Settings.remove({ _id: "organizationSaml" });
+  settings.upsert({ _id: "organizationMembership" }, { value: orgMembership });
+  settings.remove({ _id: "organizationGoogle" });
+  settings.remove({ _id: "organizationEmail" });
+  settings.remove({ _id: "organizationLdap" });
+  settings.remove({ _id: "organizationSaml" });
 };
 
-const unsetSmtpDefaultHostnameIfNoUsersExist = function () {
+const unsetSmtpDefaultHostnameIfNoUsersExist = function (db) {
   // We don't actually want to have the default hostname "localhost" set.
   // If the user has already finished configuring their server, then this migration should do
   // nothing (since we might break their deployment), but for new installs (which will have no users
   // at the time this migration runs) we'll unset the hostname if it's still the previously-filled
   // default value.
-  const hasUsers = Meteor.users.findOne();
+  const hasUsers = db.collections.users.findOne();
   if (!hasUsers) {
-    const entry = Settings.findOne({ _id: "smtpConfig" });
+    const entry = db.collections.settings.findOne({ _id: "smtpConfig" });
     const smtpConfig = entry.value;
     if (smtpConfig.hostname === "localhost") {
       smtpConfig.hostname = "";
-      Settings.upsert({ _id: "smtpConfig" }, { value: smtpConfig });
+      db.collections.settings.upsert({ _id: "smtpConfig" }, { value: smtpConfig });
     }
   }
 };
 
-const extractLastUsedFromApiTokenOwner = function () {
+const extractLastUsedFromApiTokenOwner = function (db) {
   // We used to store lastUsed as a field on owner.user.  It makes more sense to store lastUsed on
   // the apiToken as a whole.  This migration hoists such values from owner.user onto the apiToken
   // itself.
-  ApiTokens.find({ "owner.user": { $exists: true } }).forEach(function (token) {
+  db.collections.apiTokens.find({ "owner.user": { $exists: true } }).forEach(function (token) {
     const lastUsed = token.owner.user.lastUsed;
-    ApiTokens.update({ _id: token._id }, {
+    db.collections.apiTokens.update({ _id: token._id }, {
       $set: { lastUsed: lastUsed },
       $unset: { "owner.user.lastUsed": true },
     });
   });
 };
 
-const setUpstreamTitles = function () {
+const setUpstreamTitles = function (db) {
   // Initializes the `upstreamTitle` and `renamed` fields of `ApiToken.owner.user`.
 
-  const apiTokensRaw = ApiTokens.rawCollection();
+  const apiTokensRaw = db.collections.apiTokens.rawCollection();
   const aggregateApiTokens = Meteor.wrapAsync(apiTokensRaw.aggregate, apiTokensRaw);
 
   // First, construct a list of all *shared* grains. We will need to do a separate update()
@@ -577,7 +604,7 @@ const setUpstreamTitles = function () {
   ]).map(grain => grain._id);
 
   let count = 0;
-  Grains.find({ _id: { $in: grainIds } }, { fields: { title: 1 } }).forEach((grain) => {
+  db.collections.grains.find({ _id: { $in: grainIds } }, { fields: { title: 1 } }).forEach((grain) => {
     if (count % 100 == 0) {
       console.log(count + " / " + grainIds.length);
     }
@@ -595,24 +622,24 @@ const setUpstreamTitles = function () {
     //    other hand, if we guessed wrongly in the other direction, the user would see
     //    "User's title (renamed from: Owners title)", which would be wrong if it was in fact the
     //    owner who renamed post-sharing.
-    ApiTokens.update({
+    db.collections.apiTokens.update({
       grainId: grain._id,
       "owner.user.title": { $exists: true, $ne: grain.title },
     }, { $set: { "owner.user.upstreamTitle": grain.title } }, { multi: true });
   });
 };
 
-const markAllRead = function () {
+const markAllRead = function (db) {
   // Mark as "read" all grains and tokens that predate the creation of read/unread status.
   // Otherwise it's pretty annoying to see all your old grains look like they have activity.
 
-  Grains.update({}, { $set: { ownerSeenAllActivity: true } }, { multi: true });
-  ApiTokens.update({ "owner.user": { $exists: true } },
-                   { $set: { "owner.user.seenAllActivity": true } },
-                   { multi: true });
+  db.collections.grains.update({}, { $set: { ownerSeenAllActivity: true } }, { multi: true });
+  db.collections.apiTokens.update({ "owner.user": { $exists: true } },
+      { $set: { "owner.user.seenAllActivity": true } },
+      { multi: true });
 };
 
-const clearAppIndex = function () {
+const clearAppIndex = function (db) {
   // Due to a bug in the app update code, some app update notifications that the user accepted
   // around July 9-16, 2016 may not have applied. We have no way of knowing exactly which updates
   // the user accepted but didn't receive. Instead, to recover, we are clearing the local cache of
@@ -621,10 +648,10 @@ const clearAppIndex = function () {
   // everyone. This may mean users get notifications that they previously dismissed, but they can
   // click "dismiss" again easily enough.
 
-  AppIndex.remove({});
+  db.collections.appIndex.remove({});
 };
 
-const assignEmailVerifierIds = function () {
+const assignEmailVerifierIds = function (db) {
   // Originally, the ID of an EmailVerifier was actually the _id of the root token from which it
   // was restored. This was broken, though: Conceptually, it meant that you couldn't have a working
   // EmailVerifier that had not been restore()d from disk. In practice, that wasn't a problem due
@@ -635,20 +662,20 @@ const assignEmailVerifierIds = function () {
   // ugly because it was puncturing layers of abstraction. So, we switched to doing the right
   // thing: assigning an ID to the EmailVerifier on first creation and storing it separately.
 
-  ApiTokens.find({ "frontendRef.emailVerifier": { $exists: true } }).forEach(token => {
-    ApiTokens.update(token._id, { $set: { "frontendRef.emailVerifier.id": token._id } });
+  db.collections.apiTokens.find({ "frontendRef.emailVerifier": { $exists: true } }).forEach(token => {
+    db.collections.apiTokens.update(token._id, { $set: { "frontendRef.emailVerifier.id": token._id } });
   });
 };
 
-const startPreinstallingApps = function () {
+const startPreinstallingApps = function (db) {
   // This isn't really a normal migration. It will run only on brand new servers, and it has to
   // run after the `clearAppIndex` migration because it relies on populating AppIndex.
 
   const startPreinstallingAppsHelper = function () {
-    localSandstormDb.updateAppIndex();
+    db.updateAppIndex();
 
-    const preinstalledApps = globalDb.collections.appIndex.find({ _id: {
-      $in: globalDb.getProductivitySuiteAppIds(), },
+    const preinstalledApps = db.collections.appIndex.find({ _id: {
+      $in: db.getProductivitySuiteAppIds(), },
     }).fetch();
     const appAndPackageIds = _.map(preinstalledApps, (app) => {
       return {
@@ -657,44 +684,44 @@ const startPreinstallingApps = function () {
       };
     });
 
-    localSandstormDb.setPreinstalledApps(appAndPackageIds);
+    db.setPreinstalledApps(appAndPackageIds);
   };
 
-  if (!Meteor.settings.public.isTesting && !localSandstormDb.allowDevAccounts()) {
+  if (!Meteor.settings.public.isTesting && !db.allowDevAccounts()) {
     // We want preinstalling apps to run async and not block startup.
     Meteor.setTimeout(startPreinstallingAppsHelper, 0);
   }
 };
 
-const setNewServer = function () {
+const setNewServer = function (db) {
   // This migration only applies to "old" servers. New servers will set
   // new_server_migrations_applied to false before any migrations run.
-  if (!Migrations.findOne({ _id: "new_server_migrations_applied" })) {
-    Migrations.insert({ _id: "new_server_migrations_applied", value: true });
+  if (!db.collections.migrations.findOne({ _id: "new_server_migrations_applied" })) {
+    db.collections.migrations.insert({ _id: "new_server_migrations_applied", value: true });
   }
 };
 
-function backgroundFillInGrainSizes() {
+function backgroundFillInGrainSizes(db) {
   // Fill in sizes for all grains that don't have them. Since computing a grain size requires a
   // directory walk, we don't want to do them all at once. Instead, we compute one a second until
   // all grains have sizes.
 
   try {
-    const grain = Grains.findOne({ size: { $exists: false } }, { fields: { _id: 1, userId: 1 } });
+    const grain = db.collections.grains.findOne({ size: { $exists: false } }, { fields: { _id: 1, userId: 1 } });
 
     if (grain) {
       // Compute size!
       try {
         const result = waitPromise(globalBackend.cap().getGrainStorageUsage(
             grain.userId, grain._id));
-        Grains.update({ _id: grain._id, size: { $exists: false } },
-                      { $set: { size: parseInt(result.size) } });
+        db.collections.grains.update({ _id: grain._id, size: { $exists: false } },
+            { $set: { size: parseInt(result.size) } });
       } catch (err) {
         if (err.kjType === "failed") {
           // Backend had a problem. Maybe the grain doesn't actually exist on disk and the database
           // is messed up. We'll set the size to zero and move on.
           console.error("Error while backfilling grain size for", grain._id, ":", err.stack);
-          Grains.update({ _id: grain._id, size: { $exists: false } }, { $set: { size: 0 } });
+          db.collections.grains.update({ _id: grain._id, size: { $exists: false } }, { $set: { size: 0 } });
         } else {
           // Rethrow on disconnected / overloaded / unimplemented.
           throw err;
@@ -702,7 +729,7 @@ function backgroundFillInGrainSizes() {
       }
 
       // Do another one in a second.
-      Meteor.setTimeout(backgroundFillInGrainSizes, 1000);
+      Meteor.setTimeout(backgroundFillInGrainSizes.bind(this, db), 1000);
     }
   } catch (err) {
     // We'll just stop for now, to avoid spamming logs if this error persists. Next time the server
@@ -751,7 +778,7 @@ const NEW_SERVER_STARTUP = [
   startPreinstallingApps,
 ];
 
-const migrateToLatest = function () {
+const migrateToLatest = function (db) {
   if (Meteor.settings.replicaNumber) {
     // This is a replica. Wait for the first replica to perform migrations.
 
@@ -763,7 +790,7 @@ const migrateToLatest = function () {
       if (doc.value >= MIGRATIONS.length) done.return();
     };
 
-    const observer = Migrations.find({ _id: "migrations_applied" }).observe({
+    const observer = db.collections.migrations.find({ _id: "migrations_applied" }).observe({
       added: change,
       changed: change,
     });
@@ -776,7 +803,7 @@ const migrateToLatest = function () {
       }
     };
 
-    const newServerObserver = Migrations.find({ _id: "new_server_migrations_applied" }).observe({
+    const newServerObserver = db.collections.migrations.find({ _id: "new_server_migrations_applied" }).observe({
       added: newServerChange,
       changed: newServerChange,
     });
@@ -786,18 +813,17 @@ const migrateToLatest = function () {
     newServerDone.wait();
     newServerObserver.stop();
     console.log("Migrations have completed on replica zero.");
-
   } else {
-    const applied = Migrations.findOne({ _id: "migrations_applied" });
+    const applied = db.collections.migrations.findOne({ _id: "migrations_applied" });
     let start;
     if (!applied) {
       // Migrations table is not yet seeded with a value.  This means it has
       // applied 0 migrations.  Persist this.
-      Migrations.insert({ _id: "migrations_applied", value: 0 });
+      db.collections.migrations.insert({ _id: "migrations_applied", value: 0 });
       start = 0;
 
       // This also means this is a brand new server
-      Migrations.insert({ _id: "new_server_migrations_applied", value: false });
+      db.collections.migrations.insert({ _id: "new_server_migrations_applied", value: false });
     } else {
       start = applied.value;
     }
@@ -807,26 +833,26 @@ const migrateToLatest = function () {
     for (let i = start; i < MIGRATIONS.length; i++) {
       // Apply migration i, then record that migration i was successfully run.
       console.log("Applying migration " + (i + 1));
-      MIGRATIONS[i]();
-      Migrations.update({ _id: "migrations_applied" }, { $set: { value: i + 1 } });
+      MIGRATIONS[i](db);
+      db.collections.migrations.update({ _id: "migrations_applied" }, { $set: { value: i + 1 } });
       console.log("Applied migration " + (i + 1));
     }
 
-    if (!Migrations.findOne({ _id: "new_server_migrations_applied" }).value) {
+    if (!db.collections.migrations.findOne({ _id: "new_server_migrations_applied" }).value) {
       // new_server_migrations_applied is guaranteed to exist since we have a migration that
       // ensures it.
       for (let i = 0; i < NEW_SERVER_STARTUP.length; i++) {
         console.log("Running new server startup function " + (i + 1));
-        NEW_SERVER_STARTUP[i]();
+        NEW_SERVER_STARTUP[i](db);
         console.log("Running new server startup function " + (i + 1));
       }
 
-      Migrations.update({ _id: "new_server_migrations_applied" }, { $set: { value: true } });
+      db.collections.migrations.update({ _id: "new_server_migrations_applied" }, { $set: { value: true } });
     }
 
     // Start background migrations.
-    backgroundFillInGrainSizes();
+    backgroundFillInGrainSizes(db);
   }
 };
 
-SandstormDb.prototype.migrateToLatest = migrateToLatest;
+export { migrateToLatest };

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -948,15 +948,18 @@ SandstormDb = function (quotaManager) {
 
   this.quotaManager = quotaManager;
   this.collections = {
-    // Direct access to underlying collections. DEPRECATED.
+    // Direct access to underlying collections. DEPRECATED, but better than accessing the top-level
+    // collection globals directly.
     //
     // TODO(cleanup): Over time, we will provide methods covering each supported query and remove
     //   direct access to the collections.
+    users: Meteor.users,
 
     packages: Packages,
     devPackages: DevPackages,
     userActions: UserActions,
     grains: Grains,
+    roleAssignments: RoleAssignments, // Deprecated, only used by the migration that eliminated it.
     contacts: Contacts,
     sessions: Sessions,
     signupKeys: SignupKeys,
@@ -966,19 +969,19 @@ SandstormDb = function (quotaManager) {
     apiTokens: ApiTokens,
     apiHosts: ApiHosts,
     notifications: Notifications,
+    // Omitted: ActivitySubscriptions
     statsTokens: StatsTokens,
     misc: Misc,
     settings: Settings,
+    migrations: Migrations,
+    // Omitted: StaticAssets
+    // Omitted: AssetUploadTokens
+    plans: Plans,
     appIndex: AppIndex,
     keybaseProfiles: KeybaseProfiles,
     featureKey: FeatureKey,
     setupSession: SetupSession,
-    users: Meteor.users,
     desktopNotifications: DesktopNotifications,
-
-    // Intentionally omitted:
-    // - Migrations, since it's used only within this package.
-    // - RoleAssignments, since it is deprecated and only used by the migration that eliminated it.
   };
 };
 

--- a/shell/packages/sandstorm-db/migrations.js
+++ b/shell/packages/sandstorm-db/migrations.js
@@ -82,7 +82,7 @@ const denormalizeInviteInfo = function () {
   });
 };
 
-function mergeRoleAssignmentsIntoApiTokens() {
+const mergeRoleAssignmentsIntoApiTokens = function () {
   RoleAssignments.find().forEach(function (roleAssignment) {
     ApiTokens.insert({
       grainId: roleAssignment.grainId,
@@ -98,14 +98,14 @@ function mergeRoleAssignmentsIntoApiTokens() {
       },
     });
   });
-}
+};
 
-function fixOasisStorageUsageStats() {}
+const fixOasisStorageUsageStats = function () {};
 // This migration only pertained to Oasis and it was successfully applied there. Since it referred
 // to some global variables that we later wanted to remove and/or rename, we've since replaced it
 // with a no-op.
 
-function fetchProfilePictures() {
+const fetchProfilePictures = function () {
   Meteor.users.find({}).forEach(function (user) {
     const url = userPictureUrl(user);
     if (url) {
@@ -116,23 +116,23 @@ function fetchProfilePictures() {
       }
     }
   });
-}
+};
 
-function assignPlans() {
+const assignPlans = function () {
   if (localSandstormDb.isReferralEnabled() && SandstormDb.paymentsMigrationHook) {
     SandstormDb.paymentsMigrationHook(SignupKeys, Plans.find().fetch());
   }
-}
+};
 
-function removeKeyrings() {
+const removeKeyrings = function () {
   // These blobs full of public keys were not intended to find their way into mongo and while
   // harmless they slow things down because they're huge. Remove them.
   Packages.update({ "manifest.metadata.pgpKeyring": { $exists: true } },
       { $unset: { "manifest.metadata.pgpKeyring": "" } },
       { multi: true });
-}
+};
 
-function useLocalizedTextInUserActions() {
+const useLocalizedTextInUserActions = function () {
   function toLocalizedText(newObj, oldObj, field) {
     if (field in oldObj) {
       if (typeof oldObj[field] === "string") {
@@ -150,9 +150,9 @@ function useLocalizedTextInUserActions() {
     toLocalizedText(fields, userAction, "nounPhrase");
     UserActions.update(userAction._id, { $set: fields });
   });
-}
+};
 
-function verifyAllPgpSignatures() {
+const verifyAllPgpSignatures = function () {
   Packages.find({}).forEach(function (pkg) {
     try {
       console.log("checking PGP signature for package:", pkg._id);
@@ -168,9 +168,9 @@ function verifyAllPgpSignatures() {
       console.error(err.stack);
     }
   });
-}
+};
 
-function splitUserIdsIntoAccountIdsAndIdentityIds() {
+const splitUserIdsIntoAccountIdsAndIdentityIds = function () {
   Meteor.users.find().forEach(function (user) {
     const identity = {};
     let serviceUserId;
@@ -251,15 +251,15 @@ function splitUserIdsIntoAccountIdsAndIdentityIds() {
   // We've renamed `Grain.UserInfo.userId` to `Grain.userInfo.identityId`. The only place
   // that this field could show up in the database was in this deprecated, no-longer-functional
   // form of API token.
-}
+};
 
-function appUpdateSettings() {
+const appUpdateSettings = function () {
   Settings.insert({ _id: "appMarketUrl", value: "https://apps.sandstorm.io" });
   Settings.insert({ _id: "appIndexUrl", value: "https://app-index.sandstorm.io" });
   Settings.insert({ _id: "appUpdatesEnabled", value: true });
-}
+};
 
-function moveDevAndEmailLoginDataIntoIdentities() {
+const moveDevAndEmailLoginDataIntoIdentities = function () {
   Meteor.users.find().forEach(function (user) {
     if (user.identities.length != 1) {
       throw new Error("User does not have exactly one identity: ", user);
@@ -293,9 +293,9 @@ function moveDevAndEmailLoginDataIntoIdentities() {
 
     Meteor.users.update({ _id: user._id }, modifier);
   });
-}
+};
 
-function repairEmailIdentityIds() {
+const repairEmailIdentityIds = function () {
   Meteor.users.find({ "identities.service.emailToken": { $exists: 1 } }).forEach(function (user) {
     if (user.identities.length != 1) {
       throw new Error("User does not have exactly one identity: ", user);
@@ -326,9 +326,9 @@ function repairEmailIdentityIds() {
 
     Meteor.users.update({ _id: user._id }, { $set: { identities: [newIdentity] } });
   });
-}
+};
 
-function splitAccountUsersAndIdentityUsers() {
+const splitAccountUsersAndIdentityUsers = function () {
   Meteor.users.find({ identities: { $exists: true } }).forEach(function (user) {
     if (user.identities.length != 1) {
       throw new Error("User does not have exactly one identity: ", user);
@@ -373,9 +373,9 @@ function splitAccountUsersAndIdentityUsers() {
     Meteor.users.update({ _id: identity._id }, { $unset: { stagedServices: 1 },
                                               $set: { services: identity.stagedServices }, });
   });
-}
+};
 
-function populateContactsFromApiTokens() {
+const populateContactsFromApiTokens = function () {
   ApiTokens.find({ "owner.user.identityId": { $exists: 1 },
                   accountId: { $exists: 1 }, }).forEach(function (token) {
     const identityId = token.owner.user.identityId;
@@ -391,9 +391,9 @@ function populateContactsFromApiTokens() {
       });
     }
   });
-}
+};
 
-function cleanUpApiTokens() {
+const cleanUpApiTokens = function () {
   // The `splitUserIdsIntoAccountIdsAndIdentityIds()` migration only added `identityId` in cases
   // where the user still existed in the database.
   ApiTokens.remove({ userId: { $exists: true }, identityId: { $exists: false } });
@@ -420,15 +420,15 @@ function cleanUpApiTokens() {
 
   ApiTokens.find({ grainId: { $exists: true }, identityId: { $exists: true },
                   parentToken: { $exists: false }, }).forEach(repairChain);
-}
+};
 
-function initServerTitleAndReturnAddress() {
+const initServerTitleAndReturnAddress = function () {
   const hostname = Url.parse(process.env.ROOT_URL).hostname;
   Settings.insert({ _id: "serverTitle", value: hostname });
   Settings.insert({ _id: "returnAddress", value: "no-reply@" + hostname });
-}
+};
 
-function sendReferralNotifications() {
+const sendReferralNotifications = function () {
   if (localSandstormDb.isReferralEnabled()) {
     Meteor.users.find({
       loginIdentities: { $exists: true },
@@ -437,15 +437,15 @@ function sendReferralNotifications() {
       sendReferralProgramNotification(user._id);
     });
   }
-}
+};
 
-function assignBonuses() {
+const assignBonuses = function () {
   if (localSandstormDb.isReferralEnabled() && SandstormDb.bonusesMigrationHook) {
     SandstormDb.bonusesMigrationHook();
   }
-}
+};
 
-function splitSmtpUrl() {
+const splitSmtpUrl = function () {
   const smtpUrlSetting = Settings.findOne({ _id: "smtpUrl" });
   const smtpUrl = smtpUrlSetting ? smtpUrlSetting.value : process.env.MAIL_URL;
   const returnAddress = Settings.findOne({ _id: "returnAddress" });
@@ -490,9 +490,9 @@ function splitSmtpUrl() {
   Settings.upsert({ _id: "smtpConfig" }, { value: smtpConfig });
   Settings.remove({ _id: "returnAddress" });
   Settings.remove({ _id: "smtpUrl" });
-}
+};
 
-function smtpPortShouldBeNumber() {
+const smtpPortShouldBeNumber = function () {
   const entry = Settings.findOne({ _id: "smtpConfig" });
   if (entry) {
     const setting = entry.value;
@@ -501,9 +501,9 @@ function smtpPortShouldBeNumber() {
       Settings.upsert({ _id: "smtpConfig" }, { value: setting });
     }
   }
-}
+};
 
-function consolidateOrgSettings() {
+const consolidateOrgSettings = function () {
   const orgGoogleDomain = Settings.findOne({ _id: "organizationGoogle" });
   const orgEmailDomain = Settings.findOne({ _id: "organizationEmail" });
   const orgLdap = Settings.findOne({ _id: "organizationLdap" });
@@ -531,9 +531,9 @@ function consolidateOrgSettings() {
   Settings.remove({ _id: "organizationEmail" });
   Settings.remove({ _id: "organizationLdap" });
   Settings.remove({ _id: "organizationSaml" });
-}
+};
 
-function unsetSmtpDefaultHostnameIfNoUsersExist() {
+const unsetSmtpDefaultHostnameIfNoUsersExist = function () {
   // We don't actually want to have the default hostname "localhost" set.
   // If the user has already finished configuring their server, then this migration should do
   // nothing (since we might break their deployment), but for new installs (which will have no users
@@ -548,9 +548,9 @@ function unsetSmtpDefaultHostnameIfNoUsersExist() {
       Settings.upsert({ _id: "smtpConfig" }, { value: smtpConfig });
     }
   }
-}
+};
 
-function extractLastUsedFromApiTokenOwner() {
+const extractLastUsedFromApiTokenOwner = function () {
   // We used to store lastUsed as a field on owner.user.  It makes more sense to store lastUsed on
   // the apiToken as a whole.  This migration hoists such values from owner.user onto the apiToken
   // itself.
@@ -561,9 +561,9 @@ function extractLastUsedFromApiTokenOwner() {
       $unset: { "owner.user.lastUsed": true },
     });
   });
-}
+};
 
-function setUpstreamTitles() {
+const setUpstreamTitles = function () {
   // Initializes the `upstreamTitle` and `renamed` fields of `ApiToken.owner.user`.
 
   const apiTokensRaw = ApiTokens.rawCollection();
@@ -600,9 +600,9 @@ function setUpstreamTitles() {
       "owner.user.title": { $exists: true, $ne: grain.title },
     }, { $set: { "owner.user.upstreamTitle": grain.title } }, { multi: true });
   });
-}
+};
 
-function markAllRead() {
+const markAllRead = function () {
   // Mark as "read" all grains and tokens that predate the creation of read/unread status.
   // Otherwise it's pretty annoying to see all your old grains look like they have activity.
 
@@ -610,9 +610,9 @@ function markAllRead() {
   ApiTokens.update({ "owner.user": { $exists: true } },
                    { $set: { "owner.user.seenAllActivity": true } },
                    { multi: true });
-}
+};
 
-function clearAppIndex() {
+const clearAppIndex = function () {
   // Due to a bug in the app update code, some app update notifications that the user accepted
   // around July 9-16, 2016 may not have applied. We have no way of knowing exactly which updates
   // the user accepted but didn't receive. Instead, to recover, we are clearing the local cache of
@@ -622,9 +622,9 @@ function clearAppIndex() {
   // click "dismiss" again easily enough.
 
   AppIndex.remove({});
-}
+};
 
-function assignEmailVerifierIds() {
+const assignEmailVerifierIds = function () {
   // Originally, the ID of an EmailVerifier was actually the _id of the root token from which it
   // was restored. This was broken, though: Conceptually, it meant that you couldn't have a working
   // EmailVerifier that had not been restore()d from disk. In practice, that wasn't a problem due
@@ -638,9 +638,9 @@ function assignEmailVerifierIds() {
   ApiTokens.find({ "frontendRef.emailVerifier": { $exists: true } }).forEach(token => {
     ApiTokens.update(token._id, { $set: { "frontendRef.emailVerifier.id": token._id } });
   });
-}
+};
 
-function startPreinstallingApps() {
+const startPreinstallingApps = function () {
   // This isn't really a normal migration. It will run only on brand new servers, and it has to
   // run after the `clearAppIndex` migration because it relies on populating AppIndex.
 
@@ -664,15 +664,15 @@ function startPreinstallingApps() {
     // We want preinstalling apps to run async and not block startup.
     Meteor.setTimeout(startPreinstallingAppsHelper, 0);
   }
-}
+};
 
-function setNewServer() {
+const setNewServer = function () {
   // This migration only applies to "old" servers. New servers will set
   // new_server_migrations_applied to false before any migrations run.
   if (!Migrations.findOne({ _id: "new_server_migrations_applied" })) {
     Migrations.insert({ _id: "new_server_migrations_applied", value: true });
   }
-}
+};
 
 function backgroundFillInGrainSizes() {
   // Fill in sizes for all grains that don't have them. Since computing a grain size requires a
@@ -751,7 +751,7 @@ const NEW_SERVER_STARTUP = [
   startPreinstallingApps,
 ];
 
-function migrateToLatest() {
+const migrateToLatest = function () {
   if (Meteor.settings.replicaNumber) {
     // This is a replica. Wait for the first replica to perform migrations.
 
@@ -827,6 +827,6 @@ function migrateToLatest() {
     // Start background migrations.
     backgroundFillInGrainSizes();
   }
-}
+};
 
 SandstormDb.prototype.migrateToLatest = migrateToLatest;

--- a/shell/packages/sandstorm-db/package.js
+++ b/shell/packages/sandstorm-db/package.js
@@ -29,7 +29,6 @@ Package.onUse(function (api) {
   api.use("sandstorm-identicons", ["client", "server"]);
 
   api.addFiles(["db.js", "profile.js"]);
-  api.addFiles(["user.js", "migrations.js"], "server");
   api.export("SandstormDb");
 });
 

--- a/shell/server/00-startup.js
+++ b/shell/server/00-startup.js
@@ -17,6 +17,7 @@
 import "/imports/db-deprecated.js";
 import { FrontendRefRegistry } from "/imports/server/frontend-ref.js";
 import { PersistentImpl } from "/imports/server/persistent.js";
+import { migrateToLatest } from "/imports/server/migrations.js";
 
 globalFrontendRefRegistry = new FrontendRefRegistry();
 
@@ -46,4 +47,4 @@ SandstormDb.periodicCleanup(24 * 60 * 60 * 1000, () => {
   SandstormAutoupdateApps.updateAppIndex(globalDb);
 });
 
-Meteor.startup(() => { globalDb.migrateToLatest(); });
+Meteor.startup(() => { migrateToLatest(globalDb); });

--- a/shell/server/00-startup.js
+++ b/shell/server/00-startup.js
@@ -47,4 +47,4 @@ SandstormDb.periodicCleanup(24 * 60 * 60 * 1000, () => {
   SandstormAutoupdateApps.updateAppIndex(globalDb);
 });
 
-Meteor.startup(() => { migrateToLatest(globalDb); });
+Meteor.startup(() => { migrateToLatest(globalDb, globalBackend); });


### PR DESCRIPTION
This changeset extracts migrations out of sandstorm-db and into a separate file.

I also extracted some accounts-related network-touching code that previously lived in `sandstorm-db` because it needed to be executed during migrations.

`migrateToLatest` now receives two arguments, an instance of `SandstormDb` and an instance of `SandstormBackend`.  It no longer reaches into global state.

This is one of several steps involved in my ongoing effort to clean up initialization order.