### PR TITLE
docs about permissions and roles

### DIFF
--- a/docs/developing/handbook.md
+++ b/docs/developing/handbook.md
@@ -155,12 +155,7 @@ A third header, `X-Sandstorm-Permissions`, specifies the permissions
 this user has on the particular app instance, such as "read" or
 "write". These permissions are set through the Sandstorm sharing UI,
 outside of the app itself, although the app defines what permissions
-are available in its package definition. (As of this writing, the
-sharing UI is still in development, but you can use permissions to
-distinguish between the grain's owner vs. other users. Currently, the
-owner will always have all defined permissions, whereas other users
-will have none, so you may simply define a permission called `owner`
-or `admin` to distinguish.)
+are available in its package definition.
 
 With these headers in hand, a Sandstorm app can and should avoid
 implementing any internal user model. An app should not ask users to
@@ -192,9 +187,8 @@ means for the app, and automatically log the user into that account.
 
 When the sharing link was created, Sandstorm asked the user what
 permissions to grant to someone who visits a grain with the link.
-Your app needs to make its own decisions about what permission levels
-exist.  You can read the [full description
-here](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/grain.capnp#L179).
+Your app needs to make its own decisions about what permission levels exist.
+[Read more about how to define permissions](/developing/auth#defining-permissions-and-roles).
 
 A totally logged-out user can also visit a sharing link. They should
 be granted the same permission level as a logged-in user with the

--- a/docs/developing/path.md
+++ b/docs/developing/path.md
@@ -178,7 +178,7 @@ send a `X-Forwarded-Proto` however.
 
 `X-Sandstorm-Base-Path` is created from the `WebSession` attribute called
 `basePath`. Read the [current
-implementation](https://github.com/sandstorm-io/sandstorm/blob/71fd830f0f1ac9fd1b759e4492eb70dabe001c48/src/sandstorm/web-session.capnp)
+implementation](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/web-session.capnp)
 for its Cap'n Proto documentation. Consider also reading the source of
 [sandstorm-http-bridge](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/sandstorm-http-bridge.c++#L1033).
 

--- a/docs/developing/powerbox.md
+++ b/docs/developing/powerbox.md
@@ -6,8 +6,9 @@ The definitive reference for the powerbox's interfaces
 is the Cap'n Proto schema files where they are defined. The main relevant schemas are
 [powerbox.capnp](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/powerbox.capnp),
 [grain.capnp](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/grain.capnp),
+[identity.capnp](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/identity.capnp),
 and
-[identity.capnp](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/identity.capnp).
+[activity.capnp](https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/activity.capnp).
 
 A common thing that a grain might want to request is network access, the
 corresponding interfaces for which are defined in


### PR DESCRIPTION
Closes #489.

Also includes a few other minor updates. Principle when including github links: if linking to a specific line number, then use `/blob/v0.latest/whatever#line`, because line numbers are likely to change. If linking to a file, then use `/blob/master/whatever`.