### PR TITLE
Fix email driver behavior when .name present in EmailAddress struct

### DIFF
--- a/shell/server/drivers/mail.js
+++ b/shell/server/drivers/mail.js
@@ -198,22 +198,6 @@ Meteor.startup(function () {
   }
 });
 
-const formatAddress = function (field) {
-  if (!field) {
-    return null;
-  }
-
-  if (Array.isArray(field)) {
-    return field.map(formatAddress);
-  }
-
-  if (field.name) {
-    return field.name + " <" + field.address + ">";
-  }
-
-  return field.address;
-};
-
 hackSendEmail = (session, email) => {
   return inMeteor((function () {
     let recipientCount = 0;
@@ -243,11 +227,8 @@ hackSendEmail = (session, email) => {
         userAddress.address + ". Yours was: " + email.from.address);
     }
 
-    const from = formatAddress(email.from);
-    const to = formatAddress(email.to);
-    const cc = formatAddress(email.cc);
-    const bcc = formatAddress(email.bcc);
-    const replyTo = formatAddress(email.replyTo);
+    // Unpack fields
+    const { from, to, cc, bcc, replyTo, subject, text, html } = email;
 
     const options = {
       from,
@@ -255,9 +236,9 @@ hackSendEmail = (session, email) => {
       cc,
       bcc,
       replyTo,
-      subject:  email.subject,
-      text:     email.text,
-      html:     email.html,
+      subject,
+      text,
+      html,
       envelope: {
         from: grainAddress,
         to,


### PR DESCRIPTION
nodemailer accepts message objects in precisely the format the capnp
struct expects, so we no longer need to stringify addresses, and it's
better that we present them in a well-typed format than as a string.

Code deleted is code tested!

Fixes #2409.