### PR TITLE
Allow sorting grain list by last used, title, and size

### DIFF
--- a/shell/client/apps/app-details-client.js
+++ b/shell/client/apps/app-details-client.js
@@ -44,7 +44,7 @@ const appGrains = function (db, appId, trashed) {
                   function (grain) {return grain.appId === appId; });
 };
 
-const filteredSortedGrains = function (db, staticAssetHost, appId, appTitle, filterText, viewingTrash) {
+const filteredGrains = function (db, staticAssetHost, appId, appTitle, filterText, viewingTrash) {
   const pkg = latestPackageForAppId(db, appId);
 
   const grainsMatchingAppId = appGrains(db, appId, viewingTrash);
@@ -73,8 +73,6 @@ const filteredSortedGrains = function (db, staticAssetHost, appId, appTitle, fil
   return _.chain([itemsFromGrains, itemsFromSharedGrains])
       .flatten()
       .filter(filter)
-      .sortBy("lastUsed") // TODO: allow sorting by other columns
-      .reverse()
       .value();
 };
 
@@ -343,18 +341,18 @@ Template.sandstormAppDetailsPage.helpers({
     };
   },
 
-  filteredSortedGrains: function () {
+  filteredGrains: function () {
     const instance = Template.instance();
     const ref = instance.data;
-    return filteredSortedGrains(ref._db, ref._staticHost, ref._appId, getAppTitle(ref),
+    return filteredGrains(ref._db, ref._staticHost, ref._appId, getAppTitle(ref),
                                 instance._filter.get(), ref.viewingTrash);
   },
 
-  filteredSortedTrashedGrains: function () {
+  filteredTrashedGrains: function () {
     const instance = Template.instance();
     const ref = instance.data;
-    return filteredSortedGrains(ref._db, ref._staticHost, ref._appId, getAppTitle(ref),
-                                instance._filter.get(), true);
+    return filteredGrains(ref._db, ref._staticHost, ref._appId, getAppTitle(ref),
+                          instance._filter.get(), true);
   },
 
   isFiltering: function () {
@@ -448,7 +446,7 @@ Template.sandstormAppDetailsPage.events({
     const ref = Template.instance().data;
     if (event.keyCode === 13) {
       // Enter pressed.  If a single grain is shown, open it.
-      const grains = filteredSortedGrains(ref._db, ref._staticHost, ref._appId,
+      const grains = filteredGrains(ref._db, ref._staticHost, ref._appId,
                                           getAppTitle(ref), instance._filter.get(), ref.viewingTrash);
       if (grains.length === 1) {
         // Unique grain found with current filter.  Activate it!

--- a/shell/client/apps/app-details.html
+++ b/shell/client/apps/app-details.html
@@ -49,7 +49,7 @@
       </p>
     {{/if}}
 
-    {{#let grains=filteredSortedGrains}}
+    {{#let grains=filteredGrains}}
       {{>sandstormGrainTable grains=grains actions=actions
                              onGrainClicked=onGrainClicked _db=_db showHintIfEmpty=1
                              alwaysShowTableHeaders=1 bulkActionButtons=bulkActionButtons}}
@@ -57,7 +57,7 @@
         {{#if isFiltering}}
           <div class="no-grains">
             <p><strong>No matching grains found.</strong></p>
-            {{#if filteredSortedTrashedGrains}}
+            {{#if filteredTrashedGrains}}
               <p>Some grains in your trash match your search.
                <button class="toggle-show-trash">View trash</button>
               </p>

--- a/shell/client/grain/grainlist.html
+++ b/shell/client/grain/grainlist.html
@@ -49,7 +49,7 @@
       </p>
     {{/if}}
 
-    {{#let grains=filteredSortedGrains}}
+    {{#let grains=filteredGrains}}
       {{>sandstormGrainTable grains=grains onGrainClicked=onGrainClicked
                              bulkActionButtons=bulkActionButtons}}
 
@@ -57,7 +57,7 @@
         <div class="no-grains">
           {{#if searchText}}
             <p><strong>No matching grains found.</strong></p>
-            {{#if filteredSortedTrashedGrains}}
+            {{#if filteredTrashedGrains}}
               <p>Some grains in your trash match your search.
                <button class="show-trash">View trash</button>
               </p>
@@ -78,7 +78,7 @@
 </template>
 
 <template name="sandstormGrainTable">
-  {{!-- A pure functional template.  Pass in grains as a list of objects with shape:
+  {{!-- A mostly pure-functional template.  Pass in grains as a list of objects with shape:
   {
     _id: String,
     appTitle: String,
@@ -109,7 +109,9 @@
       onClicked(myGrainIds, sharedWithMeGrainIds): function that performs the action on the
          selected grains.
     }
-  Future work: callbacks for requesting different sort orders?
+
+  The table itself tracks and applies a sort order to the grains passed in.  The initial sort
+  order is by lastUsed, descending.
   --}}
   {{#let buttons=bulkActionButtons mine=mineSelected shared=sharedSelected}}
   <form class="standard-form bulk-action-buttons">
@@ -130,9 +132,36 @@
               <input title={{selectAllTitle}} type="checkbox">
             </td>
             <td class="td-app-icon"></td>
-            <td class="grain-name">Name</td>
-            <td class="grain-size">Size</td>
-            <td class="last-used">Last activity</td>
+            <td class="grain-name">
+              Name
+              {{#if equal sortOrder.key "title"}}
+                {{#if equal sortOrder.order "ascending"}}
+                  ▾
+                {{else}}
+                  ▴
+                {{/if}}
+              {{/if}}
+            </td>
+            <td class="grain-size">
+              Size
+              {{#if equal sortOrder.key "size"}}
+                {{#if equal sortOrder.order "ascending"}}
+                  ▾
+                {{else}}
+                  ▴
+                {{/if}}
+              {{/if}}
+            </td>
+            <td class="last-used">
+              Last activity
+              {{#if equal sortOrder.key "lastUsed"}}
+                {{#if equal sortOrder.order "ascending"}}
+                  ▾
+                {{else}}
+                  ▴
+                {{/if}}
+              {{/if}}
+            </td>
             <td class="shared-or-owned">Mine/Shared</td>
             {{!-- Collaborators, size TODO
             <td>Collaborators</td>
@@ -149,7 +178,7 @@
           <td class="action-button" colspan="4"><button class="action">{{buttonText}}</button></td>
         </tr>
         {{/each}}
-        {{#each grains}}
+        {{#each (sortedGrains grains)}}
         <tr class="grain {{#if unread}}unread{{/if}}" data-grainid="{{ _id }}">
           <td class="select-grain {{#if isOwnedByMe}}mine{{else}}shared{{/if}}">
             <input title="select this grain"

--- a/shell/client/styles/_grainlist.scss
+++ b/shell/client/styles/_grainlist.scss
@@ -136,12 +136,10 @@
     border-bottom: 1px solid #aaa;
     >td {
       border: 1px solid white;
-      /* interactivity disabled until we can sort by different column
-      cursor:pointer;
-      &:hover {
+      &.grain-name:hover, &.grain-size:hover, &.last-used:hover {
         background-color: $grainlist-table-header-background-color-hover;
+        cursor: pointer;
       }
-      */
       &.grain-size {
         width: 80px;
         // The mobile viewport is too small to display this much text


### PR DESCRIPTION
Now that we let you see per-grain size everywhere, it makes sense to also
allow sorting the grain list by size, in addition to the default sort order
of "last activity".  And we might as well let you sort by title too, if you want.

![grain-list](https://cloud.githubusercontent.com/assets/307325/17828155/95712740-663e-11e6-9826-7feb7b2bffa2.png)

![app-details-page](https://cloud.githubusercontent.com/assets/307325/17828156/9bba7606-663e-11e6-8f7d-5287c1445762.png)