### PR TITLE
Adjust size of most-used apps row on mobile.

### DIFF
--- a/shell/client/styles/_applist.scss
+++ b/shell/client/styles/_applist.scss
@@ -39,7 +39,7 @@
       height: 280px;
     }
     @media #{$mobile} {
-      height: 160px;
+      height: 142px;
     }
   }
   >h2, >.popular-container>h2 {
@@ -68,7 +68,7 @@
     }
     @media #{$mobile} {
       width: 74px;
-      height: 100px;
+      height: 102px;
       margin-left: 5px;
       margin-right: 5px;
       margin-bottom: 10px;


### PR DESCRIPTION
Previously, a sliver of the second row of most-used was visible.

I also added two pixels to the height of the cards because on Firefox I was seeing the bottom of the app short descriptions getting cut off.

Fixes #2427