### PR TITLE
Grainlist: make space for the ▴ on Windows

### DIFF
--- a/shell/client/styles/_grainlist.scss
+++ b/shell/client/styles/_grainlist.scss
@@ -141,11 +141,14 @@
         cursor: pointer;
       }
       &.grain-size {
-        width: 80px;
+        width: 70px;
         // The mobile viewport is too small to display this much text
         @media #{$mobile} {
           display: none;
         }
+      }
+      &.last-used {
+        width: 110px;
       }
       &.shared-or-owned {
         width: 110px;
@@ -200,14 +203,14 @@
         }
       }
       &.grain-size {
-        width: 80px;
+        width: 70px;
         // The mobile viewport is too small to display this much text
         @media #{$mobile} {
           display: none;
         }
       }
       &.last-used {
-        width: 100px;
+        width: 110px;
       }
       &.shared-or-owned {
         width: 110px;


### PR DESCRIPTION
Font metrics/rendering are different on Windows, which causes the arrow in the
last activity column to wrap on Windows.

This change takes 10 pixels from the Size column (which is nowhere close to needing all the space) and gives it to the last used column.