### PR TITLE
Pad search bar by 4px so the cursor doesn't blend into the border

### DIFF
--- a/shell/client/styles/_partials.scss
+++ b/shell/client/styles/_partials.scss
@@ -229,6 +229,7 @@
       flex: 1 1 auto;
       font-size: 16pt;
       height: 32px;
+      padding-left: 4px;
       background-color: $grainlist-searchbar-background-color;
       border: 1px solid $grainlist-searchbar-outline-color;
       &:focus {


### PR DESCRIPTION
Fixes #2436.