### PR TITLE
Account buttons cleanup

### DIFF
--- a/shell/client/accounts/account-settings.html
+++ b/shell/client/accounts/account-settings.html
@@ -106,7 +106,7 @@ limitations under the License.
     <div class="add-new">
       Add new e-mail address
       {{> emailAuthenticationForm emailLoginFormData}}
-      {{> _loginButtonsMessages}}
+      {{> _loginButtonsMessages "" }}
     </div>
   </div>
 
@@ -229,7 +229,7 @@ setActionCompleted: (optional) Function.  Callback triggered on profile saved or
             </li>
           {{/with}}
           {{#if isPaymentsEnabled}}
-            {{> billingOptins}}
+            {{> billingOptins "" }}
           {{/if}}
         {{/unless}}
 

--- a/shell/client/accounts/identity/identity-client.js
+++ b/shell/client/accounts/identity/identity-client.js
@@ -366,8 +366,9 @@ Template.identityPicker.events({
 
 Template.identityPicker.helpers({
   isCurrentIdentity() {
-    const instance = Template.instance();
-    return instance.data._id === Template.instance().data.currentIdentityId;
+    // N.B. currentData() is affected by #with and #each, but Template.instance().data is not
+    const currentData = Template.currentData();
+    return currentData._id === Template.instance().data.currentIdentityId;
   },
 });
 

--- a/shell/client/accounts/identity/identity-client.js
+++ b/shell/client/accounts/identity/identity-client.js
@@ -368,14 +368,18 @@ Template.identityPicker.helpers({
   isCurrentIdentity() {
     // N.B. currentData() is affected by #with and #each, but Template.instance().data is not
     const currentData = Template.currentData();
-    return currentData._id === Template.instance().data.currentIdentityId;
+    return (currentData && currentData._id) === Template.instance().data.currentIdentityId;
   },
 });
 
 Template.identityCard.helpers({
   intrinsicName() {
     const instance = Template.instance();
-    if (instance.data.privateIntrinsicName) {
+    if (!instance.data) {
+      // Still loading. We don't guarantee that identity subscriptions are ready before rendering
+      // the shell, so we have to catch that here instead.
+      return "";
+    } else if (instance.data.privateIntrinsicName) {
       return instance.data.privateIntrinsicName;
     } else {
       return instance.data.profile && instance.data.profile.intrinsicName;

--- a/shell/client/accounts/identity/identity.html
+++ b/shell/client/accounts/identity/identity.html
@@ -219,7 +219,7 @@ limitations under the License.
          {{> Template.dynamic template=name}}
        </div>
     {{/with}}
-    {{> _loginButtonsMessages}}
+    {{> _loginButtonsMessages ""}}
    {{else}}
      {{#with unclickedMessage}}
        <p>{{.}}</p>

--- a/shell/client/accounts/login-buttons.html
+++ b/shell/client/accounts/login-buttons.html
@@ -160,10 +160,10 @@ licenses, included in the LICENSES directory.
     {{/linkTo}}
   {{/each}}
 
-  {{> _loginButtonsMessages}}
+  {{> _loginButtonsMessages "" }}
 
   {{#if showTroubleshooting}}
-    {{> _loginButtonsSeparator}}
+    {{> _loginButtonsSeparator "" }}
     <a class="troubleshooting" href="https://docs.sandstorm.io/en/latest/administering/faq/" target="_blank">troubleshooting</a>
   {{/if}}
 

--- a/shell/client/accounts/login-buttons.html
+++ b/shell/client/accounts/login-buttons.html
@@ -55,11 +55,11 @@ licenses, included in the LICENSES directory.
 
 <template name="loginButtonsPopup">
   {{!-- Data context is an instance of AccountsUi. --}}
-  {{> _loginButtonsLoggedOutDropdown}}
+  {{> _loginButtonsLoggedOutDropdown . }}
 </template>
 
 <template name="accountButtonsPopup">
-  {{> _loginButtonsLoggedInDropdown}}
+  {{> _loginButtonsLoggedInDropdown . }}
 </template>
 
 <template name="_loginButtonsMessages">
@@ -111,13 +111,13 @@ licenses, included in the LICENSES directory.
   {{#if isDemoUser}}
     <h4>Create account</h4>
     <p class="demo-note">Your demo data will be transferred to your new account.</p>
-    {{> loginButtonsList}}
+    {{> loginButtonsList . }}
   {{else}}
     <h4>Sign in</h4>
     {{#if isCurrentRoute 'shared'}}
       <p class="demo-note">Sign in so that collaborators know who you are.</p>
       {{#if choseLogin}}
-        {{> loginButtonsList}}
+        {{> loginButtonsList . }}
       {{else}}
         <div class="login-suggestion" role="menu">
           <button class="login" role="menuitem">
@@ -129,7 +129,7 @@ licenses, included in the LICENSES directory.
         </div>
       {{/if}}
     {{else}}
-      {{> loginButtonsList}}
+      {{> loginButtonsList . }}
     {{/if}}
   {{/if}}
 </template>
@@ -144,7 +144,7 @@ licenses, included in the LICENSES directory.
       {{#if allowUninvited}}Create account{{else}}Sign in{{/if}}
     </h4>
 
-    {{> loginButtonsList}}
+    {{> loginButtonsList . }}
   </div>
 </template>
 

--- a/shell/client/accounts/login-buttons.js
+++ b/shell/client/accounts/login-buttons.js
@@ -29,20 +29,12 @@ import { loginWithSaml } from "/imports/client/accounts/saml/saml-client.js";
 // for convenience
 const loginButtonsSession = Accounts._loginButtonsSession;
 
-const helpers = {
-  isCurrentRoute: function (routeName) {
-    return Router.current().route.getName() == routeName;
-  },
 
-  isDemoUser: function () {
-    return this._db.isDemoUser();
-  },
+const isDemoUserHelper = function () {
+  return this._db.isDemoUser();
 };
 
-Template.loginButtons.helpers(helpers);
-Template.loginButtonsPopup.helpers(helpers);
-Template._loginButtonsLoggedOutDropdown.helpers(helpers);
-Template._loginButtonsLoggedInDropdown.helpers(helpers);
+Template.loginButtons.helpers({ isDemoUser: isDemoUserHelper });
 
 Template.loginButtonsPopup.onCreated(function () {
   this.autorun(() => {
@@ -165,6 +157,12 @@ Template._loginButtonsLoggedOutDropdown.onCreated(function () {
 });
 
 Template._loginButtonsLoggedOutDropdown.helpers({
+  isDemoUser: isDemoUserHelper,
+
+  isCurrentRoute: function (routeName) {
+    return Router.current().route.getName() == routeName;
+  },
+
   choseLogin: function () {
     return Template.instance()._choseLogin.get();
   },
@@ -182,6 +180,16 @@ Template._loginButtonsLoggedOutDropdown.events({
 
 Template._loginButtonsLoggedInDropdown.onCreated(function () {
   this._identitySwitcherExpanded = new ReactiveVar(false);
+
+  // Should be the same as the args to accountButtonsPopup
+  this.autorun(() => {
+    const data = Template.currentData();
+    check(data, {
+      isAdmin: Boolean,
+      grains: GrainViewList,
+      showSendFeedback: Boolean,
+    });
+  });
 });
 
 Template._loginButtonsLoggedInDropdown.helpers({

--- a/shell/client/accounts/login-buttons.js
+++ b/shell/client/accounts/login-buttons.js
@@ -25,6 +25,7 @@ import {
 } from "/imports/client/accounts/email-token/token-login-helpers.js";
 import { loginWithLDAP } from "/imports/client/accounts/ldap/ldap-client.js";
 import { loginWithSaml } from "/imports/client/accounts/saml/saml-client.js";
+import AccountsUi from "/imports/client/accounts/accounts-ui.js";
 
 // for convenience
 const loginButtonsSession = Accounts._loginButtonsSession;
@@ -38,9 +39,7 @@ Template.loginButtons.helpers({ isDemoUser: isDemoUserHelper });
 Template.loginButtonsPopup.onCreated(function () {
   this.autorun(() => {
     const data = Template.currentData();
-    check(data, {
-      _db: SandstormDb,
-    });
+    check(data, AccountsUi);
   });
 });
 

--- a/shell/client/accounts/login-buttons.js
+++ b/shell/client/accounts/login-buttons.js
@@ -29,7 +29,6 @@ import { loginWithSaml } from "/imports/client/accounts/saml/saml-client.js";
 // for convenience
 const loginButtonsSession = Accounts._loginButtonsSession;
 
-
 const isDemoUserHelper = function () {
   return this._db.isDemoUser();
 };

--- a/shell/client/accounts/login-buttons.js
+++ b/shell/client/accounts/login-buttons.js
@@ -44,6 +44,15 @@ Template.loginButtonsPopup.helpers(helpers);
 Template._loginButtonsLoggedOutDropdown.helpers(helpers);
 Template._loginButtonsLoggedInDropdown.helpers(helpers);
 
+Template.loginButtonsPopup.onCreated(function () {
+  this.autorun(() => {
+    const data = Template.currentData();
+    check(data, {
+      _db: SandstormDb,
+    });
+  });
+});
+
 Template.loginButtonsPopup.onRendered(function () {
   let element = this.find(".login-buttons-list :first-child");
   if (!element) {
@@ -51,6 +60,17 @@ Template.loginButtonsPopup.onRendered(function () {
   }
 
   if (element) element.focus();
+});
+
+Template.accountButtonsPopup.onCreated(function () {
+  this.autorun(() => {
+    const data = Template.currentData();
+    check(data, {
+      isAdmin: Boolean,
+      grains: GrainViewList,
+      showSendFeedback: Boolean,
+    });
+  });
 });
 
 Template.accountButtonsPopup.onRendered(function () {
@@ -78,7 +98,8 @@ Template.accountButtons.helpers({
       return { loading: true };
     }
 
-    const currentIdentityId = getActiveIdentityId(this.grains);
+    const grains = Template.currentData().grains;
+    const currentIdentityId = getActiveIdentityId(grains);
     const user = Meteor.users.findOne({ _id: currentIdentityId });
     if (currentIdentityId && !user) {
       // Need to wait for the `identityProfile` subscription to be ready.
@@ -175,7 +196,7 @@ Template._loginButtonsLoggedInDropdown.helpers({
   },
 
   identitySwitcherData: function () {
-    const grains = this.grains;
+    const grains = Template.currentData().grains;
     const identities = SandstormDb.getUserIdentityIds(Meteor.user()).map(function (id) {
       const identity = Meteor.users.findOne({ _id: id });
       if (identity) {
@@ -289,8 +310,9 @@ Template.oauthLoginButton.events({
 
 Template.loginButtonsList.helpers({
   configured: function () {
-    return !!ServiceConfiguration.configurations.findOne({ service: this.name }) ||
-           Template.instance().data._services.get(this.name);
+    const name = Template.currentData().name;
+    return !!ServiceConfiguration.configurations.findOne({ service: name }) ||
+           Template.instance().data._services.get(name);
   },
 
   services: getServices,

--- a/shell/client/accounts/login-buttons.js
+++ b/shell/client/accounts/login-buttons.js
@@ -123,13 +123,11 @@ function getServices() {
 }
 
 Template._loginButtonsMessages.helpers({
-  errorMessage: function () {
+  errorMessage() {
     return loginButtonsSession.get("errorMessage");
   },
-});
 
-Template._loginButtonsMessages.helpers({
-  infoMessage: function () {
+  infoMessage() {
     return loginButtonsSession.get("infoMessage");
   },
 });

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -9,7 +9,7 @@
   {{#if currentFeatureKey}}
     <h2>Current feature key</h2>
     {{> adminFeatureKeyDetails featureKey=currentFeatureKey }}
-    {{> adminFeatureKeyModifyForm }}
+    {{> adminFeatureKeyModifyForm "" }}
 
     <p>Looking to configure Sandstorm for Work-exclusive features?</p>
     <ul>
@@ -60,7 +60,7 @@
       </div>
     </div>
 
-    {{> featureKeyUploadForm }}
+    {{> featureKeyUploadForm "" }}
   {{/if}}
 
 </template>
@@ -135,6 +135,9 @@
 </template>
 
 <template name="featureKeyUploadForm">
+  {{!-- Takes arguments:
+    successCb: optional Function to call when a new key is uploaded successfully
+  --}}
   <form class="feature-key-form">
     {{#with error=currentError}}
       {{#if error}}
@@ -154,6 +157,11 @@
 </template>
 
 <template name="featureKeyDeleteForm">
+  {{!-- Takes arguments:
+     token: optional String to pass as a session token to submitFeatureKey
+     cancelCb: optional Function to call when user decides not to erase feature key
+     successCb: optional Function to call when feature key is successfully removed
+  --}}
   <p>
     Really delete feature key?  This will disable Sandstorm for Work features, like LDAP and SAML
     login, organizational user management, and organizational controls.

--- a/shell/client/admin/identity-providers.html
+++ b/shell/client/admin/identity-providers.html
@@ -78,7 +78,7 @@
   {{/if}}
 
   <form class="setup-idp-form">
-    {{> googleLoginSetupInstructions }}
+    {{> googleLoginSetupInstructions "" }}
 
     <p>Then, copy over your Client ID and Client secret below:</p>
 
@@ -132,7 +132,7 @@
   <h2>GitHub login configuration</h2>
 
   <form class="setup-idp-form">
-    {{> githubLoginSetupInstructions }}
+    {{> githubLoginSetupInstructions "" }}
 
     <p>Then, copy over your Client ID and Client secret below:</p>
     <div class="form-group">

--- a/shell/client/admin/organization.html
+++ b/shell/client/admin/organization.html
@@ -23,7 +23,7 @@
     </div>
   {{/unless}}
 
-  {{> organizationSettingsBlurb }}
+  {{> organizationSettingsBlurb "" }}
 
   {{#if hasSuccess }}
     {{#focusingSuccessBox}}

--- a/shell/client/admin/system-status.html
+++ b/shell/client/admin/system-status.html
@@ -25,5 +25,5 @@
     </form>
   </h2>
 
-  {{> newAdminLog }}
+  {{> newAdminLog "" }}
 </template>

--- a/shell/client/admin/user-details.html
+++ b/shell/client/admin/user-details.html
@@ -166,7 +166,7 @@
                 primaryEmail=account.primaryEmail
                 }}
         {{else}}
-          {{> newAdminUserDetailsIdentityMIATableRow }}
+          {{> newAdminUserDetailsIdentityMIATableRow "" }}
         {{/if}}
       {{/each}}
       {{#each identity in (nonloginIdentities account) }}
@@ -177,7 +177,7 @@
                 primaryEmail=account.primaryEmail
                 }}
         {{else}}
-          {{> newAdminUserDetailsIdentityMIATableRow }}
+          {{> newAdminUserDetailsIdentityMIATableRow "" }}
         {{/if}}
       {{/each}}
     </div>

--- a/shell/client/admin/user-invite.html
+++ b/shell/client/admin/user-invite.html
@@ -95,7 +95,7 @@ bob@example.com"></textarea>
     </ul>
   </h1>
 
-  {{> newAdminUserInviteLink }}
+  {{> newAdminUserInviteLink "" }}
   <hr>
-  {{> newAdminUserInviteEmail }}
+  {{> newAdminUserInviteEmail "" }}
 </template>

--- a/shell/client/apps/app-details.html
+++ b/shell/client/apps/app-details.html
@@ -4,7 +4,7 @@
   {{#if newGrainIsLoading}}
     {{!-- It's bad style to use the globally defined _grainSpinner, but we get the benefit of blaze
           re-using the live HTML and not causing a flash for the user. --}}
-    {{> _grainSpinner}}
+    {{> _grainSpinner ""}}
   {{else}}
 
   <div class="app-details{{#if isAppInDevMode}} dev-background{{/if}}">

--- a/shell/client/apps/applist.html
+++ b/shell/client/apps/applist.html
@@ -4,7 +4,7 @@
   {{#if appIsLoading}}
     {{!-- It's bad style to use the globally defined _grainSpinner, but we get the benefit of blaze
           re-using the live HTML and not causing a flash for the user. --}}
-    {{> _grainSpinner}}
+    {{> _grainSpinner "" }}
   {{else}}{{#if isSignedUpOrDemo}}
   <div class="app-list">
     <h1>Apps

--- a/shell/client/demo.html
+++ b/shell/client/demo.html
@@ -1,9 +1,9 @@
 <template name="appdemo">
-  {{> drydemo}}
+  {{> drydemo . }}
 </template>
 
 <template name="demo">
-  {{> drydemo}}
+  {{> drydemo . }}
 </template>
 
 <template name="drydemo">

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -684,8 +684,10 @@ Template.grainView.helpers({
     });
 
     const grain = globalGrains.getActive();
-    return { identities: identities,
-            onPicked: function (identityId) { grain.revealIdentity(identityId); }, };
+    return {
+      identities: identities,
+      onPicked: function (identityId) { grain.revealIdentity(identityId); },
+    };
   },
 });
 

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -587,9 +587,10 @@ Template.grainSharePopup.helpers({
 Template.grainInMyTrash.events({
   "click button.restore-from-trash": function (event, instance) {
     const grain = globalGrains.getActive();
-    Meteor.call("moveGrainsOutOfTrash", [this.grainId], function (err, result) {
+    const data = Template.currentData();
+    Meteor.call("moveGrainsOutOfTrash", [data.grainId], function (err, result) {
       if (err) {
-        console.error(error.stack);
+        console.error(err.stack);
       } else {
         grain.reset(grain.identityId());
         grain.openSession();

--- a/shell/client/grain.html
+++ b/shell/client/grain.html
@@ -7,7 +7,7 @@
     <div class="grain-container {{#if active}}active-grain{{else}}inactive-grain{{/if}}">
     {{#if error}}
       {{#if inMyTrash}}
-        {{> grainInMyTrash ""}}
+        {{> grainInMyTrash . }}
       {{else}}
         {{#if inOwnersTrash}}
           {{> grainInOwnersTrash ""}}

--- a/shell/client/grain.html
+++ b/shell/client/grain.html
@@ -7,16 +7,16 @@
     <div class="grain-container {{#if active}}active-grain{{else}}inactive-grain{{/if}}">
     {{#if error}}
       {{#if inMyTrash}}
-        {{> grainInMyTrash}}
+        {{> grainInMyTrash ""}}
       {{else}}
         {{#if inOwnersTrash}}
-          {{> grainInOwnersTrash}}
+          {{> grainInOwnersTrash ""}}
         {{else}}
           {{#if unauthorized}}
             {{#if token}}
-              {{> revokedShareLink}}
+              {{> revokedShareLink ""}}
             {{else}}
-              {{> requestAccess}}
+              {{> requestAccess . }}
             {{/if}}
           {{else}}
             {{#if notFound}}
@@ -35,7 +35,7 @@
             used for testing purposes. --}}
       <iframe data-grainid="{{grainId}}" id="grain-frame-{{grainId}}" class="grain-frame" src="{{appOrigin}}/_sandstorm-init?sessionid={{sessionId}}&path={{originalPath}}"></iframe>
       {{#if hasNotLoaded}}
-        {{> _grainSpinner}}
+        {{> _grainSpinner ""}}
       {{/if}}
     {{else}}
     {{#if interstitial.chooseIdentity}}
@@ -47,7 +47,7 @@
         {{/if}}
       </div>
     {{else}}
-      {{> _grainSpinner}}
+      {{> _grainSpinner ""}}
     {{/if}}
     {{/if}}
     {{/if}}
@@ -507,7 +507,7 @@
     {{grainSize}}
   {{/sandstormTopbarItem}}
 
-  {{>sandstormTopbarBlockReload}}
+  {{>sandstormTopbarBlockReload ""}}
 
   {{setGrainWindowTitle}}
 

--- a/shell/client/grain/contact-autocomplete.html
+++ b/shell/client/grain/contact-autocomplete.html
@@ -17,7 +17,7 @@
         {{#each autoCompleteContacts}}
           <li class="autocomplete {{#if isCurrentlySelected}}selected {{/if}}{{#if failure}}failed{{/if}}"
               id="{{#if isCurrentlySelected}}{{templateId}}contact-selected{{/if}}">
-            {{> identityCard}}
+            {{> identityCard . }}
             {{failure}}
           </li>
         {{/each}}

--- a/shell/client/notifications-client.js
+++ b/shell/client/notifications-client.js
@@ -136,23 +136,28 @@ Template.notifications.helpers({
 
 Template.notificationItem.helpers({
   isAppUpdates: function () {
-    return !!this.appUpdates;
+    const data = Template.currentData();
+    return !!data.appUpdates;
   },
 
   isMailingListBonus() {
-    return !!this.mailingListBonus;
+    const data = Template.currentData();
+    return !!data.mailingListBonus;
   },
 
   isReferral() {
-    return !!this.referral;
+    const data = Template.currentData();
+    return !!data.referral;
   },
 
   isAdminNotification() {
-    return !!this.admin;
+    const data = Template.currentData();
+    return !!data.admin;
   },
 
   isOngoing() {
-    return !!this.ongoing;
+    const data = Template.currentData();
+    return !!data.ongoing;
   },
 });
 

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -109,7 +109,7 @@
 <template name="setupWizardLayout">
 <div class="setup-root">
   {{> yield}}
-  {{> setupWizardHelpFooter }}
+  {{> setupWizardHelpFooter "" }}
   <div class="sandstorm-logo-row">
     <div class="sandstorm-logo"></div>
   </div>
@@ -150,7 +150,7 @@
         </p>
       {{else}}
         {{#if identityUser}}
-          {{> identityLoginInterstitial }}
+          {{> identityLoginInterstitial "" }}
         {{else}}
           <p class="center">
             <button class="make-self-admin">Give yourself admin privileges</button>
@@ -232,12 +232,12 @@
   {{#if currentFeatureKey}}
     <h4>Current feature key</h4>
     {{> adminFeatureKeyDetails featureKey=currentFeatureKey }}
-    {{> adminFeatureKeyModifyForm }}
+    {{> adminFeatureKeyModifyForm "" }}
   {{else}}
     <h4>Upload feature key</h4>
     <p>To make use of Sandstorm for Work features like LDAP and SAML login and organization
       management, enter your feature key.</p>
-    {{> featureKeyUploadForm }}
+    {{> featureKeyUploadForm "" }}
 
     <h4>Don't have one?</h4>
     <p>Sandstorm for Work adds LDAP support, with more features arriving soon.</p>
@@ -295,7 +295,7 @@
 {{#if hasFeatureKey}}
   {{> setupWizardProgressBar currentStep="organization"}}
 
-  {{> organizationSettingsBlurb }}
+  {{> organizationSettingsBlurb "" }}
 
   {{#if errorMessage}}
     {{#focusingErrorBox}}
@@ -548,7 +548,7 @@
   {{/if}}
 
 {{#if identityUser}}
-  {{> identityLoginInterstitial }}
+  {{> identityLoginInterstitial "" }}
 {{else}}
   {{#if currentUser}}
     {{#if currentUserFirstLogin}}
@@ -556,7 +556,7 @@
         <h2>Confirm your profile</h2>
         <div class="single-identity-editor">
           {{#with accountProfileEditorData}}
-            {{> _accountProfileEditor}}
+            {{> _accountProfileEditor .}}
           {{/with}}
         </div>
       </div>

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -54,7 +54,7 @@ limitations under the License.
   {{else}}
   {{#with firstTimeBillingPromptState}}
     <div class="first-sign-in-main-content {{#if hideNavbar}}hide-navbar{{else}}{{#if shrinkNavbar}}shrink-navbar{{/if}}{{/if}}">
-      {{> billingPromptFirstTime}}
+      {{> billingPromptFirstTime . }}
     </div>
   {{else}}
 
@@ -124,7 +124,7 @@ limitations under the License.
     {{#unless identityUser}}
       {{#unless firstLogin}}
         {{#unless firstTimeBillingPromptState}}
-          {{> desktopNotifications }}
+          {{> desktopNotifications "" }}
           {{> yield}}
         {{/unless}}
       {{/unless}}
@@ -154,7 +154,7 @@ limitations under the License.
   <ul class="notification-list">
     {{#each notifications}}
       <li>
-        {{> notificationItem}}
+        {{> notificationItem .}}
       </li>
     {{else}}
     <li>No notifications...</li>
@@ -403,7 +403,7 @@ limitations under the License.
     <section class="changelog">
       <h2>Recent changes</h2>
 
-      {{> changelog}}
+      {{> changelog ""}}
     </section>
 
     <section class="developers">

--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -1575,11 +1575,14 @@ ul.identity-card-list {
   padding-left: 0;
   li {
     list-style-type: none;
+    margin-bottom: 12px;
     button {
+      height: 54px;
       @include unstyled-button();
       border: 1px solid black;
     }
     &.current-identity>button {
+      height: 58px;
       border: 3px solid black;
     }
   }

--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -1579,11 +1579,11 @@ ul.identity-card-list {
     button {
       height: 54px;
       @include unstyled-button();
-      border: 1px solid black;
+      border: 1px solid $generic-border-color;
     }
     &.current-identity>button {
-      height: 58px;
-      border: 3px solid black;
+      height: 56px;
+      border: 2px solid black;
     }
   }
 }

--- a/shell/client/styles/_applist.scss
+++ b/shell/client/styles/_applist.scss
@@ -139,7 +139,7 @@
       }
       &.install-icon {
         background-image: url('/install-9E40B5.svg');
-        border: 1px solid #b3b3b3;
+        border: 1px solid $generic-border-color;
 
         &:hover {
           background-image: url('/install-6A237C.svg');

--- a/shell/client/styles/_colors.scss
+++ b/shell/client/styles/_colors.scss
@@ -9,6 +9,9 @@ $darker-purple-color: #65468e;
 $focus-outline-color: $sandstorm-purple-color;
 $half-focus-outline-color: rgba(118, 47, 135, 0.5);
 
+// The color to use for your border when you want to faintly outline something.
+$generic-border-color: darken(white, 30%);
+
 // Colors for success/error message box backgrounds.
 $error-background-color: #ffdddd;
 $success-background-color: #ddffdd;

--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -20,9 +20,9 @@
       <div class="selected-card">
         <div class="powerbox-card" data-card-id="{{ option._id }}"
              style="background-image: url('{{ iconSrc }}');">
-          {{>cardTemplate}}
+          {{>cardTemplate . }}
         </div>
-        {{>configureTemplate}}
+        {{>configureTemplate . }}
       </div>
     {{else}}
       <div class="search-row">
@@ -36,7 +36,7 @@
         <li class="powerbox-card">
           <button class="card-button" data-card-id="{{ option._id }}"
                   style="background-image: url('{{ iconSrc }}');">
-            {{>cardTemplate}}
+            {{>cardTemplate . }}
           </button>
         </li>
       {{else}}

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -75,7 +75,7 @@ limitations under the License.
   <div class="menu-button {{#if _menuExpanded.get}}expanded{{/if}}"></div>
   {{!-- We wish to block reload if there are *any* grains open, regardless of the current route --}}
   {{#if grainCount }}
-    {{>sandstormTopbarBlockReload}}
+    {{>sandstormTopbarBlockReload ""}}
   {{/if}}
 
   {{#with currentPopup}}


### PR DESCRIPTION
* Fix bug where identity cards weren't looking up the current identity correctly
* Give identity cards some margin so they don't look weird when stacked
* Audit the codebase for use of `{{> someTemplate }}` and convert to either `{{> someTemplate . }}` (explicitly passing on data context) or `{{> someTemplate ""}}` (passing on an empty data context).
* Add a couple typechecks on the args to the login/account button templates