### PR TITLE
tests/run-local.sh: preserve sandstorm data dir on testsuite failure

### DIFF
--- a/tests/run-local.sh
+++ b/tests/run-local.sh
@@ -32,14 +32,21 @@ SELENIUM_DOWNLOAD_URL="https://selenium-release.storage.googleapis.com/2.53/$SEL
 cleanExit () {
   rc=$1
 
-  if [ $rc != 0 ]; then
+  if [ $rc -ne 0 ]; then
     echo "Log output: "
     cat "$SANDSTORM_DIR/var/log/sandstorm.log"
   fi
 
   "$SANDSTORM_DIR/sandstorm" stop
   sleep 1
-  rm -rf "$SANDSTORM_DIR"
+
+  if [ $rc -eq 0 ]; then
+    # Only clean up the test directory if the test run was successful - if tests failed,
+    # it's nice to be able to inspect the logs.  We wipe out $SANDSTORM_DIR before starting
+    # a new test run, so this is fine.
+    rm -rf "$SANDSTORM_DIR"
+  fi
+
   if [ -n "$XVFB_PID" ] ; then
     # Send SIGINT to the selenium-server child of the backgrounded xvfb-run, so
     # it will exit cleanly and the Xvfb process will also be cleaned up.


### PR DESCRIPTION
Often there are interesting logs or grain logs or other grain state that might
be interesting to look at in a post-mortem analysis, but the script immediately
wipes everything out, preventing further analysis.

This change preserves the `tests/tmp-sandstorm` folder if the testsuite doesn't
pass.