### PR TITLE
Inject db into SandstormCore and associated functions

### DIFF
--- a/shell/imports/server/backend.js
+++ b/shell/imports/server/backend.js
@@ -183,7 +183,7 @@ class SandstormBackend {
 
     let storagePromise = undefined;
     if (this._db.isQuotaEnabled() && !storageUsageUnimplemented) {
-      storagePromise = globalBackend._backendCap.getUserStorageUsage(userId);
+      storagePromise = this._backendCap.getUserStorageUsage(userId);
     }
 
     const now = new Date();

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -286,7 +286,6 @@ globalFrontendRefRegistry.register({
   },
 });
 
-
 function dismissNotification(db, notificationId, callCancel) {
   const notification = db.collections.notifications.findOne({ _id: notificationId });
   if (notification) {

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -172,7 +172,7 @@ BASIC_AUTH_USER_AGENTS_REGEX = new RegExp("^(" + BASIC_AUTH_USER_AGENTS.join("|"
 
 const SESSION_PROXY_TIMEOUT = 60000;
 
-const sandstormCoreFactory = makeSandstormCoreFactory();
+const sandstormCoreFactory = makeSandstormCoreFactory(globalDb);
 const backendAddress = "unix:" + (SANDSTORM_ALTHOME || "") + Backend.socketPath;
 let sandstormBackendConnection = Capnp.connect(backendAddress, sandstormCoreFactory);
 let sandstormBackend = sandstormBackendConnection.restore(null, Backend);


### PR DESCRIPTION
With this change, `shell/server/core.js` no longer refers to `globalDb`.

We still refer to some other globals, which I'll find ways to inject in separate PRs:

* injecting a db with which to access `ApiTokens` in `unwrapFrontendCap` will require a coordinated change in Blackrock
* `globalBackend` is still used.  There's a weird circular dependency between `SandstormCoreImpl` and `SandstormBackend` - you can't construct a `SandstormBackend` without first having a `SandstormCoreFactory`, which produces a `SandstormCoreImpl`, which makes calls on the `SandstormBackend`.

  This can maybe be resolved by adding a `setSandstormBackend()` method on `SandstormCoreFactory`, and then having SandstormCoreFactory inject that `SandstormBackend` into any `SandstormCore` it constructs.
* `globalFrontendRefRegistry` is also used.  This should be fairly trivial to inject.