### PR TITLE
Email config: allow de-configuring email

### DIFF
--- a/shell/client/admin/email-config.html
+++ b/shell/client/admin/email-config.html
@@ -78,12 +78,19 @@
     <div class="button-row">
       <button class="submit" type="submit" disabled={{saveDisabled}}>Save Configuration</button>
       <button class="test" type="button" disabled={{testDisabled}}>Test</button>
+      <button class="disable" type="button" disabled={{disableDisabled}}>Disable email</button>
     </div>
   </form>
 
   {{#if showTestSendEmailPopup}}
-    {{#modalDialogWithBackdrop onDismiss=closePopupCallback}}
-      {{> emailTestPopup smtpConfig=getSmtpConfig onDismiss=closePopupCallback }}
+    {{#modalDialogWithBackdrop onDismiss=closeTestPopupCallback}}
+      {{> emailTestPopup smtpConfig=getSmtpConfig onDismiss=closeTestPopupCallback }}
+    {{/modalDialogWithBackdrop}}
+  {{/if}}
+
+  {{#if showConfirmDisableEmailPopup}}
+    {{#modalDialogWithBackdrop onDismiss=closeConfirmDisableEmailPopupCallback}}
+      {{> emailDisablePopup onDismiss=closeConfirmDisableEmailPopupCallback}}
     {{/modalDialogWithBackdrop}}
   {{/if}}
 </template>
@@ -121,6 +128,35 @@
       {{/if}}
     </button>
     <button type="button" class="close-dialog">
+      Close
+    </button>
+  </div>
+</form>
+</template>
+
+<template name="emailDisablePopup">
+{{!-- Takes two arguments via data context:
+       token: String (optional) Setup token to use to authorize a disableEmail call.
+   onDismiss: Function to call when the Close button is clicked or the disableEmail call completes.
+--}}
+<h2>Really disable email?</h2>
+{{#if hasError}}
+  {{#focusingErrorBox}}
+    {{message}}
+  {{/focusingErrorBox}}
+{{/if}}
+
+<p>
+  This will disable all outbound email delivery for this server, including sharing via email, email
+  token login (if enabled), and email notifications to users.
+</p>
+
+<form class="email-disable-form">
+  <div class="button-row">
+    <button type="button" name="disable-email" class="danger" {{htmlDisabled}}>
+      Disable email
+    </button>
+    <button type="button" name="close-dialog">
       Close
     </button>
   </div>

--- a/shell/client/styles/_admin-email.scss
+++ b/shell/client/styles/_admin-email.scss
@@ -26,6 +26,10 @@
   }
 }
 
-.email-test-form {
+.email-test-form, .email-disable-form {
   @extend %standard-form;
+
+  button.danger {
+    @extend %button-danger;
+  }
 }

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -99,6 +99,13 @@ Meteor.methods({
     Settings.upsert({ _id: "smtpConfig" }, { $set: { value: config } });
   },
 
+  disableEmail: function (token) {
+    checkAuth(token);
+
+    const db = this.connection.sandstormDb;
+    db.collections.settings.update({ _id: "smtpConfig" }, { $set: { "value.hostname": "" } });
+  },
+
   setSetting: function (token, name, value) {
     checkAuth(token);
     check(name, String);


### PR DESCRIPTION
Some users can't trust email providers and would like to be able to disable
email after they've previously configured it.  This adds a reset button to do
just that.

Fixes #2446.

![new-button](https://cloud.githubusercontent.com/assets/307325/17962166/6bee4c98-6a64-11e6-817a-e51782579971.png)

![confirm-form](https://cloud.githubusercontent.com/assets/307325/17962173/740fef12-6a64-11e6-8e99-5342e0866c8f.png)

![email-disabled](https://cloud.githubusercontent.com/assets/307325/17962232/b0a67482-6a64-11e6-91dd-d9af8ce2806c.png)