### PR TITLE
Better error message when calling SandstormApi.save() with cap = null.

### DIFF
--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1815,6 +1815,7 @@ public:
 
   kj::Promise<void> save(SaveContext context) override {
     auto args = context.getParams();
+    KJ_REQUIRE(args.hasCap(), "Cannot save a null capability.");
     auto req = args.getCap().template castAs<SystemPersistent>().saveRequest();
     auto grainOwner = req.getSealFor().initGrain();
     grainOwner.setGrainId(grainId);


### PR DESCRIPTION
Currently if you call `SandstormApi.save()` and forget to set `cap`, you get this error: 

```
Failed: remote exception: Called null capability.
```

which is not super helpful. This patch changes the error to:

```
Failed: remote exception: expected args.hasCap(); Cannot save a null capability.
```