### PR TITLE
Implement Identity.getProfile().

### DIFF
--- a/shell/imports/server/static-asset.js
+++ b/shell/imports/server/static-asset.js
@@ -1,0 +1,48 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2014-2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const Capnp = Npm.require("capnp");
+const Url = Npm.require("url");
+const StaticAsset = Capnp.importSystem("sandstorm/grain.capnp").StaticAsset;
+
+const PROTOCOL = Url.parse(process.env.ROOT_URL).protocol;
+
+class StaticAssetImpl {
+  constructor(assetId) {
+    check(assetId, String);
+    this._protocol = PROTOCOL.slice(0, -1);
+    this._hostPath = makeWildcardHost("static") + "/" + assetId;
+  }
+
+  getUrl() {
+    return { protocol: this._protocol, hostPath: this._hostPath, };
+  }
+};
+
+class IdenticonStaticAssetImpl {
+  constructor(hash, size) {
+    check(hash, String);
+    check(size, Match.Integer);
+    this._protocol = PROTOCOL.slice(0, -1);
+    this._hostPath =  makeWildcardHost("static") + "/identicon/" + hash + "?s=" + size;
+  }
+
+  getUrl() {
+    return { protocol: this._protocol, hostPath: this._hostPath, };
+  }
+};
+
+export { StaticAssetImpl, IdenticonStaticAssetImpl };

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -15,9 +15,9 @@
 // limitations under the License.
 
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
+import { StaticAssetImpl, IdenticonStaticAssetImpl } from "/imports/server/static-asset.js";
 const Capnp = Npm.require("capnp");
 const Crypto = Npm.require("crypto");
-const Url = Npm.require("url");
 import { PersistentImpl, hashSturdyRef, generateSturdyRef, checkRequirements }
     from "/imports/server/persistent.js";
 
@@ -26,7 +26,7 @@ const SandstormCore = Capnp.importSystem("sandstorm/supervisor.capnp").Sandstorm
 const SandstormCoreFactory = Capnp.importSystem("sandstorm/backend.capnp").SandstormCoreFactory;
 const PersistentOngoingNotification = Capnp.importSystem("sandstorm/supervisor.capnp").PersistentOngoingNotification;
 const PersistentUiView = Capnp.importSystem("sandstorm/persistentuiview.capnp").PersistentUiView;
-const StaticAsset = Capnp.importSystem("sandstorm/grain.capnp").StaticAsset;
+const StaticAsset = Capnp.importSystem("sandstorm/util.capnp").StaticAsset;
 const SystemPersistent = Capnp.importSystem("sandstorm/supervisor.capnp").SystemPersistent;
 
 class SandstormCoreImpl {
@@ -183,33 +183,6 @@ class NotificationHandle extends PersistentImpl {
         dismissNotification(this.notificationId);
       }
     });
-  }
-}
-
-const PROTOCOL = Url.parse(process.env.ROOT_URL).protocol;
-
-class StaticAssetImpl {
-  constructor(assetId) {
-    check(assetId, String);
-    this._protocol = PROTOCOL.slice(0, -1);
-    this._hostPath = makeWildcardHost("static") + "/" + assetId;
-  }
-
-  getUrl() {
-    return { protocol: this._protocol, hostPath: this._hostPath, };
-  }
-}
-
-class IdenticonStaticAssetImpl {
-  constructor(hash, size) {
-    check(hash, String);
-    check(size, Match.Integer);
-    this._protocol = PROTOCOL.slice(0, -1);
-    this._hostPath =  makeWildcardHost("static") + "/identicon/" + hash + "?s=" + size;
-  }
-
-  getUrl() {
-    return { protocol: this._protocol, hostPath: this._hostPath, };
   }
 }
 

--- a/src/sandstorm/grain.capnp
+++ b/src/sandstorm/grain.capnp
@@ -121,23 +121,6 @@ interface SandstormApi(AppObjectId) {
   # user. For activity that should be attributed to a user, use SessionContext.activity().
 }
 
-interface StaticAsset @0xfabb5e621fa9a23f {
-  # A file served by the Sandstorm frontend, suitable for embedding e.g. in <img> elements
-  # inside of a grain iframe.
-
-  enum Protocol {
-    # To prevent XSS attacks, we restrict the protocols allowed in static asset URLs. For example,
-    # allowing "javascript:" URLs would be dangerous because then the static asset could provide
-    # abritrary code that would likely be executed in the context of the calling app.
-
-     https @0;
-     http @1;
-  }
-
-  getUrl @0 () -> (protocol: Protocol, hostPath :Text);
-  # To reconstruct the full URL from the return value, concatenate: `protocol + "://" + hostPath`.
-}
-
 interface UiView @0xdbb4d798ea67e2e7 {
   # Implements a user interface with which a user can interact with the grain.  We call this a
   # "view" because a single grain may actually have multiple "views" that provide different
@@ -255,7 +238,7 @@ interface UiView @0xdbb4d798ea67e2e7 {
     appTitle @5 :Util.LocalizedText;
     # Title for the app of which this grain is an instance.
 
-    grainIcon @6 :StaticAsset;
+    grainIcon @6 :Util.StaticAsset;
     # Icon for the app of which this grain is an instance, suitable for display in a grain list.
 
     eventTypes @7 :List(Activity.ActivityTypeDef);

--- a/src/sandstorm/identity.capnp
+++ b/src/sandstorm/identity.capnp
@@ -38,13 +38,14 @@ interface Identity {
   # This capability is always persistable.
 
   # TODO(someday): Public key info? Ability to seal messages / check signatures?
+
+  getProfile @0 () -> (profile: Profile);
+  # Get the identity's current profile.
 }
 
-struct UserInfo @0x94b9d1efb35d11d3 {
-  # Information about the user opening a new session.
-  #
-  # TODO(soon):  More details:
-  # - Sharing/authority chain:  "Carol (via Bob, via Alice)"
+struct Profile @0xd3d0c34d7201fcef {
+  # Personal information provided by a user, intended to be displayed to other users when
+  # they come in contact.
 
   displayName @0 :Util.LocalizedText;
   # Name by which to identify this user within the user interface.  For example, if two users are
@@ -54,20 +55,14 @@ struct UserInfo @0x94b9d1efb35d11d3 {
   # Display names are NOT unique nor stable:  two users could potentially have the same display
   # name and a user's display name could change.
 
-  preferredHandle @4 :Text;
+  preferredHandle @1 :Text;
   # The user's preferred "handle", as set in their account settings. This is guaranteed to be
   # composed only of lowercase English letters, digits, and underscores, and will not start with
   # a digit. It is NOT guaranteed to be unique; if your app dislikes duplicate handles, it must
   # check for them and do something about them.
 
-  pictureUrl @6 :Text;
-  # URL of the user's profile picture, appropriate for displaying in a 64x64 context.
-  #
-  # TODO(security) TODO(apibump): If we allow UserInfo to come from untrusted sources then this
-  #   field is XSS-prone. Currently UserInfo only comes from the front-end.
-
-  pronouns @5 :Pronouns;
-  # Indicates which pronouns the user prefers you use to refer to them.
+  picture @2 :Util.StaticAsset;
+  # The user's profile picture, appropriate for displaying in a 64x64 context.
 
   enum Pronouns {
     neutral @0;  # "they"
@@ -75,6 +70,33 @@ struct UserInfo @0x94b9d1efb35d11d3 {
     female @2;   # "she" / "her"
     robot @3;    # "it"
   }
+
+  pronouns @3 :Pronouns;
+  # Indicates which pronouns the user prefers you use to refer to them.
+}
+
+struct UserInfo @0x94b9d1efb35d11d3 {
+  # Information about the user opening a new session, including a snapshot of the user's
+  # profile.
+  #
+  # TODO(soon):  More details:
+  # - Sharing/authority chain:  "Carol (via Bob, via Alice)"
+
+  displayName @0 :Util.LocalizedText;
+  # The current value of `identity.getProfile().displayName`, provided here for convenience.
+
+  preferredHandle @4 :Text;
+  # The current value of `identity.getProfile().preferredHandle`, provided here for convenience.
+
+  pictureUrl @6 :Text;
+  # The current value of `identity.getProfile().staticAsset.getUrl()`, provided here for
+  # convenience.
+  #
+  # TODO(security) TODO(apibump): If we allow UserInfo to come from untrusted sources then this
+  #   field is XSS-prone. Currently UserInfo only comes from the front-end.
+
+  pronouns @5 :Profile.Pronouns;
+  # The current value of `identity.getProfile().pronouns`, provided here for convenience.
 
   deprecatedPermissionsBlob @1 :Data;
   permissions @3 :PermissionSet;
@@ -108,7 +130,7 @@ struct UserInfo @0x94b9d1efb35d11d3 {
   # safely truncate it down to some shorter prefix according to its own security/storage trade-off
   # needs.
   #
-  # If the user is not logged in, `userId` is null.
+  # If the user is not logged in, `identityId` is null.
 
   identity @7 :Identity;
   # The identity capability for this user. null if the user is not logged in.

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -1460,7 +1460,7 @@ private:
   kj::String userDisplayName;
   kj::String userHandle;
   kj::String userPicture;
-  UserInfo::Pronouns userPronouns = UserInfo::Pronouns::NEUTRAL;
+  Profile::Pronouns userPronouns = Profile::Pronouns::NEUTRAL;
   kj::Maybe<kj::String> userId;
   kj::String permissions;
   kj::String basePath;
@@ -1523,7 +1523,7 @@ private:
       if (userPicture.size() > 0) {
         lines.add(kj::str("X-Sandstorm-User-Picture: ", userPicture));
       }
-      capnp::EnumSchema schema = capnp::Schema::from<UserInfo::Pronouns>();
+      capnp::EnumSchema schema = capnp::Schema::from<Profile::Pronouns>();
       uint pronounValue = static_cast<uint>(userPronouns);
       auto enumerants = schema.getEnumerants();
       if (pronounValue > 0 && pronounValue < enumerants.size()) {

--- a/src/sandstorm/util.capnp
+++ b/src/sandstorm/util.capnp
@@ -166,3 +166,20 @@ interface Assignable(T) {
     set @0 (value :T) -> ();
   }
 }
+
+interface StaticAsset @0xfabb5e621fa9a23f {
+  # A file served by the Sandstorm frontend, suitable for embedding e.g. in <img> elements
+  # inside of a grain iframe.
+
+  enum Protocol {
+    # To prevent XSS attacks, we restrict the protocols allowed in static asset URLs. For example,
+    # allowing "javascript:" URLs would be dangerous because then the static asset could provide
+    # abritrary code that would likely be executed in the context of the calling app.
+
+     https @0;
+     http @1;
+  }
+
+  getUrl @0 () -> (protocol: Protocol, hostPath :Text);
+  # To reconstruct the full URL from the return value, concatenate: `protocol + "://" + hostPath`.
+}


### PR DESCRIPTION
This allows grains to retrieve up-to-date profile information on their users, even for users who have not visited the grain in a long time, and even for users who have never visited the grain at all (as may happen if the grain powerbox-requests an identity).

After this change, a grain can have a very simple user database consisting of a map from identity ID to Identity sturdyref, where `SandstormApi.restore()` and `Identity.getProfile()` are called whenever a particular user's profile is needed.

I have tested this change on a branch of the Collections app that implements an "added-by" column.