### PR TITLE
Add link parameter to offer template

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1436,11 +1436,9 @@ Meteor.startup(function () {
         });
 
         rawLink = call.link;
-        // TODO(soon): check against whitelist
         // rfc3986 specifies schemes as:
         // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
-        if (rawLink && (rawLink.scheme.search(/^[^a-zA-Z]/) !== -1 ||
-                        rawLink.scheme.search(/[^a-zA-Z0-9+-.]/) !== -1)) {
+        if (rawLink && (rawLink.scheme.search(/[^a-zA-Z0-9+-.]/) !== -1)) {
           throw new Meteor.Error(400, "rawlink.scheme has invalid characters.");
         }
       } catch (error) {
@@ -1528,7 +1526,7 @@ Meteor.startup(function () {
                                          .replace(/\$GRAIN_TITLE_SLUG/g, grainTitleSlug);
         let link = undefined;
         if (rawLink) {
-          link = `${rawLink.scheme}:${window.location.protocol}//${host}#${tokenId}`;
+          link = `clientapp-${rawLink.scheme}:${window.location.protocol}//${host}#${tokenId}`;
         }
 
         sessionStorage.setItem(key, JSON.stringify({

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1528,7 +1528,7 @@ Meteor.startup(function () {
                                          .replace(/\$GRAIN_TITLE_SLUG/g, grainTitleSlug);
         let link = undefined;
         if (rawLink) {
-          link = `${rawLink.scheme}://${window.location.protocol}//${host}#${tokenId}`;
+          link = `${rawLink.scheme}:${window.location.protocol}//${host}#${tokenId}`;
         }
 
         sessionStorage.setItem(key, JSON.stringify({

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1439,8 +1439,8 @@ Meteor.startup(function () {
         // TODO(soon): check against whitelist
         // rfc3986 specifies schemes as:
         // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
-        if (rawLink.scheme.search(/^[^a-zA-Z]/) !== -1 ||
-            rawLink.scheme.search(/[^a-zA-Z0-9+-.]/) !== -1) {
+        if (rawLink && (rawLink.scheme.search(/^[^a-zA-Z]/) !== -1 ||
+                        rawLink.scheme.search(/[^a-zA-Z0-9+-.]/) !== -1)) {
           throw new Meteor.Error(400, "rawlink.scheme has invalid characters.");
         }
       } catch (error) {

--- a/shell/public/offer-template.html
+++ b/shell/public/offer-template.html
@@ -142,7 +142,7 @@ setInterval(function() {
           console.error(xhr.responseText);
           var textElement = document.getElementById("text");
           textElement.textContent = errorText;
-          var link = document.getElementById("href");
+          var link = document.getElementById("link");
           if (link) {
             var container = document.getElementById("container");
             container.removeChild(link);

--- a/shell/public/offer-template.html
+++ b/shell/public/offer-template.html
@@ -76,8 +76,19 @@ body {
 // Templates are namespaced in sessionStorage by the prefix "offerTemplate"
 var templateToken = "offerTemplate" + window.location.hash.substring(1);
 var record = JSON.parse(sessionStorage.getItem(templateToken));
+var textElement = document.getElementById("text");
+textElement.textContent = record.renderedTemplate;
+if (record.link) {
+  var container = document.getElementById("container");
+  var link = document.createElement("a");
+  link.href = record.link;
+  link.target = "_blank";
+  link.id = "link";
 
-document.getElementById("text").textContent = record.renderedTemplate;
+  container.appendChild(link);
+  container.removeChild(textElement);
+  link.appendChild(textElement);
+}
 
 if(record.clipboardButton && record.clipboardButton !== "none") {
   if(record.clipboardButton === "left") {
@@ -129,7 +140,14 @@ setInterval(function() {
        } else {
           var errorText = "Error refreshing token. Reloading the page might help.";
           console.error(xhr.responseText);
-          document.getElementById("text").textContent = errorText;
+          var textElement = document.getElementById("text");
+          textElement.textContent = errorText;
+          var link = document.getElementById("href");
+          if (link) {
+            var container = document.getElementById("container");
+            container.removeChild(link);
+            container.appendChild(textElement);
+          }
        }
     }
   };


### PR DESCRIPTION
This allows you to make the whole offer template into a link. At the
moment, the only thing you can specify is a scheme, and the rest is
autogenerated for you.

This needs some input on what we're actually going to do about filtering dangerous schemes. Either add a whitelist or only allow them to start with "sandstorm-" (or automatically prefix it ourselves).