### PR TITLE
Send an email to admins/users on account deletion

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -2752,51 +2752,6 @@ if (Meteor.isServer) {
     backend.deleteUser(userId);
     Meteor.users.remove({ _id: userId });
   };
-
-  Meteor.methods({
-    suspendAccount(userId, willDelete) {
-      check(userId, String);
-      check(willDelete, Boolean);
-
-      if (!isAdmin()) {
-        throw new Meteor.Error(403, "Only admins can suspend other users.");
-      }
-
-      this.connection.sandstormDb.suspendAccount(userId, Meteor.userId(), willDelete);
-    },
-
-    deleteOwnAccount() {
-      const db = this.connection.sandstormDb;
-      if (!Meteor.userId()) {
-        throw new Meteor.Error(403, "Must be logged in to delete an account");
-      }
-
-      if (db.isUserInOrganization(Meteor.user())) {
-        throw new Meteor.Error(403, "Users in an organization cannot delete their own account. " +
-          "Please ask your admin to do it for you.");
-      }
-
-      db.suspendAccount(Meteor.userId(), null, true);
-    },
-
-    unsuspendAccount(userId) {
-      check(userId, String);
-
-      if (!isAdmin()) {
-        throw new Meteor.Error(403, "Only admins can unsuspend other users.");
-      }
-
-      this.connection.sandstormDb.unsuspendAccount(userId, Meteor.userId());
-    },
-
-    unsuspendOwnAccount() {
-      if (!Meteor.userId()) {
-        throw new Meteor.Error(403, "Must be logged in to unsuspend an account");
-      }
-
-      this.connection.sandstormDb.unsuspendAccount(Meteor.userId());
-    },
-  });
 }
 
 Meteor.methods({

--- a/shell/server/account-suspension.js
+++ b/shell/server/account-suspension.js
@@ -72,7 +72,7 @@ Meteor.methods({
     this.connection.sandstormDb.suspendAccount(userId, Meteor.userId(), willDelete);
 
     if (willDelete) {
-      sendDeletionEmails(this.connection.sandstormDb, userId, byAdminUserId);
+      sendDeletionEmails(this.connection.sandstormDb, userId, Meteor.userId());
     }
   },
 

--- a/shell/server/account-suspension.js
+++ b/shell/server/account-suspension.js
@@ -1,0 +1,60 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Meteor.methods({
+  suspendAccount(userId, willDelete) {
+    check(userId, String);
+    check(willDelete, Boolean);
+
+    if (!isAdmin()) {
+      throw new Meteor.Error(403, "Only admins can suspend other users.");
+    }
+
+    this.connection.sandstormDb.suspendAccount(userId, Meteor.userId(), willDelete);
+  },
+
+  deleteOwnAccount() {
+    const db = this.connection.sandstormDb;
+    if (!Meteor.userId()) {
+      throw new Meteor.Error(403, "Must be logged in to delete an account");
+    }
+
+    if (db.isUserInOrganization(Meteor.user())) {
+      throw new Meteor.Error(403, "Users in an organization cannot delete their own account. " +
+        "Please ask your admin to do it for you.");
+    }
+
+    db.suspendAccount(Meteor.userId(), null, true);
+  },
+
+  unsuspendAccount(userId) {
+    check(userId, String);
+
+    if (!isAdmin()) {
+      throw new Meteor.Error(403, "Only admins can unsuspend other users.");
+    }
+
+    this.connection.sandstormDb.unsuspendAccount(userId, Meteor.userId());
+  },
+
+  unsuspendOwnAccount() {
+    if (!Meteor.userId()) {
+      throw new Meteor.Error(403, "Must be logged in to unsuspend an account");
+    }
+
+    this.connection.sandstormDb.unsuspendAccount(Meteor.userId());
+  },
+});

--- a/shell/server/account-suspension.js
+++ b/shell/server/account-suspension.js
@@ -28,7 +28,7 @@ function sendDeletionEmails(db, deletedUserId, byAdminUserId) {
       const emailOptions = {
         from: db.getReturnAddress(),
         subject: `Your account on ${db.getServerTitle()} will be deleted in 7 days.`,
-        text: `You have requested that your Sandstorm account on ${db.getServerTitle()} be deleted. Your account has been suspended and will be fully deleted in seven days. If you chance your mind, log into ${process.env.ROOT_URL} to cancel the process.
+        text: `You have requested that your Sandstorm account on ${db.getServerTitle()} be deleted. Your account has been suspended and will be fully deleted in seven days. If you change your mind, log into ${process.env.ROOT_URL} to cancel the process.
 
 If you did not request this deletion, please contact the server administrator immediately.`,
       };


### PR DESCRIPTION
This isn't quite ready to merge as it needs better text (and perhaps an html version?).

I would like comments on if you think it's appropriate to inject an email object similar to quoteManager into SandstormDb.