### PR TITLE
update some mentions of .sandstorm-api-token to .sandstorm-token

### DIFF
--- a/docs/developing/http-apis.md
+++ b/docs/developing/http-apis.md
@@ -203,16 +203,16 @@ work around this, you must pass the token as part of the URL path. It must be at
 the path and of the form:
 
 ```
-/.sandstorm-api-token/<token>
+/.sandstorm-token/<token>
 ```
 
 For example:
 
 ```
-wss://api-qxJ58hKANkbmJLQdSDk4.oasis.sandstorm.io/.sandstorm-api-token/RfNqni4FEHXkWC5B8v6t/some/path
+wss://api-qxJ58hKANkbmJLQdSDk4.oasis.sandstorm.io/.sandstorm-token/RfNqni4FEHXkWC5B8v6t/some/path
 ```
 
-The "/.sandstorm-api-token/&lt;token&gt;" part of the path will be stripped, and the remaining
+The "/.sandstorm-token/&lt;token&gt;" part of the path will be stripped, and the remaining
 segment of the path will be passed onto your app.
 
 

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -921,7 +921,7 @@ const apiTokenForRequest = (req, hostId) => {
     } else {
       token = parts[1];
       req.url = "/" + parts.slice(2).join("/");
-      // remove .sandstorm-api-token/$TOKEN from path
+      // remove .sandstorm-token/$TOKEN from path
     }
   } else {
     token = undefined;


### PR DESCRIPTION
The code updated to use `.sandstorm-token` in [this commit](https://github.com/sandstorm-io/sandstorm/pull/1949/commits/ac3e9b3b92c6d4f40f69fbc33b1745e8e122c31a), but several mentions in the documentation did not get updated.