### PR TITLE
HTTP APIs: gracefully handle case when user-agent header is missing

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -899,7 +899,7 @@ const apiUseBasicAuth = (req, hostId) => {
   // Since many clients in the wild have already been configured to use the shared API host, we
   // must continue to support them, so this logic remains.
   const agent = req.headers["user-agent"];
-  return agent.match(BASIC_AUTH_USER_AGENTS_REGEX);
+  return agent && agent.match(BASIC_AUTH_USER_AGENTS_REGEX);
 };
 
 const apiTokenForRequest = (req, hostId) => {


### PR DESCRIPTION
@zenhack observed Sandstorm returning a consfusing 500 error due to this problem.