### PR TITLE
Log a message if grain is slow to start

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -2124,12 +2124,30 @@ public:
       // Wait until connections are accepted.
       // TODO(soon): Don't block pure-Cap'n-Proto RPCs on this. Just block HTTP requests.
       bool success = false;
+      int numTriesSoFar = 0;
+      bool loggedSlowStartupMessage = false;
       for (;;) {
         kj::runCatchingExceptions([&]() {
+          if (! loggedSlowStartupMessage) {
+            numTriesSoFar++;
+          }
           address->connect().wait(ioContext.waitScope);
           success = true;
         });
-        if (success) break;
+        if (success) {
+          if (loggedSlowStartupMessage) {
+            KJ_LOG(WARNING, "App successfully started listening for TCP connections!");
+          }
+          break;
+        }
+
+        if (!loggedSlowStartupMessage && numTriesSoFar == (30 * 100)) {
+          // After 30 seconds (30 * 100 centiseconds) of failure, log a message once.
+          KJ_LOG(WARNING, "App isn't listening for TCP connections after 30 seconds. Continuing "
+                 "to attempt to connect",
+                 address->toString());
+          loggedSlowStartupMessage = true;
+        }
 
         // Wait 10ms and try again.
         usleep(10000);


### PR DESCRIPTION
This is intended to help:

- App authors who are mistaken about which port number their app was
  supposed to bind to, e.g. an app author a few months ago.

- App authors who forgot to ever actually listen on the port, e.g. an app
  author who showed up to IRC today.