### PR TITLE
Dropping a token you don't own should not be an error.

### DIFF
--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -567,7 +567,11 @@ function dropInternal(db, sturdyRef, ownerPattern) {
     return;
   }
 
-  check(token.owner, ownerPattern);
+  if (!Match.test(token.owner, ownerPattern)) {
+    // Not an error. For example, if a grain gets backed up and restored, there should not be an
+    // error when it tries to drop one of its pre-backup tokens.
+    return;
+  }
 
   if (token.frontendRef && token.frontendRef.notificationHandle) {
     const notificationId = token.frontendRef.notificationHandle;

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -568,8 +568,10 @@ function dropInternal(db, sturdyRef, ownerPattern) {
   }
 
   if (!Match.test(token.owner, ownerPattern)) {
-    // Not an error. For example, if a grain gets backed up and restored, there should not be an
-    // error when it tries to drop one of its pre-backup tokens.
+    // The caller of `drop()` does not own the token. From the caller's perspective, this means
+    // that there is actually nothing to be dropped. For example, perhaps a grain got backed up
+    // and restored, and now is trying to drop one of its pre-backup tokens. The call to
+    // `SandstormApi.drop()` should succeed, behaving exactly as if the token was not found.
     return;
   }
 


### PR DESCRIPTION
Currently, if you back up and restore a grain that uses a self-repairing identity database as in #2441, and the original grain has not been completely deleted, the restored grain ends up with identities accumulating in its trash directory, because `drop()` fails. This patch fixes the problem.