### PR TITLE
Fix typo in grain-owner-suspended error

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -303,7 +303,7 @@ Meteor.methods({
     } else if (grain.trashed) {
       throw new Meteor.Error("grain-is-in-trash", "Grain is in trash", "Grain ID: " + grainId);
     } else if (grain.suspended) {
-      throw new Meteor.Error("grain-owner-suspended", "Grain's ownder is suspended",
+      throw new Meteor.Error("grain-owner-suspended", "Grain's owner is suspended",
         "Grain ID: " + grainId);
     }
 


### PR DESCRIPTION
## In short
* Fix typo of ```ownder``` → ```owner``` for the grain-owner-suspended error

*As this is a very small change, I've skipped the usual breakdown and risk analysis*