### PR TITLE
Opt Sandstorm for Work trial users into stats reporting

### DIFF
--- a/shell/client/admin/stats-client.js
+++ b/shell/client/admin/stats-client.js
@@ -56,7 +56,7 @@ Template.newAdminStats.helpers({
 
   undecided() {
     const setting = Settings.findOne({ _id: "reportStats" });
-    return setting && setting.value === "unset" && !globalDb.isFeatureKeyOptedIntoStats();
+    return setting && setting.value === "unset";
   },
 
   sendStats() {

--- a/shell/client/admin/stats-client.js
+++ b/shell/client/admin/stats-client.js
@@ -45,6 +45,10 @@ Template.newAdminStats.onCreated(function () {
 });
 
 Template.newAdminStats.helpers({
+  featureKeyForceStats() {
+    return globalDb.isFeatureKeyOptedIntoStats();
+  },
+
   ready() {
     const instance = Template.instance();
     return instance.ready();
@@ -52,7 +56,7 @@ Template.newAdminStats.helpers({
 
   undecided() {
     const setting = Settings.findOne({ _id: "reportStats" });
-    return setting && setting.value === "unset";
+    return setting && setting.value === "unset" && !globalDb.isFeatureKeyOptedIntoStats();
   },
 
   sendStats() {

--- a/shell/client/admin/stats.html
+++ b/shell/client/admin/stats.html
@@ -117,6 +117,11 @@
     </ul>
   </h1>
 
+  {{#if featureKeyForceStats}}
+    <div class="flash-message info-message">
+      During your free trial of Sandstorm for Work, the stats on this page will be reported to Sandstorm.io so that we can help you get up and running. Once you purchase a key (or downgrade to standard Sandstorm by removing your trial key), these stats will stop being reported.
+    </div>
+  {{else}}
   <h2>Publish anonymously to Sandstorm dev team</h2>
 
   {{#if hasSuccess}}
@@ -159,9 +164,6 @@
       Any stats shared are submitted anonymously.
     </p>
     <p>
-      {{#if featureKeyForceStats}}
-        You have a Sandstorm for Work trial key, and as part of that agreement, you elected to opt into stats reporting. Please upgrade to a paid key if you wish to disable this.
-      {{else}}
       Anonymous stats reporting to sandstorm.io:
       {{#if sendStats}}
         <span class="stats-enabled">Enabled</span>
@@ -175,8 +177,8 @@
         <button type="button" class="button-enable" name="enable-stats">Enable</button>
         {{/if}}
       </form>
-      {{/if}}
     </p>
+  {{/if}}
   {{/if}}
 
 

--- a/shell/client/admin/stats.html
+++ b/shell/client/admin/stats.html
@@ -50,7 +50,7 @@
 </template>
 
 <template name="statsAppsTable">
-{{!-- expects a single argument: 
+{{!-- expects a single argument:
   apps: Array of Object like ActivityStats, plus `appTitle`
  ready: Boolean, indicates readiness, to avoid rerendering as data streams in
 --}}
@@ -159,6 +159,9 @@
       Any stats shared are submitted anonymously.
     </p>
     <p>
+      {{#if featureKeyForceStats}}
+        You have a Sandstorm for Work trial key, and as part of that agreement, you elected to opt into stats reporting. Please upgrade to a paid key if you wish to disable this.
+      {{else}}
       Anonymous stats reporting to sandstorm.io:
       {{#if sendStats}}
         <span class="stats-enabled">Enabled</span>
@@ -172,6 +175,7 @@
         <button type="button" class="button-enable" name="enable-stats">Enable</button>
         {{/if}}
       </form>
+      {{/if}}
     </p>
   {{/if}}
 
@@ -223,4 +227,3 @@
 
   {{> statsAppsTable apps=apps ready=ready}}
 </template>
-

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1449,6 +1449,12 @@ _.extend(SandstormDb.prototype, {
     return featureKey && (parseInt(featureKey.expires) > (Date.now() / 1000));
   },
 
+  isFeatureKeyOptedIntoStats: function () {
+    const featureKey = this.currentFeatureKey();
+    return featureKey && featureKey.isTrial && parseInt(featureKey.issued) > 1472601600;
+    // 1472601600 is 2016 Aug 31 in seconds since the epoch
+  },
+
   getLdapUrl: function () {
     const setting = Settings.findOne({ _id: "ldapUrl" });
     return setting ? setting.value : "";  // empty if subscription is not ready.

--- a/shell/server/stats-server.js
+++ b/shell/server/stats-server.js
@@ -165,6 +165,16 @@ computeStats = function (since) {
 };
 
 function recordStats() {
+  const postStats = function (record) {
+    HTTP.post("https://alpha-api.sandstorm.io/data", {
+      data: record,
+      headers: {
+        Authorization: "Bearer aT-mGyNwsgwZBbZvd5FWr0Ma79O9IehI4NiEO94y_oR",
+        "Content-Type": "application/json",
+      },
+    });
+  };
+
   const now = new Date();
 
   const planStats = _.countBy(
@@ -185,33 +195,25 @@ function recordStats() {
 
   ActivityStats.insert(record);
   const age = ActivityStats.find().count();
-  if (age > 3) {
+  // The stats page which the user agreed we can send actually displays the whole history
+  // of the server, but we're only sending stats from the last day. Let's also throw in the
+  // length of said history. This is still strictly less information than what the user said
+  // we're allowed to send.
+  record.serverAge = age;
+
+  if (globalDb.isFeatureKeyOptedIntoStats()) {
+    record.customerId = globalDb.currentFeatureKey().customer.id;
+    postStats(record);
+  } else if (age > 3) {
     const reportSetting = Settings.findOne({ _id: "reportStats" });
-    const isFeatureKeyOptedIntoStats = globalDb.isFeatureKeyOptedIntoStats();
 
-    if (isFeatureKeyOptedIntoStats) {
-      record.customerId = globalDb.currentFeatureKey().customer.id;
-    }
-
-    if (!reportSetting && !isFeatureKeyOptedIntoStats) {
+    if (!reportSetting) {
       // Setting not set yet, send out notifications and set it to false
       globalDb.sendAdminNotification("You can help Sandstorm by sending us some anonymous " +
         "usage stats. Click here for more info.", "/admin/stats");
       Settings.insert({ _id: "reportStats", value: "unset" });
-    } else if (reportSetting.value === true || isFeatureKeyOptedIntoStats) {
-      // The stats page which the user agreed we can send actually displays the whole history
-      // of the server, but we're only sending stats from the last day. Let's also throw in the
-      // length of said history. This is still strictly less information than what the user said
-      // we're allowed to send.
-      record.serverAge = age;
-
-      HTTP.post("https://alpha-api.sandstorm.io/data", {
-        data: record,
-        headers: {
-          Authorization: "Bearer aT-mGyNwsgwZBbZvd5FWr0Ma79O9IehI4NiEO94y_oR",
-          "Content-Type": "application/json",
-        },
-      });
+    } else if (reportSetting.value === true) {
+      postStats(record);
     }
   }
 }

--- a/shell/server/stats-server.js
+++ b/shell/server/stats-server.js
@@ -187,12 +187,18 @@ function recordStats() {
   const age = ActivityStats.find().count();
   if (age > 3) {
     const reportSetting = Settings.findOne({ _id: "reportStats" });
-    if (!reportSetting) {
+    const isFeatureKeyOptedIntoStats = globalDb.isFeatureKeyOptedIntoStats();
+
+    if (isFeatureKeyOptedIntoStats) {
+      record.customerId = globalDb.currentFeatureKey().customer.id;
+    }
+
+    if (!reportSetting && !isFeatureKeyOptedIntoStats) {
       // Setting not set yet, send out notifications and set it to false
       globalDb.sendAdminNotification("You can help Sandstorm by sending us some anonymous " +
         "usage stats. Click here for more info.", "/admin/stats");
       Settings.insert({ _id: "reportStats", value: "unset" });
-    } else if (reportSetting.value === true) {
+    } else if (reportSetting.value === true || isFeatureKeyOptedIntoStats) {
       // The stats page which the user agreed we can send actually displays the whole history
       // of the server, but we're only sending stats from the last day. Let's also throw in the
       // length of said history. This is still strictly less information than what the user said


### PR DESCRIPTION
The hard coded date assumes we update our terms/privacy policy for the
feature key vendor by tomorrow.

Also add their customer ID to the stats object
