### PR TITLE
Implement `spk dev --proc`.

### DIFF
--- a/shell/imports/server/backend.js
+++ b/shell/imports/server/backend.js
@@ -119,10 +119,12 @@ class SandstormBackend {
     // package, so that the grain runs using the dev app.
     const devPackage = DevPackages.findOne({ appId: grain.appId });
     let isDev;
+    let mountProc;
     let pkg;
     if (devPackage) {
       isDev = true;
       pkg = devPackage;
+      mountProc = pkg.mountProc;
     } else {
       pkg = Packages.findOne(grain.packageId);
       if (!pkg) {
@@ -140,12 +142,12 @@ class SandstormBackend {
     }
 
     const result = this.startGrainInternal(
-        packageId, grainId, grain.userId, manifest.continueCommand, false, isDev);
+        packageId, grainId, grain.userId, manifest.continueCommand, false, isDev, mountProc);
     result.packageSalt = isDev ? pkg._id : grain.packageSalt;
     return result;
   }
 
-  startGrainInternal(packageId, grainId, ownerId, command, isNew, isDev) {
+  startGrainInternal(packageId, grainId, ownerId, command, isNew, isDev, mountProc) {
     // Starts the grain supervisor.  Must be executed in a Meteor context.  Blocks until grain is
     // started. Returns a promise for an object containing two fields: `owner` (the ID of the owning
     // user) and `supervisor` (the supervisor capability).
@@ -174,7 +176,7 @@ class SandstormBackend {
       delete command.executablePath;
     }
 
-    return this._backendCap.startGrain(ownerId, grainId, packageId, command, isNew, isDev);
+    return this._backendCap.startGrain(ownerId, grainId, packageId, command, isNew, isDev, mountProc);
   }
 
   updateLastActive(grainId, userId, identityId) {

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -186,6 +186,7 @@ DevPackages = new Mongo.Collection("devpackages");
 //     published, all running instances are reset. This is used e.g. to reset the app each time
 //     changes are made to the source code.
 //   manifest:  The app's manifest, as with Packages.manifest.
+//   mountProc: True if the supervisor should mount /proc.
 
 UserActions = new Mongo.Collection("userActions");
 // List of actions that each user has installed which create new grains.  Each app may install

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -255,10 +255,12 @@ Meteor.methods({
 
     let pkg = Packages.findOne(packageId);
     let isDev = false;
+    let mountProc = false;
     if (!pkg) {
       // Maybe they wanted a dev package.  Check there too.
       pkg = DevPackages.findOne(packageId);
       isDev = true;
+      mountProc = pkg.mountProc;
     }
 
     if (!pkg) {
@@ -280,7 +282,8 @@ Meteor.methods({
       size: 0,
     });
 
-    globalBackend.startGrainInternal(packageId, grainId, this.userId, command, true, isDev);
+    globalBackend.startGrainInternal(packageId, grainId, this.userId, command, true,
+                                     isDev, mountProc);
     globalBackend.updateLastActive(grainId, this.userId, identityId);
     return grainId;
   },

--- a/src/sandstorm/backend.capnp
+++ b/src/sandstorm/backend.capnp
@@ -37,7 +37,8 @@ interface Backend {
   # ----------------------------------------------------------------------------
 
   startGrain @0 (ownerId :Text, grainId :Text, packageId :Text,
-                 command :Package.Manifest.Command, isNew :Bool, devMode :Bool = false)
+                 command :Package.Manifest.Command, isNew :Bool,
+                 devMode :Bool = false, mountProc :Bool = false)
              -> (supervisor :Supervisor);
   # Start a grain.
 

--- a/src/sandstorm/backend.h
+++ b/src/sandstorm/backend.h
@@ -90,7 +90,8 @@ private:
   class FileUploadStream;
 
   kj::Promise<Supervisor::Client> bootGrain(kj::StringPtr grainId, kj::StringPtr packageId,
-      spk::Manifest::Command::Reader command, bool isNew, bool devMode, bool isRetry);
+      spk::Manifest::Command::Reader command, bool isNew, bool devMode, bool mountProce,
+      bool isRetry);
 
   static kj::Promise<void> ignoreAll(kj::AsyncInputStream& input);
   static kj::Promise<kj::String> readAll(kj::AsyncInputStream& input,


### PR DESCRIPTION
This allows dev-mode apps to opt-in to getting a procfs. I've verified that it does indeed allow Rust programs to generate human-readable stack traces (see #371).

Since `--proc` already exists as a supervisor flag, most of the changes here are to propagate the flag from `spk dev` to the supervisor. This involves writing a "1\n" or a "0\n" to a socket, adding a field to `DevPackages`, and adding an argument to `Backend.startGrain()`. 