### PR TITLE
Accounts page rework for mobile

### DIFF
--- a/shell/client/accounts/account-settings.html
+++ b/shell/client/accounts/account-settings.html
@@ -67,11 +67,6 @@ limitations under the License.
             <button class="account-button logout-other-sessions" disabled={{logoutOtherSessionsInFlight}}>
               Log out all other sessions
             </button>
-            {{#if showDeleteButton}}
-            <button class="account-button delete-account" disabled={{logoutOtherSessionsInFlight}}>
-              Delete account
-            </button>
-            {{/if}}
           {{/if}}
         </div>
       </div>
@@ -122,6 +117,15 @@ limitations under the License.
   <h2>Billing</h2>
   {{> billingUsage db=db topbar=_topbar}}
   {{> billingSettings db=db}}
+  </div>
+  {{/if}}
+
+  {{#if showDeleteButton}}
+  <div class="danger-zone">
+    <h3>Delete account</h3>
+    <button class="delete-account" disabled={{logoutOtherSessionsInFlight}}>
+      Delete your account
+    </button>
   </div>
   {{/if}}
 

--- a/shell/client/accounts/account-settings.html
+++ b/shell/client/accounts/account-settings.html
@@ -45,7 +45,7 @@ limitations under the License.
   {{#unless isLinkingNewIdentity}}
   <ul role="tablist" >
     {{#each identities}}
-    <li role="tab" aria-controls="profile-tab-{{_id}}" id="profile-tab-header-{{_id}}"
+    <li role="tab" tabindex="0" aria-controls="profile-tab-{{_id}}" id="profile-tab-header-{{_id}}"
         aria-selected="{{isIdentitySelected _id}}" data-identity-id="{{_id}}">
       {{> identityCard .}}
     </li>

--- a/shell/client/accounts/account-settings.html
+++ b/shell/client/accounts/account-settings.html
@@ -23,69 +23,69 @@ limitations under the License.
     Account settings
   {{/sandstormTopbarItem}}
 
-  <h2>My account</h2>
+  <h1>Account</h1>
   <div class="identities-editor">
 
-  <h3 class="title-bar">Linked identities</h3>
+    <h3 class="title-bar">Linked identities</h3>
 
-  {{#with actionCompleted}}
-    {{#if success}}
-      {{#focusingSuccessBox}}
-        Success: {{success}}
-      {{/focusingSuccessBox}}
-    {{/if}}
-    {{#if error}}
-      {{#focusingErrorBox}}
-        {{error}}
-      {{/focusingErrorBox}}
-    {{/if}}
-  {{/with}}
-
-  <div class="identities-tabs">
-  {{#unless isLinkingNewIdentity}}
-  <ul role="tablist" >
-    {{#each identities}}
-    <li role="tab" tabindex="0" aria-controls="profile-tab-{{_id}}" id="profile-tab-header-{{_id}}"
-        aria-selected="{{isIdentitySelected _id}}" data-identity-id="{{_id}}">
-      {{> identityCard .}}
-    </li>
-    {{/each}}
-  </ul>
-  {{/unless}}
-  {{#if isAccountUser}}
-    {{#if isLinkingNewIdentity}}
-      <h4>Link new identity:</h4>
-      {{#with linkingNewIdentity=linkingNewIdentityData}}
-        {{> loginButtonsList globalAccountsUi}}
-      {{/with}}
-    <p><button class="account-button cancel-link-new-identity">Cancel</button></p>
-    {{else}}
-    <p><button class="account-button link-new-identity">Link new identity</button></p>
-    {{/if}}
-  {{/if}}
-  {{#unless isLinkingNewIdentity}}
-    <p>
-      <button class="account-button logout-other-sessions" disabled={{logoutOtherSessionsInFlight}}>
-        Log out all other sessions
-      </button>
-    </p>
-    <p>
-      {{#if showDeleteButton}}
-      <button class="account-button delete-account" disabled={{logoutOtherSessionsInFlight}}>
-        Delete account
-      </button>
+    {{#with actionCompleted}}
+      {{#if success}}
+        {{#focusingSuccessBox}}
+          Success: {{success}}
+        {{/focusingSuccessBox}}
       {{/if}}
-    </p>
-  {{/unless}}
-  </div><section class="profile">
-    {{#each identities}}
-    <div id="profile-tab-{{_id}}" aria-labelled-by="profile-tab-header-{{_id}}"
-         role="tabpanel" aria-hidden="{{isIdentityHidden _id}}">
-      {{>_accountProfileEditor identity=. setActionCompleted=setActionCompleted
-                               staticHost=../_staticHost}}
-     </div>
-    {{/each}}
-  </section>
+      {{#if error}}
+        {{#focusingErrorBox}}
+          {{error}}
+        {{/focusingErrorBox}}
+      {{/if}}
+    {{/with}}
+
+    <div class="identities-and-editor">
+      <div class="identities-tabs">
+
+        {{#unless isLinkingNewIdentity}}
+        <ul role="tablist" >
+          {{#each identities}}
+          <li role="tab" tabindex="0" aria-controls="profile-tab-{{_id}}" id="profile-tab-header-{{_id}}"
+              aria-selected="{{isIdentitySelected _id}}" data-identity-id="{{_id}}">
+            {{> identityCard .}}
+          </li>
+          {{/each}}
+        </ul>
+        {{/unless}}
+
+        <div class="account-buttons">
+          {{#if isLinkingNewIdentity}}
+            <h4>Link new identity:</h4>
+            {{#with linkingNewIdentity=linkingNewIdentityData}}
+              {{> loginButtonsList globalAccountsUi}}
+            {{/with}}
+            <button class="account-button cancel-link-new-identity">Cancel</button>
+          {{else}}
+            <button class="account-button link-new-identity">Link new identity</button>
+            <button class="account-button logout-other-sessions" disabled={{logoutOtherSessionsInFlight}}>
+              Log out all other sessions
+            </button>
+            {{#if showDeleteButton}}
+            <button class="account-button delete-account" disabled={{logoutOtherSessionsInFlight}}>
+              Delete account
+            </button>
+            {{/if}}
+          {{/if}}
+        </div>
+      </div>
+
+      <section class="profile">
+        {{#each identities}}
+        <div id="profile-tab-{{_id}}" aria-labelled-by="profile-tab-header-{{_id}}"
+             role="tabpanel" aria-hidden="{{isIdentityHidden _id}}">
+          {{>_accountProfileEditor identity=. setActionCompleted=setActionCompleted
+                                   staticHost=../_staticHost}}
+         </div>
+        {{/each}}
+      </section>
+    </div>
   </div>
 
   <h3 class="title-bar">Primary e-mail address for service-related notifications</h3>
@@ -258,14 +258,14 @@ setActionCompleted: (optional) Function.  Callback triggered on profile saved or
         </li>
 
         <li class="form-group">
-          {{#with identity.profile}}
+          {{#with prounoun=identity.profile.pronoun}}
           <label>
             Preferred pronoun:
             <select name="pronoun">
-              <option value="neutral" selected="{{isNeutral}}">they (unspecified)</option>
-              <option value="male" selected="{{isMale}}">he/him (male)</option>
-              <option value="female" selected="{{isFemale}}">she/her (female)</option>
-              <option value="robot" selected="{{isRobot}}">it (robot)</option>
+              <option value="neutral" selected="{{isNeutral pronoun}}">they (unspecified)</option>
+              <option value="male" selected="{{isMale pronoun}}">he/him (male)</option>
+              <option value="female" selected="{{isFemale pronoun}}">she/her (female)</option>
+              <option value="robot" selected="{{isRobot pronoun}}">it (robot)</option>
             </select>
           </label>
           {{/with}}

--- a/shell/client/accounts/account-settings.js
+++ b/shell/client/accounts/account-settings.js
@@ -248,6 +248,14 @@ Template.sandstormAccountSettings.events({
     instance._selectedIdentityId.set(ev.currentTarget.getAttribute("data-identity-id"));
   },
 
+  "keydown [role='tab']"(ev, instance) {
+    if (ev.keyCode === 13) { // Enter key
+      ev.preventDefault();
+      instance._actionCompleted.set();
+      instance._selectedIdentityId.set(ev.currentTarget.getAttribute("data-identity-id"));
+    }
+  },
+
   "click button.link-new-identity": function (ev, instance) {
     instance._isLinkingNewIdentity.set(true);
   },

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -228,6 +228,7 @@ limitations under the License.
 </template>
 
 <template name="account">
+{{!-- Data context is an instance of SandstormAccountSettingsUi --}}
   <div class="account">
     {{#if .}}
       {{>sandstormAccountSettings .}}

--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -514,6 +514,10 @@ body>.main-content>.account {
           width: 225px;
         }
 
+        &:focus {
+          @extend %custom-focus-ring;
+        }
+
         .make-login {
           @include unstyled-button();
         }

--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -605,9 +605,6 @@ body>.main-content>.account {
         }
       }
 
-      &.delete-account {
-        @extend %button-danger;
-      }
     }
   }
 
@@ -1036,6 +1033,13 @@ div.billing {
         flex-shrink: 0;
       }
     }
+  }
+}
+
+.danger-zone {
+  button.delete-account {
+    @extend %button-base;
+    @extend %button-danger;
   }
 }
 

--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -444,9 +444,27 @@ body>.popup.account>.frame-container {
 
 body>.main-content>.account {
   text-align: left;
-  padding-left: 32px;
+
+  @media #{$desktop} {
+    padding: 32px;
+  }
+
   @media #{$mobile} {
-    padding: 0;
+    padding-top: 0px;
+    padding-bottom: 32px;
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+
+  h1 {
+    margin-top: 0px;
+    padding-top: 0px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid $default-rule-color;
+    margin-bottom: 12px;
+
+    font-size: 24pt;
+    font-weight: 400;
   }
 
   .identities-editor {
@@ -468,50 +486,61 @@ body>.main-content>.account {
   }
 
   h3.title-bar {
-    width: 660px;
     margin-bottom: 5px;
     border: none;
     font-size: 14pt;
     padding: 5px;
   }
 
-  div.action-completed {
-    margin-top: 10px;
-    width: 660px;
-    border: 1px solid transparent;
-    border-radius: 4px;
+  .identities-and-editor {
+    @media #{$not-mobile-only} {
+      width: 660px;
+      flex-direction: row;
+      align-items: flex-start;
+    }
 
-    &.success {
-      color: #3c763d;
-      background-color: #dff0d8;
-      border-color: #d6e9c6;
+    @media #{$mobile-only} {
+      flex-direction: column;
+      align-items: stretch;
     }
-    &.error {
-      color: #a94442;
-      background-color: #f2dede;
-      border-color: #ebccd1;
-    }
+
+    display: flex;
+    justify-content: flex-start;
   }
 
   .identities-tabs {
-    display: inline-block;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+
     white-space: normal;
     vertical-align: top;
-    width: 225px;
+
     ul {
       position: relative;
-      margin-top: 0;
-      padding-left: 0;
+      margin: 0px;
+      padding: 0px;
+
       li {
         list-style-type: none;
         cursor: pointer;
         background-color: white;
-        width: 218px;
         margin-bottom: 10px;
 
-        &[aria-selected=true] {
-          z-index: 1;
-          width: 225px;
+        @media #{$not-mobile-only} {
+          margin-right: 7px;
+
+          &[aria-selected=true] {
+            margin-right: 0px;
+          }
+        }
+        @media #{$mobile-only} {
+          border: 1px solid $generic-border-color;
+
+          &[aria-selected=true] {
+            border: 2px solid $generic-border-color;
+          }
         }
 
         &:focus {
@@ -527,25 +556,50 @@ body>.main-content>.account {
       }
     }
     .login-buttons-list {
+      width: 218px;
+      margin-right: 7px;
       .troubleshooting, a[href="/about"] {
         display: none;
+      }
+    }
+
+    .account-buttons {
+      @media #{$not-mobile-only} {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        justify-content: flex-start;
+      }
+      @media #{$mobile-only} {
+        order: -1;
+        display: flex;
+        flex-direction: row;
+        align-items: stretch;
+        justify-content: flex-start;
       }
     }
 
     button.account-button {
       @extend %button-base;
       @extend %button-secondary;
-      width: 218px;
-      height: 30px;
+      @media #{$not-mobile-only} {
+        margin-right: 7px;
+      }
+
+      @media #{$mobile-only} {
+        flex: 1;
+        &:not(:last-child) {
+          margin-right: 8px;
+        }
+      }
+
+      min-height: 30px;
+
+      margin-bottom: 12px;
 
       &.link-new-identity {
-        position: relative;
-
         @extend .icon-link;
         &::before {
-          position: absolute;
-          left: 30px;
-          top: 2px;
           font-size: 24px;
           @extend .icon;
         }
@@ -558,7 +612,13 @@ body>.main-content>.account {
   }
 
   .profile {
-    display: inline-block;
+    @media #{$not-mobile-only} {
+      display: inline-block;
+    }
+    @media #{$mobile-only} {
+      display: block;
+    }
+
     white-space: normal;
 
     div[aria-hidden=true] {
@@ -574,10 +634,20 @@ body>.main-content>.account {
   .verified-emails-editor {
     position: relative;
     .already-verified {
-      display: inline-block;
-      width: 340px;
-      left: 0px;
-      vertical-align: top;
+      @media #{$not-mobile-only} {
+        display: inline-block;
+        width: 340px;
+        left: 0px;
+        vertical-align: top;
+      }
+
+      @media #{$mobile-only} {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        justify-content: flex-start;
+      }
+
       ul {
         margin-top: 4px;
         padding-left: 0px;
@@ -614,17 +684,46 @@ body>.main-content>.account {
         }
       }
     }
+
     .add-new {
-      display: inline-block;
-      width: 330px;
-      vertical-align: top;
+      @media #{$not-mobile-only} {
+        display: inline-block;
+        width: 330px;
+        vertical-align: top;
+        input[name="email"] {
+          width: 200px;
+          height: 26px;
+        }
+      }
+
+      @media #{$mobile-only} {
+        form.email {
+          display: flex;
+          flex-direction: row;
+          align-items: stretch;
+          justify-content: space-between;
+          label {
+            flex: 1;
+            display: flex;
+            flex-direction: row;
+            align-items: stretch;
+            justify-content: flex-start;
+          }
+          input[name="email"] {
+            flex: 1;
+            margin-right: 8px;
+          }
+
+          div.button-box {
+            flex: 0;
+          }
+        }
+      }
+
       .info, .hidden {
         display: none;
       }
-      input[name="email"] {
-        width: 200px;
-        height: 26px;
-      }
+
       div.button-box {
         display: inline-block;
         >button {
@@ -637,18 +736,14 @@ body>.main-content>.account {
 }
 
 div.billing {
-  padding-bottom: 64px;
-
   >section.payment-methods {
-    display: inline-block;
-    vertical-align: top;
+    display: block;
 
     h3 {
       margin: 0.5em 0;
     }
 
-    max-width: 432px;
-    padding: 0 16px;
+    max-width: 478px;
 
     >.balance {
       margin-left: 16px;
@@ -792,9 +887,8 @@ div.billing {
   }
 
   div.usage {
-    display: inline-block;
+    display: block;
     vertical-align: top;
-    margin-right: 32px;
 
     h3 {
       margin: 0.5em 0;
@@ -804,11 +898,16 @@ div.billing {
       margin: 0;
     }
 
-    max-width: 482px;
-    padding: 0 16px;
+    @media #{$not-mobile-only} {
+      max-width: 482px;
+    }
 
     span.plan-name {
       text-transform: capitalize;
+    }
+
+    table {
+      width: 100%;
     }
 
     tr:first-of-type {
@@ -856,7 +955,6 @@ div.billing {
 
     div.progress-bar {
       height: 12px;
-      width: 300px;
       background-color: white;
       border: 1px solid #b2b2b2;
       margin: 4px 0;
@@ -864,10 +962,6 @@ div.billing {
       >div {
         height: 100%;
         background-color: #65468e;
-      }
-
-      @media (max-width: 500px) {
-        width: 200px;
       }
     }
 
@@ -904,6 +998,12 @@ div.billing {
     tr.bonus {
       color: #6d6d6d;
       font-size: 90%;
+      p.bonus {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
     }
 
     h4.free-stuff-section-header {
@@ -977,13 +1077,16 @@ div.single-identity-editor {
 }
 
 div.identity-editor {
-  width: 435px;
+  @media #{$not-mobile-only} {
+    width: 435px;
+  }
+
   background-color: white;
   padding: 22px;
 
   form.account-profile-editor {
     @extend %standard-form;
-    width: 390px;
+    display: block;
 
     .inline-icon {
       width: 20px;

--- a/shell/client/styles/_focus.scss
+++ b/shell/client/styles/_focus.scss
@@ -9,7 +9,11 @@ input::-moz-focus-inner {
     padding: 0;
 }
 
-a:focus, button:focus, input:focus, select:focus, textarea:focus {
+%custom-focus-ring {
   outline: $focus-outline-color solid 1px;
   box-shadow: inset 0 1px 2px rgba(0,0,0,0.075), 0 0 5px $half-focus-outline-color;
+}
+
+a:focus, button:focus, input:focus, select:focus, textarea:focus {
+  @extend %custom-focus-ring;
 }

--- a/shell/client/styles/_geometry.scss
+++ b/shell/client/styles/_geometry.scss
@@ -10,6 +10,8 @@
 //
 // NOTE: If you change the definition of $mobile or $desktop, run: `git grep -F '$mobile'`
 // in order to find places in the Javascript code that hard-code this 900px breakpoint.
+$mobile-only: "(max-width: 600px)";
+$not-mobile-only: "(min-width: 601px)";
 $mobile: "(max-width: 900px)";
 $desktop: "(min-width: 901px)";
 


### PR DESCRIPTION
I tried to avoid significantly changing the existing design on desktop, but it
probably wouldn't hurt to make it fluid within a given set of widths rather
than strictly fixed-width.  Perhaps we can do that when we move profiles
off identities and onto accounts, which simplifies the profile editor?

Longer term, we probably want to make more things use the 600px breakpoint
rather than the current 900px one, but I don't have time to audit the entire
codebase for designs that only work at fixed widths right now.

Fixes #2122.

![screenshot1](https://cloud.githubusercontent.com/assets/307325/18150952/caa25dac-6f9f-11e6-8f15-3a27630cb485.png)

![screenshot2](https://cloud.githubusercontent.com/assets/307325/18150993/10f6b244-6fa0-11e6-8e28-9dc0129532ab.png)