### PR TITLE
Make the fiber pool size infinite(ish)!

### DIFF
--- a/shell/server/00-startup.js
+++ b/shell/server/00-startup.js
@@ -52,3 +52,35 @@ SandstormDb.periodicCleanup(24 * 60 * 60 * 1000, () => {
 });
 
 Meteor.startup(() => { migrateToLatest(globalDb, globalBackend); });
+
+// Make the fiber pool size infinite(ish)!
+//
+// Each fiber created adds an entry to `v8::Isolate::ThreadDataTable`. Unfortunatley, items are
+// never deleted from this table. So if we create and delete a lot of fibers, then we leak memory.
+// Worse yet, the table is represented as a linked list, and v8 performs a linear scan of this
+// linked list every time we switch fibers. We've seen cases where Sandstorm was spending 65% of
+// its CPU time just scanning this list! The v8 people say this is "working as intended".
+//
+// The fibers package has implemented a work-around by maintaining a fiber pool. Fibers are not
+// deleted; they are returned to the pool. Unfortunately the pool has a default size of 120. So
+// if we pass 120 simultaneous fibers, we start leaking and slowing down. It's very easy to hit
+// this number with a few dozen users present.
+//
+// Up until it hits the limit, the fibers module will grow the pool dynamically, starting with an
+// empty pool and adding each new fiber to it. Therefore, if we set the pool size to an impossibly
+// large number, we effectively get a pool size equal to the maximum number of simultaneous fibers
+// seen. This is exactly what we want! Now no fibers are ever deleted, so we never leak. A
+// Sandstorm server that sees a brief surge of traffic may end up holding on to unused RAM
+// long-term, but this is a relatively obscure problem.
+//
+// I initially tried to use the value `Infinity` here, but somehow when this made its way down into
+// the C++ code and was converted to an integer, that integer ended up being zero. So instead we
+// use 1e9 (1 billion), which ought to be enough for anyone.
+//
+// Third-party issues, for reference:
+//
+//    https://bugs.chromium.org/p/v8/issues/detail?id=5338
+//    https://bugs.chromium.org/p/v8/issues/detail?id=3777
+//    https://github.com/laverdet/node-fibers/issues/305
+import Fiber from "fibers";
+Fiber.poolSize = 1e9;


### PR DESCRIPTION
Each fiber created adds an entry to `v8::Isolate::ThreadDataTable`. Unfortunatley, items are
never deleted from this table. So if we create and delete a lot of fibers, then we leak memory.
Worse yet, the table is represented as a linked list, and v8 performs a linear scan of this
linked list every time we switch fibers. We've seen cases where Sandstorm was spending 65% of
its CPU time just scanning this list! The v8 people say this is "working as intended".

The fibers package has implemented a work-around by maintaining a fiber pool. Fibers are not
deleted; they are returned to the pool. Unfortunately the pool has a default size of 120. So
if we pass 120 simultaneous fibers, we start leaking and slowing down. It's very easy to hit
this number with a few dozen users present.

Up until it hits the limit, the fibers module will grow the pool dynamically, starting with an
empty pool and adding each new fiber to it. Therefore, if we set the pool size to an impossibly
large number, we effectively get a pool size equal to the maximum number of simultaneous fibers
seen. This is exactly what we want! Now no fibers are ever deleted, so we never leak. A
Sandstorm server that sees a brief surge of traffic may end up holding on to unused RAM
long-term, but this is a relatively obscure problem.

Third-party issues, for reference:

  https://bugs.chromium.org/p/v8/issues/detail?id=5338
  https://bugs.chromium.org/p/v8/issues/detail?id=3777
  https://github.com/laverdet/node-fibers/issues/305

Screenshots of perf showing 65% CPU time spent scanning a linked list, for posterity:

![screenshot from 2016-08-31 19-23-41](https://cloud.githubusercontent.com/assets/4001805/18154242/d02a058c-6fb7-11e6-80f3-77be8b844dfa.png)
![screenshot from 2016-08-31 19-24-22](https://cloud.githubusercontent.com/assets/4001805/18154241/d0282262-6fb7-11e6-8504-e6e7df90d884.png)
![screenshot from 2016-08-31 19-23-11](https://cloud.githubusercontent.com/assets/4001805/18154250/e8af1a8e-6fb7-11e6-9cb9-5a90bf53a1be.png)
