### PR TITLE
Make `db.userGrains()` and `db.currentUserGrains()` more flexible.

### DIFF
--- a/shell/client/apps/app-details-client.js
+++ b/shell/client/apps/app-details-client.js
@@ -40,7 +40,7 @@ const compileMatchFilter = function (searchString) {
 };
 
 const appGrains = function (db, appId, trashed) {
-  return _.filter(db.currentUserGrains({ trashed: { $exists: trashed } }).fetch(),
+  return _.filter(db.currentUserGrains({ includeTrashOnly: trashed }).fetch(),
                   function (grain) {return grain.appId === appId; });
 };
 

--- a/shell/client/apps/app-details-client.js
+++ b/shell/client/apps/app-details-client.js
@@ -40,7 +40,7 @@ const compileMatchFilter = function (searchString) {
 };
 
 const appGrains = function (db, appId, trashed) {
-  return _.filter(db.currentUserGrains(trashed).fetch(),
+  return _.filter(db.currentUserGrains({ trashed: { $exists: trashed } }).fetch(),
                   function (grain) {return grain.appId === appId; });
 };
 

--- a/shell/client/apps/applist-client.js
+++ b/shell/client/apps/applist-client.js
@@ -126,7 +126,7 @@ Template.sandstormAppListPage.helpers({
     // Count the number of grains owned by this user created by each app.
     const actions = ref._db.currentUserActions().fetch();
     const appIds = _.pluck(actions, "appId");
-    const grains = ref._db.currentUserGrains().fetch();
+    const grains = ref._db.currentUserGrains({ trashed: { $exists: false }, }).fetch();
     const appCounts = _.countBy(grains, function (x) { return x.appId; });
     // Sort apps by the number of grains created, descending.
     const apps = matchApps(ref._filter.get());

--- a/shell/client/apps/applist-client.js
+++ b/shell/client/apps/applist-client.js
@@ -126,7 +126,7 @@ Template.sandstormAppListPage.helpers({
     // Count the number of grains owned by this user created by each app.
     const actions = ref._db.currentUserActions().fetch();
     const appIds = _.pluck(actions, "appId");
-    const grains = ref._db.currentUserGrains({ trashed: { $exists: false }, }).fetch();
+    const grains = ref._db.currentUserGrains().fetch();
     const appCounts = _.countBy(grains, function (x) { return x.appId; });
     // Sort apps by the number of grains created, descending.
     const apps = matchApps(ref._filter.get());
@@ -245,7 +245,7 @@ Template.sandstormAppListPage.onRendered(() => {
     // about how "Share access" works.
     //
     // Persist between reloads via localStorage.
-    const grainsCount = db.currentUserGrains().count();
+    const grainsCount = db.currentUserGrains({ includeTrash: true }).count();
     if (grainsCount === 0) {
       Meteor._localStorage.setItem("userNeedsShareAccessHint", true);
     }

--- a/shell/client/grain/grainlist-client.js
+++ b/shell/client/grain/grainlist-client.js
@@ -169,7 +169,7 @@ const sortGrains = function (grains, sortRules) {
 const filteredGrains = function (showTrash) {
   const ref = Template.instance().data;
   const db = ref._db;
-  const grains = db.currentUserGrains(showTrash).fetch();
+  const grains = db.currentUserGrains({ trashed: { $exists: showTrash } }).fetch();
   const grainIdSet = {};
   grains.map((g) => grainIdSet[g._id] = true);
 
@@ -274,8 +274,7 @@ Template.sandstormGrainListPage.helpers({
   },
 
   myGrainsCount: function () {
-    return Template.instance().data._db.currentUserGrains(false).count() +
-           Template.instance().data._db.currentUserGrains(true).count();
+    return Template.instance().data._db.currentUserGrains().count();
   },
 
   trashCount: function () {
@@ -703,8 +702,7 @@ Template.sandstormGrainTable.onRendered(function () {
   // We could abort this function if (! globalSubs['grainsMenu'].ready()). However, at the moment,
   // we already waitOn the globalSubs, so that would be a no-op.
 
-  const hasGrains = !!(_db.currentUserGrains().count() ||
-                      _db.currentUserApiTokens().count());
+  const hasGrains = !!(_db.currentUserGrains().count() || _db.currentUserApiTokens().count());
   if (!hasGrains) {
     const intro = Template.instance().intro = introJs();
     intro.setOptions({

--- a/shell/client/grain/grainlist-client.js
+++ b/shell/client/grain/grainlist-client.js
@@ -169,7 +169,7 @@ const sortGrains = function (grains, sortRules) {
 const filteredGrains = function (showTrash) {
   const ref = Template.instance().data;
   const db = ref._db;
-  const grains = db.currentUserGrains({ trashed: { $exists: showTrash } }).fetch();
+  const grains = db.currentUserGrains({ includeTrashOnly: showTrash }).fetch();
   const grainIdSet = {};
   grains.map((g) => grainIdSet[g._id] = true);
 
@@ -274,7 +274,7 @@ Template.sandstormGrainListPage.helpers({
   },
 
   myGrainsCount: function () {
-    return Template.instance().data._db.currentUserGrains().count();
+    return Template.instance().data._db.currentUserGrains({ includeTrash: true }).count();
   },
 
   trashCount: function () {
@@ -702,7 +702,8 @@ Template.sandstormGrainTable.onRendered(function () {
   // We could abort this function if (! globalSubs['grainsMenu'].ready()). However, at the moment,
   // we already waitOn the globalSubs, so that would be a no-op.
 
-  const hasGrains = !!(_db.currentUserGrains().count() || _db.currentUserApiTokens().count());
+  const hasGrains = !!(_db.currentUserGrains({ includeTrash: true }).count() ||
+                       _db.currentUserApiTokens().count());
   if (!hasGrains) {
     const intro = Template.instance().intro = introJs();
     intro.setOptions({

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1179,15 +1179,14 @@ _.extend(SandstormDb.prototype, {
     return SandstormDb.getUserIdentityIds(user).indexOf(identityId) != -1;
   },
 
-  userGrains: function userGrains(userId, trashed) {
+  userGrains: function userGrains(userId, queryExtension) {
     check(userId, Match.OneOf(String, undefined, null));
-    check(trashed, Match.OneOf(Boolean, undefined, null));
-
-    return this.collections.grains.find({ userId: userId, trashed: { $exists: !!trashed, }, });
+    check(queryExtension, Match.OneOf(undefined, null, { trashed: { $exists: Boolean }, }));
+    return this.collections.grains.find(_.extend({ userId: userId }, queryExtension));
   },
 
-  currentUserGrains: function currentUserGrains(trashed) {
-    return this.userGrains(Meteor.userId(), trashed);
+  currentUserGrains: function currentUserGrains(queryExtension) {
+    return this.userGrains(Meteor.userId(), queryExtension);
   },
 
   getGrain: function getGrain(grainId) {

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -211,7 +211,8 @@ function registerUiViewQueryHandler(frontendRefRegistry) {
       // TODO(someday): Allow `value` to specify app IDs to filter for.
 
       const sharedGrainIds = db.userApiTokens(userId).map(token => token.grainId);
-      const ownedGrainIds = db.userGrains(userId).map(grain => grain._id);
+      const ownedGrainIds = db.userGrains(userId, { trashed: { $exists: false }, })
+          .map(grain => grain._id);
 
       return _.uniq(sharedGrainIds.concat(ownedGrainIds)).map(grainId => {
         return new PowerboxOption({

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -211,8 +211,7 @@ function registerUiViewQueryHandler(frontendRefRegistry) {
       // TODO(someday): Allow `value` to specify app IDs to filter for.
 
       const sharedGrainIds = db.userApiTokens(userId).map(token => token.grainId);
-      const ownedGrainIds = db.userGrains(userId, { trashed: { $exists: false }, })
-          .map(grain => grain._id);
+      const ownedGrainIds = db.userGrains(userId).map(grain => grain._id);
 
       return _.uniq(sharedGrainIds.concat(ownedGrainIds)).map(grainId => {
         return new PowerboxOption({


### PR DESCRIPTION
We've noticed that the observer [here](https://github.com/sandstorm-io/sandstorm/blob/990debe376cf545931853664834e880c5e665aeb/shell/packages/sandstorm-db/db.js#L2662-L2677) can spawn a large number of fibers when a user moves a bunch of grains into their trash. It seems that the problem has to do with the observed cursor's query, which includes `{ trashed: { $exists: false } }`. In addition to to the performance problem, there is a bug. We actually want the query to simply be `Grains.find({userId: this.userId})`.

This patch makes it easier to ask for what you want in `db.userGrains()` and `db.currentUserGrains()`. In particular, if you want *all* of the grains, including the trashed ones, you don't provide any additional arguments. So this fixes the problem case described above. It also clarifies other uses of the function.