### PR TITLE
Add button to feature key page linking to key vendor.

### DIFF
--- a/docs/administering/for-work.md
+++ b/docs/administering/for-work.md
@@ -4,7 +4,7 @@ Sandstorm server running at their own organization. Special pricing, sometimes i
 feature keys, are available to [non-profits and community groups](#special-pricing). For pricing,
 please read the information on the [main website](https://sandstorm.io/business).
 
-For now, feature keys are typically 90-day trial keys. This gives you time to evaluate Sandstorm for
+For now, feature keys are typically 60-day trial keys. This gives you time to evaluate Sandstorm for
 Work, and it gives us time to finish testing the payments system.
 
 ## Sandstorm for Work in depth

--- a/shell/client/admin/feature-key-client.js
+++ b/shell/client/admin/feature-key-client.js
@@ -149,6 +149,19 @@ Template.adminFeatureKeyModifyForm.helpers({
       instance.showForm.set(undefined);
     };
   },
+
+  keySecret() {
+    function hexString(bytes) {
+      const DIGITS = "0123456789abcdef";
+
+      // Watch out: Uint8Array.map() constructs a new Uint8Arary.
+      return Array.prototype.map
+          .call(bytes, byte => DIGITS[Math.floor(byte / 16)] + DIGITS[byte % 16])
+          .join("");
+    }
+
+    return hexString(globalDb.currentFeatureKey().secret);
+  },
 });
 
 Template.adminFeatureKeyModifyForm.events({

--- a/shell/client/admin/feature-key-client.js
+++ b/shell/client/admin/feature-key-client.js
@@ -165,9 +165,7 @@ Template.adminFeatureKeyModifyForm.helpers({
 });
 
 Template.adminFeatureKeyModifyForm.events({
-  "submit .feature-key-modify-form"(evt) {
-    evt.preventDefault();
-    evt.stopPropagation();
+  "click button.feature-key-upload-button"(evt) {
     Template.instance().showForm.set("update");
   },
 

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -48,13 +48,13 @@
         </ul>
 
         <p>
-          Sandstorm for Work is priced at $15/user/month.
+          Sandstorm for Work is priced at $10/user/month.
           Start a 60-day free trial, no credit card required:
         </p>
 
         <form class="get-feature-key-form">
           <a class="button-primary" href="https://sandstorm.io/get-feature-key">
-            Get your Sandstorm for Work trial key
+            Get Sandstorm for Work
           </a>
         </form>
       </div>

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -128,9 +128,9 @@
   {{/if}}
   <form class="feature-key-modify-form">
     <div class="button-row">
-      <button type="submit" class="feature-key-upload-button">Upload new feature key...</button>
+      <a class="button primary" target="_blank" href="https://sandstorm.io/get-feature-key#key/{{keySecret}}">Manage billing</a>
+      <button type="button" class="feature-key-upload-button">Replace feature key</button>
       <button type="button" class="feature-key-delete-button">Delete feature key</button>
-      <a class="button" target="_blank" href="https://sandstorm.io/get-feature-key#key/{{keySecret}}">Update billing</a>
     </div>
   </form>
 </template>

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -49,7 +49,7 @@
 
         <p>
           Sandstorm for Work is priced at $15/user/month.
-          Start a 90-day free trial, no credit card required:
+          Start a 60-day free trial, no credit card required:
         </p>
 
         <form class="get-feature-key-form">

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -130,6 +130,7 @@
     <div class="button-row">
       <button type="submit" class="feature-key-upload-button">Upload new feature key...</button>
       <button type="button" class="feature-key-delete-button">Delete feature key</button>
+      <a class="button" target="_blank" href="https://sandstorm.io/get-feature-key#key/{{keySecret}}">Update billing</a>
     </div>
   </form>
 </template>

--- a/shell/client/styles/_partials.scss
+++ b/shell/client/styles/_partials.scss
@@ -203,6 +203,18 @@
     }
   }
 
+  a.button {
+    @extend %button-base;
+    @extend %button-secondary;
+    &.primary {
+      @extend %button-primary;
+    }
+    &.danger {
+      @extend %button-danger;
+    }
+    font-weight: inherit;
+  }
+
   &.disabled {
     // Used for marking that the entire form is disabled.  Note that this does not disable the
     // <input>s; you should still add the disabled attribute to each control.

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -41,6 +41,7 @@ const publicAdminSettings = [
 
 const FEATURE_KEY_FIELDS_PUBLISHED_TO_ADMINS = [
   "customer", "expires", "features", "isElasticBilling", "isTrial", "issued", "userLimit",
+  "secret",
 ];
 
 const PUBLIC_FEATURE_KEY_FIELDS = [


### PR DESCRIPTION
Any admin will be able to click on the button and arrive at the key's info in the feature key vendor, where they can do things like convert a trial key to permanent, specify payment source, purchase more users, change contact info, etc.

Currently the button looks like this:

![screenshot from 2016-09-01 16-56-04](https://cloud.githubusercontent.com/assets/4001805/18188205/08f99d20-7065-11e6-90d4-0d3f72ad1205.png)

@neynah, @zarvox: Any opinions on the button style and label? Maybe this should be promoted to the primary button, or otherwise colored differently?