### PR TITLE
Build and ship a patched node in the Sandstorm bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ IMAGES= \
 # Meta rules
 
 .SUFFIXES:
-.PHONY: all install clean continuous shell-env fast deps bootstrap-ekam deps update-deps clobber-deps test installer-test app-index-dev
+.PHONY: all install clean continuous shell-env fast deps bootstrap-ekam update-deps clobber-deps test installer-test app-index-dev
 
 all: sandstorm-$(BUILD).tar.xz
 
@@ -164,10 +164,11 @@ REMOTE_ekam=https://github.com/sandstorm-io/ekam.git
 REMOTE_libseccomp=https://github.com/seccomp/libseccomp
 REMOTE_libsodium=https://github.com/jedisct1/libsodium.git
 REMOTE_node-capnp=https://github.com/kentonv/node-capnp.git
+REMOTE_node=https://github.com/sandstorm-io/node
 
 deps: tmp/.deps
 
-tmp/.deps: deps/capnproto deps/ekam deps/libseccomp deps/libsodium deps/node-capnp
+tmp/.deps: deps/capnproto deps/ekam deps/libseccomp deps/libsodium deps/node-capnp deps/node
 	@mkdir -p tmp
 	@touch tmp/.deps
 
@@ -198,9 +199,16 @@ deps/node-capnp:
 	@mkdir -p deps
 	git clone $(REMOTE_node-capnp) deps/node-capnp
 
+deps/node:
+	@$(call color,downloading node)
+	@mkdir -p deps
+	git clone $(REMOTE_node) deps/node
+	@echo "checking out std-unordered-map-for-thread-data branch..."
+	@cd deps/node && git checkout std-unordered-map-for-thread-data && cd ../..
+
 update-deps:
 	@$(call color,updating all dependencies)
-	@$(foreach DEP,capnproto ekam libseccomp libsodium node-capnp, \
+	@$(foreach DEP,capnproto ekam libseccomp libsodium node-capnp node, \
 	    cd deps/$(DEP) && \
 	    echo "pulling $(DEP)..." && \
 	    git pull $(REMOTE_$(DEP)) `git symbolic-ref --short HEAD` && \
@@ -222,6 +230,11 @@ clobber-deps:
 	@cd deps/libsodium && \
 	    echo "fetching libsodium..." && \
 	    git fetch $(REMOTE_libsodium) stable && \
+	    git reset --hard FETCH_HEAD && \
+	    cd ../../
+	@cd deps/node && \
+	    echo "fetching node..." && \
+	    git fetch $(REMOTE_node) std-unordered-map-for-thread-data && \
 	    git reset --hard FETCH_HEAD && \
 	    cd ../../
 

--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -85,12 +85,23 @@ METEOR_DEV_BUNDLE=$(./find-meteor-dev-bundle.sh)
 # Build patched nodejs from source.  Our patches significantly improve performance in the
 # presence of many fibers.  See https://github.com/sandstorm-io/sandstorm/pull/2484 and
 # https://github.com/sandstorm-io/node/tree/std-unordered-map-for-thread-data
-echo "Building node"
-pushd deps/node
+#
+# We build node out of tree because Jenkins wants to run builds in folders with spaces, and GNU make
+# makes dealing with spaces in implicit rules exceedingly difficult.  So we build in a fixed path in
+# /var/tmp.  If we were to vary the path, we would lose the ability to cache the build artifacts,
+# which is also rather undesirable.
+NODE_BUILD_ROOT=/var/tmp/sandstorm-node-build-dir
+echo "Building node out-of-tree"
+rm -rf "$NODE_BUILD_ROOT"
+mkdir -p "$NODE_BUILD_ROOT"
+cp -a deps/node "$NODE_BUILD_ROOT"
+pushd "$NODE_BUILD_ROOT/node"
 # The rebuild here is fast if nothing has changed.
 ./configure --partly-static
 make -j$(nproc)
 popd
+rm -rf deps/node/out
+mv "$NODE_BUILD_ROOT/node/out" deps/node/
 
 # Start with the meteor bundle.
 cp -r shell-build/bundle bundle

--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -82,6 +82,16 @@ done
 
 METEOR_DEV_BUNDLE=$(./find-meteor-dev-bundle.sh)
 
+# Build patched nodejs from source.  Our patches significantly improve performance in the
+# presence of many fibers.  See https://github.com/sandstorm-io/sandstorm/pull/2484 and
+# https://github.com/sandstorm-io/node/tree/std-unordered-map-for-thread-data
+echo "Building node"
+pushd deps/node
+# The rebuild here is fast if nothing has changed.
+./configure --partly-static
+make -j$(nproc)
+popd
+
 # Start with the meteor bundle.
 cp -r shell-build/bundle bundle
 rm -f bundle/README
@@ -90,17 +100,16 @@ cp meteor-bundle-main.js bundle/sandstorm-main.js
 # Meteor wants us to do `npm install` in the bundle to prepare it.
 # The fibers package builds native extensions, choosing the target v8 version based on
 # the version of `/usr/bin/env node`. We need to make it does not pick up the wrong binary,
-# so we prepend `METEOR_DEV_BUNDLE/bin` to `PATH`.
-# Additional native extensions require node-pre-gyp, which lives in the .bin folder of the
-# dev bundle's node_modules.
+# so we place our custom node first on `PATH`.  Additional native extensions require node-pre-gyp,
+# which lives in the .bin folder of the dev bundle's node_modules.
 (cd bundle/programs/server && \
- PATH=$METEOR_DEV_BUNDLE/lib/node_modules/.bin:$METEOR_DEV_BUNDLE/bin:$PATH "$METEOR_DEV_BUNDLE/bin/npm" install)
+ PATH=$PWD/deps/node/out/Release:$METEOR_DEV_BUNDLE/lib/node_modules/.bin:$METEOR_DEV_BUNDLE/bin:$PATH "$METEOR_DEV_BUNDLE/bin/npm" install)
 
 # Copy over key binaries.
 mkdir -p bundle/bin
 cp bin/sandstorm-http-bridge bundle/bin/sandstorm-http-bridge
 cp bin/sandstorm bundle/sandstorm
-cp $METEOR_DEV_BUNDLE/bin/node bundle/bin
+cp deps/node/out/Release/node bundle/bin
 
 # We used to pull mongodb out of the meteor dev bundle, but we need to figure out how to safely
 # upgrade some databases created with very old mongo versions, so we're shipping mongo 2.6 for


### PR DESCRIPTION
v8's performance in the face of many fibers is currently quite poor because
they use a linked list for all thread control block lookups.  We've observed
frontends on Oasis sitting with 65% CPU usage just navigating that linked
list.  See #2484 for screenshots.

Switching to a real data structure (a hash map) improves this situation
drastically.  @jparyani's test app [1] spends 46% of CPU time in
Isolate::FindOrAllocatePerThreadDataForThisThread when run with the default
meteor-bundled node.  That function doesn't even register in the perf report
when run against a node compiled with the hashmap patch.

I'm not thrilled about building node and carrying this patch, so if we can get
a proper fix upstream, that would be preferable.

[1] - https://github.com/jparyani/meteor-fiber-repro

Profiles from the test app:

Bad:
![perf-bad](https://cloud.githubusercontent.com/assets/307325/18220189/82be227e-7124-11e6-9ea7-cc4cee88d4c4.png)

Good:
![perf-good](https://cloud.githubusercontent.com/assets/307325/18220195/8731e606-7124-11e6-95a6-75efffd6b9c4.png)
