### PR TITLE
Email all admins when an admin deletes an account, including the one who did it.

### DIFF
--- a/shell/server/account-suspension.js
+++ b/shell/server/account-suspension.js
@@ -57,10 +57,6 @@ If you did not request this deletion, please contact the server administrator im
   }
 
   Meteor.users.find({ isAdmin: true }).forEach((user) => {
-    if (user._id === byAdminUserId) {
-      return; // Skip the admin who initiated the deletion.
-    }
-
     const email = _.findWhere(SandstormDb.getUserEmails(user), { primary: true });
     if (!email) {
       console.error("No email found for admin with userId:", user._id);


### PR DESCRIPTION
The idea here is that deleting accounts is one of the few really dangerous things an admin can do, so if an admin account is hijacked and the hijacker starts deleting accounts, the admin should be notified.