### PR TITLE
Make sections of 'Billing' appear side-by-side again, when space permits.

### DIFF
--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -734,7 +734,8 @@ body>.main-content>.account {
 
 div.billing {
   >section.payment-methods {
-    display: block;
+    display: inline-block;
+    vertical-align: top;
 
     h3 {
       margin: 0.5em 0;
@@ -884,8 +885,12 @@ div.billing {
   }
 
   div.usage {
-    display: block;
+    display: inline-block;
     vertical-align: top;
+
+    @media #{$not-mobile-only} {
+      margin-right: 32px;
+    }
 
     h3 {
       margin: 0.5em 0;


### PR DESCRIPTION
@zarvox I'm assuming this change was a mistake but if it's intentional let's discuss next week. Changing this back doesn't appear to affect the new mobile style.