### PR TITLE
Make sure to send a well-formed options object to currentUserGrains().

### DIFF
--- a/shell/client/apps/app-details-client.js
+++ b/shell/client/apps/app-details-client.js
@@ -40,7 +40,7 @@ const compileMatchFilter = function (searchString) {
 };
 
 const appGrains = function (db, appId, trashed) {
-  return _.filter(db.currentUserGrains({ includeTrashOnly: trashed }).fetch(),
+  return _.filter(db.currentUserGrains({ includeTrashOnly: !!trashed }).fetch(),
                   function (grain) {return grain.appId === appId; });
 };
 

--- a/shell/client/grain/grainlist-client.js
+++ b/shell/client/grain/grainlist-client.js
@@ -169,7 +169,7 @@ const sortGrains = function (grains, sortRules) {
 const filteredGrains = function (showTrash) {
   const ref = Template.instance().data;
   const db = ref._db;
-  const grains = db.currentUserGrains({ includeTrashOnly: showTrash }).fetch();
+  const grains = db.currentUserGrains({ includeTrashOnly: !!showTrash }).fetch();
   const grainIdSet = {};
   grains.map((g) => grainIdSet[g._id] = true);
 


### PR DESCRIPTION
Since #2489, if you upload an spk upgrade to one of your apps and then you visit the app details page, the javascript console shows:

```
Exception in template helper: Error: Match error: Failed Match.OneOf, Match.Maybe or Match.Optional validation
    at exports.check (http://sandstorm-radon.dwrensha.ws:6080/packages/check.js?hash=bf95dee84c2be9008274d2385c637659760b9057:67:15)
    at SandstormDb.userGrains (http://sandstorm-radon.dwrensha.ws:6080/packages/sandstorm-db.js?hash=48eb3dbed6e1c8a3a60977905c2450e43f34e280:1271:7)
    at SandstormDb.currentUserGrains (http://sandstorm-radon.dwrensha.ws:6080/packages/sandstorm-db.js?hash=48eb3dbed6e1c8a3a60977905c2450e43f34e280:1290:19)
    at appGrains (http://sandstorm-radon.dwrensha.ws:6080/app/app.js?hash=034f1a98e827442e998904d5a63a2826dae0f18f:13195:22)
    at Object.hasNewerVersion (http://sandstorm-radon.dwrensha.ws:6080/app/app.js?hash=034f1a98e827442e998904d5a63a2826dae0f18f:13661:20)
    at http://sandstorm-radon.dwrensha.ws:6080/packages/blaze.js?hash=ef41aed769a8945fc99ac4954e8c9ec157a88cea:2994:16
    at http://sandstorm-radon.dwrensha.ws:6080/packages/blaze.js?hash=ef41aed769a8945fc99ac4954e8c9ec157a88cea:1653:16
    at http://sandstorm-radon.dwrensha.ws:6080/packages/blaze.js?hash=ef41aed769a8945fc99ac4954e8c9ec157a88cea:3046:66
    at Function.Template._withTemplateInstanceFunc (http://sandstorm-radon.dwrensha.ws:6080/packages/blaze.js?hash=ef41aed769a8945fc99ac4954e8c9ec157a88cea:3687:12)
    at http://sandstorm-radon.dwrensha.ws:6080/packages/blaze.js?hash=ef41aed769a8945fc99ac4954e8c9ec157a88cea:3045:27
```

And you don't see the prompt which should say "Some of your grains were made with an older version of this app. Upgrade them?"

This patch fixes the problem.