### PR TITLE
Minor bugfix for 'select all grains' checkbox.

### DIFF
--- a/shell/client/grain/grainlist-client.js
+++ b/shell/client/grain/grainlist-client.js
@@ -497,19 +497,9 @@ Template.sandstormGrainTable.onCreated(function () {
       if (this._selectedSharedWithMeIds.get(grain._id)) {
         sharedResult += 1;
       }
-
-      this._numMineSelectedShown.set(mineResult);
-      this._numSharedWithMeSelectedShown.set(sharedResult);
-
-      if (this.view.isRendered) {
-        let el = this.find(".select-all-grains>input");
-        if (mineResult == 0 && sharedResult == 0) {
-          el.checked = false;
-        } else {
-          el.checked = true;
-        }
-      }
     });
+    this._numMineSelectedShown.set(mineResult);
+    this._numSharedWithMeSelectedShown.set(sharedResult);
   });
 });
 
@@ -530,6 +520,12 @@ Template.sandstormGrainTable.helpers({
     } else {
       return "unselect all";
     }
+  },
+
+  selectAllChecked: function () {
+    const instance = Template.instance();
+    return instance._numMineSelectedShown.get() > 0 ||
+        instance._numSharedWithMeSelectedShown.get() > 0;
   },
 
   isChecked: function () {
@@ -619,6 +615,7 @@ Template.sandstormGrainTable.events({
   },
 
   "click .select-all-grains>input": function (event, instance) {
+    event.preventDefault();
     if (instance._numMineSelectedShown.get() == 0 &&
         instance._numSharedWithMeSelectedShown.get() == 0) {
       // select all

--- a/shell/client/grain/grainlist.html
+++ b/shell/client/grain/grainlist.html
@@ -129,7 +129,7 @@
         {{#if showTableHeaders}}
         <tr>
             <td class="select-all-grains">
-              <input title={{selectAllTitle}} type="checkbox">
+              <input title={{selectAllTitle}} type="checkbox" checked={{selectAllChecked}}>
             </td>
             <td class="td-app-icon"></td>
             <td class="grain-name">


### PR DESCRIPTION
Currently, if you have no grains in your trash, if you visit your trash and then click "View main list", your browser console will show an exception:

```
typeError: Cannot set property 'checked' of null
```

and the "select grain" check boxes will be broken until you reload the page.

This patch fixes the problem by simplifying the logic that updates the state of the "select all" checkbox. 