### PR TITLE
Assert that tokens returned from client powerbox requests are URL-safe.

### DIFF
--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -1510,6 +1510,12 @@ SandstormPermissions.createNewApiToken = function (db, provider, grainId, petnam
   }
 
   const token = Random.secret();
+  if (encodeURIComponent(token) !== token) {
+    // Sandstorm guarantees that tokens with a `clientPowerboxRequest` owner are URL-safe.
+    // `Random.secret()` only uses base64url characters, so we should never get here.
+    throw new Meteor.Error(500, "Random.secret() returned a non-URL safe token: " + token);
+  }
+
   const apiToken = {
     _id: Crypto.createHash("sha256").update(token).digest("base64"),
     grainId: grainId,

--- a/src/sandstorm/grain.capnp
+++ b/src/sandstorm/grain.capnp
@@ -412,7 +412,9 @@ interface SessionContext {
   # callback to the grain will occur. You can listen for such a message like so:
   # window.addEventListener("message", function (event) {
   #   if (event.data.rpcId === myRpcId && !event.data.error) {
-  #     // pass event.data.token to your app's server and call SessionContext.claimRequest() with it
+  #     // Pass `event.data.token` to your app's server and call SessionContext.claimRequest() with
+  #     // it. The token is guaranteed to be a URL-safe string. That is, passing it through
+  #     // encodeURIComponent() should be a no-op.
   #   }
   # }, false)
 


### PR DESCRIPTION
For apps that use the client powerbox request flow, a common way to get a token to the server is to make a POST to a path like `/token/<TOKEN>`. This works currently because the token can only contain alphanumeric characters plus '-' and '_'. Let's promise to our app developers that it will continue to work in the future.