### PR TITLE
Accounts page: wait for subscriptions

### DIFF
--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -909,6 +909,10 @@ Router.map(function () {
   this.route("account", {
     path: "/account",
 
+    waitOn() {
+      return globalSubs;
+    },
+
     data: function () {
       // Don't allow logged-out or demo users to visit the accounts page. There should be no way
       // for them to get there except for typing the URL manually. In theory showing the accounts


### PR DESCRIPTION
Without this, you get some nasty flashes of partial content on the page if you refresh `/account`