### PR TITLE
Remove `/account/usage` route

### DIFF
--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -921,8 +921,4 @@ Router.map(function () {
       }
     },
   });
-
-  this.route("accountUsage", {
-    path: "/account/usage",
-  });
 });

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -236,11 +236,6 @@ limitations under the License.
   </div>
 </template>
 
-<template name="accountUsage">
-  {{> billingUsage db=globalDb}}
-  {{> billingSettings db=globalDb}}
-</template>
-
 <template name="signup">
   {{>title "Claim Invite"}}
 


### PR DESCRIPTION
It doesn't render correctly (too dependent on DOM hierarchy) and appears to be
completely unused to boot.  (If you think it is used somewhere and we should resurrect it, please close this PR.)