### PR TITLE
Fix the size of the close button in recent Chrome releases

### DIFF
--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -727,6 +727,7 @@ body>.topbar {
         }
         .close-button {
           @include unstyled-button();
+          @extend %pseudo-img-tag;
           position: absolute;
           top: 1px;
           right: 0px;
@@ -735,7 +736,7 @@ body>.topbar {
           margin: 2px;
           display: block;
           background-image: url("/close.svg");
-          border: 1px transparent;
+          border: 1px solid transparent;
           border-radius: 4px;
           &:hover {
             border: 1px solid $topbar-foreground-color-hover;


### PR DESCRIPTION
For some reason, a "1px transparent" border doesn't seem to be treated
the same as a "1px solid transparent" border.  Also, we should be specifying
`background-size` and `background-repeat`.

Observed behavior before this patch:
![tiny-x](https://cloud.githubusercontent.com/assets/307325/18337510/3d815e58-7546-11e6-9a56-e579f7f8f487.png)

But things were fine on hover:
![normal-size-x-on-hover](https://cloud.githubusercontent.com/assets/307325/18337528/6429c19e-7546-11e6-8cad-dc20d6900117.png)