### PR TITLE
Implement feature key auto-renewal

### DIFF
--- a/shell/client/admin/feature-key-client.js
+++ b/shell/client/admin/feature-key-client.js
@@ -127,6 +127,7 @@ Template.featureKeyUploadForm.helpers({
 
 Template.adminFeatureKeyModifyForm.onCreated(function () {
   this.showForm = new ReactiveVar(undefined);
+  this.renewInFlight = new ReactiveVar(false);
 });
 
 Template.adminFeatureKeyModifyForm.helpers({
@@ -166,6 +167,10 @@ Template.adminFeatureKeyModifyForm.helpers({
   renewalProblem() {
     return globalDb.currentFeatureKey().renewalProblem;
   },
+
+  renewInFlight() {
+    return Template.instance().renewInFlight.get();
+  },
 });
 
 Template.adminFeatureKeyModifyForm.events({
@@ -175,6 +180,21 @@ Template.adminFeatureKeyModifyForm.events({
 
   "click button.feature-key-delete-button"(evt) {
     Template.instance().showForm.set("delete");
+  },
+
+  "click .feature-key-renewal-problem button.retry"(evt) {
+    const instance = Template.instance();
+    const state = Iron.controller().state;
+    const token = state.get("token");
+    const renewInFlight = instance.renewInFlight;
+    renewInFlight.set(true);
+    Meteor.call("renewFeatureKey", token, (err) => {
+      renewInFlight.set(false);
+      if (err) {
+        // Note: Renewal failures aren't reported this way. If we get here there was a bug.
+        console.error(err);
+      }
+    });
   },
 });
 

--- a/shell/client/admin/feature-key-client.js
+++ b/shell/client/admin/feature-key-client.js
@@ -162,6 +162,10 @@ Template.adminFeatureKeyModifyForm.helpers({
 
     return hexString(globalDb.currentFeatureKey().secret);
   },
+
+  renewalProblem() {
+    return globalDb.currentFeatureKey().renewalProblem;
+  },
 });
 
 Template.adminFeatureKeyModifyForm.events({

--- a/shell/client/admin/feature-key-client.js
+++ b/shell/client/admin/feature-key-client.js
@@ -193,6 +193,7 @@ Template.adminFeatureKeyModifyForm.events({
       if (err) {
         // Note: Renewal failures aren't reported this way. If we get here there was a bug.
         console.error(err);
+        alert(err.message);
       }
     });
   },

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -126,6 +126,50 @@
       {{> featureKeyDeleteForm cancelCb=hideFormCb successCb=hideFormCb token=token }}
     {{/modalDialogWithBackdrop}}
   {{/if}}
+
+  {{#with renewalProblem}}
+    <div class="feature-key-renewal-problem">
+      {{#if noPaymentSource}}
+        Your feature key cannot be renewed because you have not provided a payment source.
+        Please <a class="button primary" target="_blank"
+           href="https://sandstorm.io/get-feature-key#key/{{keySecret}}">update your billing
+           settings &raquo;</a>
+      {{/if}}
+      {{#if paymentFailed}}
+        Your feature key cannot be renewed because there is a problem with your payment source:
+        {{paymentFailed}}<br>
+        Please <a class="button primary" target="_blank"
+        href="https://sandstorm.io/get-feature-key#key/{{keySecret}}">update your billing
+        settings &raquo;</a>
+      {{/if}}
+      {{#if noSuchKey}}
+        There is no record of your feature key in Sandstorm's database. If you believe this is an
+        error, contact <a target="_blank"
+        href="mailto:priority-support@sandstorm.io">priority-support@sandstorm.io</a>.
+        Otherwise, please <a target="_blank" href="https://sandstorm.io/get-feature-key">purchase
+        a new key &raquo;</a>
+      {{/if}}
+      {{#if revoked}}
+        Your feature key has been revoked. This can happen if your key is used on multiple servers
+        or if you have otherwise violated the Terms of Service. If you believe this is in error,
+        please contact <a target="_blank"
+        href="mailto:priority-support@sandstorm.io">priority-support@sandstorm.io</a>.
+      {{/if}}
+      {{#if unknownResponse}}
+        Your feature key could not be renewed because the renewal service returned an unrecognized
+        response. This is a bug in Sandstorm. Please report it to <a target="_blank"
+        href="mailto:priority-support@sandstorm.io">priority-support@sandstorm.io</a>.
+        Response text: <code>{{unknownResponse}}</code>
+      {{/if}}
+      {{#if exception}}
+        Sandstorm was unable to contact the renewal service. If your Sandstorm server is not
+        connected to the internet, you will need to <a class="button primary" target="_blank"
+        href="https://sandstorm.io/get-feature-key#key/{{keySecret}}">renew manually</a>
+        and then upload your new key. The error was: <code>{{exception}}</code>
+      {{/if}}
+    </div>
+  {{/with}}
+
   <form class="feature-key-modify-form">
     <div class="button-row">
       <a class="button primary" target="_blank" href="https://sandstorm.io/get-feature-key#key/{{keySecret}}">Manage billing</a>

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -89,12 +89,12 @@
         <span class="feature-key-property-key">Issued</span>
         <span class="feature-key-property-value">{{renderDateString featureKey.issued}}</span>
       </div>
-      {{#unless featureKey.isFreeKey}}
       <div class="feature-key-property-row">
-        <span class="feature-key-property-key">Expires</span>
+        <span class="feature-key-property-key">
+          {{#if featureKey.isTrial}}Expires{{else}}Next Renewal{{/if}}
+        </span>
         <span class="feature-key-property-value">{{renderDateString featureKey.expires}}</span>
       </div>
-      {{/unless}}
     </div>
     <div class="feature-key-org-info">
       {{#with customer=featureKey.customer}}

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -168,7 +168,7 @@
         and then upload your new key. The error was: <code>{{exception}}</code>
       {{/if}}
 
-      <button class="retry">Retry</button>
+      <button class="retry" disabled={{renewInFlight}}>Retry</button>
     </div>
   {{/with}}
 

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -167,6 +167,8 @@
         href="https://sandstorm.io/get-feature-key#key/{{keySecret}}">renew manually</a>
         and then upload your new key. The error was: <code>{{exception}}</code>
       {{/if}}
+
+      <button class="retry">Retry</button>
     </div>
   {{/with}}
 

--- a/shell/client/notifications-client.js
+++ b/shell/client/notifications-client.js
@@ -247,12 +247,17 @@ Template.referralNotificationItem.events({
 });
 
 Template.adminNotificationItem.helpers({
-  isStatsNotification() {
-    return this.admin.type === "reportStats";
+  isType(type) {
+    return this.admin.type === type;
   },
 
   actionTarget() {
     return this.admin.action;
+  },
+
+  isUrgent() {
+    const map = { cantRenewFeatureKey: true, trialFeatureKeyExpired: true };
+    return map[this.admin.type];
   },
 });
 

--- a/shell/client/notifications.html
+++ b/shell/client/notifications.html
@@ -77,23 +77,28 @@
 </template>
 
 <template name="adminNotificationItem">
-{{!-- The only admin notification type that exists is the stats notification.
-      If there wind up being more types, extract those into separate
-      notification items --}}
-  {{#if isStatsNotification}}
-    {{#linkTo route="newAdminStats" class="notification-item"}}
-      <div class="notification-title">
-        Notification from system:
-      </div>
+  <a href="{{actionTarget}}" class="notification-item {{#if isUrgent}}urgent{{/if}}">
+    <div class="notification-icon">
+      <img src="/sandstorm-gradient-logo.svg">
+    </div>
 
+    {{#if isType "reportStats"}}
       You can help Sandstorm by sending us some anonymous usage stats.
       Click here for more info.
+    {{/if}}
+    {{#if isType "cantRenewFeatureKey"}}
+      Error renewing your Sandstorm for Work subscription.
+      Click here to resolve the problem, or Sandstorm for Work features may become unavailable.
+    {{/if}}
+    {{#if isType "trialFeatureKeyExpired"}}
+      Your Sandstorm for Work trial has expired.
+      Click here to upgrade, or Sandstorm for Work features may become unavailable.
+    {{/if}}
 
-      <div class="notification-footer">
-        <span title="{{timestamp}}" class="notification-timestamp">{{dateString timestamp}}</span>
-      </div>
-    {{/linkTo}}
-  {{/if}}
+    <div class="notification-footer">
+      <span title="{{timestamp}}" class="notification-timestamp">{{dateString timestamp}}</span>
+    </div>
+  </a>
 </template>
 
 <template name="backgroundedGrainNotificationItem">

--- a/shell/client/styles/_admin.scss
+++ b/shell/client/styles/_admin.scss
@@ -96,7 +96,7 @@ form.feature-key-form, form.feature-key-modify-form {
 
   >.retry {
     @extend %button-base;
-    @extend %button-primary;
+    @extend %button-secondary;
 
     position: absolute;
     right: 16px;

--- a/shell/client/styles/_admin.scss
+++ b/shell/client/styles/_admin.scss
@@ -86,3 +86,10 @@ form.feature-key-form, form.feature-key-modify-form {
     min-height: 60px;
   }
 }
+
+.feature-key-renewal-problem {
+  border-radius: 5px;
+  padding: 16px;
+  margin-bottom: 20px;
+  background-color: $error-background-color;
+}

--- a/shell/client/styles/_admin.scss
+++ b/shell/client/styles/_admin.scss
@@ -89,7 +89,17 @@ form.feature-key-form, form.feature-key-modify-form {
 
 .feature-key-renewal-problem {
   border-radius: 5px;
-  padding: 16px;
+  padding: 16px 66px 16px 16px;  // space for retry button on right
   margin-bottom: 20px;
   background-color: $error-background-color;
+  position: relative;
+
+  >.retry {
+    @extend %button-base;
+    @extend %button-primary;
+
+    position: absolute;
+    right: 16px;
+    top: 16px;
+  }
 }

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -1286,6 +1286,10 @@ body>.popup {
         // Guarantee position-absolute icons don't get cut off
         min-height: $topbar-popup-padding + $topbar-popup-padding + 64px;
 
+        &.urgent {
+          background-color: $error-background-color;
+        }
+
         &[href]:hover {
           background-color: #eee;
         }

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -540,7 +540,8 @@ Notifications = new Mongo.Collection("notifications", collectionOptions);
 //   admin:        If present, this is a notification intended for an admin.
 //     action:     If present, this is a (string) link that the notification should direct the
 //                 admin to.
-//     type:       The type of notification (currently only "reportStats").
+//     type:       The type of notification -- can be "reportStats", "cantRenewFeatureKey", or
+//                 "trialFeatureKeyExpired".
 //   appUpdates:   If present, this is an app update notification. It is an object with the appIds
 //                 as keys.
 //     $appId:     The appId that has an outstanding update.
@@ -1363,15 +1364,11 @@ _.extend(SandstormDb.prototype, {
     }
   },
 
-  sendAdminNotification(message, link) {
+  sendAdminNotification(type, action) {
     Meteor.users.find({ isAdmin: true }, { fields: { _id: 1 } }).forEach(function (user) {
       Notifications.insert({
-        admin: {
-          action: link,
-          type: "reportStats",
-        },
+        admin: { action, type },
         userId: user._id,
-        text: { defaultText: message },
         timestamp: new Date(),
         isUnread: true,
       });

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -2729,7 +2729,7 @@ if (Meteor.isServer) {
     // once we can use ES6 modules.
     const rawFeatureKey = loadSignedFeatureKey(buf);
     return processRawFeatureKey(rawFeatureKey, doc.renewalProblem);
-  }
+  };
 
   SandstormDb.prototype.currentFeatureKey = function () {
     // Returns an object with all of the current signed feature key properties,
@@ -2746,16 +2746,18 @@ if (Meteor.isServer) {
       added(doc) {
         callback(processFeatureKeyDoc(doc));
       },
+
       changed(newDoc, oldDoc) {
         if (newDoc.value !== oldDoc.value) {
           callback(processFeatureKeyDoc(newDoc));
         }
       },
+
       removed() {
         callback(null);
       },
     });
-  }
+  };
 } else {
   SandstormDb.prototype.currentFeatureKey = function () {
     const featureKey = this.collections.featureKey.findOne({ _id: "currentFeatureKey" });

--- a/shell/server/00-startup.js
+++ b/shell/server/00-startup.js
@@ -162,3 +162,10 @@ if ("replicaNumber" in Meteor.settings) {
   addFiberSampling(Meteor._SynchronousQueue.prototype, "queueTask");
   addFiberSampling(Meteor, "bindEnvironment");
 }
+
+if (!Meteor.settings.replicaNumber) {
+  Meteor.startup(() => {
+    // Defined in feature-key.js.
+    keepFeatureKeyRenewed(globalDb);
+  });
+}

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -126,6 +126,15 @@ Meteor.methods({
     setNewFeatureKey(db, textBlock);
   },
 
+  renewFeatureKey: function (token) {
+    checkAuth(token);
+
+    const db = this.connection.sandstormDb;
+
+    // renewFeatureKey is provided in feature-key.js.
+    renewFeatureKey(db, {interactive: true});
+  },
+
   saveOrganizationSettings(token, params) {
     checkAuth(token);
     check(params, {

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -132,7 +132,7 @@ Meteor.methods({
     const db = this.connection.sandstormDb;
 
     // renewFeatureKey is provided in feature-key.js.
-    renewFeatureKey(db, {interactive: true});
+    renewFeatureKey(db, { interactive: true });
   },
 
   saveOrganizationSettings(token, params) {

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -41,7 +41,7 @@ const publicAdminSettings = [
 
 const FEATURE_KEY_FIELDS_PUBLISHED_TO_ADMINS = [
   "customer", "expires", "features", "isElasticBilling", "isTrial", "issued", "userLimit",
-  "secret",
+  "secret", "renewalProblem",
 ];
 
 const PUBLIC_FEATURE_KEY_FIELDS = [
@@ -630,6 +630,9 @@ Meteor.publish("featureKey", function (forAdmin, token) {
       // Load and verify the signed feature key.
       const buf = new Buffer(doc.value);
       const featureKey = loadSignedFeatureKey(buf);
+      if (doc.renewalProblem) {
+        featureKey.renewalProblem = doc.renewalProblem;
+      }
 
       if (featureKey) {
         // If the signature is valid, publish the feature key information.
@@ -642,6 +645,11 @@ Meteor.publish("featureKey", function (forAdmin, token) {
       // Load and reverify the new signed feature key.
       const buf = new Buffer(newDoc.value);
       const featureKey = loadSignedFeatureKey(buf);
+      if (newDoc.renewalProblem) {
+        featureKey.renewalProblem = newDoc.renewalProblem;
+      } else if (oldDoc.renewalProblem) {
+        featureKey.renewalProblem = undefined;
+      }
 
       if (featureKey) {
         // If the signature is valid, call this.changed() with the interesting fields.

--- a/shell/server/admin-server.js
+++ b/shell/server/admin-server.js
@@ -122,37 +122,8 @@ Meteor.methods({
 
     const db = this.connection.sandstormDb;
 
-    if (!textBlock) {
-      // Delete the feature key.
-      db.collections.featureKey.remove("currentFeatureKey");
-      return;
-    }
-
-    // textBlock is a base64'd string, possibly with newlines and comment lines starting with "-"
-    const featureKeyBase64 = _.chain(textBlock.split("\n"))
-        .filter(line => (line.length > 0 && line[0] !== "-"))
-        .value()
-        .join("");
-
-    const buf = new Buffer(featureKeyBase64, "base64");
-    if (buf.length < 64) {
-      throw new Meteor.Error(401, "Invalid feature key");
-    }
-
-    // loadSignedFeatureKey is provided in feature-key.js
-    const featureKey = loadSignedFeatureKey(buf);
-    if (!featureKey) {
-      throw new Meteor.Error(401, "Invalid feature key");
-    }
-
-    // Persist the feature key in the database.
-    db.collections.featureKey.upsert(
-      "currentFeatureKey",
-      {
-        _id: "currentFeatureKey",
-        value: buf,
-      }
-    );
+    // setNewFeatureKey is provided in feature-key.js
+    setNewFeatureKey(db, textBlock);
   },
 
   saveOrganizationSettings(token, params) {

--- a/shell/server/feature-key.js
+++ b/shell/server/feature-key.js
@@ -100,7 +100,7 @@ setNewFeatureKey = function (db, textBlock) {
     // No luck.
     throwExpired();
   });
-}
+};
 
 function setNewFeatureKeyInternal(db, textBlock, ifExpired) {
   if (!textBlock) {
@@ -169,7 +169,7 @@ renewFeatureKey = function (db, options) {
     // Count number of user accounts (not including visitors) active in the last month.
     let count = 0;
     const oneMonthAgo = new Date(Date.now() - 30 * 86400000);
-    Meteor.users.find({loginIdentities: {$exists: true}, lastActive: {$gt: oneMonthAgo}})
+    Meteor.users.find({ loginIdentities: { $exists: true }, lastActive: { $gt: oneMonthAgo } })
         .forEach(user => {
       if (db.isAccountSignedUp(user)) {
         ++count;
@@ -191,13 +191,13 @@ renewFeatureKey = function (db, options) {
 
     const data = response.data;
     if (data.noPaymentSource !== undefined) {
-      reportRenewalProblem(db, key, options, {noPaymentSource: true});
+      reportRenewalProblem(db, key, options, { noPaymentSource: true });
     } else if (data.paymentFailed !== undefined) {
-      reportRenewalProblem(db, key, options, {paymentFailed: data.paymentFailed});
+      reportRenewalProblem(db, key, options, { paymentFailed: data.paymentFailed });
     } else if (data.revoked !== undefined) {
-      reportRenewalProblem(db, key, options, {revoked: true});
+      reportRenewalProblem(db, key, options, { revoked: true });
     } else if (data.noSuchKey !== undefined) {
-      reportRenewalProblem(db, key, options, {noSuchKey: true});
+      reportRenewalProblem(db, key, options, { noSuchKey: true });
     } else if (data.success !== undefined ||
                data.tooEarly !== undefined ||
                data.pendingPayment !== undefined) {
@@ -215,19 +215,19 @@ renewFeatureKey = function (db, options) {
         });
       }
     } else {
-      reportRenewalProblem(db, key, options, {unknownResponse: response.content});
+      reportRenewalProblem(db, key, options, { unknownResponse: response.content });
     }
   } catch (err) {
     console.error("Exception when trying to renew feature key:", err.stack);
-    reportRenewalProblem(db, key, options, {exception: err.message});
+    reportRenewalProblem(db, key, options, { exception: err.message });
   }
-}
+};
 
 function fetchUpdatedFeautureKeyFromVendor(key) {
   const fetchResponse = HTTP.get(RENEW_API_HOST + "/keys/" + key.secret.toString("hex"), {
     headers: {
       "Authorization": "Bearer " + RENEW_API_TOKEN,
-    }
+    },
   });
   const result = fetchResponse.data.key;
   if (!result) throw new Error("Renewal server returned invalid GetKeyResponse.");
@@ -255,7 +255,9 @@ function reportRenewalProblem(db, key, options, problem) {
         ? "This is an automated message from your Sandstorm server. Your trial of Sandstorm for Work has expired. To continue using Sandstorm for Work, update your subscription here:"
         : "This is an automated message from your Sansdtorm server. There was an error when trying to renew your Sandstorm for Work subscription. To resolve the issue, please go to:";
 
-    emailOptions.text += `\n\n${process.env.ROOT_URL}/admin/feature-key`;
+    emailOptions.text += `
+
+${process.env.ROOT_URL}/admin/feature-key`;
 
     Meteor.users.find({ isAdmin: true }).forEach((user) => {
       const email = _.findWhere(SandstormDb.getUserEmails(user), { primary: true });
@@ -320,4 +322,4 @@ keepFeatureKeyRenewed = function (db) {
 
     scheduleRenewal();
   });
-}
+};

--- a/shell/server/feature-key.js
+++ b/shell/server/feature-key.js
@@ -73,3 +73,36 @@ loadSignedFeatureKey = function (buf) {
     return undefined;
   }
 };
+
+setNewFeatureKey = function (db, textBlock) {
+  if (!textBlock) {
+    // Delete the feature key.
+    db.collections.featureKey.remove("currentFeatureKey");
+    return;
+  }
+
+  // textBlock is a base64'd string, possibly with newlines and comment lines starting with "-"
+  const featureKeyBase64 = _.chain(textBlock.split("\n"))
+      .filter(line => (line.length > 0 && line[0] !== "-"))
+      .value()
+      .join("");
+
+  const buf = new Buffer(featureKeyBase64, "base64");
+  if (buf.length < 64) {
+    throw new Meteor.Error(401, "Invalid feature key");
+  }
+
+  const featureKey = loadSignedFeatureKey(buf);
+  if (!featureKey) {
+    throw new Meteor.Error(401, "Invalid feature key");
+  }
+
+  // Persist the feature key in the database.
+  db.collections.featureKey.upsert(
+    "currentFeatureKey",
+    {
+      _id: "currentFeatureKey",
+      value: buf,
+    }
+  );
+}

--- a/shell/server/notifications-server.js
+++ b/shell/server/notifications-server.js
@@ -213,8 +213,26 @@ Meteor.methods({
         type: "reportStats",
       },
       userId: this.userId,
-      text: { defaultText: "You can help Sandstorm by sending us some anonymous " +
-                           "usage stats. Click here for more info.", },
+      timestamp: new Date(),
+      isUnread: true,
+    });
+
+    Notifications.insert({
+      admin: {
+        action: "/admin/feature-key",
+        type: "cantRenewFeatureKey",
+      },
+      userId: this.userId,
+      timestamp: new Date(),
+      isUnread: true,
+    });
+
+    Notifications.insert({
+      admin: {
+        action: "/admin/feature-key",
+        type: "trialFeatureKeyExpired",
+      },
+      userId: this.userId,
       timestamp: new Date(),
       isUnread: true,
     });

--- a/shell/server/stats-server.js
+++ b/shell/server/stats-server.js
@@ -213,8 +213,7 @@ function recordStats() {
 
     if (!reportSetting) {
       // Setting not set yet, send out notifications and set it to false
-      globalDb.sendAdminNotification("You can help Sandstorm by sending us some anonymous " +
-        "usage stats. Click here for more info.", "/admin/stats");
+      globalDb.sendAdminNotification("reportStats", "/admin/stats");
       Settings.insert({ _id: "reportStats", value: "unset" });
     } else if (reportSetting.value === true) {
       postStats(record);


### PR DESCRIPTION
The commits are arranged in bite-sized chunks for your reviewing pleasure.

Overview:
* Once a feature key is installed, it will be automatically renewed.
    * To avoid accidents, we no longer allow installing a feature key that is expired, since this would trigger immediate renewal, which could be a costly mistake for the user.
    * However, if the user tries to install an expired key, we will go check if a newer version of the same key is available, e.g. because it had been renewed already, and the user just happened to use the wrong version. If so, we'll go ahead and use the new version. This will not trigger a renewal.
* If renewal fails, we will record the error.
    * We display it on the feature key config page, in a red box.
    * The box has a "retry" button to immediately retry renewal.
    * We also deliver a bell notification (with a scary red background) and an email notification (labeled "URGENT:").

Note that this doesn't yet implement actual enforcement of expired keys or user limits, but those will come soon once everyone has received plenty of warning and opportunity to do something about it.

![screenshot from 2016-09-09 01-31-06](https://cloud.githubusercontent.com/assets/4001805/18380743/b24fd952-762d-11e6-8b40-a323d0f7223d.png)
![screenshot from 2016-09-09 01-32-56](https://cloud.githubusercontent.com/assets/4001805/18380748/b6c3cf2a-762d-11e6-8954-6c4e6a23f62b.png)
