### PR TITLE
Don't hide topbar trash button when user has some tokens in trash and some not.

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -731,8 +731,23 @@ Template.grain.helpers({
   },
 
   displayTrashButton: function () {
-    const grain = globalGrains.getActive();
-    return Meteor.userId() && grain && !grain.isInMyTrash();
+    const grainview = globalGrains.getActive();
+    if (!grainview) return false;
+    const grainId = grainview.grainId();
+    const grain = Grains.findOne({
+      _id: grainId,
+      userId: Meteor.userId(),
+      trashed: { $exists: false },
+    });
+
+    if (grain) return true;
+
+    const myIdentityIds = SandstormDb.getUserIdentityIds(Meteor.user());
+    return !!ApiTokens.findOne({
+      grainId: grainId,
+      "owner.user.identityId": { $in: myIdentityIds },
+      trashed: { $exists: false },
+    });
   },
 
   showPowerboxOffer: function () {


### PR DESCRIPTION
Fixes a bug where sometimes the trash button does not show up in the topbar. The problem is that we are checking whether the user has the grain in the trash while what we should really be checking is whether the user has any *non-trashed* references to the grain.

Also adds a test that fails before and passes after the fix.