### PR TITLE
Add X-Phabricator-* to the HTTP header whitelist

### DIFF
--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -159,6 +159,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       "oc-fileid",             # Owncloud client
       "oc-chunked",            # Owncloud client
       "x-hgarg-*",             # Mercurial client
+      "x-phabricator-*",       # Phabricator
     ];
   }
 


### PR DESCRIPTION
Phabricator's CSRF tokens for AJAX requests are passed in this manner, and
there are a couple other headers they use like `X-Phabricator-Via` that it'd be
better to not remove from requests.

cc @liamzdenek