### PR TITLE
Fix collections app not being preinstalled by the wizard

### DIFF
--- a/shell/client/setup-wizard/wizard.js
+++ b/shell/client/setup-wizard/wizard.js
@@ -677,7 +677,8 @@ Template.setupWizardPreinstalled.helpers({
   allowSkip() {
     const instance = Template.instance();
     const apps = globalDb.collections.appIndex.find({ _id: {
-      $in: globalDb.getProductivitySuiteAppIds(), },
+      $in: globalDb.getProductivitySuiteAppIds().concat(
+        globalDb.getSystemSuiteAppIds()), },
     }).fetch();
     const appIndexCount = globalDb.collections.appIndex.find({}).count();
     const failedAppsCount = globalDb.collections.packages.find({

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -673,7 +673,8 @@ const startPreinstallingApps = function (db, backend) {
     db.updateAppIndex();
 
     const preinstalledApps = db.collections.appIndex.find({ _id: {
-      $in: db.getProductivitySuiteAppIds(), },
+      $in: db.getProductivitySuiteAppIds().concat(
+        db.getSystemSuiteAppIds()), },
     }).fetch();
     const appAndPackageIds = _.map(preinstalledApps, (app) => {
       return {


### PR DESCRIPTION
Fortunately?, the check which prevents users from clicking "Next" on this
page was also not checking for collections, so it all worked out without
anyone complaining.