### PR TITLE
Don't hide "Upload app" button while searching on app list page

### DIFF
--- a/shell/client/apps/applist.html
+++ b/shell/client/apps/applist.html
@@ -17,7 +17,7 @@
                     title="Uninstall an app"
             >Uninstall...</button>
           {{/if}}
-          <button type="button" class="upload-button {{#if searching}}hide{{/if}}">Upload app...
+          <button type="button" class="upload-button">Upload app...
             <input type="file" style="display:none" accept=".spk">
           </button>
         </div>


### PR DESCRIPTION
Now that we've moved the two buttons up above the horizontal rule, they should
no longer be confused as being related to search results.

Fixes #2038.