### PR TITLE
Locale aware grain and app sorting

### DIFF
--- a/shell/client/apps/applist-client.js
+++ b/shell/client/apps/applist-client.js
@@ -114,11 +114,32 @@ Template.sandstormAppListPage.helpers({
   apps: function () {
     const ref = Template.instance().data;
     const apps = matchApps(ref._filter.get());
-    return _.chain(apps)
-            .map(appToTemplateObject)
-            .sortBy(function (appTemplateObj) { return appTemplateObj.appTitle.toLowerCase(); })
-            .sortBy(function (appTemplateObj) { return appTemplateObj.dev ? 0 : 1; })
-            .value();
+    const appTemplateObjects = apps.map(appToTemplateObject);
+
+    appTemplateObjects.sort((a, b) => {
+      // Dev apps sort first.
+      if (a.dev && !b.dev) return -1;
+      if (b.dev && !a.dev) return 1;
+
+      // Use locale-aware comparison if available.
+      // Otherwise, directly compare lowercased app titles.
+      if (String.prototype.localeCompare) {
+        return a.appTitle.localeCompare(b.appTitle);
+      }
+
+      const aLower = a.appTitle.toLowerCase();
+      const bLower = b.appTitle.toLowerCase();
+
+      if (aLower < bLower) {
+        return -1;
+      } else if (aLower > bLower) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+
+    return appTemplateObjects;
   },
 
   popularApps: function () {

--- a/shell/client/grain/grainlist-client.js
+++ b/shell/client/grain/grainlist-client.js
@@ -107,8 +107,16 @@ const sortGrains = function (grains, sortRules) {
       return function (a, b) {
         const aRaw = a[key];
         const bRaw = b[key];
+
+        // Use locale-aware comparison if available.  Not all browsers support this.
+        if (String.prototype.localeCompare) {
+          return aRaw.localeCompare(bRaw) * multiplier;
+        }
+
+        // Otherwise, fall back to direct string comparison on lowercased strings.
         const aLower = aRaw.toLowerCase();
         const bLower = bRaw.toLowerCase();
+
         if (aLower < bLower) {
           return -1 * multiplier;
         } else if (aLower > bLower) {


### PR DESCRIPTION
If available, use [String.prototype.localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) when sorting app titles or grain titles.  (It's [not available in some versions of Safari](http://caniuse.com/#feat=internationalization), so we retain the fallback logic of comparing lowercased strings directly.)

Fixes #2529.