### PR TITLE
Add X-Requested-With to the HTTP header whitelist

### DIFF
--- a/docs/developing/raw-ruby-on-rails.md
+++ b/docs/developing/raw-ruby-on-rails.md
@@ -311,30 +311,6 @@ directory where it was installed.
 Sandstorm does not forward the `Referer` header,
 so things like `redirect_to :back` will fail.
 
-### Accept header
-
-The `X-Requested-With` header is not on Sandstorm's whitelist of headers to
-forward. This can confuse Rails in some cases. You may find it useful
-to add this monkey patch as `config/initializers/sandstorm_accept_header.rb`:
-
-```ruby
-# For obscure reasons, if Rails gets an XMLHttpRequest with an Accept header like
-# "application/json, text/javascript, */*; q=0.01" and does not get an
-# X-Requested-With header, it will report that HTML is the desired format in calls
-# to `respond_to`. This monkey patch should fix the problem. I think the worst
-# possible side effect is that certain old browsers might display some content wrong.
-module ActionDispatch
-  module Http
-    module MimeNegotiation
-      def valid_accept_header
-        true
-      end
-    end
-  end
-end
-```
-
-
 ### Javascript Runtime
 
 The execjs gem wants a javascript runtime to exist on startup.

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -160,7 +160,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       "oc-chunked",            # Owncloud client
       "x-hgarg-*",             # Mercurial client
       "x-phabricator-*",       # Phabricator
-      "x-requested-with-*",    # JQuery header used by Rails and other frameworks
+      "x-requested-with",      # JQuery header used by Rails and other frameworks
     ];
   }
 

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -160,6 +160,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       "oc-chunked",            # Owncloud client
       "x-hgarg-*",             # Mercurial client
       "x-phabricator-*",       # Phabricator
+      "x-requested-with-*",    # JQuery header used by Rails and other frameworks
     ];
   }
 


### PR DESCRIPTION
jQuery provides the X-Requested-With header that is required by
a number of applications, including Trac.