### PR TITLE
fix pronoun selector on account settings page

### DIFF
--- a/shell/client/accounts/account-settings.html
+++ b/shell/client/accounts/account-settings.html
@@ -262,7 +262,7 @@ setActionCompleted: (optional) Function.  Callback triggered on profile saved or
         </li>
 
         <li class="form-group">
-          {{#with prounoun=identity.profile.pronoun}}
+          {{#with pronoun=identity.profile.pronoun}}
           <label>
             Preferred pronoun:
             <select name="pronoun">


### PR DESCRIPTION
Fixes a typo introduced in https://github.com/sandstorm-io/sandstorm/commit/87de090c061608167336dfa7bb5a89bfb2df8369 that causes the account profile page to always display "they" as the chosen pronoun.