### PR TITLE
fix new user validation to include 'pronoun' instead of 'pronouns' 

### DIFF
--- a/shell/server/accounts/accounts-server.js
+++ b/shell/server/accounts/accounts-server.js
@@ -76,7 +76,7 @@ Accounts.onCreateUser(function (options, user) {
     user.unverifiedEmail = options.unverifiedEmail;
   }
 
-  user.profile = _.pick(options.profile || {}, "name", "handle", "pronouns");
+  user.profile = _.pick(options.profile || {}, "name", "handle", "pronoun");
 
   // Try downloading avatar.
   const url = userPictureUrl(user);


### PR DESCRIPTION
"pronoun" is the correct field to be using here: https://github.com/sandstorm-io/sandstorm/blob/v0.185/shell/packages/sandstorm-db/db.js#L86

I don't think we ever actually fill in this field when creating a new user (usually it gets filled in lazily, with a default being inferred from the service-specific identity data), so I don't think there would be any point in writing a migration to clean up database entries that have a `profile.pronouns` field.
