### PR TITLE
fix broken 'this' reference in `removeApiTokens()`

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1130,7 +1130,7 @@ if (Meteor.isServer) {
   SandstormDb.prototype.removeApiTokens = function (query) {
     // Remove all API tokens matching the query, making sure to clean up ApiHosts as well.
 
-    this.collections.apiTokens.find(query).forEach(function (token) {
+    this.collections.apiTokens.find(query).forEach((token) => {
       // Clean up ApiHosts for webkey tokens.
       if (token.hasApiHost) {
         const hash2 = Crypto.createHash("sha256").update(token._id).digest("base64");


### PR DESCRIPTION
The bug was introduced in https://github.com/sandstorm-io/sandstorm/commit/d4f96cea87024305daa6f3ebcb50e1c69ddfe07d.