### PR TITLE
Implement powerbox requests for identities.

### DIFF
--- a/shell/imports/server/frontend-ref.js
+++ b/shell/imports/server/frontend-ref.js
@@ -63,32 +63,37 @@ class FrontendRefRegistry {
     }
   }
 
-  validate(db, session, mutableFrontendRef, options) {
+  validate(db, session, frontendRefRequest) {
     // Validates a powerbox request on the given `session` (a record from the Sessions table)
-    // requesting the creation of the given frontendRef type. `mutableFrontendRef` is expected to
-    // come directly from the client; calling validate() verifies that it has a valid type, and
-    // may modify the value to add bits that need to be generated server-side. `validate()` also
-    // returns an array of MembraneRequirements that shall apply to the capability. These
-    // requirements will not yet have been checked, so the caller should check them before
-    // proceeding.
+    // requesting the creation of the given frontendRef type. `frontendRefRequest` is expected to
+    // come directly from the client; calling validate() verifies that it is well-formed and
+    // carries out any type-specific server-side work needed to construct the desired frontendRef.
+    // `validate()` also returns an array of MembraneRequirements that shall apply to the
+    // capability. These requirements will not yet have been checked, so the caller should check
+    // them before proceeding.
 
-    const keys = Object.keys(mutableFrontendRef);
+    const keys = Object.keys(frontendRefRequest);
     if (keys.length != 1) {
-      throw new Error("invalid frontendRef: " + JSON.stringify(mutableFrontendRef));
+      throw new Error("invalid frontendRefRequest: " + JSON.stringify(frontendRefRequest));
     }
 
     const key = keys[0];
     const handler = this._frontendRefHandlers[key];
     if (!handler) {
-      throw new Error("invalid frontendRef: " + JSON.stringify(mutableFrontendRef));
+      throw new Error("invalid frontendRefRequest: " + JSON.stringify(frontendRefRequest));
     }
 
     if (!handler.validate) {
       throw new Error("frontendRef type cannot be created via powerbox: " +
-                      JSON.stringify(mutableFrontendRef));
+                      JSON.stringify(frontendRefRequest));
     }
 
-    return handler.validate(db, session, mutableFrontendRef[key], options);
+    const { descriptor, requirements, frontendRef } =
+          handler.validate(db, session, frontendRefRequest[key]);
+
+    const result = { descriptor, requirements, frontendRef: {}, };
+    result.frontendRef[key] = frontendRef;
+    return result;
   }
 
   register(object) {
@@ -104,22 +109,21 @@ class FrontendRefRegistry {
     //     `capability` (returned): A Cap'n Proto capability implementing SystemPersistent along
     //         with whatever other interfaces are appropriate for the ref type.
     //   `validate`: Callback to validate a powerbox request for a new capability of this type.
-    //       Has signature `(db, session, mutableValue, options) -> {descriptor, requirements}`,
+    //       Has signature `(db, session, request) -> {descriptor, requirements, frontendRef}`,
     //       where:
-    //     `mutableValue` is the value of the single field of `frontendRef` for this capability.
-    //         If this is an object value, the callback may optionally modify it, e.g. adding
-    //         additional fields that need to be generated server-side. The callback *must*, at
-    //         the very least, type-check this value. It should throw an exception if the vaule is
+    //     `request` is type-specific information describing the requested capability. The
+    //         callback *must* type-check this value, and should throw an exception if it is
     //         not valid.
     //     `session` is the record from the Sessions table of the UI session where the powerbox
     //         request occurred.
-    //     `options` is an optional object with supplemental information.
     //     `descriptor` (returned) is the JSON-encoded PowerboxDescriptor for the capability. Note
     //         that if the descriptor contains any `tag.value`s, they of course need to be
     //         presented as capnp-encoded Buffers.
     //     `requirements` (returned) is an array of MembraneRequirements which should apply to the
     //         new capability. Note that these requirements will be checked immediately and the
     //         powerbox request will fail if they aren't met.
+    //     `frontendRef` (returned) is the value that will be written for the key specified
+    //         by `frontendRefField` in the single-key object `ApiTokens.frontendRef`.
     //    `query`: Callback to populate options for a powerbox request for this type ID. Has
     //        signature `(db, userAccountId, tagValue) -> options`, where:
     //      `tagValue`: A Buffer of the Cap'n-Proto-encoded `PowerboxDescriptor.Tag.value`.

--- a/shell/imports/server/frontend-ref.js
+++ b/shell/imports/server/frontend-ref.js
@@ -63,7 +63,7 @@ class FrontendRefRegistry {
     }
   }
 
-  validate(db, session, mutableFrontendRef) {
+  validate(db, session, mutableFrontendRef, options) {
     // Validates a powerbox request on the given `session` (a record from the Sessions table)
     // requesting the creation of the given frontendRef type. `mutableFrontendRef` is expected to
     // come directly from the client; calling validate() verifies that it has a valid type, and
@@ -88,7 +88,7 @@ class FrontendRefRegistry {
                       JSON.stringify(mutableFrontendRef));
     }
 
-    return handler.validate(db, session, mutableFrontendRef[key]);
+    return handler.validate(db, session, mutableFrontendRef[key], options);
   }
 
   register(object) {
@@ -104,7 +104,8 @@ class FrontendRefRegistry {
     //     `capability` (returned): A Cap'n Proto capability implementing SystemPersistent along
     //         with whatever other interfaces are appropriate for the ref type.
     //   `validate`: Callback to validate a powerbox request for a new capability of this type.
-    //       Has signature `(db, session, mutableValue) -> {descriptor, requirements}`, where:
+    //       Has signature `(db, session, mutableValue, options) -> {descriptor, requirements}`,
+    //       where:
     //     `mutableValue` is the value of the single field of `frontendRef` for this capability.
     //         If this is an object value, the callback may optionally modify it, e.g. adding
     //         additional fields that need to be generated server-side. The callback *must*, at
@@ -112,6 +113,7 @@ class FrontendRefRegistry {
     //         not valid.
     //     `session` is the record from the Sessions table of the UI session where the powerbox
     //         request occurred.
+    //     `options` is an optional object with supplemental information.
     //     `descriptor` (returned) is the JSON-encoded PowerboxDescriptor for the capability. Note
     //         that if the descriptor contains any `tag.value`s, they of course need to be
     //         presented as capnp-encoded Buffers.

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -88,7 +88,7 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
     } else if (card.option.frontendRef) {
       this.completeNewFrontendRef(card.option.frontendRef);
     } else {
-      this.failRequest(new Error("not sure how to complete powerbox request for non-frontedRef " +
+      this.failRequest(new Error("not sure how to complete powerbox request for non-frontendRef " +
                                  "that didn't provide a configureTemplate"));
     }
   }
@@ -177,11 +177,10 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
     return {};
   }
 
-  completeNewFrontendRef(frontendRef, options) {
+  completeNewFrontendRef(frontendRefRequest) {
     Meteor.call("newFrontendRef",
       this._requestInfo.sessionId,
-      frontendRef,
-      options,
+      frontendRefRequest,
       (err, result) => {
         if (err) {
           this.failRequest(err);
@@ -441,10 +440,12 @@ Template.identityPowerboxConfiguration.events({
         roleAssignment = { roleId: role };
       }
 
-      this.powerboxRequest.completeNewFrontendRef(
-        instance.data.option.frontendRef,
-        { roleAssignment }
-      );
+      this.powerboxRequest.completeNewFrontendRef({
+        identity: {
+          id: instance.data.option.frontendRef.identity,
+          roleAssignment,
+        },
+      });
     }
   },
 });

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -419,11 +419,25 @@ Template.uiViewPowerboxConfiguration.events({
   },
 });
 
+const isSubsetOf = function (p1, p2) {
+  for (let idx = 0; idx < p1.length; ++idx) {
+    if (p1[idx] && !p2[idx]) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
 Template.identityPowerboxConfiguration.helpers({
-  viewInfo: function () {
+  sufficientRoles: function () {
+    const requestedPermissions = this.option.requestedPermissions;
+
     const session = this.db.collections.sessions.findOne(
       { _id: this.powerboxRequest._requestInfo.sessionId, });
-    return prepareViewInfoForDisplay(session.viewInfo);
+    const roles = prepareViewInfoForDisplay(session.viewInfo).roles;
+
+    return roles && roles.filter(r => isSubsetOf(requestedPermissions, r.permissions));
   },
 });
 

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -39,10 +39,10 @@ function encodePowerboxDescriptor(desc) {
 }
 
 Meteor.methods({
-  newFrontendRef(sessionId, frontendRef, options) {
+  newFrontendRef(sessionId, frontendRefRequest) {
     // Completes a powerbox request for a frontendRef capability.
     check(sessionId, String);
-    // frontendRef is type-checked by frontendRefRegistry.validate(), below.
+    // frontendRefRequest is type-checked by frontendRefRegistry.validate(), below.
 
     const db = this.connection.sandstormDb;
     const frontendRefRegistry = this.connection.frontendRefRegistry;
@@ -53,8 +53,8 @@ Meteor.methods({
       throw new Meteor.Error(403, "Invalid session ID");
     }
 
-    let { descriptor, requirements } =
-        frontendRefRegistry.validate(db, session, frontendRef, options);
+    let { descriptor, requirements, frontendRef } =
+        frontendRefRegistry.validate(db, session, frontendRefRequest);
     descriptor = encodePowerboxDescriptor(descriptor);
 
     const grainId = session.grainId;

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -39,7 +39,7 @@ function encodePowerboxDescriptor(desc) {
 }
 
 Meteor.methods({
-  newFrontendRef(sessionId, frontendRef) {
+  newFrontendRef(sessionId, frontendRef, options) {
     // Completes a powerbox request for a frontendRef capability.
     check(sessionId, String);
     // frontendRef is type-checked by frontendRefRegistry.validate(), below.
@@ -53,7 +53,8 @@ Meteor.methods({
       throw new Meteor.Error(403, "Invalid session ID");
     }
 
-    let { descriptor, requirements } = frontendRefRegistry.validate(db, session, frontendRef);
+    let { descriptor, requirements } =
+        frontendRefRegistry.validate(db, session, frontendRef, options);
     descriptor = encodePowerboxDescriptor(descriptor);
 
     const grainId = session.grainId;

--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -92,7 +92,7 @@
 <template name="identityPowerboxConfiguration">
   <form>
     <p>with permissions:</p>
-    {{#each role in viewInfo.roles}}
+    {{#each role in sufficientRoles}}
       <label><input type="radio" name="role" value="{{role.index}}">{{role.title.defaultText}} - {{role.verbPhrase.defaultText}}</label>
     {{else}}
       <label><input type="radio" checked="true" name="role" value="all">Full access</label>

--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -84,3 +84,19 @@
 <template name="verifiedEmailPowerboxCard">
   {{ option.frontendRef.verifiedEmail.address }}
 </template>
+
+<template name="identityPowerboxCard">
+  {{ option.profile.name }}
+</template>
+
+<template name="identityPowerboxConfiguration">
+  <form>
+    <p>with permissions:</p>
+    {{#each role in viewInfo.roles}}
+      <label><input type="radio" name="role" value="{{role.index}}">{{role.title.defaultText}} - {{role.verbPhrase.defaultText}}</label>
+    {{else}}
+      <label><input type="radio" checked="true" name="role" value="all">Full access</label>
+    {{/each}}
+    <button class="connect-button">Connect</button>
+  </form>
+</template>

--- a/shell/server/core.js
+++ b/shell/server/core.js
@@ -163,6 +163,12 @@ class SandstormCoreImpl {
       this.db.collections.users.update(result.value.userId, { $inc: { storageUsage: diff } });
     }
   }
+
+  getIdentityId(identity) {
+    return unwrapFrontendCap(identity, "identity", (identityId) => {
+      return { id: new Buffer(identityId, "hex") };
+    });
+  }
 }
 
 const makeSandstormCore = (db, grainId) => {

--- a/shell/server/drivers/ip.js
+++ b/shell/server/drivers/ip.js
@@ -143,6 +143,7 @@ Meteor.startup(() => {
       return {
         descriptor: { tags: [{ id: IpRpc.IpInterface.typeId }] },
         requirements: [{ userIsAdmin: session.userId }],
+        frontendRef: value,
       };
     },
 
@@ -268,6 +269,7 @@ Meteor.startup(() => {
       return {
         descriptor: { tags: [{ id: IpRpc.IpNetwork.typeId }] },
         requirements: [{ userIsAdmin: session.userId }],
+        frontendRef: value,
       };
     },
 

--- a/shell/server/drivers/mail.js
+++ b/shell/server/drivers/mail.js
@@ -392,6 +392,7 @@ Meteor.startup(() => {
       return {
         descriptor: { tags: [{ id: EmailRpc.EmailVerifier.typeId }] },
         requirements: [],
+        frontendRef: value,
       };
     },
 
@@ -451,6 +452,7 @@ Meteor.startup(() => {
       return {
         descriptor: { tags: [{ id: EmailRpc.VerifiedEmail.typeId, value: tagValue }] },
         requirements: [],
+        frontendRef: value,
       };
     },
 

--- a/shell/server/identity.js
+++ b/shell/server/identity.js
@@ -79,8 +79,8 @@ globalFrontendRefRegistry.register({
                                 IdentityRpc.PersistentIdentity);
   },
 
-  validate(db, session, identityId, options) {
-    check(identityId, String);
+  validate(db, session, value) {
+    check(value, { id: String, roleAssignment: SandstormDb.prototype.roleAssignmentPattern, });
 
     if (!session.userId) {
       throw new Meteor.Error(403, "Not logged in.");
@@ -94,8 +94,8 @@ globalFrontendRefRegistry.register({
       },
       session.grainId,
       "petname",
-      options.roleAssignment,
-      { user: { identityId: identityId, title: grain.title, }, });
+      value.roleAssignment,
+      { user: { identityId: value.id, title: grain.title, }, });
 
     return {
       descriptor: {
@@ -104,19 +104,20 @@ globalFrontendRefRegistry.register({
             id: Identity.typeId,
             value: Capnp.serialize(
               Identity.PowerboxTag,
-              { identityId: new Buffer(identityId, "hex"), }),
+              { identityId: new Buffer(value.id, "hex"), }),
           },
         ],
       },
       requirements: [
         {
           permissionsHeld: {
-            identityId: identityId,
+            identityId: value.id,
             grainId: session.grainId,
             permissions: [],
           },
         },
       ],
+      frontendRef: value.id,
     };
   },
 

--- a/shell/server/identity.js
+++ b/shell/server/identity.js
@@ -113,7 +113,6 @@ globalFrontendRefRegistry.register({
             value: Capnp.serialize(
               Identity.PowerboxTag,
               {
-                identityId: new Buffer(value.id, "hex"),
                 permissions: permissions,
               }),
           },

--- a/shell/server/notifications-server.js
+++ b/shell/server/notifications-server.js
@@ -24,7 +24,7 @@ const SystemPersistent = SupervisorCapnp.SystemPersistent;
 logActivity = function (grainId, identityId, event) {
   check(grainId, String);
   check(identityId, String);
-  // `event` is always an ActivityEvent parsed from Cap'n Proto buf that's too complicated to check
+  // `event` is always an ActivityEvent parsed from Cap'n Proto but that's too complicated to check
   // here.
 
   // TODO(perf): A cached copy of the grain from when the session opened would be fine to use

--- a/src/sandstorm/grain.capnp
+++ b/src/sandstorm/grain.capnp
@@ -119,6 +119,13 @@ interface SandstormApi(AppObjectId) {
   backgroundActivity @9 (event :Activity.ActivityEvent);
   # Post an activity event to the grain's activity log that was *not* initiated by any particular
   # user. For activity that should be attributed to a user, use SessionContext.activity().
+
+  getIdentityId @10 (identity: Identity.Identity) -> (id :Data);
+  # Gets the ID of the identity, as it would appear in UserInfo.identityId.
+  #
+  # This method is here on `SandstormApi` rather than on `Identity` in order to ease a possible
+  # future transition to a model where identity IDs are not globally stable and each grain has a
+  # separate (possibly incompatible) map from identity ID to account ID.
 }
 
 interface UiView @0xdbb4d798ea67e2e7 {

--- a/src/sandstorm/identity.capnp
+++ b/src/sandstorm/identity.capnp
@@ -23,7 +23,7 @@ using Util = import "util.capnp";
 using PermissionSet = List(Bool);
 # Set of permission IDs, represented as a bitfield.
 
-interface Identity {
+interface Identity @0xc084987aa951dd18  {
   # Represents a user identity.
   #
   # Things you can do:
@@ -38,6 +38,13 @@ interface Identity {
   # This capability is always persistable.
 
   # TODO(someday): Public key info? Ability to seal messages / check signatures?
+
+  struct PowerboxTag {
+    # Tag to be used in a `PowerboxDescriptor` to describe an `Identity`.
+
+    identityId @0 :Data;
+    # The 32-byte identity ID of the identity.
+  }
 
   getProfile @0 () -> (profile: Profile);
   # Get the identity's current profile.

--- a/src/sandstorm/identity.capnp
+++ b/src/sandstorm/identity.capnp
@@ -44,6 +44,13 @@ interface Identity @0xc084987aa951dd18  {
 
     identityId @0 :Data;
     # The 32-byte identity ID of the identity.
+
+    permissions @1 :PermissionSet;
+    # In a query, the permissions that the requester wishes to be held by the identity. When
+    # the powerbox UI asks the user to select a role, it hides any roles that do not provide all of
+    # these permissions.
+    #
+    # In a  provision, the current permissions actually held by the identity.
   }
 
   getProfile @0 () -> (profile: Profile);

--- a/src/sandstorm/identity.capnp
+++ b/src/sandstorm/identity.capnp
@@ -42,10 +42,7 @@ interface Identity @0xc084987aa951dd18  {
   struct PowerboxTag {
     # Tag to be used in a `PowerboxDescriptor` to describe an `Identity`.
 
-    identityId @0 :Data;
-    # The 32-byte identity ID of the identity.
-
-    permissions @1 :PermissionSet;
+    permissions @0 :PermissionSet;
     # In a query, the permissions that the requester wishes to be held by the identity. When
     # the powerbox UI asks the user to select a role, it hides any roles that do not provide all of
     # these permissions.

--- a/src/sandstorm/identity.capnp
+++ b/src/sandstorm/identity.capnp
@@ -47,7 +47,7 @@ interface Identity @0xc084987aa951dd18  {
     # the powerbox UI asks the user to select a role, it hides any roles that do not provide all of
     # these permissions.
     #
-    # In a  provision, the current permissions actually held by the identity.
+    # In a fulfillment, the current permissions actually held by the identity.
   }
 
   getProfile @0 () -> (profile: Profile);

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1902,6 +1902,16 @@ public:
     return req.send().ignoreResult();
   }
 
+  kj::Promise<void> getIdentityId(GetIdentityIdContext context) override {
+    auto params = context.getParams();
+    auto req = sandstormCore.getIdentityIdRequest(params.totalSize());
+    req.setIdentity(params.getIdentity());
+    context.releaseParams();
+    return req.send().then([context](auto args) mutable -> void {
+      context.getResults().setId(args.getId());
+    });
+  }
+
 private:
   void dropHandle(kj::ArrayPtr<byte> sturdyRef) {
     auto req = sandstormCore.dropRequest();

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -184,6 +184,9 @@ interface SandstormCore {
   # Reports the current disk storage usage of the grain. The supervisor monitors storage usage
   # while the grain runs and calls this method periodically. In order to avoid unnecessary traffic,
   # the supervisor may choose not to report insignificant changes.
+
+  getIdentityId @9 (identity :Identity.Identity) -> (id :Data);
+  # Gets the ID of the identity, as it would appear in UserInfo.identityId.
 }
 
 struct MembraneRequirement {

--- a/tests/apps/ip-networking.js
+++ b/tests/apps/ip-networking.js
@@ -17,7 +17,7 @@
 "use strict";
 
 // Tests the `IpNetwork` and `IpInterface` capabilities using the sandstorm-test-python app.
-// The app's source code is hosted at https://github.com/zarvox/sandstorm-test-python.
+// The app's source code is hosted at https://github.com/sandstorm-io/sandstorm-test-python.
 
 var utils = require("../utils"),
     short_wait = utils.short_wait,
@@ -32,8 +32,8 @@ module.exports = {};
 module.exports["Test Ip Networking"] = function (browser) {
   browser
     .loginDevAccount(null, true)
-    .installApp("http://sandstorm.io/apps/david/sandstorm-test-python4.spk",
-                "874e67d3cd02486198d046909149723c",
+    .installApp("http://sandstorm.io/apps/david/sandstorm-test-python6.spk",
+                "a8c2128e401f1d20a426b24aa589c637",
                 "umeqc9yhncg63fjj6sahtw30nf99kfm6tgkuz8rmhn5dqtusnwah")
     .assert.containsText("#grainTitle", "Untitled Test App test page")
     .waitForElementVisible('.grain-frame', short_wait)
@@ -56,8 +56,8 @@ module.exports["Test Ip Networking"] = function (browser) {
 module.exports["Test Ip Interface"] = function (browser) {
   browser
     .loginDevAccount(null, true)
-    .installApp("http://sandstorm.io/apps/david/sandstorm-test-python4.spk",
-                "874e67d3cd02486198d046909149723c",
+    .installApp("http://sandstorm.io/apps/david/sandstorm-test-python6.spk",
+                "a8c2128e401f1d20a426b24aa589c637",
                 "umeqc9yhncg63fjj6sahtw30nf99kfm6tgkuz8rmhn5dqtusnwah")
     .assert.containsText("#grainTitle", "Untitled Test App test page")
     .waitForElementVisible('.grain-frame', short_wait)

--- a/tests/tests/powerbox-contacts.js
+++ b/tests/tests/powerbox-contacts.js
@@ -43,8 +43,8 @@ module.exports["Test powerbox request contact"] = function (browser) {
 
   browser
     .loginDevAccount(aliceName)
-    .installApp("http://sandstorm.io/apps/david/sandstorm-test-python6.spk",
-                "a8c2128e401f1d20a426b24aa589c637",
+    .installApp("http://sandstorm.io/apps/david/sandstorm-test-python7.spk",
+                "b06dc34b21ba3e8dcedc6d8bab351eac",
                 APP_ID)
     .assert.containsText("#grainTitle", "Untitled Test App test page")
     .waitForElementVisible('.grain-frame', short_wait)
@@ -94,6 +94,7 @@ module.exports["Test powerbox request contact"] = function (browser) {
                 .assert.containsText("form.test-identity div.result", bobName)
 
                 // Now trash the grain as Bob.
+                .frame()
                 .execute("window.Meteor.logout()")
                 .loginDevAccount(bobName)
                 .url(browser.launch_url + "/grain")

--- a/tests/tests/powerbox-contacts.js
+++ b/tests/tests/powerbox-contacts.js
@@ -1,0 +1,121 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2016 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+"use strict";
+
+// Tests powerbox requests for `Identity` capabilities.
+// The app's source code is hosted at https://github.com/sandstorm-io/sandstorm-test-python.
+
+var crypto = require("crypto");
+var utils = require("../utils"),
+    short_wait = utils.short_wait,
+    medium_wait = utils.medium_wait,
+    long_wait = utils.long_wait,
+    very_long_wait = utils.very_long_wait;
+
+var APP_ID = "umeqc9yhncg63fjj6sahtw30nf99kfm6tgkuz8rmhn5dqtusnwah";
+
+module.exports = {};
+
+module.exports["Test powerbox request contact"] = function (browser) {
+  // We need to prepend 'A' so that the default handle is always valid.
+  var aliceName = "A" + crypto.randomBytes(10).toString("hex");
+  var bobName = "A" + crypto.randomBytes(10).toString("hex");
+  var aliceIdentityId = crypto.createHash("sha256").update("dev:" + aliceName).digest("hex");
+  var bobIdentityId = crypto.createHash("sha256").update("dev:" + bobName).digest("hex");
+
+  var powerboxCardSelector =
+      ".popup.request .candidate-cards .powerbox-card button[data-card-id=frontendref-identity-" +
+      bobIdentityId + "]";
+
+  browser
+    .loginDevAccount(aliceName)
+    .installApp("http://sandstorm.io/apps/david/sandstorm-test-python6.spk",
+                "a8c2128e401f1d20a426b24aa589c637",
+                APP_ID)
+    .assert.containsText("#grainTitle", "Untitled Test App test page")
+    .waitForElementVisible('.grain-frame', short_wait)
+
+    // First we need to make sure that Bob is in Alice's contacts
+    .executeAsync(function (aliceIdentityId, bobIdentityId, done) {
+      var grainId = Grains.findOne()._id;
+      Meteor.call("newApiToken", { identityId: aliceIdentityId },
+                  grainId, "petname", { allAccess: null },
+                  { webkey: { forSharing: true }, },
+                  function(error, result) {
+                    Meteor.logout();
+                    done({ error: error, result: result, });
+                    });
+      }, [aliceIdentityId, bobIdentityId], function (result) {
+        browser.assert.equal(!result.value.error, true)
+        browser
+          .loginDevAccount(bobName)
+          .url(browser.launch_url + "/shared/" + result.value.result.token)
+          .waitForElementVisible("button.pick-identity", short_wait)
+          .click("button.pick-identity")
+          .waitForElementVisible('.grain-frame', medium_wait)
+          .execute("window.Meteor.logout()")
+
+          // OK, now create a new grain and share it to Bob through the powerbox.
+          .loginDevAccount(aliceName)
+          .disableGuidedTour(function () {
+            browser.newGrain(APP_ID, function(grainId) {
+              browser
+                .waitForElementVisible("#grainTitle", short_wait)
+                .assert.containsText("#grainTitle", "Untitled Test App test page")
+                .grainFrame()
+                .waitForElementVisible("#powerbox-request-identity", short_wait)
+                .click("#powerbox-request-identity")
+                .frameParent()
+                .waitForElementVisible(powerboxCardSelector, short_wait)
+                .click(powerboxCardSelector)
+
+                .waitForElementVisible(".popup.request .selected-card>form button.connect-button",
+                                       short_wait)
+                .click(".popup.request .selected-card>form button.connect-button")
+                .grainFrame()
+                .waitForElementVisible("span.token", short_wait)
+                .waitForElementVisible("form.test-identity button", short_wait)
+                .click("form.test-identity button")
+                .waitForElementVisible("form.test-identity div.result", short_wait)
+                .assert.containsText("form.test-identity div.result", bobName)
+
+                // Now trash the grain as Bob.
+                .execute("window.Meteor.logout()")
+                .loginDevAccount(bobName)
+                .url(browser.launch_url + "/grain")
+                .waitForElementVisible(".grain-list-table .select-all-grains>input", short_wait)
+                .click(".grain-list-table .select-all-grains>input")
+                .click(".bulk-action-buttons button.move-to-trash")
+
+                // Now check that the grain can no longer restore the Identity capability.
+                .execute("window.Meteor.logout()")
+                .loginDevAccount(aliceName)
+                .url(browser.launch_url + "/grain/" + grainId)
+                .waitForElementVisible("#grainTitle", short_wait)
+                .assert.containsText("#grainTitle", "Untitled Test App test page")
+                .grainFrame()
+                .waitForElementVisible("span.token", short_wait)
+                .waitForElementVisible("form.test-identity button", short_wait)
+                .click("form.test-identity button")
+                .waitForElementVisible("form.test-identity div.result", short_wait)
+                .assert.containsText("form.test-identity div.result",
+                                     "failed to fetch profile")
+                .end()
+            });
+          });
+      });
+};


### PR DESCRIPTION
Allows a user to introduce one of their contacts to a grain, giving the grain access to the contact's profile information while simultaneously granting the contact access to the grain.

I've updated the sandstorm-test-python app to test out this functionality. I also have a Wekan branch that uses it.

Looks like:
![contacts](https://cloud.githubusercontent.com/assets/495768/18573945/3b8fbae4-7b96-11e6-8d8c-acd27b0c98c8.png)

Future work is to figure out some nice way to include the identity-provider icon and the intrinsic name on these powerbox cards.