### PR TITLE
add membrane requirements to identities

### DIFF
--- a/shell/server/identity.js
+++ b/shell/server/identity.js
@@ -49,6 +49,27 @@ class IdentityImpl extends PersistentImpl {
   }
 };
 
+// TODO(cleanup): Find a better home for this.
+const MembraneRequirement = Match.OneOf(
+  { tokenValid: String },
+  { permissionsHeld:
+    { identityId: String, grainId: String, permissions: Match.Optional([Boolean]), } },
+  { permissionsHeld:
+    { tokenId: String, grainId: String, permissions: Match.Optional([Boolean]), } },
+  { userIsAdmin: String });
+
+
+makeIdentity = (identityId, requirements) => {
+  const saveTemplate = { frontendRef: { identity: identityId } };
+  if (requirements) {
+    check(requirements, [MembraneRequirement])
+    saveTemplate.requirements = requirements;
+  }
+
+  return new Capnp.Capability(new IdentityImpl(globalDb, saveTemplate, identityId),
+                              IdentityRpc.PersistentIdentity);
+};
+
 globalFrontendRefRegistry.register({
   frontendRefField: "identity",
 

--- a/shell/server/identity.js
+++ b/shell/server/identity.js
@@ -49,12 +49,6 @@ class IdentityImpl extends PersistentImpl {
   }
 };
 
-makeIdentity = (identityId, requriements) => {
-  const saveTemplate = { frontendRef: { identity: identityId } };
-  return new Capnp.Capability(new IdentityImpl(globalDb, saveTemplate, identityId),
-                              IdentityRpc.PersistentIdentity);
-};
-
 globalFrontendRefRegistry.register({
   frontendRefField: "identity",
 

--- a/shell/server/identity.js
+++ b/shell/server/identity.js
@@ -53,16 +53,15 @@ class IdentityImpl extends PersistentImpl {
 const MembraneRequirement = Match.OneOf(
   { tokenValid: String },
   { permissionsHeld:
-    { identityId: String, grainId: String, permissions: Match.Optional([Boolean]), } },
+    { identityId: String, grainId: String, permissions: Match.Optional([Boolean]), }, },
   { permissionsHeld:
-    { tokenId: String, grainId: String, permissions: Match.Optional([Boolean]), } },
+    { tokenId: String, grainId: String, permissions: Match.Optional([Boolean]), }, },
   { userIsAdmin: String });
-
 
 makeIdentity = (identityId, requirements) => {
   const saveTemplate = { frontendRef: { identity: identityId } };
   if (requirements) {
-    check(requirements, [MembraneRequirement])
+    check(requirements, [MembraneRequirement]);
     saveTemplate.requirements = requirements;
   }
 

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1236,7 +1236,10 @@ class Proxy {
         displayName: { defaultText: identity.profile.name },
         preferredHandle: identity.profile.handle,
         identityId: new Buffer(identity._id, "hex"),
-        identity: makeIdentity(identity._id, [idCapRequirement]),
+        identity: globalFrontendRefRegistry.create(
+          globalDb,
+          { identity: identityId },
+          [idCapRequirement]),
       };
       if (identity.profile.pictureUrl) {
         this.userInfo.pictureUrl = identity.profile.pictureUrl;

--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1236,10 +1236,7 @@ class Proxy {
         displayName: { defaultText: identity.profile.name },
         preferredHandle: identity.profile.handle,
         identityId: new Buffer(identity._id, "hex"),
-        identity: globalFrontendRefRegistry.create(
-          globalDb,
-          { identity: identityId },
-          [idCapRequirement]),
+        identity: makeIdentity(identity._id, [idCapRequirement]),
       };
       if (identity.profile.pictureUrl) {
         this.userInfo.pictureUrl = identity.profile.pictureUrl;


### PR DESCRIPTION
Our current `makeIdentity()` function ignores its `requirements` parameter. Therefore `Identity` capabilities passed to grains have no membrane requirements, and hence #2414.

This patch migrates existing saved identity capabilities to add the appropriate membrane requirement. It also removes the buggy `makeIdentity()` function in favor of `FrontendRefRegistry.create()`, which additionally validates the requirement. (A potential downside here is that this triggers another permissions computation. I don't think we've seen performance problems related to permissions computations yet, so maybe this isn't worth worrying about.)

This patch helps with https://github.com/sandstorm-io/sandstorm/issues/2414, but is not a complete fix; it does not kill any live identity capabilities and hence still requires grains to be rebooted before the revocation takes full effect.