### PR TITLE
Soften our claim about being the "only" way to make open source web apps viable.

### DIFF
--- a/shell/client/demo.html
+++ b/shell/client/demo.html
@@ -25,7 +25,7 @@
         {{/if}}
       </button>
 
-      <p>Sandstorm makes it easy to run apps on your own server. In addition to improving privacy and control, <a href="https://blog.sandstorm.io/news/2014-07-21-open-source-web-apps-require-federated-hosting.html" target="_blank">this is the only way to make Open Source web apps viable.</a></p>
+      <p>Sandstorm makes it easy to run apps on your own server. In addition to improving privacy and control, <a href="https://blog.sandstorm.io/news/2014-07-21-open-source-web-apps-require-federated-hosting.html" target="_blank">this brings Open Source apps to a wide audience.</a></p>
       <p>Sandstorm is also <strong>ridiculously secure</strong>. If security interests you, check out <a href="https://docs.sandstorm.io/en/latest/developing/security-practices/" target="_blank">Sandstorm's security model overview</a>.</p>
     {{else}}
       <p>Sorry, this server does not allow demo accounts.</p>


### PR DESCRIPTION
The intended meaning was: "Making it easy to run apps on your own server is the only way to make open source web apps viable."

However, it was easy to interpret: "Sandstorm is the only way to make open source web apps viable."

I couldn't think of an easy way to clarify, so I removed the word "only" to sound less Trumpian.