### PR TITLE
Fix that the preinstalled app package IDs could become outdated.

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1694,6 +1694,10 @@ _.extend(SandstormDb.prototype, {
         } else {
           this.startInstall(app.packageId, url, false, true);
         }
+      } else if (isAppPreinstalled) {
+        // The new version is already installed, but we still need to update the preinstall
+        // packageId.
+        globalDb.setPreinstallAppAsReady(app.appId, app.packageId);
       }
     });
   },


### PR DESCRIPTION
When an app update is discovered through an app index refresh, if the newer version of the app was already installed (for example, because someone had gone to the app market and installed it manually before the index update landed), then the preinstall package ID was never updated. This means the old version continued to be preinstalled and also broke appdemos of the particular app.