### PR TITLE
don't try to make powerbox cards for identities that don't exist

### DIFF
--- a/shell/server/identity.js
+++ b/shell/server/identity.js
@@ -140,19 +140,21 @@ globalFrontendRefRegistry.register({
 
     db.collections.contacts.find({ ownerId: userId }).forEach(contact => {
       const identity = db.getIdentity(contact.identityId);
-      result.push({
-        _id: "frontendref-identity-" + contact.identityId,
-        frontendRef: { identity: contact.identityId },
-        cardTemplate: "identityPowerboxCard",
-        configureTemplate: "identityPowerboxConfiguration",
-        profile: identity.profile,
-        requestedPermissions,
-        searchTerms: [
-          identity.profile.name,
-          identity.profile.handle,
-          identity.profile.intrinsicName,
-        ],
-      });
+      if (identity) {
+        result.push({
+          _id: "frontendref-identity-" + contact.identityId,
+          frontendRef: { identity: contact.identityId },
+          cardTemplate: "identityPowerboxCard",
+          configureTemplate: "identityPowerboxConfiguration",
+          profile: identity.profile,
+          requestedPermissions,
+          searchTerms: [
+            identity.profile.name,
+            identity.profile.handle,
+            identity.profile.intrinsicName,
+          ],
+        });
+      }
     });
 
     return result;


### PR DESCRIPTION
@jparyani noticed that the new powerbox contact picker sometimes fails on Oasis. The problem is that it's possible for an entry in the `Contacts` table to have an `identityId` for an identity that no longer exists (maybe because it was a demo identity), and we don't account for that possibility.

I think that after https://github.com/sandstorm-io/sandstorm/pull/2587 we now do clean up newly-dead contacts when identities get deleted, but that doesn't do anything to clean up the existing dead contacts in the database. 