### PR TITLE
Fix findIdentitiesByEmail()

### DIFF
--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -281,10 +281,15 @@ SandstormDb.prototype.findIdentitiesByEmail = function (email) {
 
   check(email, String);
 
+  // For LDAP, the field containing the e-mail address is configurable...
+  const ldapQuery = {};
+  ldapQuery["services.ldap.rawAttrs." + this.getLdapEmailField()] = email;
+
   return Meteor.users.find({ $or: [
     { "services.google.email": email },
     { "services.email.email": email },
     { "services.github.emails.email": email },
+    ldapQuery,
     { "services.saml.email": email },
   ], }).fetch().filter(function (identity) {
     // Verify that the email is verified, since our query doesn't technically do that.

--- a/shell/packages/sandstorm-db/profile.js
+++ b/shell/packages/sandstorm-db/profile.js
@@ -288,7 +288,7 @@ SandstormDb.prototype.findIdentitiesByEmail = function (email) {
     { "services.saml.email": email },
   ], }).fetch().filter(function (identity) {
     // Verify that the email is verified, since our query doesn't technically do that.
-    return !!_findWhere(SandstormDb.getVerifiedEmails(identity), { email: email });
+    return !!_.findWhere(SandstormDb.getVerifiedEmails(identity), { email: email });
   });
 };
 


### PR DESCRIPTION
This isn't called from the Sandstorm codebase, but is called by the code which receives mailing list subscribe/unsubscribe events from Mailchimp and updates bonuses accordingly. Probably, a few people who unsubscribed are still receiving the bonus. Oh well.

Also fixed it to handle LDAP correctly, even though this code is not currently used on any server that uses LDAP.