### PR TITLE
Don't count trashed grains against grain quota.

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1896,7 +1896,7 @@ _.extend(SandstormDb.prototype, {
 
     const plan = this.getUserQuota(user);
     if (plan.grains < Infinity) {
-      const count = this.collections.grains.find({ userId: user._id },
+      const count = this.collections.grains.find({ userId: user._id, trashed: { $exists: false } },
         { fields: {}, limit: plan.grains }).count();
       if (count >= plan.grains) return "outOfGrains";
     }
@@ -1916,7 +1916,7 @@ _.extend(SandstormDb.prototype, {
 
     // quota.grains = Infinity means unlimited grains. IEEE754 defines Infinity == Infinity.
     if (quota.grains < Infinity) {
-      const count = this.collections.grains.find({ userId: user._id },
+      const count = this.collections.grains.find({ userId: user._id, trashed: { $exists: false } },
         { fields: {}, limit: quota.grains * 2 }).count();
       if (count >= quota.grains * 2) return "outOfGrains";
     }


### PR DESCRIPTION
Users find this confusing.

A better solution would be to automatically delete trashed grains as needed when the user is running up against quota limits, but that would be trickier to implement, and as a result we haven't done it. In the meantime, this stopgap is much better than nothing.

Technically a user could abuse this by swapping grains in and out of their trash, but whatever.