### PR TITLE
Add SandstormHttpBridge.saveIdentity() method.

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -1953,6 +1953,16 @@ public:
     return kj::READY_NOW;
   }
 
+  kj::Promise<void> saveIdentity(SaveIdentityContext context) override {
+    auto identity = context.getParams().getIdentity();
+    context.releaseParams();
+    auto request = apiCap.getIdentityIdRequest();
+    request.setIdentity(identity);
+    return request.send().then([this, KJ_MVCAP(identity)](auto response) mutable -> void {
+      bridgeContext.saveIdentity(response.getId(), kj::mv(identity));
+    });
+  }
+
 private:
   SandstormApi<>::Client apiCap;
   BridgeContext& bridgeContext;

--- a/src/sandstorm/sandstorm-http-bridge.capnp
+++ b/src/sandstorm/sandstorm-http-bridge.capnp
@@ -36,4 +36,8 @@ interface SandstormHttpBridge {
   # If BridgeConfig.saveIdentityCaps is true for this app, then you can call this method to fetch
   # the saved identity capability for a particular identityId as passed in the
   # `X-Sandstorm-User-Id` header.
+
+  saveIdentity @3 (identity :Identity.Identity);
+  # If BridgeConfig.saveIdentityCaps is true for this app, adds the given identity to the
+  # grain's database, allowing it to be fetched later with `getSavedIdentity()`.
 }


### PR DESCRIPTION
This allows Wekan to send notifications to a user who has been added to a grain but has not yet opened the grain.