### PR TITLE
Make system log accessible during setup wizard

### DIFF
--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -37,8 +37,16 @@ const newAdminRoute = RouteController.extend({
     const websocketSeemsBroken = (
       Session.get("websocketSeemsBroken")
     );
+
+    const hasSetupToken = !!sessionStorage.getItem("setup-token");
+
+    // Most of the admin panel requires login, but we make a special exception for viewing the
+    // system log, since this is important for debugging problems that could be preventing login.
+    const isUserPermittedBySetupToken = hasSetupToken &&
+        Router.current().route.getName() == "newAdminStatus";
+
     return {
-      isUserPermitted: isAdmin(),
+      isUserPermitted: isAdmin() || isUserPermittedBySetupToken,
       wildcardHostSeemsBroken,
       websocketSeemsBroken,
     };

--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -46,6 +46,7 @@ const newAdminRoute = RouteController.extend({
         Router.current().route.getName() == "newAdminStatus";
 
     return {
+      hasSetupToken,
       isUserPermitted: isAdmin() || isUserPermittedBySetupToken,
       wildcardHostSeemsBroken,
       websocketSeemsBroken,

--- a/shell/client/admin-client.js
+++ b/shell/client/admin-client.js
@@ -19,10 +19,12 @@ Meteor.subscribe("publicAdminSettings");
 const newAdminRoute = RouteController.extend({
   template: "newAdmin",
   waitOn: function () {
+    const token = sessionStorage.getItem("setup-token");
+
     const subs = [
-      Meteor.subscribe("admin", this.params._token),
-      Meteor.subscribe("adminServiceConfiguration", this.params._token),
-      Meteor.subscribe("featureKey", true, this.params._token),
+      Meteor.subscribe("admin", token),
+      Meteor.subscribe("adminServiceConfiguration", token),
+      Meteor.subscribe("featureKey", true, token),
     ];
 
     return subs;

--- a/shell/client/admin/admin.html
+++ b/shell/client/admin/admin.html
@@ -45,10 +45,18 @@
     {{#if isUserPermitted}}
       {{> Template.dynamic template=adminTab}}
     {{else}}
-      <p>
-        You are not logged in as an admin. To access the admin panel, log in as an admin user or
-        generate a token from the command line by running `sandstorm admin-token`.
-      </p>
+      {{#if hasSetupToken}}
+        <p>
+          You are not logged in as an admin, but you do have a setup token. You can either
+          <a href="/setup">visit the setup wizard</a> or
+          <a href="/admin/status">view the system log</a>.
+        </p>
+      {{else}}
+        <p>
+          You are not logged in as an admin. To access the admin panel, log in as an admin user or
+          generate a token from the command line by running `sandstorm admin-token`.
+        </p>
+      {{/if}}
     {{/if}}
   </div>
 </template>

--- a/shell/client/admin/system-status-client.js
+++ b/shell/client/admin/system-status-client.js
@@ -110,7 +110,8 @@ Template.newAdminLog.helpers({
 });
 
 Template.newAdminStatus.onCreated(function () {
-  this.subscribe("adminLog");
+  // This route can be used with a setup token (unlike most admin routes).
+  this.subscribe("adminLog", sessionStorage.getItem("setup-token"));
 });
 
 Template.newAdminStatus.onDestroyed(function () {
@@ -119,7 +120,8 @@ Template.newAdminStatus.onDestroyed(function () {
 
 Template.newAdminStatus.events({
   "click button[name=download-full-log]"(evt) {
-    Meteor.call("adminGetServerLogDownloadToken", (err, token) => {
+    Meteor.call("adminGetServerLogDownloadToken", sessionStorage.getItem("setup-token"),
+        (err, token) => {
       if (err) {
         console.log(err.message);
       } else {

--- a/shell/client/admin/system-status-client.js
+++ b/shell/client/admin/system-status-client.js
@@ -111,56 +111,10 @@ Template.newAdminLog.helpers({
 
 Template.newAdminStatus.onCreated(function () {
   this.subscribe("adminLog");
-  this.subscribe("systemStatus");
-  // global exported from lib/demo.js
-  if (allowDemo) {
-    this.subscribe("adminDemoUsers");
-  }
-  // We keep a reference date in a ReactiveVar so that we can update it ever so often and the demo
-  // user count will reflect users that are still not expired at the current time.
-  this.referenceDate = new ReactiveVar(new Date());
-  this.intervalHandle = window.setInterval(() => {
-    this.referenceDate.set(new Date());
-  }, 60000);
 });
 
 Template.newAdminStatus.onDestroyed(function () {
   window.clearInterval(this.intervalHandle);
-});
-
-Template.newAdminStatus.helpers({
-  grainsActive() {
-    const data = systemStatus.findOne("globalStatus");
-    return data && data.activeGrains || 0;
-  },
-
-  usersActive() {
-    const data = systemStatus.findOne("globalStatus");
-    return data && data.activeUsers || 0;
-  },
-
-  allowDemo() {
-    // global exported from lib/demo.js
-    return allowDemo;
-  },
-
-  demosActive() {
-    const instance = Template.instance();
-    const query = globalDb.collections.users.find({
-      expires: {
-        $gt: instance.referenceDate.get(),
-      },
-      loginIdentities: {
-        $exists: true,
-      },
-    });
-    return query.count();
-  },
-
-  sandstormVersion() {
-    const buildInfo = getBuildInfo();
-    return buildInfo.build;
-  },
 });
 
 Template.newAdminStatus.events({

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -100,6 +100,7 @@
 <template name="setupWizardHelpFooter">
 <div class="setup-help-row">
   <span class="setup-help-label">Need help?</span>
+  <a class="setup-help-link" target="_blank" href="/admin/status">System Log</a>
   <a class="setup-help-link" target="_blank" href="https://docs.sandstorm.io/en/latest/administering/">Documentation</a>
   <a class="setup-help-link" href="mailto:support@sandstorm.io">Email support</a>
   {{!-- TODO(someday): Live Chat link --}}

--- a/shell/client/setup-wizard/wizard.js
+++ b/shell/client/setup-wizard/wizard.js
@@ -906,7 +906,7 @@ const setupRoute = RouteController.extend({
 
     const isUserPermitted = isAdmin() || (tokenStatus && tokenStatus.tokenIsValid);
     if (!isUserPermitted) {
-      Router.go("setupWizardTokenExpired");
+      Router.go("setupWizardTokenExpired", {}, { replaceState: true });
     }
 
     this.render();

--- a/shell/server/admin/system-status-server.js
+++ b/shell/server/admin/system-status-server.js
@@ -3,6 +3,7 @@ import { Router } from "meteor/iron:router";
 import { Random } from "meteor/random";
 import Crypto from "crypto";
 import Fs from "fs";
+import { checkAuth } from "/imports/server/auth.js";
 
 import { SANDSTORM_LOGDIR } from "/imports/server/constants.js";
 
@@ -16,11 +17,8 @@ const SYSTEM_LOG_DOWNLOAD_TOKENS = {};
 const SYSTEM_LOG_DOWNLOAD_TOKEN_VALIDITY_DURATION = 60000; // 60 seconds
 
 Meteor.methods({
-  adminGetServerLogDownloadToken() {
-    const db = this.connection.sandstormDb;
-    if (!db.isAdminById(this.userId)) {
-      throw new Meteor.Error(403, "User must be admin to download system log.");
-    }
+  adminGetServerLogDownloadToken(setupToken) {
+    checkAuth(setupToken);
 
     const token = Random.id(22);
     SYSTEM_LOG_DOWNLOAD_TOKENS[token] = Date.now();


### PR DESCRIPTION
This:
* Allows access to `/admin/status` with only a setup token (not logged in).
* Adds a button to the setup wizard footer to open the log.
* Improves some adjacent code.

This is important because often debugging login problems requires looking at the system log. #2603 in particular adds more debug logging around SAML and adds a link to `/admin/status` to the SAML error page; this isn't helpful if the user has to be logged in to view the log.