### PR TITLE
Allow apps to display 'data:' and 'blob:' URLs in their iframe.

### DIFF
--- a/shell/server/shell-server.js
+++ b/shell/server/shell-server.js
@@ -40,6 +40,8 @@ Meteor.startup(() => {
   const frameSetter = () => {
     BrowserPolicy.content.disallowFrame(); // This clears all the old rules
     BrowserPolicy.content.allowFrameOrigin(getWildcardOrigin());
+    BrowserPolicy.content.allowFrameOrigin("data:");
+    BrowserPolicy.content.allowFrameOrigin("blob:");
     const billingPromptUrl = globalDb.getBillingPromptUrl();
     if (billingPromptUrl) {
       BrowserPolicy.content.allowFrameOrigin(billingPromptUrl);


### PR DESCRIPTION
The purposes of restricting frame-src is more to prevent weird behavior than it is security: We don't want the grain iframe to browse to an external site because that would be weird and confusing. I don't see any reason to prevent data or blob URLs, though, and they are very useful for some kinds of apps.

Fixes #2602
