### PR TITLE
fix segfault in spk pack

### DIFF
--- a/src/sandstorm/spk.c++
+++ b/src/sandstorm/spk.c++
@@ -1302,7 +1302,9 @@ private:
       }
     }
 
-    node.setTarget(kj::mv(mapping.sourcePaths[0]));
+    if (mapping.sourcePaths.size() > 0) {
+      node.setTarget(kj::mv(mapping.sourcePaths[0]));
+    }
   }
 
   kj::String getHttpBridgeExe() {


### PR DESCRIPTION
Fixes #2582.

The case where `target` remains uninitialized is apparently already handled: https://github.com/sandstorm-io/sandstorm/blob/v0.187/src/sandstorm/spk.c%2B%2B#L1110-L1113