### PR TITLE
UiView powerbox: sort unopened apiTokens by created if no lastUsed

### DIFF
--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -168,7 +168,7 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
             (window.location.protocol + "//" + staticAssetHost + "/" + grainInfo.icon.assetId) :
             Identicon.identiconForApp(
                 (grainInfo && grainInfo.appId) || "00000000000000000000000000000000"),
-        lastUsed: apiToken.lastUsed,
+        lastUsed: apiToken.lastUsed || apiToken.created,
         apiTokenId: apiToken._id,
       };
     }


### PR DESCRIPTION
Jade reported that she struggled to find her recently-created item to attach
when doing a powerbox query, and that the grains seemed unordered.

While we do sort the grains by last used time, it seems that grains shared with
you that you never opened sit at the top of the list, whereas you probably want
them to show up in the grain list by their creation timestamp, as we do in the
grain list.

cc @jadeqwang 