### PR TITLE
Automatically remove '---BEGIN CERTIFICATE---', etc. from SAML certs.

### DIFF
--- a/shell/server/accounts/saml/saml-server.js
+++ b/shell/server/accounts/saml/saml-server.js
@@ -84,7 +84,8 @@ const generateService = function () {
     "entryPoint": db.getSamlEntryPoint(),
     // TODO(someday): find a better way to inject the DB
     "issuer": entityId || HOSTNAME,
-    "cert": db.getSamlPublicCert(),
+    // If the certificate has "-----BEGIN CERTIFICATE-----" markers, automatically remove those.
+    "cert": db.getSamlPublicCert().replace(/-[^\n]*-/g, "").trim(),
   };
   return service;
 };


### PR DESCRIPTION
It's probably typical for users to include these when pasting.