### PR TITLE
Make it possible to view the system log inline in the setup wizard

### DIFF
--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -100,10 +100,36 @@
 <template name="setupWizardHelpFooter">
 <div class="setup-help-row">
   <span class="setup-help-label">Need help?</span>
-  <a class="setup-help-link" target="_blank" href="/admin/status">System Log</a>
   <a class="setup-help-link" target="_blank" href="https://docs.sandstorm.io/en/latest/administering/">Documentation</a>
   <a class="setup-help-link" href="mailto:support@sandstorm.io">Email support</a>
+  <button type="button" name="system-log" class="setup-help-link">System Log</button>
   {{!-- TODO(someday): Live Chat link --}}
+  {{#if showSystemLog}}
+    {{#modalDialogWithBackdrop onDismiss=hideSystemLogCallback}}
+      {{> setupWizardSystemLog "" }}
+    {{/modalDialogWithBackdrop}}
+  {{/if}}
+</div>
+</template>
+
+<template name="setupWizardSystemLog">
+<div class="setup-system-log">
+  {{#if ready}}
+    {{#if isUserPermitted}}
+      <h2 class="setup-system-log-header">
+        <span class="setup-system-log-header-text">System log</span>
+        <form class="standard-form">
+          <button type="button" name="download-full-log">Download log</button>
+        </form>
+      </h2>
+      {{> newAdminLog ""}}
+    {{else}}
+      <p>
+        You cannot view the system log because you are not logged in as an admin
+        and you do not have a setup token.
+      </p>
+    {{/if}}
+  {{/if}}
 </div>
 </template>
 

--- a/shell/client/setup-wizard/wizard.js
+++ b/shell/client/setup-wizard/wizard.js
@@ -165,7 +165,7 @@ Template.setupWizardHelpFooter.onCreated(function () {
 
 Template.setupWizardHelpFooter.helpers({
   showSystemLog() {
-    const instance = Template.instance()
+    const instance = Template.instance();
     return instance.showSystemLogOverlay.get();
   },
 
@@ -192,7 +192,6 @@ Template.setupWizardSystemLog.onCreated(function () {
   }
 
   this.adminLogSub = this.subscribe("adminLog", token);
-  systemLog = this;
 });
 
 Template.setupWizardSystemLog.helpers({

--- a/shell/client/setup-wizard/wizard.js
+++ b/shell/client/setup-wizard/wizard.js
@@ -1,5 +1,6 @@
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
 import AccountsUi from "/imports/client/accounts/accounts-ui.js";
+import downloadFile from "/imports/client/download-file.js";
 
 // Pseudocollection telling the client if there's an admin user yet.
 HasAdmin = new Mongo.Collection("hasAdmin");
@@ -155,6 +156,76 @@ Template.setupWizardVerifyToken.helpers({
 
   rejected() {
     return Iron.controller().state.get("redeemStatus") === "rejected";
+  },
+});
+
+Template.setupWizardHelpFooter.onCreated(function () {
+  this.showSystemLogOverlay = new ReactiveVar(false);
+});
+
+Template.setupWizardHelpFooter.helpers({
+  showSystemLog() {
+    const instance = Template.instance()
+    return instance.showSystemLogOverlay.get();
+  },
+
+  hideSystemLogCallback() {
+    const instance = Template.instance();
+    return () => {
+      instance.showSystemLogOverlay.set(false);
+    };
+  },
+});
+
+Template.setupWizardHelpFooter.events({
+  "click button[name=system-log]"() {
+    const instance = Template.instance();
+    instance.showSystemLogOverlay.set(true);
+  },
+});
+
+Template.setupWizardSystemLog.onCreated(function () {
+  const token = sessionStorage.getItem("setup-token");
+  this.token = token;
+  if (this.token) {
+    this.adminTokenSub = this.subscribe("adminToken", token);
+  }
+
+  this.adminLogSub = this.subscribe("adminLog", token);
+  systemLog = this;
+});
+
+Template.setupWizardSystemLog.helpers({
+  ready() {
+    const instance = Template.instance();
+    return (!instance.token || instance.adminTokenSub.ready()) &&
+        instance.adminLogSub.ready();
+  },
+
+  isUserPermitted() {
+    const instance = Template.instance();
+    let tokenStatus = undefined;
+    if (instance.token) {
+      tokenStatus = AdminToken.findOne();
+    }
+
+    const isUserPermitted = isAdmin() || (tokenStatus && tokenStatus.tokenIsValid);
+    return isUserPermitted;
+  },
+});
+
+Template.setupWizardSystemLog.events({
+  "click button[name=download-full-log]"(evt) {
+    Meteor.call("adminGetServerLogDownloadToken", sessionStorage.getItem("setup-token"),
+        (err, token) => {
+      if (err) {
+        console.log(err.message);
+      } else {
+        const url = "/admin/status/server-log/" + token;
+        const suggestedFilename = "sandstorm.log";
+        downloadFile(url, suggestedFilename);
+      }
+    });
   },
 });
 
@@ -898,7 +969,6 @@ const setupRoute = RouteController.extend({
     const token = sessionStorage.getItem("setup-token");
     const state = this.state;
     state.set("token", token);
-    // Using AdminToken pseudocollection from admin-client.js
     let tokenStatus = undefined;
     if (token) {
       tokenStatus = AdminToken.findOne();

--- a/shell/client/styles/_setup-wizard.scss
+++ b/shell/client/styles/_setup-wizard.scss
@@ -52,6 +52,22 @@
     margin: 4px;
     text-decoration: none;
   }
+
+  .setup-system-log {
+    color: #000000;
+  }
+
+  .setup-system-log-header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+
+    .setup-system-log-header-text {
+      font-size: 24px;
+      font-weight: normal;
+    }
+  }
 }
 
 .setup-progress {


### PR DESCRIPTION
The link at the bottom of the page is now turned into a button that shows the log inline on the page.

Closes #1956 

![logged-in](https://cloud.githubusercontent.com/assets/307325/19058105/9294cfe0-8989-11e6-8863-af77c05e63ea.png)

![unauthorized](https://cloud.githubusercontent.com/assets/307325/19058120/b7c054f6-8989-11e6-86cf-fefaa5479b8b.png)