### PR TITLE
Avoid make thinking that deps/node has been modified

### DIFF
--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -100,6 +100,9 @@ pushd "$NODE_BUILD_ROOT/node"
 ./configure --partly-static
 make -j$(nproc)
 popd
+# Avoid making changes that would update the mtime of deps/node, which make would interpret
+# as needing to rebuild all the C++ (and everything after it in the build flow) again.
+# Instead, just modify the contents of deps/node/out.
 mkdir -p deps/node/out
 rm -rf deps/node/out/*
 mv "$NODE_BUILD_ROOT/node/out"/* deps/node/out/

--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -100,8 +100,9 @@ pushd "$NODE_BUILD_ROOT/node"
 ./configure --partly-static
 make -j$(nproc)
 popd
-rm -rf deps/node/out
-mv "$NODE_BUILD_ROOT/node/out" deps/node/
+mkdir -p deps/node/out
+rm -rf deps/node/out/*
+mv "$NODE_BUILD_ROOT/node/out"/* deps/node/out/
 
 # Start with the meteor bundle.
 cp -r shell-build/bundle bundle


### PR DESCRIPTION
Creating or removing children of a directory causes the directory's mtime to change.  The node-building code previously rm'd `deps/node/out` and replaced it with a newly-built one.  This caused make to think that we had updated `deps/node`, which would force an ekam run and everything else that follows in the build process, when really a rebuild on unchanged source should be a noop.

@dwrensha This should make repeated `make update` calls fast, as they used to be.