### PR TITLE
Implement "add a new email" in verifiedEmail powerbox picker.

### DIFF
--- a/shell/client/accounts/email-token/token-client.js
+++ b/shell/client/accounts/email-token/token-client.js
@@ -86,10 +86,8 @@ Template.addNewVerifiedEmailPowerboxConfiguration.onCreated(function () {
     const result = [];
     SandstormDb.getUserIdentityIds(Meteor.user()).forEach((identityId) => {
       let identity = Meteor.users.findOne({ _id: identityId });
-      if (identity) {
-        SandstormDb.getVerifiedEmails(identity).forEach((value) => {
-          result.push(value.email);
-        });
+      if (identity && identity.services.email) {
+        result.push(identity.services.email.email);
       }
     });
     _this.verifiedEmails.set(result);

--- a/shell/client/accounts/email-token/token-client.js
+++ b/shell/client/accounts/email-token/token-client.js
@@ -187,4 +187,14 @@ Template.addNewVerifiedEmailPowerboxConfiguration.events({
       }
     });
   },
+
+  "click button[name='reset']": function (event, instance) {
+    if (instance.completionObserver) {
+      instance.completionObserver.stop();
+    }
+
+    instance.token.set(null);
+    instance.email.set(null);
+    instance.state.set({ enterEmail: true });
+  },
 });

--- a/shell/client/accounts/email-token/token-client.js
+++ b/shell/client/accounts/email-token/token-client.js
@@ -167,7 +167,7 @@ Template.addNewVerifiedEmailPowerboxConfiguration.events({
           instance.state.set({ enterEmail: true, error: err.reason || "Unknown error", });
         } else {
           instance.enterTokenMessage.set(
-            "We've sent a confirmation e-mail to " + email +
+            "We've sent a confirmation email to " + email +
               ". It may take a few moments for it to show up in your inbox.");
           instance.state.set({ enterToken: true, });
         }

--- a/shell/client/accounts/email-token/token-templates.html
+++ b/shell/client/accounts/email-token/token-templates.html
@@ -34,13 +34,13 @@
   {{/if}}
 
   {{#if state.enterToken }}
+    {{#if state.error}}
+      <button name="reset" type="button">Try a different address</button>
+    {{/if}}
     <p>{{enterTokenMessage}}</p>
     <form class="verified-email" name="enter-token">
       <input type="text" name="token" placeholder="enter your token" value={{token}}>
       <button class="connect-button" disabled={{#unless token}}true{{/unless}}>Confirm</button>
-      {{#if state.error}}
-        <button name="reset" type="button">Try a different address</button>
-      {{/if}}
     </form>
   {{/if}}
 

--- a/shell/client/accounts/email-token/token-templates.html
+++ b/shell/client/accounts/email-token/token-templates.html
@@ -23,14 +23,14 @@
         <button class="connect-button">Select</button>
       {{else}}
         <button class="connect-button" disabled={{#unless email}}true{{/unless}}>
-          Send verification email
+          Send confirmation email
         </button>
       {{/if}}
     </form>
   {{/if}}
 
   {{#if state.sendingEmail }}
-    <p>Sending e-mail to {{email}}...</p>
+    <p>Sending to {{email}}...</p>
   {{/if}}
 
   {{#if state.enterToken }}

--- a/shell/client/accounts/email-token/token-templates.html
+++ b/shell/client/accounts/email-token/token-templates.html
@@ -12,11 +12,13 @@
 <template name="addNewVerifiedEmailPowerboxConfiguration">
   {{#if state.enterEmail}}
     <form class="verified-email" name="enter-email">
-      <input type="text" name="email" placeholder="enter email address">
+      <input type="text" name="email" placeholder="enter email address" value={{email}}>
       {{#if alreadyVerified}}
-        <button class="connect-button">Select (already verified)</button>
+        <button class="connect-button">Select</button>
       {{else}}
-        <button class="connect-button">Send verification email</button>
+        <button class="connect-button" disabled={{#unless email}}true{{/unless}}>
+          Send verification email
+        </button>
       {{/if}}
     </form>
   {{/if}}
@@ -26,10 +28,10 @@
   {{/if}}
 
   {{#if state.enterToken }}
-    <p>{{state.enterToken}}</p>
+    <p>{{enterTokenMessage}}</p>
     <form class="verified-email" name="enter-token">
-      <input type="text" name="token" placeholder="enter your token">
-      <button class="connect-button">Confirm</button>
+      <input type="text" name="token" placeholder="enter your token" value={{token}}>
+      <button class="connect-button" disabled={{#unless token}}true{{/unless}}>Confirm</button>
     </form>
   {{/if}}
 
@@ -38,7 +40,6 @@
   {{/if}}
 
   {{#if state.error}}
-    <p>{{state.error}}</p>
-    <button name="reset">Start over</button>
+    <p class="error">{{state.error}}</p>
   {{/if}}
 </template>

--- a/shell/client/accounts/email-token/token-templates.html
+++ b/shell/client/accounts/email-token/token-templates.html
@@ -38,6 +38,9 @@
     <form class="verified-email" name="enter-token">
       <input type="text" name="token" placeholder="enter your token" value={{token}}>
       <button class="connect-button" disabled={{#unless token}}true{{/unless}}>Confirm</button>
+      {{#if state.error}}
+        <button name="reset" type="button">Try a different address</button>
+      {{/if}}
     </form>
   {{/if}}
 

--- a/shell/client/accounts/email-token/token-templates.html
+++ b/shell/client/accounts/email-token/token-templates.html
@@ -35,7 +35,9 @@
 
   {{#if state.enterToken }}
     {{#if state.error}}
+    <div class="reset-row">
       <button name="reset" type="button">Try a different address</button>
+    </div>
     {{/if}}
     <p>{{enterTokenMessage}}</p>
     <form class="verified-email" name="enter-token">

--- a/shell/client/accounts/email-token/token-templates.html
+++ b/shell/client/accounts/email-token/token-templates.html
@@ -10,6 +10,12 @@
 </template>
 
 <template name="addNewVerifiedEmailPowerboxConfiguration">
+  {{#if state.error}}
+    {{#focusingErrorBox}}
+      {{state.error}}
+    {{/focusingErrorBox}}
+  {{/if}}
+
   {{#if state.enterEmail}}
     <form class="verified-email" name="enter-email">
       <input type="text" name="email" placeholder="enter email address" value={{email}}>
@@ -37,9 +43,5 @@
 
   {{#if state.sendingToken }}
     <p>Verifying token...</p>
-  {{/if}}
-
-  {{#if state.error}}
-    <p class="error">{{state.error}}</p>
   {{/if}}
 </template>

--- a/shell/client/accounts/email-token/token-templates.html
+++ b/shell/client/accounts/email-token/token-templates.html
@@ -8,3 +8,37 @@
   </h2>
   {{error}}
 </template>
+
+<template name="addNewVerifiedEmailPowerboxConfiguration">
+  {{#if state.enterEmail}}
+    <form class="verified-email" name="enter-email">
+      <input type="text" name="email" placeholder="enter email address">
+      {{#if alreadyVerified}}
+        <button class="connect-button">Select (already verified)</button>
+      {{else}}
+        <button class="connect-button">Send verification email</button>
+      {{/if}}
+    </form>
+  {{/if}}
+
+  {{#if state.sendingEmail }}
+    <p>Sending e-mail to {{email}}...</p>
+  {{/if}}
+
+  {{#if state.enterToken }}
+    <p>{{state.enterToken}}</p>
+    <form class="verified-email" name="enter-token">
+      <input type="text" name="token" placeholder="enter your token">
+      <button class="connect-button">Confirm</button>
+    </form>
+  {{/if}}
+
+  {{#if state.sendingToken }}
+    <p>Verifying token...</p>
+  {{/if}}
+
+  {{#if state.error}}
+    <p>{{state.error}}</p>
+    <button name="reset">Start over</button>
+  {{/if}}
+</template>

--- a/shell/client/styles/_powerbox.scss
+++ b/shell/client/styles/_powerbox.scss
@@ -92,10 +92,10 @@ body>.popup.request>.frame-container>.frame {
       >input[type=text] {
         font-size: 16pt;
       }
-      button[name=reset] {
-        @extend %button-base;
-        @extend %button-secondary;
-      }
+    }
+    button[name=reset] {
+      @extend %button-base;
+      @extend %button-secondary;
     }
   }
 }

--- a/shell/client/styles/_powerbox.scss
+++ b/shell/client/styles/_powerbox.scss
@@ -88,9 +88,8 @@ body>.popup.request>.frame-container>.frame {
       @extend %button-base;
       @extend %button-primary;
     }
-    button[name=reset] {
-      @extend %button-base;
-      @extend %button-secondary;
+    p.error {
+      background-color: $error-background-color;
     }
     form.verified-email {
       >input[type=text] {

--- a/shell/client/styles/_powerbox.scss
+++ b/shell/client/styles/_powerbox.scss
@@ -88,9 +88,6 @@ body>.popup.request>.frame-container>.frame {
       @extend %button-base;
       @extend %button-primary;
     }
-    p.error {
-      background-color: $error-background-color;
-    }
     form.verified-email {
       >input[type=text] {
         font-size: 16pt;

--- a/shell/client/styles/_powerbox.scss
+++ b/shell/client/styles/_powerbox.scss
@@ -119,6 +119,6 @@ body>.popup.request>.frame-container>.frame {
     background-position: 4px 4px;
     background-repeat: no-repeat;
     padding-left: 32px;
-    height: 32px;
+    height: 31px;
   }
 }

--- a/shell/client/styles/_powerbox.scss
+++ b/shell/client/styles/_powerbox.scss
@@ -92,6 +92,10 @@ body>.popup.request>.frame-container>.frame {
       >input[type=text] {
         font-size: 16pt;
       }
+      button[name=reset] {
+        @extend %button-base;
+        @extend %button-secondary;
+      }
     }
   }
 }

--- a/shell/client/styles/_powerbox.scss
+++ b/shell/client/styles/_powerbox.scss
@@ -93,9 +93,13 @@ body>.popup.request>.frame-container>.frame {
         font-size: 16pt;
       }
     }
-    button[name=reset] {
-      @extend %button-base;
-      @extend %button-secondary;
+    div.reset-row {
+      display: flex;
+      justify-content: flex-end;
+      button[name=reset] {
+        @extend %button-base;
+        @extend %button-secondary;
+      }
     }
   }
 }

--- a/shell/client/styles/_powerbox.scss
+++ b/shell/client/styles/_powerbox.scss
@@ -88,6 +88,15 @@ body>.popup.request>.frame-container>.frame {
       @extend %button-base;
       @extend %button-primary;
     }
+    button[name=reset] {
+      @extend %button-base;
+      @extend %button-secondary;
+    }
+    form.verified-email {
+      >input[type=text] {
+        font-size: 16pt;
+      }
+    }
   }
 }
 

--- a/shell/imports/client/accounts/email-token/token-login-helpers.js
+++ b/shell/imports/client/accounts/email-token/token-login-helpers.js
@@ -54,12 +54,11 @@ const loginWithEmailToken = function (email, token, callback) {
  * @param {String} resumePath If the user logs in by opening the link from the email, redirect them to this path on successful login.
  * @param {Function} [callback] Client only, optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
  */
-const createAndEmailTokenForUser = function (email, linkingNewIdentity, resumePath, callback) {
+const createAndEmailTokenForUser = function (email, options, callback) {
   check(email, String);
-  check(linkingNewIdentity, Boolean);
-  check(resumePath, String);
+  check(options, { resumePath: String, linking: Match.Optional({ allowLogin: Boolean }), });
 
-  Meteor.call("createAndEmailTokenForUser", email, linkingNewIdentity, resumePath, callback);
+  Meteor.call("createAndEmailTokenForUser", email, options, callback);
 };
 
 export { loginWithEmailToken, createAndEmailTokenForUser };

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -487,3 +487,4 @@ Template.emailVerifierPowerboxCard.helpers({
 
 Template.emailVerifierPowerboxCard.powerboxIconSrc = () => "/email-m.svg";
 Template.verifiedEmailPowerboxCard.powerboxIconSrc = () => "/email-m.svg";
+Template.addNewVerifiedEmailPowerboxCard.powerboxIconSrc = () => "/plus-6A237C.svg";

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -487,4 +487,4 @@ Template.emailVerifierPowerboxCard.helpers({
 
 Template.emailVerifierPowerboxCard.powerboxIconSrc = () => "/email-m.svg";
 Template.verifiedEmailPowerboxCard.powerboxIconSrc = () => "/email-m.svg";
-Template.addNewVerifiedEmailPowerboxCard.powerboxIconSrc = () => "/plus-6A237C.svg";
+Template.addNewVerifiedEmailPowerboxCard.powerboxIconSrc = () => "/add-email-m.svg";

--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -102,5 +102,5 @@
 </template>
 
 <template name="addNewVerifiedEmailPowerboxCard">
-  Add a new email...
+  Add a new email
 </template>

--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -103,5 +103,5 @@
 </template>
 
 <template name="addNewVerifiedEmailPowerboxCard">
-  Add a new email
+  Add a new address
 </template>

--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -100,3 +100,7 @@
     <button class="connect-button">Connect</button>
   </form>
 </template>
+
+<template name="addNewVerifiedEmailPowerboxCard">
+  Add a new email...
+</template>

--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -15,8 +15,8 @@
       {{/focusingErrorBox}}
     {{/if}}
 
-    <h4>Select one:</h4>
     {{#with selectedProvider}}
+      <h4>Selected:</h4>
       <div class="selected-card">
         <div class="powerbox-card" data-card-id="{{ option._id }}"
              style="background-image: url('{{ iconSrc }}');">
@@ -25,6 +25,7 @@
         {{>configureTemplate . }}
       </div>
     {{else}}
+      <h4>Select one:</h4>
       <div class="search-row">
         <label>
           <span title="Search" class="search-icon"></span>

--- a/shell/server/accounts/email-token/token-server.js
+++ b/shell/server/accounts/email-token/token-server.js
@@ -238,7 +238,7 @@ const createAndEmailTokenForUser = function (db, email, options) {
         "alreadySentEmailToken",
         "It looks like we sent a log in email to this address not long " +
         "ago. Please use the one that was already sent (check your spam folder if you can't find " +
-        "it), or wait a while and try again");
+        "it), or wait a while and try again.");
     }
 
     userId = user._id;

--- a/src/sandstorm/email.capnp
+++ b/src/sandstorm/email.capnp
@@ -122,7 +122,7 @@ interface VerifiedEmail @0xf88bf102464dfa5a {
   #
   # To verify a user, make a powerbox request for `VerifiedEmail`. In your `PowerboxDescriptor`,
   # set the tag value to a `VerifiedEmail.PowerboxTag` which has `authority` set to the
-  # capability returned by you `EmailVerifier`'s `getAuthority()` method. The user will be asked to
+  # capability returned by your `EmailVerifier`'s `getAuthority()` method. The user will be asked to
   # choose one of their addresses. The Powerbox returns an `VerifiedEmail` for the address they
   # chose. You must then pass this object to `EmailVerifier.verifyEmail()` to verify that
   # the capability really is attached to the user's account and obtain the final address.
@@ -152,7 +152,7 @@ interface VerifiedEmail @0xf88bf102464dfa5a {
     # the matching address.
 
     domain @2 :Text;
-    # Specify a domain (like "example.com") in a Powerbox request to requiure that the user choose
+    # Specify a domain (like "example.com") in a Powerbox request to require that the user choose
     # an address under the specified domain. The user will still have the choice to refuse
     # verification, but will not be offered addresses under other domains.
     #


### PR DESCRIPTION
If the verifier is configured to accept emails from the "email" identity provider, displays a powerbox option like this:
![pickemail](https://cloud.githubusercontent.com/assets/495768/19092061/12a3a5de-8a53-11e6-9b3c-663cc59ba35a.png)

Clicking the "Add a new email..." button leads to a prompt:

![enteremail](https://cloud.githubusercontent.com/assets/495768/19092089/2e06e02a-8a53-11e6-9739-e95b5e2df46e.png)

If you enter an email that's already verified, then this is the last step, and the button automatically updates to reflect that fact:
![alreadyverified](https://cloud.githubusercontent.com/assets/495768/19092107/433330de-8a53-11e6-9413-7ca22f9fd747.png)

Otherwise, you need to get the token from your email:
![entertoken](https://cloud.githubusercontent.com/assets/495768/19092134/6509f3c8-8a53-11e6-912a-f27a97c1afe3.png)

If you enter the wrong token, you get an error:
![error](https://cloud.githubusercontent.com/assets/495768/19092157/77379050-8a53-11e6-86ab-f94f0220fbf5.png)


I opted to write these templates from scratch because our existing email login templates are kind of a mess.

By adding a `searchTerms` field, this also makes it so the powerbox search bar actually works in email requests.
