### PR TITLE
sandstorm-http-bridge: don't double-report errors upon restoring identities

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -1106,6 +1106,8 @@ public:
         kj::StringPtr textIdRef = textId;
         KJ_ASSERT(liveIdentities.insert(std::make_pair(
           textIdRef, IdentityRecord { kj::mv(textId), kj::mv(identity) })).second);
+      }, [] (auto e) {
+        // Ignore the error here because the returned capability will report it upon use.
       }));
 
       return kj::mv(identity);
@@ -1133,6 +1135,8 @@ public:
             auto iter = liveIdentities.find(textId);
             KJ_ASSERT(iter != liveIdentities.end());
             iter->second.identity = kj::mv(newIdentity);
+          }, [] (auto e) {
+            // Ignore the error here because the returned capability will report it upon use.
           }));
 
           return kj::mv(newIdentity);


### PR DESCRIPTION
`Sandstorm.getSavedIdentity()` returns a pipelined identity capability. If the `restore()` call fails, the error is reported when the app tries to use the returned pipelined identity capability. Currently, the same error is also unconditionally reported by sandstorm-http-bridge; an app that calls `whenResolved()` on the returned cap and attempts to gracefully deal with the error still ends up with the error logged by sandstorm-http-bridge. That could be confusing for someone trying to debug an app.