### PR TITLE
VM requires git - standard setup.sh doesn't install it

### DIFF
--- a/docs/developing/web-publishing.md
+++ b/docs/developing/web-publishing.md
@@ -54,7 +54,7 @@ If you are using `vagrant-spk`, also add the following to the end of your
 # /usr/local/bin. This requires a C++ compiler. We opt for clang
 # because that's what Sandstorm is typically compiled with.
 if [ ! -e /usr/local/bin/capnp ] ; then
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q clang autoconf pkg-config libtool
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q clang autoconf pkg-config libtool git
     cd /tmp
     if [ ! -e capnproto ]; then git clone https://github.com/sandstorm-io/capnproto; fi
     cd capnproto


### PR DESCRIPTION
Running `vagrant-spk vm provision` after following instructions here https://docs.sandstorm.io/en/latest/developing/web-publishing/#a-helper-program-you-can-include-to-enable-publishing-request-a-publicid failed saying git wasn't installed.

This would install git. 
