### PR TITLE
Support RHEL 7, CentOS 7, and Arch by not using userns when unavailable

### DIFF
--- a/src/sandstorm/backend.c++
+++ b/src/sandstorm/backend.c++
@@ -450,7 +450,7 @@ kj::Promise<void> BackendImpl::tryGetPackage(TryGetPackageContext context) {
     auto results = context.getResults(sizeHint);
     results.setAppId(trim(appid));
     results.setManifest(manifest);
-    KJ_IF_MAYBE(fp, checkPgpSignature(results.getAppId(), manifest.getMetadata())) {
+    KJ_IF_MAYBE(fp, checkPgpSignature(results.getAppId(), manifest.getMetadata(), sandboxUid)) {
       results.setAuthorPgpKeyFingerprint(*fp);
     }
   }

--- a/src/sandstorm/backend.c++
+++ b/src/sandstorm/backend.c++
@@ -49,8 +49,9 @@ static void tryRecursivelyDelete(kj::StringPtr path) {
 }
 
 BackendImpl::BackendImpl(kj::LowLevelAsyncIoProvider& ioProvider, kj::Network& network,
-  SandstormCoreFactory::Client&& sandstormCoreFactory)
-    : ioProvider(ioProvider), network(network), coreFactory(kj::mv(sandstormCoreFactory)), tasks(*this) {}
+  SandstormCoreFactory::Client&& sandstormCoreFactory, kj::Maybe<uid_t> sandboxUid)
+    : ioProvider(ioProvider), network(network), coreFactory(kj::mv(sandstormCoreFactory)),
+      sandboxUid(sandboxUid), tasks(*this) {}
 
 void BackendImpl::taskFailed(kj::Exception&& exception) {
   KJ_LOG(ERROR, exception);

--- a/src/sandstorm/backend.h
+++ b/src/sandstorm/backend.h
@@ -33,7 +33,8 @@ namespace sandstorm {
 class BackendImpl: public Backend::Server, private kj::TaskSet::ErrorHandler {
 public:
   BackendImpl(kj::LowLevelAsyncIoProvider& ioProvider, kj::Network& network,
-              SandstormCoreFactory::Client&& sandstormCoreFactory);
+              SandstormCoreFactory::Client&& sandstormCoreFactory,
+              kj::Maybe<uid_t> sandboxUid);
 
 protected:
   kj::Promise<void> ping(PingContext context) override;
@@ -56,6 +57,7 @@ private:
   kj::LowLevelAsyncIoProvider& ioProvider;
   kj::Network& network;
   SandstormCoreFactory::Client coreFactory;
+  kj::Maybe<uid_t> sandboxUid;   // if not using user namespaces
   kj::TaskSet tasks;
 
   class RunningGrain {

--- a/src/sandstorm/backup.h
+++ b/src/sandstorm/backup.h
@@ -19,6 +19,7 @@
 
 #include "abstract-main.h"
 #include <kj/io.h>
+#include <unistd.h>
 
 namespace sandstorm {
 
@@ -32,6 +33,7 @@ public:
   bool setRestore();
   bool setFile(kj::StringPtr arg);
   bool setRoot(kj::StringPtr arg);
+  bool setUid(kj::StringPtr arg);
   bool run(kj::StringPtr grainDir);
 
 private:
@@ -39,6 +41,7 @@ private:
   bool restore = false;
   kj::StringPtr filename;
   kj::StringPtr root = "";
+  kj::Maybe<uid_t> sandboxUid;
 
   void writeSetgroupsIfPresent(const char *contents);
   void writeUserNSMap(const char *type, kj::StringPtr contents);

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1430,15 +1430,15 @@ private:
   }
 
   void dropPrivs(const UserIds& uids) {
+    // Defense in depth: Don't give my children any new caps for any reason.
+    KJ_SYSCALL(prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0));
+
     if (runningAsRoot) {
       KJ_SYSCALL(setresgid(uids.gid, uids.gid, uids.gid));
       KJ_SYSCALL(setgroups(uids.groups.size(), uids.groups.begin()));
       KJ_SYSCALL(setresuid(uids.uid, uids.uid, uids.uid));
     } else {
       // We're using UID namespaces.
-
-      // Defense in depth: Don't give my children any new caps for any reason.
-      KJ_SYSCALL(prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0));
 
       // Defense in depth: Drop all capabilities from the set of caps which my children are allowed
       //   to ever have.

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1318,8 +1318,8 @@ private:
       // But if our UID is zero, then the file's attributes are ignored and all capabilities are
       // inherited.
       writeSetgroupsIfPresent("deny\n");
-      writeUserNSMap("uid", kj::str("0 ", uid, " 1\n"));
-      writeUserNSMap("gid", kj::str("0 ", gid, " 1\n"));
+      writeUserNSMap("uid", kj::str("1000 ", uid, " 1\n"));
+      writeUserNSMap("gid", kj::str("1000 ", gid, " 1\n"));
 
       unsharedUidNamespace = true;
     }

--- a/src/sandstorm/spk.h
+++ b/src/sandstorm/spk.h
@@ -33,7 +33,8 @@ kj::String unpackSpk(int spkfd, kj::StringPtr outdir, kj::StringPtr tmpdir);
 void verifySpk(int spkfd, int tmpfile, spk::VerifiedInfo::Builder output);
 // Temporarily uncompress the spk, check its signature, and fill in `output` with relevant info.
 
-kj::Maybe<kj::String> checkPgpSignature(kj::StringPtr appIdString, spk::Metadata::Reader metadata);
+kj::Maybe<kj::String> checkPgpSignature(kj::StringPtr appIdString, spk::Metadata::Reader metadata,
+                                        kj::Maybe<uid_t> sandboxUid = nullptr);
 // Checks that the PGP signature embedded in the given package metadata matches the given app ID,
 // and returns the PGP key fingerprint. Returns null if there is no signature. Throws if there is
 // an invalid signature.

--- a/src/sandstorm/supervisor.h
+++ b/src/sandstorm/supervisor.h
@@ -98,7 +98,7 @@ private:
   bool devmode = false;
   bool seccompDumpPfc = false;
   bool isIpTablesAvailable = false;
-  kj::Maybe<uid_t> setuidMode;
+  kj::Maybe<uid_t> sandboxUid;  // nullptr = use userns
 
   class SandstormApiImpl;
   class SupervisorImpl;

--- a/src/sandstorm/supervisor.h
+++ b/src/sandstorm/supervisor.h
@@ -49,6 +49,7 @@ public:
   kj::MainBuilder::Validity setGrainId(kj::StringPtr id);
   kj::MainBuilder::Validity setPkg(kj::StringPtr path);
   kj::MainBuilder::Validity setVar(kj::StringPtr path);
+  kj::MainBuilder::Validity setUid(kj::StringPtr arg);
   kj::MainBuilder::Validity addEnv(kj::StringPtr arg);
   kj::MainBuilder::Validity addCommandArg(kj::StringPtr arg);
   // Flag handlers
@@ -97,6 +98,7 @@ private:
   bool devmode = false;
   bool seccompDumpPfc = false;
   bool isIpTablesAvailable = false;
+  kj::Maybe<uid_t> setuidMode;
 
   class SandstormApiImpl;
   class SupervisorImpl;

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -879,6 +879,14 @@ Subprocess::Subprocess(Options&& options)
         KJ_SYSCALL(dup2(options.moreFds[i], STDERR_FILENO + 1 + i));
       }
 
+      // Drop priveleges if requested.
+      KJ_IF_MAYBE(g, options.gid) {
+        KJ_SYSCALL(setresgid(*g, *g, *g));
+      }
+      KJ_IF_MAYBE(u, options.uid) {
+        KJ_SYSCALL(setresuid(*u, *u, *u));
+      }
+
       // Make the args vector.
       char* argv[options.argv.size() + 1];
       for (auto i: kj::indices(options.argv)) {

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -879,7 +879,7 @@ Subprocess::Subprocess(Options&& options)
         KJ_SYSCALL(dup2(options.moreFds[i], STDERR_FILENO + 1 + i));
       }
 
-      // Drop priveleges if requested.
+      // Drop privileges if requested.
       KJ_IF_MAYBE(g, options.gid) {
         KJ_SYSCALL(setresgid(*g, *g, *g));
       }

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -280,6 +280,11 @@ public:
     // An array of 'NAME=VALUE' pairs specifying the child's environment. If null, inherits the
     // parent's environment.
 
+    kj::Maybe<uid_t> uid;
+    kj::Maybe<gid_t> gid;
+    // Values to change the UID and GID to in the child process before exec. Leave null for no
+    // change.
+
     Options(kj::StringPtr executable): executable(executable), argv(&this->executable, 1) {}
     Options(kj::ArrayPtr<const kj::StringPtr> argv): executable(argv[0]), argv(argv) {}
     Options(kj::Array<const kj::StringPtr>&& argv)


### PR DESCRIPTION
This turned out significantly less horrible than imagined.

Until now our assumption had been that supporting non-userns systems would require turning the supervisor into a setuid binary. Setuid binaries are scary. Also, the supervisor isn't actually a separate binary from other Sandstorm components these days, which would be a pain to undo.

But I came up with a trick that avoids the need for setuid binaries: Instead, root privileges are handed down from the bundle runner through the "backend" process to the supervisor. The backend process runs with _effective_ UID non-root, but still has a _real_ UID of root, which allows it to run the supervisor as root. No setuid binaries.

This does mean that an RCE vulnerability in the backend process would be able to do more damage, since it could potentially setuid(0) itself. However, the backend is a relatively simple process that is not directly exposed to the internet nor to apps, so this risk seems small -- and in many cases less-bad than the risk involved in dropping a setuid binary onto the system.

For systems that support userns, this change should have no effect. Support for userns is discovered dynamically at startup. Note that I've deleted the userns-related code from the install script, which means the installer will no longer go out of its way to enable userns, which may mean that a lot of people even with newer kernels end up using the non-userns path.

With this, I successfully tested this on CentOS 7.2 (kernel 3.10).

@amluto Curious for your thoughts.

@paulproteus Please review installer changes.

@jparyani Please review C++ changes.