### PR TITLE
installer-tests: Use a more specific cleanup function

### DIFF
--- a/installer-tests/full-server-install-on-jessie-with-mta.t
+++ b/installer-tests/full-server-install-on-jessie-with-mta.t
@@ -1,7 +1,7 @@
 Title: Ensure that Sandstorm installs OK when there is a MTA
 Vagrant-Box: jessie
 Precondition: sandstorm_not_installed
-Cleanup: uninstall_sandstorm
+Cleanup: uninstall_sandstorm_and_postfix
 
 $[run]sudo cat /proc/sys/kernel/unprivileged_userns_clone
 $[slow]0


### PR DESCRIPTION
Earlier, I had added purging postfix to cleanup for all tests. However, not all of our test VMs run Debian,
so this was a pretty silly idea in hindsight.

This Sandstorm commit uses a new cleanup function defined here:
https://github.com/paulproteus/stodgy-tester/commit/51ed3de778ca3aa289ece69024a576449a3afbe4
so that Postfix is successfully removed from the VM to avoid disruption to
other installer-tests.

**Testing done:** Currently running this on `asheeshdev.sandcats.io` with the latest version of `stodgy-tester`. Once that passes, I'll merge this, and re-enable https://build.sandstorm.io/job/Sandstorm-installer/ and do a test build on Jenkins to make sure all is well.