### PR TITLE
Move info/error messages in the login dialog to the top of the form

### DIFF
--- a/shell/client/accounts/login-buttons.html
+++ b/shell/client/accounts/login-buttons.html
@@ -150,6 +150,8 @@ licenses, included in the LICENSES directory.
 
 <template name="loginButtonsList">
   <div class="login-buttons-list">
+  {{> _loginButtonsMessages "" }}
+
   {{#each services}}
     {{#with data=loginTemplate.data linkingNewIdentity=linkingNewIdentity}}
       {{> Template.dynamic template=../loginTemplate.name }}
@@ -159,8 +161,6 @@ licenses, included in the LICENSES directory.
       configure login
     {{/linkTo}}
   {{/each}}
-
-  {{> _loginButtonsMessages "" }}
 
   {{#if showTroubleshooting}}
     {{> _loginButtonsSeparator "" }}


### PR DESCRIPTION
Placing errors below the thing the user is interacting with is bad because:

* the errors can wind up completely off-screen if they appear below the fold
* users are less likely to associate the error message with the action they
  just took if it is in a section that they haven't read/interacted with on the
  page.

It is better to place errors at the top of the context to which they apply
than to place them below the context to which they apply.

Ideally, we'd place errors associated with a particular login mechanism just
above *that login mechanism's login section* but I don't think we currently
track those separately and this seems like a strict improvement.

![screenshot1](https://cloud.githubusercontent.com/assets/307325/19326278/b1fc5b18-907e-11e6-89d0-637d7fb807e2.png)