### PR TITLE
Don't accidentally send email via localhost if hostname unset

### DIFF
--- a/shell/imports/server/email.js
+++ b/shell/imports/server/email.js
@@ -11,7 +11,7 @@ const getSmtpConfig = function () {
 
 const makePool = function (mailConfig) {
   if (!mailConfig.hostname) {
-    throw new Error("No hostname configured");
+    throw new Error("This Sandstorm server has not been configured to send email.");
   }
 
   let auth = false;

--- a/shell/imports/server/email.js
+++ b/shell/imports/server/email.js
@@ -10,6 +10,10 @@ const getSmtpConfig = function () {
 };
 
 const makePool = function (mailConfig) {
+  if (!mailConfig.hostname) {
+    throw new Error("No hostname configured");
+  }
+
   let auth = false;
   if (mailConfig.auth && (mailConfig.auth.user || mailConfig.auth.pass)) {
     auth = mailConfig.auth;


### PR DESCRIPTION
Apparently nodemailer's defaults will supply "localhost" for the hostname
if none is provided.  This hilariously results in email getting sent via
localhost if you have explicitly deconfigured email.

This change makes the email pool factory throw if you provide an empty hostname.