### PR TITLE
Mask LDAP bind password in the dialog

### DIFF
--- a/shell/client/admin/identity-providers.html
+++ b/shell/client/admin/identity-providers.html
@@ -206,7 +206,7 @@
 
     <div class="form-group">
       <label>Bind user password
-        <input type="text" name="ldapSearchBindPassword" value="{{ldapSearchBindPassword}}"/>
+        <input type="password" name="ldapSearchBindPassword" value="{{ldapSearchBindPassword}}"/>
       </label>
       <span class="form-subtext">
         Optional, needed if specifying bind DN above.

--- a/shell/client/styles/_admin-identity.scss
+++ b/shell/client/styles/_admin-identity.scss
@@ -83,49 +83,11 @@
 }
 
 .setup-idp-form {
+  @extend %standard-form;
   margin-bottom: 10px;
-
-  .idp-options-group {
-    display: block;
-    position: relative;
-    padding-left: 24px;
-    margin-bottom: 20px;
-    input[type=checkbox] {
-      position: absolute;
-      margin-left: -24px;
-    }
-    &::after {
-      border-bottom: 1px solid #ddd;
-    }
-  }
-
-  .form-group {
-    margin-bottom: 10px;
-  }
-
-  label {
-    display: block;
-    font-weight: normal;
-    font-size: 20px;
-  }
-
-  input[type="text"], textarea {
-    display: block;
-    width: 100%;
-    background-color: white;
-    padding: 4px;
-    font-size: 16px;
-    border-radius: 2px;
-    border: 1px solid #d3d3d3;
-  }
 
   textarea {
     min-height: 200px;
-  }
-
-  .form-subtext {
-    font-size: 14px;
-    color: #666;
   }
 }
 


### PR DESCRIPTION
I also noticed that the styles for this form could be DRYed up, which fixed a
problem where the `<input type="password">` was not `display: block;`