### PR TITLE
Feature key upload form: show example feature key

### DIFF
--- a/shell/client/admin/feature-key-client.js
+++ b/shell/client/admin/feature-key-client.js
@@ -81,6 +81,18 @@ Template.adminFeatureKeyDetails.helpers({
   },
 });
 
+// A properly-structured-but-signed-by-an-invalid-signer key to serve as an example in the input
+// so when people see the formatted copyable feature key in the Sandstorm for Work dashboard,
+// they will recognize the similar shape and ascii armor and hopefully connect to copy/paste it
+// more easily.
+const PLACEHOLDER_KEY = `--------------------- BEGIN SANDSTORM FEATURE KEY ----------------------
+6tNStoksTdIeEUogIeE6KcF/gVFGrE8QKISLX0gy/SkPmnwGDh0M8fofCxPouY6DTgcqa5Zb
+UPu9TJHMG0BiCRATUAMCD0Tg9lcPRG0eWB//////AREFolEMAQP/V457RSOWN5kBYLA9/2nC
+fwkPemD3mf9sCbF+QdeTQgARCWIRDXIREYL/QmlnIHNwZW4AB2Rlcv9EYXZlIERldgAfIFVz
+ZXL/dGVzdEB6YXIBdm94Lm9yZwA=
+---------------------- END SANDSTORM FEATURE KEY -----------------------`;
+
+
 Template.featureKeyUploadForm.onCreated(function () {
   this.error = new ReactiveVar(undefined);
   this.text = new ReactiveVar("");
@@ -95,6 +107,12 @@ Template.featureKeyUploadForm.events({
 
     const instance = Template.instance();
     const text = instance.text.get();
+
+    if (text.lastIndexOf(PLACEHOLDER_KEY) !== -1) {
+      instance.error.set("The example key is not actually a valid key. ☺");
+      return;
+    }
+
     Meteor.call("submitFeatureKey", token, text, (err) => {
       if (err) {
         instance.error.set(err.message);
@@ -133,8 +151,12 @@ Template.featureKeyUploadForm.events({
 });
 
 Template.featureKeyUploadForm.helpers({
-  currentError: function () {
+  currentError() {
     return Template.instance().error.get();
+  },
+
+  placeholderKey() {
+    return PLACEHOLDER_KEY;
   },
 
   text() {

--- a/shell/client/admin/feature-key-client.js
+++ b/shell/client/admin/feature-key-client.js
@@ -92,7 +92,6 @@ fwkPemD3mf9sCbF+QdeTQgARCWIRDXIREYL/QmlnIHNwZW4AB2Rlcv9EYXZlIERldgAfIFVz
 ZXL/dGVzdEB6YXIBdm94Lm9yZwA=
 ---------------------- END SANDSTORM FEATURE KEY -----------------------`;
 
-
 Template.featureKeyUploadForm.onCreated(function () {
   this.error = new ReactiveVar(undefined);
   this.text = new ReactiveVar("");

--- a/shell/client/admin/feature-key.html
+++ b/shell/client/admin/feature-key.html
@@ -201,9 +201,12 @@
         {{/focusingErrorBox}}
       {{/if}}
     {{/with}}
-    <label>Enter feature key:
-      <textarea class="feature-key" placeholder="Paste feature key here..." value="{{text}}"></textarea>
-    </label>
+    <div class="form-group">
+      <label>Enter feature key:
+        <textarea class="feature-key" placeholder="{{placeholderKey}}" value="{{text}}"></textarea>
+      </label>
+      <span class="form-subtext">Paste your feature key here, then click "Verify"</span>
+    </div>
     <div class="feature-key-button-row">
       <button type="submit" class="check-key" disabled={{disabled}}>Verify</button>
     </div>

--- a/shell/client/styles/_admin.scss
+++ b/shell/client/styles/_admin.scss
@@ -83,7 +83,9 @@
 form.feature-key-form, form.feature-key-modify-form {
   @extend %standard-form;
   textarea {
-    min-height: 60px;
+    min-height: 96px;
+    font-family: monospace;
+    font-size: 12px;
   }
 }
 


### PR DESCRIPTION
In user testing, it took a user longer than I expected to realize what was they
were supposed to do next after obtaining a trial key.  In an ideal world, they
wouldn't need to take any particular action, but for now we can make this have
a bit more consistency/familiarity by mimicking the stylization and format of
the feature key in the Sandstorm for Work dashboard.

The goal here is to show an example of what a feature key looks like, so when
the user obtains one they'll more quickly connect that they're supposed to
paste it into the box.

If the user attempts to use the placeholder feature key, we will give them a
gentle admonishment.

![screenshot1](https://cloud.githubusercontent.com/assets/307325/19406137/6c185800-9235-11e6-9c22-f92e14c315a5.png)
