### PR TITLE
Revert "Move info/error messages in the login dialog to the top of the form"

### DIFF
--- a/shell/client/accounts/login-buttons.html
+++ b/shell/client/accounts/login-buttons.html
@@ -150,8 +150,6 @@ licenses, included in the LICENSES directory.
 
 <template name="loginButtonsList">
   <div class="login-buttons-list">
-  {{> _loginButtonsMessages "" }}
-
   {{#each services}}
     {{#with data=loginTemplate.data linkingNewIdentity=linkingNewIdentity}}
       {{> Template.dynamic template=../loginTemplate.name }}
@@ -161,6 +159,8 @@ licenses, included in the LICENSES directory.
       configure login
     {{/linkTo}}
   {{/each}}
+
+  {{> _loginButtonsMessages "" }}
 
   {{#if showTroubleshooting}}
     {{> _loginButtonsSeparator "" }}


### PR DESCRIPTION
Reverts sandstorm-io/sandstorm#2651

This change makes e-mail login confusing. Reverting for now until we can figure out how to make it better. See discussion on original PR.