### PR TITLE
Rework sign-in overlay postMessage API

### DIFF
--- a/shell/client/accounts/login-buttons.html
+++ b/shell/client/accounts/login-buttons.html
@@ -135,16 +135,21 @@ licenses, included in the LICENSES directory.
 </template>
 
 <template name="loginButtonsDialog">
+{{!-- takes arguments:
+  accountsUi: instance of AccountsUi
+       label: optional String which replaces top-of-dialog-label.  If absent, the dialog will show
+              either "Create account" if the server allows uninvited users or "Sign in" if not.
+--}}
   <div class="login-dialog">
     {{!-- There's no actual difference between signing "up" and "in", but people expect there to
           be a difference, so humor them by making the front-page login say "sign up". (But for a
           private server, don't offer "sign up".) --}}
     <h4>
       <span class="logo" style="background-image: url('{{logoUrl}}')"></span>
-      {{#if allowUninvited}}Create account{{else}}Sign in{{/if}}
+      {{ labelOrFallback }}
     </h4>
 
-    {{> loginButtonsList . }}
+    {{> loginButtonsList accountsUi }}
   </div>
 </template>
 

--- a/shell/client/accounts/login-buttons.js
+++ b/shell/client/accounts/login-buttons.js
@@ -274,8 +274,9 @@ const loginWithToken = function (email, token) {
 };
 
 Template.loginButtonsDialog.helpers({
-  allowUninvited() {
-    return Meteor.settings.public.allowUninvited;
+  labelOrFallback() {
+    if (this.label) return this.label;
+    return Meteor.settings.public.allowUninvited ? "Create account" : "Sign in";
   },
 
   logoUrl() {

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -693,6 +693,13 @@ Template.grainView.helpers({
       onPicked: function (identityId) { grain.revealIdentity(identityId); },
     };
   },
+
+  closeSignInOverlay() {
+    return () => {
+      const grain = globalGrains.getActive();
+      grain.disableSigninOverlay();
+    };
+  }
 });
 
 Template.grain.helpers({
@@ -1488,12 +1495,8 @@ Meteor.startup(function () {
       if (event.data.overlaySignin.disable) {
         senderGrain.disableSigninOverlay();
       } else {
-        const left = event.data.overlaySignin.left;
-        const top = event.data.overlaySignin.top;
-        check(left, Number);
-        check(top, Number);
-
-        senderGrain.showSigninOverlay(left, top);
+        const creatingAccount = !!event.data.overlaySignin.creatingAccount;
+        senderGrain.showSigninOverlay(creatingAccount);
       }
     } else if (event.data.showConnectionGraph) {
       // Allow the current grain to request that the "Who has access" dialog be shown.

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -699,7 +699,7 @@ Template.grainView.helpers({
       const grain = globalGrains.getActive();
       grain.disableSigninOverlay();
     };
-  }
+  },
 });
 
 Template.grain.helpers({

--- a/shell/client/grain.html
+++ b/shell/client/grain.html
@@ -37,9 +37,9 @@
             used for testing purposes. --}}
       <iframe data-grainid="{{grainId}}" id="grain-frame-{{grainId}}" class="grain-frame" src="{{appOrigin}}/_sandstorm-init?sessionid={{sessionId}}&path={{originalPath}}"></iframe>
       {{#with signinOverlay}}
-        <div class="signin-frame" style="left: {{left}}px; top: {{top}}px">
-          {{> loginButtonsDialog globalAccountsUi}}
-        </div>
+        {{#modalDialogWithBackdrop class="signin" onDismiss=closeSignInOverlay}}
+          {{> loginButtonsDialog label=label accountsUi=globalAccountsUi}}
+        {{/modalDialogWithBackdrop}}
       {{/with}}
       {{#if hasNotLoaded}}
         {{> _grainSpinner ""}}

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -192,7 +192,7 @@
         <div class="center">
           {{#if showSignInPanel}}
             {{#with linkingNewIdentity=notLinkingNewIdentity}}
-              {{> loginButtonsDialog freshAccountsUi}}
+              {{> loginButtonsDialog label="Sign in" accountsUi=freshAccountsUi}}
             {{/with}}
           {{else}}
           <button class="sign-in-button">Sign in to become admin</button>
@@ -617,7 +617,7 @@
       {{!-- The loginButtonsDialog apparently requires this in the parent data context, which seems
             wrong.  It should probably be passed in explicitly instead.  --}}
       {{#with linkingNewIdentity=notLinkingNewIdentity}}
-        {{> loginButtonsDialog freshAccountsUi}}
+        {{> loginButtonsDialog label="Create account" accountsUi=freshAccountsUi}}
       {{/with}}
     </div>
   {{/if}}

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -36,7 +36,7 @@ limitations under the License.
         <p>Thanks for trying the Sandstorm Demo! Your demo account has expired. If
           you'd like to continue using Sandstorm and make your data permanent, please sign in.</p>
         <div class="login">
-          {{> loginButtonsDialog globalAccountsUi}}
+          {{> loginButtonsDialog accountsUi=globalAccountsUi}}
         </div>
       {{else}}
         <p>Thanks for trying the Sandstorm Demo! Your demo account has expired.</p>
@@ -193,7 +193,7 @@ limitations under the License.
   {{>title "Home"}}
 
   <div id="intro" class="{{#if splashUrl}}has-splash{{/if}}">
-    {{> loginButtonsDialog globalAccountsUi}}
+    {{> loginButtonsDialog accountsUi=globalAccountsUi}}
     {{#if splashUrl}}
       <iframe src="{{splashUrl}}"></iframe>
     {{/if}}

--- a/shell/client/styles/_widgets.scss
+++ b/shell/client/styles/_widgets.scss
@@ -66,6 +66,26 @@
   z-index: 1010;
   display: block;
   overflow-y: auto;
+
+  &.signin {
+    // Used by the sign-in overlay, which would prefer to be minimally wide, have no background, but
+    // retain the close button.
+    .modal {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .modal-dialog {
+      display: inline-block;
+    }
+
+    .modal-content {
+      background-color: transparent;
+      padding: 0px;
+    }
+  }
 }
 
 .modal-dialog {

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -434,14 +434,16 @@ class GrainView {
     this._dep.changed();
   }
 
-  showSigninOverlay(left, top) {
-    this._signinOverlay = { left: left, top: top, };
+  showSigninOverlay(creatingAccount) {
+    this._signinOverlay = {
+      label: creatingAccount ? "Create account" : "Sign in",
+    };
 
     this._dep.changed();
   }
 
   disableSigninOverlay() {
-    this._signinOverlay = null;
+    this._signinOverlay = undefined;
 
     this._dep.changed();
   }


### PR DESCRIPTION
The previous sign-in overlay did not behave well in the presence of scrolling.
Now, we show a modal overlay rather than painting over the app at the same
time.

This change also makes the sign-in dialog's label optionally explicit, which means
we can say "Create account" in the setup wizard for the first user, or "Sign in" if you're
trying to promote an existing user to admin.