### PR TITLE
Restyle demo sidebar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,8 @@ IMAGES= \
     shell/public/email-494949.svg \
     shell/public/close-FFFFFF.svg \
                                   \
-    shell/public/install-6A237C.svg \
-    shell/public/install-9E40B5.svg \
+    shell/public/install-714DAA.svg \
+    shell/public/install-896AC6.svg \
     shell/public/plus-6A237C.svg \
     shell/public/plus-9E40B5.svg \
     shell/public/upload-B7B7B7.svg \
@@ -295,13 +295,13 @@ shell/public/close-FFFFFF.svg: icons/close.svg
 	@$(call color,custom color $<)
 	@sed -e 's/#111111/#FFFFFF/g' < $< > $@
 
-shell/public/install-6A237C.svg: icons/install.svg
+shell/public/install-714DAA.svg: icons/install.svg
 	@$(call color,custom color $<)
-	@sed -e 's/#111111/#6A237C/g' < $< > $@
+	@sed -e 's/#111111/#714DAA/g' < $< > $@
 
-shell/public/install-9E40B5.svg: icons/install.svg
+shell/public/install-896AC6.svg: icons/install.svg
 	@$(call color,custom color $<)
-	@sed -e 's/#111111/#9E40B5/g' < $< > $@
+	@sed -e 's/#111111/#896AC6/g' < $< > $@
 
 shell/public/plus-6A237C.svg: icons/plus.svg
 	@$(call color,custom color $<)

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -633,7 +633,9 @@ Template.layout.helpers({
 });
 
 Template.layout.events({
-  "click #demo-expired .logout": function (event) {
+  "click #demo-expired button[name=logout]"(evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
     logoutSandstorm();
   },
 });

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -39,8 +39,13 @@ limitations under the License.
           {{> loginButtonsDialog globalAccountsUi}}
         </div>
       {{else}}
-        <p>Thanks for trying the Sandstorm Demo! Your demo account has expired.</p>
-        <p><button class="logout">Sign out</button></p>
+        <p>Thanks for trying the Sandstorm Demo! Your demo account has expired.
+          <form class="standard-form">
+            <div class="button-row">
+              <button name="logout" type="submit">Sign out</button>
+            </div>
+          </form>
+        </p>
       {{/if}}
     </div>
   {{else}}

--- a/shell/client/styles/_applist.scss
+++ b/shell/client/styles/_applist.scss
@@ -138,11 +138,11 @@
         }
       }
       &.install-icon {
-        background-image: url('/install-9E40B5.svg');
+        background-image: url('/install-714DAA.svg');
         border: 1px solid $generic-border-color;
 
         &:hover {
-          background-image: url('/install-6A237C.svg');
+          background-image: url('/install-896AC6.svg');
         }
       }
     }

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -554,8 +554,13 @@ body>.topbar {
           padding-right: 0 !important;
         }
         .demo-notice {
-          p { font-size: 0 !important; padding: 4px !important; }
+          p { font-size: 0 !important; padding: 0px; }
+          span { display: none !important; }
           button { display: none !important; }
+          a { display: none !important; }
+        }
+        .demo-timer {
+          p { font-size: 0 !important; padding: 4px !important; }
         }
       }
       &.hide-desktop {
@@ -578,26 +583,33 @@ body>.topbar {
       background-color: #303030;
       color: #606060;
       li {
-        line-height: 32px;
-        height: 32px;
         display: block;
         position: relative;
         border-bottom: 1px solid $topbar-border-color;
         margin: 0;
         list-style-type: none;
-        a {
-          display: block;
-          min-height: 32px;
-          padding-left: $navbar-width-desktop-shrunk;
-          text-decoration: none;
-          text-overflow: ellipsis;
-          overflow: hidden;
-          white-space: nowrap;
-          &, &:visited, &:active, &:hover {
-            color: inherit;
+
+        &.navitem-open-grain, &.navitem-create-grain, &.navitem-grain {
+          a {
+            display: block;
+            min-height: 32px;
+            padding-left: $navbar-width-desktop-shrunk;
+            text-decoration: none;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+            &, &:visited, &:active, &:hover {
+              color: inherit;
+            }
           }
         }
+        &.navitem-grain {
+          line-height: 32px;
+          height: 32px;
+        }
         &.navitem-open-grain, &.navitem-create-grain {
+          display: block;
+          position: relative;
           background-repeat: no-repeat;
           background-position: (($navbar-width-desktop-shrunk - 24px) / 2) center;
           background-size: 24px 24px;
@@ -633,6 +645,12 @@ body>.topbar {
           height: auto;
           width: auto;
         }
+        &.navitem-demo-timer {
+          position: absolute;
+          bottom: 0;
+          height: auto;
+          width: 100%;
+        }
       }
     }
     @media #{$mobile} {
@@ -645,15 +663,17 @@ body>.topbar {
         position: relative;
         border-bottom: 1px solid #676767;
         margin: 0;
-        a {
-          display: block;
-          padding-left: 48px;
-          text-decoration: none;
-          text-overflow: ellipsis;
-          overflow: hidden;
-          white-space: nowrap;
-          &, &:visited, &:active, &:hover {
-            color: inherit;
+        &.navitem-open-grain, &.navitem-create-grain, &.navitem-grain {
+          a {
+            display: block;
+            padding-left: 48px;
+            text-decoration: none;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+            &, &:visited, &:active, &:hover {
+              color: inherit;
+            }
           }
         }
         &.navitem-open-grain, &.navitem-create-grain {
@@ -666,6 +686,9 @@ body>.topbar {
         }
         &.navitem-create-grain {
           background-image: url('/apps.svg');
+        }
+        &.navitem-demo-timer {
+          height: auto;
         }
       }
     }
@@ -748,61 +771,70 @@ body>.topbar {
           z-index: 2;  // Stack above <a>.
         }
       }
+    }
 
-      >li.navitem-demo-notice {
-        height: auto !important;
+    li.navitem-demo-notice {
+      height: auto !important;
+    }
+  }
+
+  .demo-notice {
+    width: 100%;
+    overflow: hidden;
+
+    p {
+      color: white;
+      padding: 8px;
+      margin: 0;
+      line-height: normal;
+      font-size: 14px;
+      transition: font-size 0.2s;
+
+      a.get-sandstorm-button {
+        display: block;
+        @extend %button-base;
+        background-color: #606060;
+        color: white;
+        &:hover {
+          background-color: #717171;
+        }
       }
     }
 
-    .demo-notice {
+    button {
+      display: block;
       width: 100%;
-      overflow: hidden;
+      text-align: center;
+      margin-top: 2px;
+      margin-bottom: 2px;
+    }
 
-      p {
-        color: $topbar-foreground-color;
-        padding: 8px;
-        margin: 0;
-        line-height: normal;
-        font-size: 14px;
-        transition: font-size 0.2s;
+    .subtext {
+      font-size: 12px;
+      color: $topbar-foreground-color;
+    }
+  }
 
-        a {
-          color: white;
-          padding: 0;
-          white-space: normal;
-          &:hover {
-            text-decoration: underline;
-          }
-        }
-      }
+  .demo-timer {
+    p {
+      margin: 0;
+      padding: 4px;
+      color: $topbar-foreground-color;
+      font-size: 14px;
+    }
+  }
 
-      .countdown {
-        display: block;
-        font-size: 30px;
-        font-weight: bold;
-        color: #bb0;
-        text-align: center;
-        border: 1px solid $topbar-foreground-color;
-        border-radius: 4px;
-        margin-top: 8px;
+  .countdown {
+    display: block;
+    font-size: 30px;
+    font-weight: bold;
+    color: #a0a0a0;
+    text-align: center;
+    border: 1px solid $topbar-foreground-color;
+    border-radius: 4px;
 
-        &.urgent {
-          color: #f00;
-        }
-      }
-
-      button {
-        @include unstyled-button();
-        display: block;
-        border: 1px solid $topbar-foreground-color;
-        border-radius: 4px;
-        width: 100%;
-        text-align: center;
-        padding: 4px;
-        background-color: $topbar-background-color-active;
-        color: $topbar-foreground-color-active;
-        margin-top: 8px;
-      }
+    &.urgent {
+      color: #f00;
     }
   }
 }
@@ -1403,5 +1435,4 @@ body>.popup {
       }
     }
   }
-
 }

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -786,11 +786,13 @@ body>.topbar {
       color: white;
       padding: 8px;
       margin: 0;
+      margin-bottom: 8px;
       line-height: normal;
       font-size: 14px;
       transition: font-size 0.2s;
 
       a.get-sandstorm-button {
+        margin-top: 6px;
         display: block;
         @extend %button-base;
         background-color: #606060;
@@ -805,8 +807,8 @@ body>.topbar {
       display: block;
       width: 100%;
       text-align: center;
-      margin-top: 2px;
-      margin-bottom: 2px;
+      margin-top: 6px;
+      margin-bottom: 4px;
     }
 
     .subtext {

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -55,18 +55,33 @@ limitations under the License.
           <button class="close-button" title="Close {{title}}"></button>
         </li>
         {{/each}}
-
-        {{#with accountExpires}}
-          <li class="navitem-demo-notice"><div class="demo-notice">
-            <p>This demo expires in: <span class="countdown {{#if urgent}}urgent{{/if}}">{{countdown}}</span></p>
-
-            <p>To make your data permanent, create an account:
-              <button class="sign-in">Create account »</button></p>
-
-            <p class="self-host"><a href="https://sandstorm.io/install/" target="_blank">Or, get Sandstorm on your own server (it's open source) »</a></p>
-          </div></li>
-        {{/with}}
       </ul>
+
+      {{#with accountExpires}}
+      <li class="navitem-demo-notice">
+        <div class="demo-notice">
+          <p>Start collaborating with others by using Sandstorm on Oasis:
+            <button class="button-primary sign-in">Create free account »</button>
+            <span class="subtext">Your demo data will be transferred.</span>
+          </p>
+
+          <p class="self-host">
+            Or, install Sandstorm for your team (it's open source):
+            <a class="get-sandstorm-button" href="https://sandstorm.io/install/" target="_blank">
+              Get Sandstorm »
+            </a>
+          </p>
+        </div>
+      </li>
+
+      <li class="navitem-demo-timer">
+        <div class="demo-timer">
+          <p>Sign up within:
+            <span class="countdown {{#if urgent}}urgent{{/if}}">{{countdown}}</span>
+          </p>
+        </div>
+      </li>
+      {{/with}}
     </ul>
   </ul>
   {{!-- Becomes hamburger menu button in mobile view.  Placed after the topbar so it stacks above

--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -67,7 +67,7 @@ limitations under the License.
 
           <p class="self-host">
             Or, install Sandstorm for your team (it's open source):
-            <a class="get-sandstorm-button" href="https://sandstorm.io/install/" target="_blank">
+            <a class="get-sandstorm-button" href="https://sandstorm.io/get" target="_blank">
               Get Sandstorm »
             </a>
           </p>


### PR DESCRIPTION
Some rejiggering was needed to keep styles from cascading where we don't want
them to cascade.  We could probably stand to avoid styling tags without a class
in all but the last item in the selector in the future.

Fixes #2658

![desktop-expiring](https://cloud.githubusercontent.com/assets/307325/19541849/994e469e-961e-11e6-86e6-b75809f4d7c1.png)

![desktop-full](https://cloud.githubusercontent.com/assets/307325/19541945/5bac42c2-961f-11e6-9547-df8b4c26cce1.png)

![desktop-collapsed](https://cloud.githubusercontent.com/assets/307325/19541937/449473ac-961f-11e6-842f-65dad8de5776.png)

![mobile-1](https://cloud.githubusercontent.com/assets/307325/19541862/bcd9d40c-961e-11e6-8456-6394f497e6b0.png)

We don't handle the case where there's too much content on mobile, but that's not new.

![mobile-cluttered](https://cloud.githubusercontent.com/assets/307325/19541958/722e7754-961f-11e6-9eb9-7e56213e76ba.png)
