### PR TITLE
Close any login overlays on login

### DIFF
--- a/shell/client/accounts/login-buttons.js
+++ b/shell/client/accounts/login-buttons.js
@@ -269,6 +269,8 @@ const loginWithToken = function (email, token) {
       // the login-initiating path if it's not the current path already anyway.
       loginButtonsSession.set("inSignupFlow", false);
       loginButtonsSession.closeDropdown();
+
+      closeLoginOverlays();
     }
   });
 };
@@ -402,6 +404,8 @@ Template.ldapLoginForm.events({
     loginWithLDAP(username, password, function (err) {
       if (err) {
         loginButtonsSession.errorMessage(err.reason || "Unknown error");
+      } else {
+        closeLoginOverlays();
       }
     });
   },
@@ -417,12 +421,26 @@ Template.devLoginForm.helpers({
   },
 });
 
+function closeLoginOverlays() {
+  // Close any open sign-in overlays
+  const grainviews = globalGrains.getAll();
+  grainviews.forEach((grainview) => {
+    grainview.disableSigninOverlay();
+  });
+}
+
 function loginDevHelper(name, isAdmin, linkingNewIdentity) {
   if (linkingNewIdentity) {
     sessionStorage.setItem("linkingIdentityLoginToken", Accounts._storedLoginToken());
   }
 
-  loginDevAccount(name, isAdmin);
+  loginDevAccount(name, isAdmin, (err) => {
+    if (err) {
+      console.error(err);
+    } else {
+      closeLoginOverlays();
+    }
+  });
 }
 
 Template.devLoginForm.events({

--- a/shell/client/dev-accounts-client.js
+++ b/shell/client/dev-accounts-client.js
@@ -14,12 +14,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-loginDevAccount = function (displayName, isAdmin) {
+loginDevAccount = function (displayName, isAdmin, callback) {
   Accounts.callLoginMethod({
     methodName: "createDevAccount",
     methodArguments: [displayName, isAdmin],
-    userCallback: function (err) {
-      if (err) {
+    userCallback(err) {
+      if (callback) {
+        callback(err);
+      } else if (err) {
         window.alert(err);
       }
     },
@@ -38,7 +40,7 @@ loginDevAccountFast = function (displayName, isAdmin) {
     Accounts.callLoginMethod({
       methodName: "createDevAccount",
       methodArguments: [displayName, isAdmin, profile, displayName + "@example.com"],
-      userCallback: function (err) {
+      userCallback(err) {
         if (err) {
           reject(new Error(err));
         } else {


### PR DESCRIPTION
Without this, login methods that do not redirect (thus refreshing the page)
leave the login overlay visible even after login has succeeded.

With this patchset, each of the non-redirect login methods (dev accounts, email
token form submission, and LDAP login) close any leftover login overlays when
login succeeds.

I had to add a continuation argument to `loginDevAccount`.