### PR TITLE
Allow logout via postmessage on standalone grains

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -1498,6 +1498,14 @@ Meteor.startup(function () {
         const creatingAccount = !!event.data.overlaySignin.creatingAccount;
         senderGrain.showSigninOverlay(creatingAccount);
       }
+    } else if (event.data.requestLogout) {
+      if (isStandalone()) {
+        // Only standalone grains get to ask the shell to log them out, and then, only because their
+        // login state is tracked separately.  In the fullness of time, maybe we should unify the
+        // login state, in which case we'll probably want to disable this option lest a malicious
+        // grain be able to DoS a user.
+        logoutSandstorm();
+      }
     } else if (event.data.showConnectionGraph) {
       // Allow the current grain to request that the "Who has access" dialog be shown.
       // Only show this popup if no other popup is currently active.

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -54,6 +54,7 @@ Tracker.autorun(function () {
 });
 
 // export: called by sandstorm-accounts-ui/login_buttons.js
+//               and grain-client.js
 logoutSandstorm = function () {
   Meteor.logout(function () {
     sessionStorage.removeItem("linkingIdentityLoginToken");


### PR DESCRIPTION
Standalone grains lack the topbar, but you should still be able to log out from them, especially if your account has e.g. credit cards on file or something of the sort.

With this change, apps can support this workflow by requesting that Sandstorm log the user out via postMessage.

To avoid allowing grains to DoS users through this postMessage, we restrict its use to standalone grains.