### PR TITLE
Adjust copy in admin root page re: Sandstorm for Work

### DIFF
--- a/shell/client/admin/admin-new-client.js
+++ b/shell/client/admin/admin-new-client.js
@@ -7,3 +7,9 @@ Template.newAdmin.helpers({
     return Session.get("alreadyTestedWildcardHost") && !Session.get("wildcardHostWorks");
   },
 });
+
+Template.newAdminRoot.helpers({
+  hasFeatureKey() {
+    return globalDb.isFeatureKeyValid();
+  },
+});

--- a/shell/client/admin/admin.html
+++ b/shell/client/admin/admin.html
@@ -87,7 +87,13 @@
           {{/adminNavItem}}
           {{#adminNavItem routeName="newAdminFeatureKey"}}
             <div class="item-name">Sandstorm for Work</div>
-            <div class="item-subtext">Get a feature key and unlock advanced features.</div>
+            <div class="item-subtext">
+                {{#if hasFeatureKey }}
+                  Manage subscription and billing.
+                {{else}}
+                  Subscribe to unlock advanced features.
+                {{/if}}
+            </div>
           {{/adminNavItem}}
           {{#adminNavItem routeName="newAdminPersonalization"}}
             <div class="item-name">Personalization</div>


### PR DESCRIPTION
1. Feature key is super technical.  Subscription is better.
2. Change the subtext when you already have SfW enabled.

Fixes #2576

No feature key:
![no-feature-key](https://cloud.githubusercontent.com/assets/307325/19615675/c7d3dda4-97b7-11e6-8d9d-b9d5b979f7f6.png)

With feature key:
![with-feature-key](https://cloud.githubusercontent.com/assets/307325/19615682/e29eb7bc-97b7-11e6-9141-c542cb181199.png)
