### PR TITLE
grainlist: make app install hint more specific

### DIFF
--- a/shell/client/grain/grainlist-client.js
+++ b/shell/client/grain/grainlist-client.js
@@ -313,6 +313,10 @@ Template.sandstormGrainListPage.helpers({
   isSignedUpOrDemo: function () {
     return this._db.isSignedUpOrDemo();
   },
+
+  hasApps() {
+    return this._db.currentUserActions().count() > 0;
+  },
 });
 
 Template.sandstormGrainListPage.onCreated(function () {

--- a/shell/client/grain/grainlist.html
+++ b/shell/client/grain/grainlist.html
@@ -67,7 +67,13 @@
               <p><strong>Trash is empty.</strong></p>
             {{else}}
               <p>You don't have any grains yet.
-                <a href="{{ pathFor route='apps' }}">Install an app to create your first grain.</a>
+                <a href="{{ pathFor route='apps' }}">
+                  {{#if hasApps}}
+                    Select an app and create your first grain.
+                  {{else}}
+                    Install an app to create your first grain.
+                  {{/if}}
+                </a>
               </p>
             {{/if}}
           {{/if}}


### PR DESCRIPTION
Since most users will have preinstalled apps, the "install an app to create a
grain" text is a little odd.

Fixes #2575

No apps installed:
![no-apps-installed](https://cloud.githubusercontent.com/assets/307325/19615764/2b9bbba8-97b9-11e6-9c6e-8c54cd7583ff.png)

Apps installed:
![apps-installed](https://cloud.githubusercontent.com/assets/307325/19615757/154c7a90-97b9-11e6-9fb1-3c16049414f7.png)