### PR TITLE
Make danger buttons not so loud

### DIFF
--- a/shell/client/styles/_partials.scss
+++ b/shell/client/styles/_partials.scss
@@ -103,11 +103,12 @@
 }
 
 %button-danger {
-  background-color: red;
-  color: white;
-  border: 1px solid darken(red, 30%);
+  color: #900;
+  background-color: white;
+  border: 1px solid darken(white, 30%);
   &:hover {
-    background-color: darken(red, 10%);
+    background-color: #af1010;
+    color: white;
   }
   &:disabled {
     @extend %button-disabled;


### PR DESCRIPTION
The existing white-on-pure-red is somewhat low-contrast.  The saturation of the
red is also very eye-catching and attention-grabbing, when most danger
buttons are not a part of the UI that we wish to draw attention to.

This change deemphasizes danger buttons, but preserves a darker red background on
hover and keeps the text red to indicate that the action is destructive to e.g.
mobile users that won't see hover states.

Fixes #2702

![no-hover](https://cloud.githubusercontent.com/assets/307325/19741225/b6cde890-9b74-11e6-9434-6c93997e69ae.png)

![hover](https://cloud.githubusercontent.com/assets/307325/19741241/c46310b6-9b74-11e6-9c3f-1b7ef0d38441.png)
