### PR TITLE
Fix powerbox requests for standalone domains.

### DIFF
--- a/shell/imports/server/backend.js
+++ b/shell/imports/server/backend.js
@@ -270,13 +270,16 @@ class SandstormBackend {
     };
 
     if (userId) {
-      session.identityId = identityId;
       session.userId = userId;
-    } else if (apiToken) {
+    }
+
+    if (identityId) {
+      session.identityId = identityId;
+    }
+
+    if (apiToken) {
       session.hashedToken = apiToken._id;
-    } else {
-      // Must be old-style sharing, i.e. !grain.private.
-    } // jscs:ignore disallowEmptyBlocks
+    }
 
     Sessions.insert(session);
 

--- a/shell/packages/sandstorm-permissions/permissions.js
+++ b/shell/packages/sandstorm-permissions/permissions.js
@@ -1489,7 +1489,7 @@ SandstormPermissions.createNewApiToken = function (db, provider, grainId, petnam
     clientPowerboxRequest: {
       grainId: String,
       sessionId: String,
-      introducerIdentity: String,
+      introducerIdentity: Match.Optional(String),  // obsolete
     },
   }, {
     frontend: null,

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-server.js
@@ -61,7 +61,6 @@ Meteor.methods({
     const apiTokenOwner = {
       clientPowerboxRequest: {
         grainId: grainId,
-        introducerIdentity: session.identityId,
         sessionId: session._id,
       },
     };
@@ -103,7 +102,6 @@ Meteor.methods({
     const owner = {
       clientPowerboxRequest: {
         grainId: ownerGrainId,
-        introducerIdentity: identityId,
         sessionId: sessionId,
       },
     };

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -312,9 +312,7 @@ struct ApiTokenOwner {
       # The ID of the session that created this token.
 
       introducerIdentity @14 :Text;
-      # The identity ID through which a user's powerbox action caused the grain to receive this
-      # token. This is the identity against which the `requiredPermissions` parameter
-      # to `claimRequest()` will be checked.
+      # Obsolete. (The introducer identity can be derived from sessionId instead.)
     }
 
     clientPowerboxOffer :group {


### PR DESCRIPTION
Claiming the request was failing if the identity didn't have direct access to the grain, because a MembraneRequirement was being added requiring that the identity have such access. Instead, we should add a token requirement.