### PR TITLE
Fixes centering of overlay signin on IE11

### DIFF
--- a/shell/client/styles/_widgets.scss
+++ b/shell/client/styles/_widgets.scss
@@ -74,7 +74,6 @@
       display: flex;
       flex-direction: row;
       align-items: center;
-      justify-content: center;
     }
 
     .modal-dialog {


### PR DESCRIPTION
It turns out that justify-content doesn't do anything meaningful for us
here on chrome/firefox, but has a weird interaction on IE11.

Fixes #2709