### PR TITLE
Fix updates for non-root installs.

### DIFF
--- a/src/sandstorm/backup.c++
+++ b/src/sandstorm/backup.c++
@@ -106,9 +106,6 @@ void BackupMain::bind(kj::StringPtr src, kj::StringPtr dst, unsigned long flags)
 }
 
 bool BackupMain::run(kj::StringPtr grainDir) {
-  KJ_ASSERT(geteuid() != 0, "can't run as user ID zero (root)");
-  KJ_ASSERT(getegid() != 0, "can't run as group ID zero (root)");
-
   // Enable no_new_privs so that once we drop privileges we can never regain them through e.g.
   // execing a suid-root binary, as a backup measure. This is a backup measure in case someone
   // finds an arbitrary code execution exploit in zip/unzip; it's not needed otherwise.

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1318,8 +1318,8 @@ private:
       // But if our UID is zero, then the file's attributes are ignored and all capabilities are
       // inherited.
       writeSetgroupsIfPresent("deny\n");
-      writeUserNSMap("uid", kj::str("1000 ", uid, " 1\n"));
-      writeUserNSMap("gid", kj::str("1000 ", gid, " 1\n"));
+      writeUserNSMap("uid", kj::str("0 ", uid, " 1\n"));
+      writeUserNSMap("gid", kj::str("0 ", gid, " 1\n"));
 
       unsharedUidNamespace = true;
     }

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -663,9 +663,6 @@ kj::MainBuilder::Validity SupervisorMain::addCommandArg(kj::StringPtr arg) {
 // =====================================================================================
 
 kj::MainBuilder::Validity SupervisorMain::run() {
-  KJ_ASSERT(geteuid() != 0, "can't run as user ID zero (root)");
-  KJ_ASSERT(getegid() != 0, "can't run as group ID zero (root)");
-
   isIpTablesAvailable = checkIfIpTablesLoaded();
 
   setupSupervisor();


### PR DESCRIPTION
Currenly, for servers running with no root privileges, each update crashes the server. Starting the server back up again works fine.

The problem was introduced in the change introducing the privileged sandbox. On non-root installs, Sandstorm's outer container needs to use a user namespace. Within that user namespace, the UID was being mapped to zero. This caused a newly-added assert in supervisor.c++ to fail. Rather than roll back the assert, I decided to change the UID mapping to non-zero, *completely ignoring* the comment *right above* the code that explained why it really does need to be zero. :(

This change goes back to mapping as UID zero and removes the asserts instead.

Note that UID zero inside the user namespace is not actually root on the system. Also, we explicitly drop crapabilities so that the front-end process does not even get within-namespace root rights.

Unfortunately, because of the nature of the bug, the update which fixes the bug will again fail -- but updates after that will succeed.

Fixes #2692.