### PR TITLE
When trashing grain, only delete the session server-side

### DIFF
--- a/shell/shared/grain-shared.js
+++ b/shell/shared/grain-shared.js
@@ -58,20 +58,21 @@ Meteor.methods({
                        { $set: { "trashed": new Date() } },
                        { multi: true });
 
-      const grainsOwned = Grains.find({
-        userId: { $eq: this.userId },
-        _id: { $in: grainIds },
-      }, { fields: { _id: 1, }, });
-      grainsOwned.forEach((grain) => {
-        Sessions.remove({ grainId: grain._id, });
-        if (!this.isSimulation) {
+      if (!this.isSimulation) {
+        const grainsOwned = Grains.find({
+          userId: { $eq: this.userId },
+          _id: { $in: grainIds },
+        }, { fields: { _id: 1, }, });
+
+        grainsOwned.forEach((grain) => {
+          Sessions.remove({ grainId: grain._id, });
           try {
             this.connection.sandstormBackend.shutdownGrain(grain._id, this.userId).await();
           } catch (err) {
             console.error("Failed to shutdown trashed grain", grain._id, err);
           }
-        }
-      });
+        });
+      }
     }
   },
 


### PR DESCRIPTION
This causes the client to now correctly handle the session closing.