### PR TITLE
nginx configuration tweaks for geolocation

### DIFF
--- a/docs/administering/sample-config/nginx-example.conf
+++ b/docs/administering/sample-config/nginx-example.conf
@@ -24,7 +24,7 @@ server {
 # Configuration for Sandstorm shell and apps, over HTTPS.
 server {
   listen 443;
-  server_name example.com *.example.com;
+  server_name example.com *.example.com ~^sandstorm-[^.]*\.example\.com$;
 
   ssl on;
   ssl_certificate /etc/nginx/ssl/sandstorm.crt;
@@ -55,6 +55,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
+    proxy_set_header X-Real-IP $remote_addr;
   }
 
   # Allow large spk uploads from the /install form and allow grains to receive large uploads.
@@ -67,7 +68,7 @@ server {
 
 # server {
 #   listen 80;
-#   server_name example.com *.example.com;
+#   server_name example.com *.example.com ~^sandstorm-[^.]*\.example\.com$;
 #
 #   location / {
 #     proxy_pass http://127.0.0.1:6080;
@@ -80,6 +81,7 @@ server {
 #     proxy_http_version 1.1;
 #     proxy_set_header Upgrade $http_upgrade;
 #     proxy_set_header Connection $connection_upgrade;
+#     proxy_set_header X-Real-IP $remote_addr;
 #   }
 #
 #   # Allow large spk uploads from the /install form and allow grains to receive large uploads.

--- a/docs/administering/sample-config/nginx-example.conf
+++ b/docs/administering/sample-config/nginx-example.conf
@@ -24,7 +24,7 @@ server {
 # Configuration for Sandstorm shell and apps, over HTTPS.
 server {
   listen 443;
-  server_name example.com *.example.com ~^sandstorm-[^.]*\.example\.com$;
+  server_name example.com *.example.com;
 
   ssl on;
   ssl_certificate /etc/nginx/ssl/sandstorm.crt;
@@ -68,7 +68,7 @@ server {
 
 # server {
 #   listen 80;
-#   server_name example.com *.example.com ~^sandstorm-[^.]*\.example\.com$;
+#   server_name example.com *.example.com;
 #
 #   location / {
 #     proxy_pass http://127.0.0.1:6080;


### PR DESCRIPTION
1. Passes the remote address in the header so that sandstorm can use the remote address in apps like Piwik (fixes https://github.com/zarvox/piwik/issues/10 )
2. Changes server_name so that sandstorm api access url will be recognized.
