### PR TITLE
Add Accept-Encoding header to Web Session

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1599,6 +1599,8 @@ class Proxy {
 
     context.accept = parseAcceptHeader(request);
 
+    context.acceptEncoding = parseAcceptEncodingHeader(request);
+
     context.eTagPrecondition = parsePreconditionHeader(request);
 
     context.additionalHeaders = [];
@@ -2250,10 +2252,7 @@ const composeETag = (tag) => {
   return result;
 };
 
-const parseAcceptHeader = (request) => {
-  // jscs:disable requireDotNotation
-  const header = request.headers["accept"];
-
+const parseAcceptHeaderString = (header, field) => {
   const result = [];
   if (header) {
     const acceptList = header.split(",");
@@ -2261,7 +2260,8 @@ const parseAcceptHeader = (request) => {
       const acceptStr = acceptList[i];
       const tokensList = acceptStr.split(";");
 
-      const temp = { mimeType: tokensList[0].trim() };
+      const temp = {};
+      temp[field] = tokensList[0].trim();
 
       const tokensListRest = tokensList.slice(1);
       for (const j in tokensListRest) {
@@ -2282,6 +2282,18 @@ const parseAcceptHeader = (request) => {
   }
 
   return result;
+};
+
+const parseAcceptHeader = (request) => {
+  // jscs:disable requireDotNotation
+  const header = request.headers["accept"];
+  return parseAcceptHeaderString(header, "mimeType");
+};
+
+const parseAcceptEncodingHeader = (request) => {
+  // jscs:disable requireDotNotation
+  const header = request.headers["accept-encoding"];
+  return parseAcceptHeaderString(header, "contentCoding");
 };
 
 // -----------------------------------------------------------------------------

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -1552,7 +1552,6 @@ private:
     if (extraHeader3 != nullptr) {
       lines.add(kj::mv(extraHeader3));
     }
-    lines.add(kj::str("Accept-Encoding: gzip"));
     if (acceptLanguages.size() > 0) {
       lines.add(kj::str("Accept-Language: ", acceptLanguages));
     }
@@ -1628,6 +1627,17 @@ private:
             }, ", ")));
     } else {
       lines.add(kj::str("Accept: */*"));
+    }
+    auto acceptEncodingList = context.getAcceptEncoding();
+    if (acceptEncodingList.size() > 0) {
+      lines.add(kj::str("Accept-Encoding: ", kj::strArray(
+            KJ_MAP(c, acceptEncodingList) {
+              if (c.getQValue() == 1.0) {
+                return kj::str(c.getContentCoding());
+              } else {
+                return kj::str(c.getContentCoding(), "; q=", c.getQValue());
+              }
+            }, ", ")));
     }
     auto additionalHeaderList = context.getAdditionalHeaders();
     if (additionalHeaderList.size() > 0) {

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -127,6 +127,9 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
     accept @2 :List(AcceptedType);
     # This corresponds to the Accept header
 
+    acceptEncoding @9 :List(AcceptedEncoding);
+    # This corresponds to the Accept-Encoding header
+
     eTagPrecondition :union {
       none @4 :Void;  # No precondition.
       exists @5 :Void;  # If-Match: *
@@ -208,6 +211,16 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
     # For example, the Accept header with value 'text/javascript; q=0.01' would have a mimeType of
     # "text/javascript" and a qValue of .01.
     mimeType @0 :Text;
+    qValue @1 :Float32 = 1;
+  }
+
+  struct AcceptedEncoding {
+    # The Accept-Encoding header contains a list of valid content codings.
+    # Each content coding could be "*", indicating an arbitrary encoding.
+    # Each content coding comes with a qValue, defaulting to 1.
+    # For example, gzip;q=0.5 indicates the "gzip" coding with qValue "0.5"
+
+    contentCoding @0 :Text;
     qValue @1 :Float32 = 1;
   }
 


### PR DESCRIPTION
This fixes #2691 where a client could get an encoding
that it did not expect since the HTTP bridge always
added gzip encoding.