### PR TITLE
update comment about supervisor SIGALRM to be consistent with code

### DIFF
--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -527,7 +527,7 @@ void registerSignalHandlers() {
   action.sa_handler = &signalHandler;
   sigfillset(&action.sa_mask);
 
-  // SIGALRM will fire every five minutes and will kill us if no keepalive was received in that
+  // SIGALRM will fire every 1.5 minutes and will kill us if no keepalive was received in that
   // time.
   KJ_SYSCALL(sigaction(SIGALRM, &action, nullptr));
 


### PR DESCRIPTION
The inconsistency originated in https://github.com/sandstorm-io/sandstorm/commit/ce3d0fd8560f62666a97140426d82a04ce0b6fa4.