### PR TITLE
Add metadata so we know when /get visits come from demo

### DIFF
--- a/shell/packages/sandstorm-ui-topbar/topbar.html
+++ b/shell/packages/sandstorm-ui-topbar/topbar.html
@@ -67,7 +67,7 @@ limitations under the License.
 
           <p class="self-host">
             Or, install Sandstorm for your team (it's open source):
-            <a class="get-sandstorm-button" href="https://sandstorm.io/get" target="_blank">
+            <a class="get-sandstorm-button" href="https://sandstorm.io/get?utm_source=demo&amp;utm_campaign=2016-11&amp;utm_medium=oasis" target="_blank">
               Get Sandstorm »
             </a>
           </p>


### PR DESCRIPTION
This is the simplest possible change that I can think of that results in us knowing if the recent changes to the demo sidebar result in increased traffic to `/get`.