### PR TITLE
Remove query string before adding index.html.

### DIFF
--- a/shell/server/pre-meteor.js
+++ b/shell/server/pre-meteor.js
@@ -65,6 +65,9 @@ function wwwHandlerForGrain(grainId) {
   return (request, response) => {
     let path = request.url;
 
+    // Strip query.
+    path = path.split("?")[0];
+
     // If a directory, open "index.html".
     if (path.slice(-1) === "/") {
       path = path + "index.html";
@@ -72,9 +75,6 @@ function wwwHandlerForGrain(grainId) {
 
     // Strip leading "/".
     if (path[0] === "/") path = path.slice(1);
-
-    // Strip query.
-    path = path.split("?")[0];
 
     let type = mime.lookup(path);
     const charset = mime.charsets.lookup(type);


### PR DESCRIPTION
Otherwise index.html does not get added to paths ending in '/', leading to other weird behavior.

Fixes #2745