### PR TITLE
Setup wizard base url changes

### DIFF
--- a/shell/client/admin/identity-providers.html
+++ b/shell/client/admin/identity-providers.html
@@ -75,6 +75,16 @@
 {{#modalDialogWithBackdrop onDismiss=onDismiss}}
   <h2>Google login configuration</h2>
 
+  {{#if formerBaseUrl}}
+    <p class="flash-message warning-message" tabindex="-1">
+      This server moved from <code>{{ formerBaseUrl }}</code> to <code>{{ siteUrlNoSlash }}</code>.
+      You'll need to visit
+      <a target="_blank" href="https://console.developers.google.com/">https://console.developers.google.com/</a>
+      and update the "Authorized Javascript Origins" and "Authorized Redirect URI" for this Client ID to
+      include the values below.
+    </p>
+  {{/if}}
+
   {{#if errorMessage}}
     {{#focusingErrorBox}}
       Failed to save changes: {{errorMessage}}
@@ -134,6 +144,15 @@
 <template name="adminIdentityProviderConfigureGitHub">
 {{#modalDialogWithBackdrop onDismiss=onDismiss}}
   <h2>GitHub login configuration</h2>
+
+  {{#if formerBaseUrl}}
+    <p class="flash-message warning-message" tabindex="-1">
+      This server moved from <code>{{ formerBaseUrl }}</code> to <code>{{ siteUrl }}</code>.
+      You'll need to visit
+      <a target="_blank" href="https://github.com/settings/developers">https://github.com/settings/developers</a>
+      and update the Homepage URL and Authorization callback URL for this application to the values below.
+    </p>
+  {{/if}}
 
   <form class="setup-idp-form">
     {{> githubLoginSetupInstructions "" }}
@@ -389,17 +408,28 @@ MIID...
 <div class="idp-table-row" role="row">
   <span class="idp" role="gridcell">{{idp.label}}</span>
   <span class="idp-status" role="gridcell">
+    <span class="left">
     {{#if idp.enabled}}
       <span class="idp-enabled">Enabled</span>
     {{else}}
       <span class="idp-disabled">Not enabled</span>
     {{/if}}
+    {{#if idp.resetNote}}
+      {{#if idp.resetNote.baseUrlChangedFrom}}
+      <span class="base-url-change-note">
+        Disabled due to BASE_URL change <button class="button-link base-url-change-button">reconfigure</button>
+      </span>
+      {{/if}}
+    {{/if}}
+    </span>
 
+    <span class="right">
     {{#if needsFeatureKey}}
       <button class="get-feature-key" title="Configure Sandstorm for Work">Configure Sandstorm for Work</button>
     {{else}}
       <button class="configure-idp" title="Configure {{idp.label}} login">Configure</button>
     {{/if}}
+    </span>
   </span>
 </div>
 </template>

--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -148,6 +148,15 @@
   <h1 class="setup-page-title">Welcome to Sandstorm!</h1>
 
   {{#if initialSetupComplete}}
+    {{#if noIdpEnabled}}
+    <p>
+      This Sandstorm server has been set up previously, but due to a change in
+      <code>sandstorm.conf</code>, you'll need to configure identity providers again.
+    </p>
+    <p class="center">
+      {{#linkTo route="setupWizardIdentity" class="setup-button-primary"}}Revisit setup wizard{{/linkTo}}
+    </p>
+    {{else}}
     <p>
       This Sandstorm server is ready to roll.
       You can adjust server settings, including which providers are
@@ -204,7 +213,7 @@
     <p class="center">
       {{#linkTo route="setupWizardIdentity" class="rerun-wizard-button"}}Revisit setup wizard{{/linkTo}}
     </p>
-
+    {{/if}}
   {{else}}
     <p>Choose what type of Sandstorm server to set up:</p>
 

--- a/shell/client/setup-wizard/wizard.js
+++ b/shell/client/setup-wizard/wizard.js
@@ -242,6 +242,10 @@ Template.setupWizardIntro.helpers({
     return hasUsersEntry && hasUsersEntry.hasUsers;
   },
 
+  noIdpEnabled() {
+    return !setupIsStepCompleted.identity();
+  },
+
   currentUserIsAdmin() {
     return isAdmin();
   },

--- a/shell/client/styles/_admin-identity.scss
+++ b/shell/client/styles/_admin-identity.scss
@@ -48,7 +48,7 @@
     @extend %idp-table-row;
     color: #5b5b5b;
     background-color: white;
-    button {
+    button.get-feature-key, button.configure-idp {
       @extend %button-base;
       @extend %button-secondary;
       min-height: 26px;


### PR DESCRIPTION
Changing BASE_URL can deconfigure Google and GitHub login, which can leave
the server in a situation where you can't log in, but you're directed to
sign in to create an admin account.  We should prompt you to reconfigure login.

Also, in the transition to the new admin UI, we stopped help text when the BASE_URL was changed.  This changeset adds a note and additional instructions when you go to reconfigure Google or GitHub login after a BASE_URL change.

Fixes #2030.

![setup-wizard-start](https://cloud.githubusercontent.com/assets/307325/20234550/0fe8ccc8-a832-11e6-8c7b-c192d13b4cec.png)

![setup-wizard-idp](https://cloud.githubusercontent.com/assets/307325/20234553/1f8d6ecc-a832-11e6-9e01-dd94ae3368cd.png)

![google-instructions](https://cloud.githubusercontent.com/assets/307325/20234562/33397790-a832-11e6-96c9-743fccb22335.png)

![github-instructions](https://cloud.githubusercontent.com/assets/307325/20234572/4e68b184-a832-11e6-901f-857378e344f0.png)