### PR TITLE
don't bother setting grainInfo.icon if there is no icon

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1267,7 +1267,10 @@ _.extend(SandstormDb.prototype, {
 
     if (pkg && pkg.manifest && pkg.manifest.metadata && pkg.manifest.metadata.icons) {
       const icons = pkg.manifest.metadata.icons;
-      grainInfo.icon = icons.grain || icons.appGrid;
+      const icon = icons.grain || icons.appGrid;
+      if (icon) {
+        grainInfo.icon = icon;
+      }
     }
 
     // Only provide an app ID if we have no icon asset to provide and need to offer an identicon.


### PR DESCRIPTION
Currently, the object returned here can have `grainInfo.icon = undefined`. When this gets written to Mongo, that `undefined` (somewhat surprisingly) morphs into a `null`, which can lead to bugs like #2633.

It's cleaner to not the `icon` field at all if there is nothing to put there.