### PR TITLE
Disable quota enforcement in app installation flow

### DIFF
--- a/shell/client/apps/applist-client.js
+++ b/shell/client/apps/applist-client.js
@@ -192,10 +192,8 @@ Template.sandstormAppListPage.events({
   "click .install-button": function (event) {
     event.preventDefault();
     event.stopPropagation();
-    Template.instance().data._quotaEnforcer.ifQuotaAvailable(function () {
-      window.open("https://apps.sandstorm.io/?host=" +
-          document.location.protocol + "//" + document.location.host, "_blank");
-    });
+    window.open("https://apps.sandstorm.io/?host=" +
+        document.location.protocol + "//" + document.location.host, "_blank");
   },
 
   "click .upload-button": function (event, instance) {

--- a/shell/server/install-server.js
+++ b/shell/server/install-server.js
@@ -71,12 +71,9 @@ Meteor.methods({
       } else { // jscs:ignore disallowEmptyBlocks
         throw new Meteor.Error(403, "You must be logged in to install packages.");
       }
-    } else if (!isSignedUp() && !isDemoUser()) {
+    } else if (!isSignedUpOrDemo()) {
       throw new Meteor.Error(403,
           "This Sandstorm server requires you to get an invite before installing apps.");
-    } else if (isUserOverQuota(Meteor.user())) {
-      throw new Meteor.Error(402,
-          "You are out of storage space. Please delete some things and try again.");
     }
 
     const pkg = Packages.findOne(packageId);


### PR DESCRIPTION
This change allows invited and demo users who are at or above their quota
limits to navigate to the app market and install apps from the app market where
previously we would have blocked the installation.

User testing reveals that demo users who hit the quota interstitial when
attempting to install a new app immediately attempt to uninstall apps to
free up quota.  This has a couple of downsides:

* The user's immediate reaction is usually to attempt to uninstall apps, which
  the user hopes will free up quota, but which doesn't actually free quota
  because app storage on Sandstorm doesn't work like storage on mobile phones.
* There's no other way for users to navigate from the Sandstorm UI to the app
  market, so they get stuck unable to look back at the app market, which is sad

Especially on Oasis, where all the apps on the market are already preinstalled
and can't actually incur a greater storage cost, we should let users install
all apps from the app market and cut them off at grain creation time, where
they're hopefully more likely to delete grains than uninstall apps.