### PR TITLE
Add `tls` parameter to `IpRemoteHost.getTcpPort()`

### DIFF
--- a/src/sandstorm/ip.capnp
+++ b/src/sandstorm/ip.capnp
@@ -127,9 +127,13 @@ interface TcpPort @0xeab20e1af07806b4 {
   # assigned.
 
   connect @0 (downstream :Util.ByteStream) -> (upstream :Util.ByteStream);
-  # Open a new byte stream connection. The callee sends bytes to the caller via `downstream`, while
+  # Opens a new byte stream connection. The callee sends bytes to the caller via `downstream`, while
   # the caller sends bytes to the callee via `upstream`. Notice that the caller may start sending
   # bytes via pipelining immediately.
+
+  connectTls @1 (downstream :Util.ByteStream) -> (upstream :Util.ByteStream);
+  # Opens a new byte stream connection layered on top of Transport Layer Security, seamlessly
+  # hiding the details of session negotiation and encryption.
 }
 
 interface UdpPort @0xc6212e1217d001ce {

--- a/src/sandstorm/ip.capnp
+++ b/src/sandstorm/ip.capnp
@@ -109,7 +109,10 @@ interface IpRemoteHost @0x905dd76b298b3130 {
   # This way the user can more easily understand what is being requested and can more easily
   # reroute when desired.
 
-  getTcpPort @0 (portNum :UInt16) -> (port :TcpPort);
+  getTcpPort @0 (portNum :UInt16, tls :Bool) -> (port :TcpPort);
+  # If `tls` is true, then the port's streams will be layered on top of Transport Layer Security,
+  # seamlessly hiding the details of session negotiation and encryption.
+
   getUdpPort @1 (portNum :UInt16) -> (port :UdpPort);
 }
 
@@ -130,10 +133,6 @@ interface TcpPort @0xeab20e1af07806b4 {
   # Opens a new byte stream connection. The callee sends bytes to the caller via `downstream`, while
   # the caller sends bytes to the callee via `upstream`. Notice that the caller may start sending
   # bytes via pipelining immediately.
-
-  connectTls @1 (downstream :Util.ByteStream) -> (upstream :Util.ByteStream);
-  # Opens a new byte stream connection layered on top of Transport Layer Security, seamlessly
-  # hiding the details of session negotiation and encryption.
 }
 
 interface UdpPort @0xc6212e1217d001ce {


### PR DESCRIPTION
The implementation is mostly a copy/paste of the `TcpPort.connect()` method.

Using this, I have successfully sent an SMS message through https://api.twilio.com from a Sandstorm grain.

This should allow an outgoing HTTP/HTTPS driver to be implemented entirely as an app, without the need to include a certificate bundle in the SPK.