### PR TITLE
Add option for IpNetwork to be layered on top of TLS.

### DIFF
--- a/shell/client/admin/network-capabilities.html
+++ b/shell/client/admin/network-capabilities.html
@@ -142,6 +142,9 @@
 <h2>Outbound network access</h2>
 {{>newAdminNetworkCapabilitiesSection caps=ipNetworkCaps}}
 
+<h2>TLS-encrypted outbound network access</h2>
+{{>newAdminNetworkCapabilitiesSection caps=ipNetworkCapsTls}}
+
 <h2>Inbound network access</h2>
 {{>newAdminNetworkCapabilitiesSection caps=ipInterfaceCaps}}
 

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -725,6 +725,14 @@ const addMembraneRequirementsToIdentities = function (db, backend) {
   });
 };
 
+const addEncryptionToFrontendRefIpNetwork = function (db, backend) {
+  db.collections.apiTokens.find({ "frontendRef.ipNetwork": true }).map((apiToken) => {
+    db.collections.apiTokens.update(
+      { _id: apiToken._id },
+      { $set: { "frontendRef.ipNetwork": { encryption: { none: null } } } });
+  });
+};
+
 function backgroundFillInGrainSizes(db, backend) {
   // Fill in sizes for all grains that don't have them. Since computing a grain size requires a
   // directory walk, we don't want to do them all at once. Instead, we compute one a second until
@@ -797,6 +805,7 @@ const MIGRATIONS = [
   assignEmailVerifierIds,
   setNewServer,
   addMembraneRequirementsToIdentities,
+  addEncryptionToFrontendRefIpNetwork,
 ];
 
 const NEW_SERVER_STARTUP = [

--- a/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox-client.js
@@ -373,6 +373,17 @@ Template.powerboxRequest.events({
 //
 // TODO(cleanup): Find a better home for these.
 
+Template.ipNetworkPowerboxCard.helpers({
+  encryption: function () {
+    const encryption = this.option.frontendRef.ipNetwork.encryption || {};
+    if ("tls" in encryption) {
+      return "TLS";
+    } else {
+      return null;
+    }
+  },
+});
+
 Template.grainPowerboxCard.powerboxIconSrc = card => {
   return card.grainInfo.iconSrc;
 };

--- a/shell/packages/sandstorm-ui-powerbox/powerbox.html
+++ b/shell/packages/sandstorm-ui-powerbox/powerbox.html
@@ -68,6 +68,9 @@
 
 <template name="ipNetworkPowerboxCard">
   Admin: grant all outgoing network access
+  {{#with encryption}}
+    (encrypted with {{.}})
+  {{/with}}
 </template>
 
 <template name="ipInterfacePowerboxCard">

--- a/shell/server/drivers/ip.js
+++ b/shell/server/drivers/ip.js
@@ -246,7 +246,7 @@ class IpNetworkImpl extends PersistentImpl {
     // However, we keep that code path active because there is in principle no reason why it
     // should always fail, and we wish to allow for a possible future in which we let users
     // specify custom certificate authorities, in which case it might be more likely for TLS
-    // to be be expected to authenticate raw IP addresses.
+    // to be expected to authenticate raw IP addresses.
 
     return { host: new IpRemoteHostImpl(addressToString(address), this.tls) };
   }

--- a/shell/server/drivers/ip.js
+++ b/shell/server/drivers/ip.js
@@ -18,6 +18,7 @@ import Bignum from "bignum";
 import { PersistentImpl } from "/imports/server/persistent.js";
 const Future = Npm.require("fibers/future");
 const Net = Npm.require("net");
+const Tls = Npm.require("tls");
 const Dgram = Npm.require("dgram");
 const Capnp = Npm.require("capnp");
 
@@ -234,16 +235,17 @@ const addressType = (address) => {
 };
 
 class IpNetworkImpl extends PersistentImpl {
-  constructor(db, saveTemplate) {
+  constructor(db, saveTemplate, tls) {
     super(db, saveTemplate);
+    this.tls = tls;
   }
 
   getRemoteHost(address) {
-    return { host: new IpRemoteHostImpl(address) };
+    return { host: new IpRemoteHostImpl(address, this.tls) };
   }
 
   getRemoteHostByName(address) {
-    return { host: new IpRemoteHostImpl(address) };
+    return { host: new IpRemoteHostImpl(address, this.tls) };
   }
 };
 
@@ -254,31 +256,46 @@ Meteor.startup(() => {
     frontendRefField: "ipNetwork",
     typeId: IpRpc.IpNetwork.typeId,
 
-    restore(db, saveTemplate) {
-      return new Capnp.Capability(new IpNetworkImpl(db, saveTemplate),
-                                  IpRpc.PersistentIpNetwork);
+    restore(db, saveTemplate, value) {
+      return new Capnp.Capability(
+        new IpNetworkImpl(db, saveTemplate, "tls" in value.encryption),
+        IpRpc.PersistentIpNetwork);
     },
 
     validate(db, session, value) {
-      check(value, true);
+      check(value, { encryption: Match.OneOf({ none: null }, { tls: null }) });
 
       if (!session.userId) {
         throw new Meteor.Error(403, "Not logged in.");
       }
 
       return {
-        descriptor: { tags: [{ id: IpRpc.IpNetwork.typeId }] },
+        descriptor: {
+          tags: [
+            {
+              id: IpRpc.IpNetwork.typeId,
+              value: Capnp.serialize(
+                IpRpc.IpNetwork.PowerboxTag,
+                value),
+            },
+          ],
+        },
         requirements: [{ userIsAdmin: session.userId }],
         frontendRef: value,
       };
     },
 
     query(db, userId, value) {
+      let encryption = { none: null };
+      if (value) {
+        encryption = Capnp.parse(IpRpc.IpNetwork.PowerboxTag, value).encryption || encryption;
+      }
+
       if (userId && Meteor.users.findOne(userId).isAdmin) {
         return [
           {
             _id: "frontendref-ipnetwork",
-            frontendRef: { ipNetwork: true },
+            frontendRef: { ipNetwork: { encryption } },
             cardTemplate: "ipNetworkPowerboxCard",
           },
         ];
@@ -290,35 +307,49 @@ Meteor.startup(() => {
 });
 
 IpRemoteHostImpl = class IpRemoteHostImpl {
-  constructor(address) {
+  constructor(address, tls) {
     if (address.upper64 || address.upper64 === 0) {
       // address is an ip.capnp:IpAddress, we need to convert it
       this.address = addressToString(address);
     } else {
       this.address = address;
     }
+
+    this.tls = tls;
   }
 
   getTcpPort(portNum) {
-    return { port: new TcpPortImpl(this.address, portNum) };
+    return { port: new TcpPortImpl(this.address, portNum, this.tls) };
   }
 
   getUdpPort(portNum) {
+    if (!this.tls) {
+      const error = new Error("UDP over TLS is not yet supported");
+      error.kjType = "unimplemented";
+      throw error;
+    }
+
     return { port: new UdpPortImpl(this.address, portNum) };
   }
 };
 
 TcpPortImpl = class TcpPortImpl {
-  constructor(address, portNum) {
+  constructor(address, portNum, tls) {
     this.address = address;
     this.port = portNum;
+    this.tls = tls;
   }
 
   connect(downstream) {
     const _this = this;
     let resolved = false;
+    let connectMethod = Net.connect;
+    if (this.tls) {
+      connectMethod = Tls.connect;
+    }
+
     return new Promise((resolve, reject) => {
-      const client = Net.connect({ host: _this.address, port: _this.port }, () => {
+      const client = connectMethod({ host: _this.address, port: _this.port }, () => {
         resolved = true;
         resolve({ upstream: new ByteStreamConnection(client) });
       });

--- a/shell/server/drivers/ip.js
+++ b/shell/server/drivers/ip.js
@@ -323,7 +323,7 @@ IpRemoteHostImpl = class IpRemoteHostImpl {
   }
 
   getUdpPort(portNum) {
-    if (!this.tls) {
+    if (this.tls) {
       const error = new Error("UDP over TLS is not yet supported");
       error.kjType = "unimplemented";
       throw error;

--- a/src/sandstorm/ip.capnp
+++ b/src/sandstorm/ip.capnp
@@ -50,6 +50,21 @@ interface IpNetwork @0xa982576b7a2a2040 {
   # access". The IpNetwork capability is a dangerous capability that should only be granted to
   # trusted drivers. Only the Sandstorm server administrator is likely to possess this capability.
 
+  struct PowerboxTag {
+    # Tag to be used in a `PowerboxDescriptor` to describe an `IpNetwork`.
+
+    encryption :union {
+      # The encryption scheme, if any, on top of which the IpNetwork will layer its connections
+      # and messages.
+
+      none @0 :Void;
+      # No encryption.
+
+      tls  @1 :Void;
+      # Transport Layer Security, using a standard set of certificates.
+    }
+  }
+
   getRemoteHost @0 (address :IpAddress) -> (host :IpRemoteHost);
   # Get the remote host corresponding to the given address.
 

--- a/src/sandstorm/ip.capnp
+++ b/src/sandstorm/ip.capnp
@@ -53,15 +53,24 @@ interface IpNetwork @0xa982576b7a2a2040 {
   struct PowerboxTag {
     # Tag to be used in a `PowerboxDescriptor` to describe an `IpNetwork`.
 
-    encryption :union {
-      # The encryption scheme, if any, on top of which the IpNetwork will layer its connections
-      # and messages.
+    encryption @0 :Encryption;
+    # The encryption scheme, if any, on top of which the `IpNetwork` layers its connections
+    # and messages.
 
-      none @0 :Void;
-      # No encryption.
+    struct Encryption @0xe2d94cf90fe4078d {
+      # Describes an encryption scheme.
+      #
+      # Capabilities derived from an `IpNetwork` may use this struct in their own powerbox
+      # descriptors, either in an explicit `PowerboxTag.encryption` field, like here with
+      # `IpNetwork`, or in an independent powerbox tag, marked by this struct's type ID.
 
-      tls  @1 :Void;
-      # Transport Layer Security, using a standard set of certificates.
+      union {
+        none @0 :Void;
+        # No encryption.
+
+        tls @1 :Void;
+        # Transport Layer Security, using a standard set of certificates.
+      }
     }
   }
 


### PR DESCRIPTION
This is an implementation of @kentonv's [suggestion](https://github.com/sandstorm-io/sandstorm/pull/2774#issuecomment-263086336) from #2774.

This changes the database representation of `IpNetwork` sturdyrefs and includes a migration to convert existing sturdyrefs of the form `ipNetwork: true` into `ipNetwork: {encryption: {none: null}}`.

Adds a "TLS-encrypted outbound network access" table to the "Network capabilities" section of the admin panel. Also in the "Network capabilities" section, fixes some bugs, most of which were introduced when we switched to using the `claimRequest()` flow. `cap.owner.grain.introducerIdentity` is now obsolete!