### PR TITLE
explicitly annotate AppPersistent's type ID

### DIFF
--- a/src/sandstorm/grain.capnp
+++ b/src/sandstorm/grain.capnp
@@ -613,7 +613,7 @@ struct GrainInfo {
 # ========================================================================================
 # Persistent objects
 
-interface AppPersistent(AppObjectId) {
+interface AppPersistent @0xaffa789add8747b8 (AppObjectId) {
   # To make an object implemented by your own app persistent, implement this interface.
   #
   # `AppObjectId` is a structure like a URL which identifies a specific object within your app.


### PR DESCRIPTION
In order to work around https://github.com/dwrensha/capnpc-rust/issues/30, I'm copy/pasting `AppPersistent` into an app-specific schema file. It would be nice if the canonical declaration of `AppPersistent` specified its type ID, so that it would be easier to verify that my copy matches up.

The ID added in this pull request was obtained from `capnp compile -ocapnp`.