### PR TITLE
Fix up the logic for garbage collecting autoupdate apps

### DIFF
--- a/shell/server/installer.js
+++ b/shell/server/installer.js
@@ -57,8 +57,8 @@ const deletePackageInternal = (pkg) => {
     const action = UserActions.findOne({ packageId: packageId });
     const grain = Grains.findOne({ packageId: packageId });
     const notificationQuery = {};
-    notificationQuery["appUpdates." + pkg.appId] = { $exists: true };
-    if (!grain && !action && !(pkg.isAutoUpdated && Notifications.findOne(notificationQuery))
+    notificationQuery["appUpdates." + pkg.appId + ".packageId"] = packageId;
+    if (!grain && !action && !Notifications.findOne(notificationQuery)
         && !globalDb.getAppIdForPreinstalledPackage(packageId)) {
       Packages.update({
         _id: packageId,


### PR DESCRIPTION
Before this change, if a user on the server manually installed the package before the autoupdate downloaded the package, and then the user deleted all their references to the package, the package would be deleted.

I don't think this actually fixes #2772, but it could be what @zarvox ran into.