### PR TITLE
prepend '/' to paths in ExternalWebSessionImpl

### DIFF
--- a/shell/server/drivers/external-ui-view.js
+++ b/shell/server/drivers/external-ui-view.js
@@ -125,7 +125,15 @@ ExternalWebSession = class ExternalWebSession {
     return new Promise((resolve, reject) => {
       const options = _.clone(session.options);
       options.headers = options.headers || {};
-      options.path = "/" + path;
+
+      // According to the specification of `WebSession`, `path` should not contain a
+      // leading slash, and therefore we need to prepend "/". However, for a long time
+      // this implementation did not in fact prepend a "/". Since some apps might rely on
+      // that behavior, we only prepend "/" if the path does not start with "/".
+      //
+      // TODO(soon): Once apps have updated, prepend "/" unconditionally.
+      options.path = path.startsWith("/") ? path : "/" + path;
+
       options.method = method;
       if (contentType) {
         options.headers["content-type"] = contentType;

--- a/shell/server/drivers/external-ui-view.js
+++ b/shell/server/drivers/external-ui-view.js
@@ -125,7 +125,7 @@ ExternalWebSession = class ExternalWebSession {
     return new Promise((resolve, reject) => {
       const options = _.clone(session.options);
       options.headers = options.headers || {};
-      options.path = path;
+      options.path = "/" + path;
       options.method = method;
       if (contentType) {
         options.headers["content-type"] = contentType;


### PR DESCRIPTION
The `path` parameter to `WebSession`'s methods should never include the leading `'/'`. (See [this](https://github.com/sandstorm-io/sandstorm/blob/v0.196/src/sandstorm/web-session.capnp#L98-L99) and [this](https://github.com/sandstorm-io/sandstorm/blob/v0.196/shell/server/proxy.js#L1863).)

In contrast, the `path` argument in a call to node's [`http.request()`](https://nodejs.org/api/http.html#http_http_request_options_callback) should have a leading `'/'`. So  this pull request adds it.

I noticed this problem when I tried making a hacky HTTP pseudodriver by copying this code.