### PR TITLE
Fix ldap quota not querying correctly

### DIFF
--- a/shell/imports/server/accounts/ldap.js
+++ b/shell/imports/server/accounts/ldap.js
@@ -219,7 +219,7 @@ LDAP.prototype.updateUserQuota = function (db, user) {
   };
 
   const setting = db.collections.settings.findOne({ _id: "quotaLdapAttribute" });
-  if (!setting) return fallback;
+  if (!setting || !setting.value) return fallback;
 
   // TODO(someday): don't just assume the first login identity is the primary identity?
   const email = db.getPrimaryEmail(user._id, user.loginIdentities[0].id);

--- a/shell/imports/server/accounts/ldap.js
+++ b/shell/imports/server/accounts/ldap.js
@@ -49,7 +49,7 @@ LDAP.prototype.ldapCheck = function (db, options) {
     _this.options.base = db.getLdapBase();
     _this.options.url = db.getLdapUrl();
     _this.options.searchBeforeBind = {};
-    _this.options.searchBeforeBind[db.getLdapSearchUsername()] = options.searchUsername ||
+    _this.options.searchBeforeBind[options.searchUsernameField || db.getLdapSearchUsername()] = options.searchUsername ||
       options.username;
     _this.options.filter = db.getLdapFilter() || "(objectclass=*)";
     _this.options.searchBindDn = db.getLdapSearchBindDn();
@@ -227,7 +227,7 @@ LDAP.prototype.updateUserQuota = function (db, user) {
 
   let ldapUser;
   try {
-    ldapUser = this.ldapCheck(db, { searchUsername: email, });
+    ldapUser = this.ldapCheck(db, { searchUsername: email, searchUsernameField: "mail", });
   } catch (err) {
     console.error("Error looking up quota from LDAP");
     return fallback;


### PR DESCRIPTION
Fixes #2778 

It turns out that we weren't querying for the `mail` field in LDAP correctly. This is now corrected, and I can confirm it displays correctly in the grains list when it is working.

![image](https://cloud.githubusercontent.com/assets/1595880/20692029/28944e22-b58a-11e6-9621-5d943e77b975.png)

