### PR TITLE
throw an error if a UiView offer provides no title

### DIFF
--- a/shell/server/hack-session.js
+++ b/shell/server/hack-session.js
@@ -122,9 +122,7 @@ SessionContextImpl = class SessionContextImpl {
         }
 
         if (!tagValue.title) {
-          // TODO(someday): We should arguably throw here, but the collections app currently
-          //   fails to provide a title.
-          tagValue.title = "offer()ed grain had no title";
+          throw new Error("No value provided for UiView.PowerboxTag.title.");
         }
 
         if (session.identityId) {


### PR DESCRIPTION
There are a few old versions of the Collections app and the Rocket.Chat app that depend on this not being an error, but any grains using those versions ought to be updated by now.