### PR TITLE
fix backup-restore test failure

### DIFF
--- a/src/sandstorm/backup.c++
+++ b/src/sandstorm/backup.c++
@@ -123,7 +123,6 @@ bool BackupMain::run(kj::StringPtr grainDir) {
   if (sandboxUid == nullptr) {
     uid_t uid = getuid();
     gid_t gid = getgid();
-    KJ_REQUIRE(uid != 0);
 
     KJ_SYSCALL(unshare(CLONE_NEWUSER | CLONE_NEWNS |
         // Unshare other stuff; like no_new_privs, this is only to defend against hypothetical

--- a/tests/tests/backup-restore.js
+++ b/tests/tests/backup-restore.js
@@ -83,8 +83,13 @@ module.exports = {
 module.exports["Test backup and restore"] = function(browser) {
   // For setting up an async watch on the filesystem
   var watcherPromise = undefined;
+
   // Fulfilled when the file is downloaded, rejected if a timeout is reached
   var downloadPromise = undefined;
+
+  // Filled in if downloading fails.
+  var downloadError = undefined;
+
   // For using the file after download completes.
   var downloadPath = undefined;
 
@@ -148,7 +153,14 @@ module.exports["Test backup and restore"] = function(browser) {
         client.assert.ok(!!stateFile, "" + fileDownloaded + " contains file /data/state");
         client.assert.ok(stateFile.asText() === randomValue, "" + fileDownloaded + "/data/state contains the expected value " + randomValue);
         done();
+      }).catch(function (error) {
+        downloadError = error;
+        done();
       });
+    })
+    .perform(function (client, done) {
+      client.assert.ifError(downloadError);
+      done();
     })
     .click('li.navitem-grain.current button.close-button')
     .url(browser.launch_url + "/grain")


### PR DESCRIPTION
Currently, the backup-restore test triggers the error:
```
sandstorm/backup.c++:126: failed: expected uid != 0
stack: 0x519863 0x494975
capnp/rpc.c++:142: info: returning failure over rpc; exception = sandstorm/util.c++:959: failed: expected exitCode == 0; child process failed; name = backup; exitCode = 1
stack: 0x5a2ccc 0x4a7a92 0x425140
Exception while invoking method 'backupGrain' Error: remote exception: expected exitCode == 0; child process failed; name = backup; exitCode = 1
    at Object.Future.wait (/programs/server/node_modules/fibers/future.js:449:15)
    at waitPromise (imports/server/async-helpers.js:39:35)
    at [object Object].backupGrain (server/backup.js:66:5)
    at maybeAuditArgumentChecks (packages/ddp-server/livedata_server.js:1711:12)
    at packages/ddp-server/livedata_server.js:711:19
    at [object Object]._.extend.withValue (packages/meteor/dynamics_nodejs.js:56:1)
    at packages/ddp-server/livedata_server.js:709:40
    at [object Object]._.extend.withValue (packages/meteor/dynamics_nodejs.js:56:1)
    at packages/ddp-server/livedata_server.js:707:46
    at Session.method (packages/ddp-server/livedata_server.js:681:23)
    - - - - -
    at Error (native)
```

However, because the error is thrown in a dangling promise continuation, instead of triggering test failure, it instead terminates the test suite early and, astonishingly, causes the test runner to exit with a success code!

The problem was apparently introduced in Jenkins build number 1239, which was https://github.com/sandstorm-io/sandstorm/pull/2713.

This means that for the past month our test suite has not been fully operational.

This pull request fixes the test so that it would have properly indicated failure. It also removes an assertion in backup.c++, causing the actual error to go away. I don't fully understand whether this is safe. @kentonv, could you please review? The problem seems related to https://github.com/sandstorm-io/sandstorm/commit/5ddb095564ba8deaf80f8e8e134f04876f6e2284