### PR TITLE
properly encode Location header in redirect responses

### DIFF
--- a/shell/server/proxy.js
+++ b/shell/server/proxy.js
@@ -1877,7 +1877,7 @@ class Proxy {
       const redirect = rpcResponse.redirect;
       const redirectCode = redirectCodes[redirect.switchToGet * 2 + redirect.isPermanent];
       response.writeHead(redirectCode.id, redirectCode.title, {
-        "Location": redirect.location,
+        "Location": encodeURI(redirect.location),
       });
       response.end();
     } else if ("clientError" in rpcResponse) {


### PR DESCRIPTION
Fixes #2809.

Note that we are already calling `encodeURI()` in [the other place we set the Location header](https://github.com/sandstorm-io/sandstorm/blob/v0.198/shell/server/proxy.js#L1603).