### PR TITLE
Increase 15-minute token timeouts to 1 hour.

### DIFF
--- a/shell/imports/server/auth.js
+++ b/shell/imports/server/auth.js
@@ -5,7 +5,7 @@ import Fs from "fs";
 import { SANDSTORM_VARDIR } from "/imports/server/constants.js";
 // TODO(cleanup): globalDb is still an unbound global, but extracting it is Hard.
 
-const ADMIN_TOKEN_EXPIRATION_TIME = 15 * 60 * 1000;
+const ADMIN_TOKEN_EXPIRATION_TIME = 60 * 60 * 1000;
 const SANDSTORM_ADMIN_TOKEN = SANDSTORM_VARDIR + "/adminToken";
 
 function clearAdminToken(token) {

--- a/shell/server/accounts/email-token/token-server.js
+++ b/shell/server/accounts/email-token/token-server.js
@@ -14,7 +14,7 @@ const V1_HASHFUNC = "sha512";
 // sufficient to reconstruct the output of pbkdf2().
 const V1_CIPHER = "AES-256-CTR"; // cipher used
 
-const TOKEN_EXPIRATION_MS = 15 * 60 * 1000;
+const TOKEN_EXPIRATION_MS = 60 * 60 * 1000;
 
 const cleanupExpiredTokens = function () {
   Meteor.users.update({


### PR DESCRIPTION
This seems particularly needed for e-mail tokens since e-mail can suffer from slow queues.

Fixes #2775.

@ndarilek 