### PR TITLE
SAML login: Don't require password authentication.

### DIFF
--- a/shell/imports/server/accounts/saml-utils.js
+++ b/shell/imports/server/accounts/saml-utils.js
@@ -84,13 +84,7 @@ SAML.prototype.generateAuthorizeRequest = function (req) {
     "\" AllowCreate=\"true\"></samlp:NameIDPolicy>\n";
   }
 
-  request +=
-    "<samlp:RequestedAuthnContext xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Comparison=\"exact\">" +
-      "<saml:AuthnContextClassRef xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">" +
-        "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport" +
-      "</saml:AuthnContextClassRef>" +
-    "</samlp:RequestedAuthnContext>\n" +
-  "</samlp:AuthnRequest>";
+  request += "</samlp:AuthnRequest>";
 
   return request;
 };


### PR DESCRIPTION
Apparently, this clause actually prevents Sandstorm from working with ADFS installations that use non-password mechanisms like Kerberos.

I do not know why SAML lets the client specify the authentication mechanism, nor do I know why our code specified password authentication here (seems to have been inherited from the old meteor-accounts-saml code).

I've tested this change against: SimpleSamlPhp, Windows Server ADFS, Azure AD.

@abliss This is the change you wanted, right?