### PR TITLE
Handle Sandstorm being bound on secondary addresses in Sandcats

### DIFF
--- a/shell/server/sandcats.js
+++ b/shell/server/sandcats.js
@@ -26,7 +26,7 @@ const Url = Npm.require("url");
 import { SANDSTORM_ALTHOME } from "/imports/server/constants.js";
 
 const SANDCATS_HOSTNAME = (Meteor.settings && Meteor.settings.public &&
-                         Meteor.settings.public.sandcatsHostname);
+                           Meteor.settings.public.sandcatsHostname);
 const SANDCATS_VARDIR = (SANDSTORM_ALTHOME || "") + "/var/sandcats";
 
 const ROOT_URL = Url.parse(process.env.ROOT_URL);

--- a/shell/server/sandcats.js
+++ b/shell/server/sandcats.js
@@ -63,6 +63,10 @@ const pingUdp = () => {
     }
   });
 
+  socket.on("error", (err) => {
+    throw err;
+  });
+
   socket.bind({ address: process.env.BIND_IP }, () => {
     socket.send(message, 0, message.length, 8080, SANDCATS_HOSTNAME, (err) => {
       if (err) {

--- a/shell/server/sandcats.js
+++ b/shell/server/sandcats.js
@@ -70,7 +70,7 @@ const pingUdp = () => {
       }
     });
 
-    Meteor.setTimeout(() => {
+    setTimeout(() => {
       socket.close();
     }, 10 * 1000);
   });

--- a/shell/server/sandcats.js
+++ b/shell/server/sandcats.js
@@ -80,6 +80,7 @@ const performSandcatsRequest = (path, hostname, postData, errorCallback, respons
   const options = {
     hostname: hostname,
     path: path,
+    localAddress: process.env.BIND_IP,
     method: "POST",
     agent: false,
     key: fs.readFileSync(SANDCATS_VARDIR + "/id_rsa"),

--- a/shell/server/sandcats.js
+++ b/shell/server/sandcats.js
@@ -63,15 +63,17 @@ const pingUdp = () => {
     }
   });
 
-  socket.send(message, 0, message.length, 8080, SANDCATS_HOSTNAME, (err) => {
-    if (err) {
-      console.error("Couldn't send UDP sandcats ping", err);
-    }
-  });
+  socket.bind({ address: process.env.BIND_IP }, () => {
+    socket.send(message, 0, message.length, 8080, SANDCATS_HOSTNAME, (err) => {
+      if (err) {
+        console.error("Couldn't send UDP sandcats ping", err);
+      }
+    });
 
-  Meteor.setTimeout(() => {
-    socket.close();
-  }, 10 * 1000);
+    Meteor.setTimeout(() => {
+      socket.close();
+    }, 10 * 1000);
+  });
 };
 
 const performSandcatsRequest = (path, hostname, postData, errorCallback, responseCallback) => {


### PR DESCRIPTION
Fixes sandstorm-io/sandcats#153.

I'm not quite sure if this actually works, as I can't actually get a local dev environment set up (and even if I could I'm not particularly sure how to test Sandcats-related stuff since it calls out to the network service). However, it does pass JSHint, so at least it's not totally busted.

Question: does Sandcats determine the IP to set the DNS record to from the IP used to send the POST request? Or is it embedded in the HTTP body? AFAICT it's the former, but I could be wrong as I don't fully understand everything this code does yet.

Also, I fixed a whitespace issue as a bonus.