### PR TITLE
Extend http-bridge to support app-to-app powerbox HTTP APIs

### DIFF
--- a/src/sandstorm/api-session.capnp
+++ b/src/sandstorm/api-session.capnp
@@ -70,9 +70,8 @@ interface ApiSession @0xc879e379c625cdc7 extends(WebSession.WebSession) {
     # Google Calendar API version 2 as "https://apidata.googleusercontent.com/caldav/v2". However,
     # you would not normally request "https://api.github.com/users" because "GitHub users" is not
     # considered a separate API but rather one part of the overall GitHub API. Note that
-    # `canonicalUrl` should never end with a '/', because request paths to `ApiSession` are
-    # required to start with a '/', so this would result in two consecutive '/'s which is usually
-    # wrong.
+    # `canonicalUrl` should never end with a '/', because a '/' is added implicitly to separate
+    # the API URL from the individual request's path.
     #
     # The HTTP driver will present `canonicalUrl` as a strong suggestion to the user. However, the
     # user is always allowed to substitute a different URL instead, causing requests to be

--- a/src/sandstorm/bridge-proxy.c++
+++ b/src/sandstorm/bridge-proxy.c++
@@ -1,0 +1,771 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2017 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bridge-proxy.h"
+#include <map>
+#include <sandstorm/api-session.capnp.h>
+#include <sandstorm/bridge-proxy.capnp.h>
+#include <capnp/compat/json.h>
+#include <kj/debug.h>
+#include "util.h"
+
+namespace sandstorm {
+namespace {
+
+kj::Maybe<kj::StringPtr> removePrefix(kj::StringPtr prefix, kj::StringPtr str) {
+  if (str.startsWith(prefix)) {
+    return str.slice(prefix.size());
+  } else {
+    return nullptr;
+  }
+}
+
+HttpStatusDescriptor::Reader getHttpStatusAnnotation(capnp::EnumSchema::Enumerant enumerant) {
+  for (auto annotation: enumerant.getProto().getAnnotations()) {
+    if (annotation.getId() == HTTP_STATUS_ANNOTATION_ID) {
+      return annotation.getValue().getStruct().getAs<HttpStatusDescriptor>();
+    }
+  }
+  KJ_FAIL_ASSERT("Missing httpStatus annotation on status code enumerant.",
+                 enumerant.getProto().getName());
+}
+
+class BridgeProxy final: public kj::HttpService {
+public:
+  BridgeProxy(SandstormApi<BridgeObjectId>::Client sandstormApi,
+              SandstormHttpBridge::Client bridge,
+              spk::BridgeConfig::Reader config,
+              kj::HttpHeaderTable::Builder& requestHeaders)
+      : sandstormApi(kj::mv(sandstormApi)),
+        bridge(kj::mv(bridge)),
+        config(config),
+        hAccept(requestHeaders.add("Accept")),
+        hAcceptEncoding(requestHeaders.add("Accept-Encoding")),
+        hAuthorization(requestHeaders.add("Authorization")),
+        hContentDisposition(requestHeaders.add("Content-Disposition")),
+        hContentEncoding(requestHeaders.add("Content-Encoding")),
+        hContentLanguage(requestHeaders.add("Content-Language")),
+        hContentType(requestHeaders.add("Content-Type")),
+        hETag(requestHeaders.add("ETag")),
+        hIfMatch(requestHeaders.add("If-Match")),
+        hIfNoneMatch(requestHeaders.add("If-None-Match")),
+        headerTable(requestHeaders.getFutureTable()),
+        successCodeTable(KJ_MAP(enumerant,
+              capnp::Schema::from<WebSession::Response::SuccessCode>().getEnumerants()) {
+          return getHttpStatusAnnotation(enumerant);
+        }),
+        errorCodeTable(KJ_MAP(enumerant,
+              capnp::Schema::from<WebSession::Response::ClientErrorCode>().getEnumerants()) {
+          return getHttpStatusAnnotation(enumerant);
+        }),
+        requestHeaderWhitelist(*WebSession::Context::HEADER_WHITELIST),
+        responseHeaderWhitelist(*WebSession::Response::HEADER_WHITELIST) {
+  }
+
+  kj::Promise<void> request(
+      kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
+      kj::AsyncInputStream& requestBody, Response& response) override {
+    KJ_IF_MAYBE(pathStr, removePrefix("http://http-bridge/", url)) {
+      KJ_REQUIRE(pathStr->findFirst('?') == nullptr, "unrecognized query string", url);
+      auto path = KJ_MAP(part, split(*pathStr, '/')) { return kj::heapString(part); };
+
+      if (path.size() > 2 && path[0] == "session" && path[2] == "claim" &&
+          method == kj::HttpMethod::POST) {
+        // POST /session/<id>/claim -- do a claimRequest().
+
+        auto context = ({
+          auto req = bridge.getSessionContextRequest();
+          req.setId(path[1]);
+          req.send().getContext();
+        });
+
+        return requestBody.readAllText()
+            .then([this,KJ_MVCAP(context)](kj::String body) mutable
+                -> kj::Promise<capnp::Response<SandstormApi<BridgeObjectId>::SaveResults>> {
+          capnp::MallocMessageBuilder builder(128);
+          auto parsedRequest = builder.initRoot<ProxyClaimRequestRequest>();
+          capnp::JsonCodec json;
+          json.decode(body, parsedRequest);
+
+          auto req = context.claimRequestRequest();
+          req.setRequestToken(parsedRequest.getRequestToken());
+
+          auto permissionDefs = config.getViewInfo().getPermissions();
+          auto requiredPerms = KJ_MAP(name, parsedRequest.getRequiredPermissions())
+                                       -> kj::StringPtr { return name; };
+
+          auto permArray = req.initRequiredPermissions(permissionDefs.size());
+
+          for (size_t i: kj::indices(permissionDefs)) {
+            auto defName = permissionDefs[i].getName();
+
+            for (auto& reqName: requiredPerms) {
+              if (reqName == defName) {
+                permArray.set(i, true);
+              }
+            }
+          }
+
+          auto req2 = sandstormApi.saveRequest();
+          req2.setCap(req.send().getCap());
+          req2.setLabel(parsedRequest.getLabel());
+          return req2.send();
+        }).then([this,&response]
+            (capnp::Response<SandstormApi<BridgeObjectId>::SaveResults>&& claim) {
+          capnp::MallocMessageBuilder builder(64);
+          auto root = builder.initRoot<ProxyClaimRequestResponse>();
+          root.setCap(base64Encode(claim.getToken(), false));
+
+          capnp::JsonCodec json;
+          kj::String text = json.encode(root);
+
+          kj::HttpHeaders headers(headerTable);
+          headers.set(hContentType, "application/json; charset=UTF-8");
+          auto stream = response.send(200, "OK", headers, text.size());
+          auto promise = stream->write(text.begin(), text.size());
+          return promise.attach(kj::mv(stream), kj::mv(text));
+        });
+      }
+    }
+
+    KJ_IF_MAYBE(auth, headers.get(hAuthorization)) {
+      if (auth->startsWith("bearer ") || auth->startsWith("Bearer ")) {
+        auto token = auth->slice(strlen("bearer "));
+        auto session = getHttpSession(token);
+        return dispatchToSession(kj::mv(session), method, url, headers, requestBody, response);
+      }
+    }
+
+    return sendError(response, 404, "Not Found");
+  }
+
+  // TODO(someday): WebSocket (when KJ HTTP supports it).
+
+private:
+  SandstormApi<BridgeObjectId>::Client sandstormApi;
+  SandstormHttpBridge::Client bridge;
+  spk::BridgeConfig::Reader config;
+
+  kj::HttpHeaderId hAccept;
+  kj::HttpHeaderId hAcceptEncoding;
+  kj::HttpHeaderId hAuthorization;
+  kj::HttpHeaderId hContentDisposition;
+  kj::HttpHeaderId hContentEncoding;
+  kj::HttpHeaderId hContentLanguage;
+  kj::HttpHeaderId hContentType;
+  kj::HttpHeaderId hETag;
+  kj::HttpHeaderId hIfMatch;
+  kj::HttpHeaderId hIfNoneMatch;
+  kj::HttpHeaderTable& headerTable;
+
+  struct TokenInfo {
+    TokenInfo(const TokenInfo&) = delete;
+    TokenInfo(TokenInfo&&) = default;
+
+    kj::String key;
+    ApiSession::Client cap;
+  };
+
+  std::map<kj::StringPtr, TokenInfo> tokenMap;
+
+  kj::Array<HttpStatusDescriptor::Reader> successCodeTable;
+  kj::Array<HttpStatusDescriptor::Reader> errorCodeTable;
+  HeaderWhitelist requestHeaderWhitelist;
+  HeaderWhitelist responseHeaderWhitelist;
+
+  template <typename T>
+  inline HttpStatusDescriptor::Reader lookupStatus(
+      kj::ArrayPtr<HttpStatusDescriptor::Reader> table,
+      T codeEnum) {
+    if (static_cast<uint>(codeEnum) < table.size()) {
+      return table[static_cast<uint>(codeEnum)];
+    } else {
+      // The first item in each table happens to be a reasonable generic code for that table.
+      return table.front();
+    }
+  }
+
+  kj::Promise<void> sendError(kj::HttpService::Response& response,
+                              uint statusCode, kj::StringPtr statusText) {
+    kj::HttpHeaders headers(headerTable);
+    return sendError(response, statusCode, statusText, headers);
+  }
+
+  kj::Promise<void> sendError(kj::HttpService::Response& response,
+                              uint statusCode, kj::StringPtr statusText,
+                              kj::HttpHeaders& headers) {
+    auto stream = response.send(statusCode, statusText, headers, statusText.size());
+    auto promise = stream->write(statusText.begin(), statusText.size());
+    return promise.attach(kj::mv(stream));
+  }
+
+  ApiSession::Client getHttpSession(kj::StringPtr token) {
+    auto iter = tokenMap.find(token);
+    if (iter == tokenMap.end()) {
+      // Use a CapRedirector to automatically reconnect after disconnects. Keep in mind that due
+      // to refcounting, the CapRedirector could outlive the BridgeProxy. Luckily it doesn't need
+      // to capture "this".
+      auto cap = capnp::Capability::Client(
+          kj::heap<CapRedirector>([sandstormApi=sandstormApi,token=kj::str(token)]() mutable {
+        auto req = sandstormApi.restoreRequest();
+        req.setToken(base64Decode(token));
+        return req.send().getCap();
+      })).castAs<ApiSession>();
+
+      TokenInfo info { kj::heapString(token), cap };
+      kj::StringPtr key = info.key;
+      tokenMap.insert(std::make_pair(key, kj::mv(info)));
+      return kj::mv(cap);
+    } else {
+      return iter->second.cap;
+    }
+  }
+
+  kj::Promise<void> dispatchToSession(ApiSession::Client session,
+      kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
+      kj::AsyncInputStream& requestBody, Response& response) {
+    // TODO(cleanup): Factor this out into a reusable component that adapts
+    //   HttpService -> WebSession. We could then consider moving the HTTP proxy code out of the
+    //   Sandstorm shell, replacing it with this! Which would be amazing!
+
+    kj::StringPtr path;
+
+    KJ_IF_MAYBE(p, removePrefix("http://", url)) {
+      path = *p;
+    } else KJ_IF_MAYBE(p, removePrefix("https://", url)) {
+      path = *p;
+    } else {
+      KJ_FAIL_REQUIRE("unknown protocol", url);
+    }
+
+    KJ_IF_MAYBE(i, path.findFirst('/')) {
+      path = path.slice(*i + 1);
+    } else {
+      path = "";
+    }
+
+    if (url.startsWith("http://")) {
+      url = url.slice(strlen("http://"));
+    }
+
+    static constexpr size_t MAX_NONSTREAMING_LENGTH = 65536;
+
+    switch (method) {
+      case kj::HttpMethod::GET:
+      case kj::HttpMethod::HEAD: {
+        auto req = session.getRequest();
+        req.setPath(path);
+        req.setIgnoreBody(method == kj::HttpMethod::HEAD);
+        auto streamer = initContext(req.initContext(), headers);
+        return handleResponse(req.send(), kj::mv(streamer), response);
+      }
+
+      case kj::HttpMethod::POST: {
+        KJ_IF_MAYBE(length, requestBody.tryGetLength()) {
+          if (*length < MAX_NONSTREAMING_LENGTH) {
+            return requestBody.readAllBytes()
+                .then([this,KJ_MVCAP(session),path,&headers,&response]
+                      (kj::Array<byte>&& data) mutable {
+              auto req = session.postRequest();
+              req.setPath(path);
+              auto content = req.initContent();
+              content.setContent(data);
+              initContent(content, headers);
+              auto streamer = initContext(req.initContext(), headers);
+              return handleResponse(req.send(), kj::mv(streamer), response);
+            });
+          }
+        }
+
+        // Fall back to streaming.
+        auto req = session.postStreamingRequest();
+        req.setPath(path);
+        initContent(req, headers);
+        auto streamer = initContext(req.initContext(), headers);
+        return handleStreamingRequestResponse(
+            req.send().getStream(), requestBody, kj::mv(streamer), response);
+      }
+
+      case kj::HttpMethod::PUT: {
+        KJ_IF_MAYBE(length, requestBody.tryGetLength()) {
+          if (*length < MAX_NONSTREAMING_LENGTH) {
+            return requestBody.readAllBytes()
+                .then([this,KJ_MVCAP(session),path,&headers,&response]
+                      (kj::Array<byte>&& data) mutable {
+              auto req = session.putRequest();
+              req.setPath(path);
+              auto content = req.initContent();
+              content.setContent(data);
+              initContent(content, headers);
+              auto streamer = initContext(req.initContext(), headers);
+              return handleResponse(req.send(), kj::mv(streamer), response);
+            });
+          }
+        }
+
+        // Fall back to streaming.
+        auto req = session.putStreamingRequest();
+        req.setPath(path);
+        initContent(req, headers);
+        auto streamer = initContext(req.initContext(), headers);
+        return handleStreamingRequestResponse(
+            req.send().getStream(), requestBody, kj::mv(streamer), response);
+      }
+
+      case kj::HttpMethod::DELETE: {
+        auto req = session.deleteRequest();
+        req.setPath(path);
+        auto streamer = initContext(req.initContext(), headers);
+        return handleResponse(req.send(), kj::mv(streamer), response);
+      }
+
+      case kj::HttpMethod::PATCH: {
+        return requestBody.readAllBytes()
+            .then([this,KJ_MVCAP(session),path,&headers,&response]
+                  (kj::Array<byte>&& data) mutable {
+          auto req = session.patchRequest();
+          req.setPath(path);
+          auto content = req.initContent();
+          content.setContent(data);
+          initContent(content, headers);
+          auto streamer = initContext(req.initContext(), headers);
+          return handleResponse(req.send(), kj::mv(streamer), response);
+        });
+      }
+
+      // TODO(soon): WebDAV methods.
+
+      default:
+        return sendError(response, 501, "Not Implemented");
+    }
+  }
+
+  kj::Own<kj::PromiseFulfiller<ByteStream::Client>> initContext(
+      WebSession::Context::Builder context, const kj::HttpHeaders& headers) {
+    // We intentionally ignore cookies.
+
+    auto paf = kj::newPromiseAndFulfiller<ByteStream::Client>();
+    context.setResponseStream(kj::mv(paf.promise));
+
+    KJ_IF_MAYBE(accept, headers.get(hAccept)) {
+      auto items = split(*accept, ',');
+      auto list = context.initAccept(items.size());
+      for (size_t i: kj::indices(items)) {
+        auto item = items[i];
+        auto builder = list[i];
+
+        auto parts = split(item, ';');
+        builder.setMimeType(trim(parts[0]));
+
+        for (auto part: parts.asPtr().slice(1, parts.size())) {
+          KJ_IF_MAYBE(name, splitFirst(part, '=')) {
+            if (trim(*name) == "q") {
+              builder.setQValue(trim(part).parseAs<float>());
+            }
+          }
+        }
+      }
+    }
+
+    KJ_IF_MAYBE(accept, headers.get(hAcceptEncoding)) {
+      auto items = split(*accept, ',');
+      auto list = context.initAcceptEncoding(items.size());
+      for (size_t i: kj::indices(items)) {
+        auto item = items[i];
+        auto builder = list[i];
+
+        auto parts = split(item, ';');
+        builder.setContentCoding(trim(parts[0]));
+
+        for (auto part: parts.asPtr().slice(1, parts.size())) {
+          KJ_IF_MAYBE(name, splitFirst(part, '=')) {
+            if (trim(*name) == "q") {
+              builder.setQValue(trim(part).parseAs<float>());
+            }
+          }
+        }
+      }
+    }
+
+    KJ_IF_MAYBE(match, headers.get(hIfMatch)) {
+      if (*match == "*") {
+        context.getETagPrecondition().setExists();
+      } else {
+        context.getETagPrecondition().adoptMatchesOneOf(
+            parseETagList(capnp::Orphanage::getForMessageContaining(context), *match));
+      }
+    } else KJ_IF_MAYBE(match, headers.get(hIfNoneMatch)) {
+      if (*match == "*") {
+        context.getETagPrecondition().setDoesntExist();
+      } else {
+        context.getETagPrecondition().adoptMatchesNoneOf(
+            parseETagList(capnp::Orphanage::getForMessageContaining(context), *match));
+      }
+    }
+
+    kj::Vector<kj::Tuple<kj::StringPtr, kj::StringPtr>> whitelisted;
+    headers.forEach([&](kj::StringPtr name, kj::StringPtr value) {
+      if (requestHeaderWhitelist.matches(name)) {
+        whitelisted.add(kj::tuple(name, value));
+      }
+    });
+    if (whitelisted.size() > 0) {
+      auto list = context.initAdditionalHeaders(whitelisted.size());
+      for (size_t i: kj::indices(whitelisted)) {
+        auto out = list[i];
+        out.setName(kj::get<0>(whitelisted[i]));
+        out.setValue(kj::get<1>(whitelisted[i]));
+      }
+    }
+
+    return kj::mv(paf.fulfiller);
+  }
+
+  template <typename Builder>
+  void initContent(Builder&& builder, const kj::HttpHeaders& headers) {
+    KJ_IF_MAYBE(value, headers.get(hContentEncoding)) {
+      builder.setEncoding(*value);
+    }
+    KJ_IF_MAYBE(value, headers.get(hContentType)) {
+      builder.setMimeType(*value);
+    }
+  }
+
+  capnp::Orphan<capnp::List<WebSession::ETag>> parseETagList(
+      capnp::Orphanage orphanage, kj::StringPtr text,
+      kj::Vector<kj::Tuple<kj::String, bool>> parsed = kj::Vector<kj::Tuple<kj::String, bool>>()) {
+    parsed.add(parseETagInternal(text));
+    if (text.size() > 0) {
+      KJ_REQUIRE(text[0] == ',', "etag must be followed by comma", text);
+      return parseETagList(orphanage, text, kj::mv(parsed));
+    } else {
+      auto result = orphanage.newOrphan<capnp::List<WebSession::ETag>>(parsed.size());
+      auto list = result.get();
+      for (size_t i: kj::indices(parsed)) {
+        auto etag = list[i];
+        etag.setValue(kj::get<0>(parsed[i]));
+        etag.setWeak(kj::get<1>(parsed[i]));
+      }
+      return result;
+    }
+  }
+
+  kj::Tuple<kj::String, bool> parseETagInternal(kj::StringPtr& text) {
+    const char* p = text.begin();
+
+    while (*p == ' ') ++p;
+
+    bool weak = false;
+    if (p[0] == 'W' && p[1] == '/') {
+      weak = true;
+      p += 2;
+    }
+
+    while (*p == ' ') ++p;
+
+    KJ_REQUIRE(*p == '\"', "invalid ETag; must be quoted", text);
+
+    ++p;
+    kj::Vector<char> chars;
+
+    for (;;) {
+      switch (*p) {
+        case '\"':
+          // done
+          while (p[0] == ' ') ++p;
+          text = text.slice(p - text.begin());
+          return kj::tuple(kj::String(chars.releaseAsArray()), weak);
+        case '\\':
+          ++p;
+          KJ_REQUIRE(*p != '\0', "invalid ETag escape sequence", text);
+          chars.add(*p);
+          break;
+        case '\0':
+          KJ_FAIL_ASSERT("invalid ETag missing end quote",text);
+        default:
+          chars.add(*p);
+          break;
+      }
+      ++p;
+    }
+  }
+
+  kj::Promise<void> handleStreamingRequestResponse(
+      WebSession::RequestStream::Client reqStream,
+      kj::AsyncInputStream& requestBody,
+      kj::Own<kj::PromiseFulfiller<ByteStream::Client>>&& streamer,
+      kj::HttpService::Response& out) {
+    auto promises = kj::heapArrayBuilder<kj::Promise<void>>(2);
+    promises.add(pump(requestBody, reqStream));
+    promises.add(handleResponse(reqStream.getResponseRequest().send(),
+                                kj::mv(streamer), out));
+    return kj::joinPromises(promises.finish());
+  }
+
+  kj::Promise<void> handleResponse(kj::Promise<capnp::Response<WebSession::Response>>&& promise,
+                                   kj::Own<kj::PromiseFulfiller<ByteStream::Client>>&& streamer,
+                                   kj::HttpService::Response& out) {
+    return promise.then([this,KJ_MVCAP(streamer),&out](
+        capnp::Response<WebSession::Response>&& in) mutable -> kj::Promise<void> {
+      // TODO(someday): cachePolicy (not supported in Sandstorm proper as of this writing)
+
+      kj::HttpHeaders headers(headerTable);
+
+      for (auto addlHeader: in.getAdditionalHeaders()) {
+        auto name = addlHeader.getName();
+        if (responseHeaderWhitelist.matches(name)) {
+          headers.add(name, addlHeader.getValue());
+        }
+      }
+
+      switch (in.which()) {
+        case WebSession::Response::CONTENT: {
+          auto content = in.getContent();
+
+          auto status = lookupStatus(successCodeTable, content.getStatusCode());
+
+          if (content.hasEncoding()) {
+            headers.set(hContentEncoding, content.getEncoding());
+          }
+          if (content.hasLanguage()) {
+            headers.set(hContentLanguage, content.getLanguage());
+          }
+          if (content.hasMimeType()) {
+            headers.set(hContentType, content.getMimeType());
+          }
+
+          if (content.hasETag()) {
+            setETag(headers, content.getETag());
+          }
+
+          auto disposition = content.getDisposition();
+          switch (disposition.which()) {
+            case WebSession::Response::Content::Disposition::NORMAL:
+              break;
+            case WebSession::Response::Content::Disposition::DOWNLOAD: {
+              headers.set(hContentDisposition,
+                  kj::str("attachment; filename=\"", escape(disposition.getDownload()), "\""));
+              break;
+            }
+          }
+
+          auto body = content.getBody();
+
+          switch (body.which()) {
+            case WebSession::Response::Content::Body::BYTES: {
+              auto data = body.getBytes();
+              auto stream = out.send(status.getId(), status.getTitle(), headers, data.size());
+              auto promise = stream->write(data.begin(), data.size());
+              return promise.attach(kj::mv(stream), kj::mv(in));
+            }
+            case WebSession::Response::Content::Body::STREAM: {
+              auto handle = body.getStream();
+              auto outStream = kj::heap<ByteStreamImpl>(
+                  status, kj::mv(headers), kj::mv(in), out);
+              auto promise = outStream->whenDone();
+              streamer->fulfill(kj::mv(outStream));
+              return promise.attach(kj::mv(handle));
+            }
+          }
+
+          KJ_UNREACHABLE;
+        }
+
+        case WebSession::Response::NO_CONTENT: {
+          auto noContent = in.getNoContent();
+
+          if (noContent.hasETag()) {
+            setETag(headers, noContent.getETag());
+          }
+
+          if (noContent.getShouldResetForm()) {
+            out.send(205, "Reset Content", headers);
+          } else {
+            out.send(204, "No Content", headers);
+          }
+          return kj::READY_NOW;
+        }
+
+        case WebSession::Response::PRECONDITION_FAILED: {
+          auto failed = in.getPreconditionFailed();
+
+          if (failed.hasMatchingETag()) {
+            setETag(headers, failed.getMatchingETag());
+          }
+
+          return sendError(out, 412, "Precondition Failed", headers);
+        }
+
+        case WebSession::Response::REDIRECT: {
+          auto redirect = in.getRedirect();
+
+          uint code;
+          kj::StringPtr name;
+          if (redirect.getSwitchToGet()) {
+            if (redirect.getIsPermanent()) {
+              code = 301; name = "Moved Permanently";
+            } else {
+              code = 303; name = "See Other";
+            }
+          } else {
+            if (redirect.getIsPermanent()) {
+              code = 308; name = "Permanent Redirect";
+            } else {
+              code = 307; name = "Temporary Redirect";
+            }
+          }
+
+          auto location = redirect.getLocation();
+          headers.set(kj::HttpHeaderId::LOCATION, location);
+
+          headers.set(kj::HttpHeaderId::CONTENT_TYPE, "text/plain; charset=UTF-8");
+          auto body = kj::str(name, ": ", location);
+
+          auto stream = out.send(code, name, headers, body.size());
+          auto promise = stream->write(body.begin(), body.size());
+          return promise.attach(kj::mv(stream), kj::mv(body));
+        }
+
+        case WebSession::Response::CLIENT_ERROR: {
+          auto error = in.getClientError();
+
+          auto status = lookupStatus(errorCodeTable, error.getStatusCode());
+
+          auto body = error.getDescriptionHtml();
+          headers.set(kj::HttpHeaderId::CONTENT_TYPE, "text/html; charset=UTF-8");
+
+          auto stream = out.send(status.getId(), status.getTitle(), headers, body.size());
+          auto promise = stream->write(body.begin(), body.size());
+          return promise.attach(kj::mv(stream), kj::mv(in));
+        }
+
+        case WebSession::Response::SERVER_ERROR: {
+          auto error = in.getServerError();
+
+          auto body = error.getDescriptionHtml();
+          headers.set(kj::HttpHeaderId::CONTENT_TYPE, "text/html; charset=UTF-8");
+
+          auto stream = out.send(500, "Internal Server Error", headers, body.size());
+          auto promise = stream->write(body.begin(), body.size());
+          return promise.attach(kj::mv(stream), kj::mv(in));
+        }
+      }
+
+      KJ_UNREACHABLE;
+    });
+  }
+
+  void setETag(kj::HttpHeaders& headers, WebSession::ETag::Reader etag) {
+    if (etag.getWeak()) {
+      headers.set(hETag, kj::str("W/\"", etag.getValue(), "\""));
+    } else {
+      headers.set(hETag, kj::str("\"", etag.getValue(), "\""));
+    }
+  }
+
+  kj::String escape(kj::StringPtr value) {
+    kj::Vector<char> chars(value.size());
+
+    for (char c: value) {
+      switch (c) {
+        case '\\':
+        case '\"':
+          chars.add('\\');
+          break;
+        default:
+          break;
+      }
+      chars.add(c);
+    }
+
+    return kj::String(chars.releaseAsArray());
+  }
+
+  class ByteStreamImpl: public ByteStream::Server {
+  public:
+    ByteStreamImpl(HttpStatusDescriptor::Reader status,
+                   kj::HttpHeaders&& headers,
+                   capnp::Response<WebSession::Response>&& inResponse,
+                   kj::HttpService::Response& response) {
+      state.init<NotStarted>(NotStarted { status, kj::mv(headers), kj::mv(inResponse), response });
+    }
+
+    kj::Promise<void> whenDone() {
+      auto paf = kj::newPromiseAndFulfiller<void>();
+      doneFulfiller = kj::mv(paf.fulfiller);
+      return kj::mv(paf.promise);
+    }
+
+    kj::Promise<void> write(WriteContext context) override {
+      auto& stream = ensureStarted(nullptr);
+      auto data = context.getParams().getData();
+      return stream.write(data.begin(), data.size());
+    }
+
+    kj::Promise<void> done(DoneContext context) override {
+      state.init<Done>();
+      doneFulfiller->fulfill();
+      return kj::READY_NOW;
+    }
+
+    kj::Promise<void> expectSize(ExpectSizeContext context) override {
+      ensureStarted(context.getParams().getSize());
+      return kj::READY_NOW;
+    }
+
+  private:
+    struct NotStarted {
+      HttpStatusDescriptor::Reader status;
+      kj::HttpHeaders headers;
+      capnp::Response<WebSession::Response> inResponse;
+      kj::HttpService::Response& response;
+    };
+
+    struct Started {
+      kj::Own<kj::AsyncOutputStream> output;
+    };
+
+    struct Done {};
+
+    kj::OneOf<NotStarted, Started, Done> state;
+    kj::Own<kj::PromiseFulfiller<void>> doneFulfiller;
+
+    kj::AsyncOutputStream& ensureStarted(kj::Maybe<uint64_t> size) {
+      if (state.is<NotStarted>()) {
+        auto& ns = state.get<NotStarted>();
+        auto stream = ns.response.send(ns.status.getId(), ns.status.getTitle(), ns.headers, size);
+        kj::AsyncOutputStream& ref = *stream;
+        state.init<Started>(Started { kj::mv(stream) });
+        return ref;
+      } else {
+        KJ_REQUIRE(!state.is<Done>(), "already called done()");
+        return *state.get<Started>().output;
+      }
+    }
+  };
+};
+
+}  // namespace
+
+kj::Own<kj::HttpService> newBridgeProxy(
+    SandstormApi<BridgeObjectId>::Client sandstormApi,
+    SandstormHttpBridge::Client bridge,
+    spk::BridgeConfig::Reader config,
+    kj::HttpHeaderTable::Builder& requestHeaders) {
+  return kj::heap<BridgeProxy>(kj::mv(sandstormApi), kj::mv(bridge), config, requestHeaders);
+}
+
+} // namespace sandstorm

--- a/src/sandstorm/bridge-proxy.capnp
+++ b/src/sandstorm/bridge-proxy.capnp
@@ -1,0 +1,30 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2017 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xbf72526e76ecd73b;
+
+$import "/capnp/c++.capnp".namespace("sandstorm");
+using Util = import "util.capnp";
+
+struct ProxyClaimRequestRequest {
+  requestToken @0 :Text;
+  requiredPermissions @1 :List(Text);
+  label @2 :Util.LocalizedText;
+}
+
+struct ProxyClaimRequestResponse {
+  cap @0 :Text;
+}

--- a/src/sandstorm/bridge-proxy.h
+++ b/src/sandstorm/bridge-proxy.h
@@ -1,0 +1,43 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2017 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SANDSTORM_BRIDGE_PROXY_H_
+#define SANDSTORM_BRIDGE_PROXY_H_
+
+#include <kj/compat/http.h>
+#include <sandstorm/sandstorm-http-bridge.capnp.h>
+#include <sandstorm/sandstorm-http-bridge-internal.capnp.h>
+#include <sandstorm/package.capnp.h>
+
+namespace sandstorm {
+
+kj::Own<kj::HttpService> newBridgeProxy(
+    SandstormApi<BridgeObjectId>::Client sandstormApi,
+    SandstormHttpBridge::Client bridge,
+    spk::BridgeConfig::Reader config,
+    kj::HttpHeaderTable::Builder& requestHeaders);
+// The BridgeProxy is a component of sandstorm-http-bridge that handles HTTP requests going in
+// the opposite direction: originating from the app server and destined for the outside world.
+//
+// The bridge proxy emulates OAuth handshakes with a variety of well-known third-party services,
+// and also allows grains to connect to each other.
+//
+// sandstorm-http-bridge automatically sets well-known environment variables to instruct the app
+// to forward HTTP requests through it.
+
+} // namespace sandstorm
+
+#endif // SANDSTORM_BRIDGE_PROXY_H_

--- a/src/sandstorm/grain.capnp
+++ b/src/sandstorm/grain.capnp
@@ -648,6 +648,10 @@ interface AppPersistent @0xaffa789add8747b8 (AppObjectId) {
   # canonicalization rules) so that it can recognize when the same object is saved multiple times.
   # `MainView.drop()` will be called when all such references have been dropped by their respective
   # clients.
+  #
+  # TODO(cleanup): How does `label` here relate to `PowerboxDisplayInfo` on `offer()` and
+  #   `fulfillRequest()`? Maybe `label` here should actually be `PowerboxDisplayInfo` and those
+  #   other methods shouldn't take that parameter?
 }
 
 interface MainView(AppObjectId) extends(UiView) {

--- a/src/sandstorm/sandstorm-http-bridge-internal.capnp
+++ b/src/sandstorm/sandstorm-http-bridge-internal.capnp
@@ -21,6 +21,8 @@
 $import "/capnp/c++.capnp".namespace("sandstorm");
 using Identity = import "identity.capnp";
 using WebSession = import "web-session.capnp".WebSession;
+using ApiSession = import "api-session.capnp".ApiSession;
+using AppPersistent = import "grain.capnp".AppPersistent;
 
 struct BridgeObjectId {
   # The object ID format used by sandstorm-http-bridge.
@@ -52,3 +54,7 @@ struct BridgeObjectId {
     # TODO(someday): restore() should provide identity information so that we don't need this.
   }
 }
+
+interface BridgeHttpSession extends(ApiSession, AppPersistent(BridgeObjectId)) {}
+
+const bridgeRequestSessionHtml :Text = embed "sandstorm-http-bridge-request.html";

--- a/src/sandstorm/sandstorm-http-bridge-internal.capnp
+++ b/src/sandstorm/sandstorm-http-bridge-internal.capnp
@@ -1,0 +1,54 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2017 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xf963cc483d8f9e3a;
+# This file defines some types used internally by sandstorm-http-bridge. App developers need not
+# concern themselves with this code.
+
+$import "/capnp/c++.capnp".namespace("sandstorm");
+using Identity = import "identity.capnp";
+using WebSession = import "web-session.capnp".WebSession;
+
+struct BridgeObjectId {
+  # The object ID format used by sandstorm-http-bridge.
+  #
+  # Recall that Sandstorm obfuscates object IDs automatically, such that clients cannot see the
+  # contents and the app can trust that the ID passed from Sandstorm is authentic. Hence, we can
+  # put all the metadata we need directly in this structure and let Sandstorm store it.
+
+  union {
+    application @0 :AnyPointer;
+    # The object ID is in a format understood by the application, not by http-bridge.
+    #
+    # This is here to allow http-bridge-based applications to implement some APIs directly in
+    # Cap'n Proto, or to transition entirely to the native API eventually while retaining backwards
+    # compatibility.
+
+    httpApi @1 :HttpApi;
+    # An HTTP API, as defined using `BridgeConfig.PowerboxApi` (see `package.capnp`).
+  }
+
+  struct HttpApi {
+    name @0 :Text;
+    path @1 :Text;
+    permissions @2 :Identity.PermissionSet;
+
+    identityId @3 :Data;
+    # Identity ID of the user who made the powerbox choice.
+    #
+    # TODO(someday): restore() should provide identity information so that we don't need this.
+  }
+}

--- a/src/sandstorm/sandstorm-http-bridge-request.html
+++ b/src/sandstorm/sandstorm-http-bridge-request.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <style type="text/css">
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        font-family: sans-serif;
+        font-size: 20px;
+      }
+      button {
+        border: none;
+        font-size: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        text-decoration: inherit;
+        color: inherit;
+        line-height: inherit;
+        background-color: transparent;
+        text-align: inherit;
+        padding: 0;
+        cursor: pointer;
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: 100%;
+        padding-left: 32px;
+        height: 31px;
+      }
+      li {
+        border: 1px solid #ddd;
+        border-bottom: none;
+        background-color: #eee;
+        vertical-align: middle;
+        height: 32px;
+      }
+      ul {
+        border-bottom: 1px solid #ddd;
+        padding: 0;
+        margin: 10px;
+        list-style-type: none;
+      }
+    </style>
+  </head>
+  <body>
+    <ul id="list">
+    </ul>
+
+    <script type="text/javascript">
+      var config = @CONFIG@;
+
+      function makeClickHandler(name) {
+        return function () {
+          var xhr = new XMLHttpRequest();
+          xhr.onload = function () {
+            if (xhr.status >= 400) {
+              alert("XHR returned status " + xhr.status + ":\n" + xhr.responseText);
+            }
+          }
+          xhr.onerror = function(e) { alert(e); };
+          xhr.open("post", "/");
+          xhr.send(name);
+        }
+      }
+
+      var list = document.getElementById("list");
+      for (var i in config) {
+        var api = config[i];
+
+        var button = document.createElement("button");
+        button.addEventListener("click", makeClickHandler(api.name));
+        if (api.displayInfo && api.displayInfo.title && api.displayInfo.title.defaultText) {
+          button.textContent = api.displayInfo.title.defaultText;
+        } else {
+          button.textContent = "Use this grain";
+        }
+
+        var item = document.createElement("li");
+        item.appendChild(button);
+
+        list.appendChild(item);
+      }
+    </script>
+  </body>
+</html>

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -2214,6 +2214,19 @@ public:
 
   kj::Promise<void> getViewInfo(GetViewInfoContext context) override {
     context.setResults(config.getViewInfo());
+
+    // Copy in powerbox API descriptors.
+    auto apis = config.getPowerboxApis();
+    if (apis.size() > 0) {
+      auto viewInfo = context.getResults();
+      auto descriptors = viewInfo.initMatchRequests(apis.size());
+      for (size_t i: kj::indices(apis)) {
+        auto tag = descriptors[i].initTags(1)[0];
+        tag.setId(capnp::typeId<ApiSession>());
+        tag.getValue().setAs<ApiSession::PowerboxTag>(apis[i].getTag());
+      }
+    }
+
     return kj::READY_NOW;
   }
 

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -66,6 +66,7 @@ kj::Array<byte> toBytes(kj::StringPtr text, kj::ArrayPtr<const byte> data = null
 
 kj::String textIdentityId(capnp::Data::Reader id) {
   // We truncate to 128 bits to be a little more wieldy. Still 32 chars, though.
+  KJ_ASSERT(id.size() == 32, "Identity ID not a SHA-256?");
   return hexEncode(id.slice(0, kj::min(id.size(), 16)));
 }
 
@@ -1286,9 +1287,6 @@ public:
         rootPath(kj::mv(rootPath)),
         remoteAddress(kj::mv(remoteAddress)) {
     if (userInfo.hasIdentityId()) {
-      auto id = userInfo.getIdentityId();
-      KJ_ASSERT(id.size() == 32, "Identity ID not a SHA-256?");
-
       userId = textIdentityId(userInfo.getIdentityId());
     }
     bridgeContext.sessions.insert({kj::StringPtr(this->sessionId), this->sessionContext});

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -495,6 +495,38 @@ private:
   void taskFailed(kj::Exception&& exception) override;
 };
 
+template <typename T>
+class OwnCapnp;
+
+template <typename Reader>
+OwnCapnp<capnp::FromReader<Reader>> newOwnCapnp(Reader value);
+
+template <typename T>
+class OwnCapnp: public T::Reader {
+  // A copy of a capnp object which lives in-memory and can be passed by ownership.
+
+public:
+  // Inherits methods of reader.
+
+private:
+  kj::Array<capnp::word> words;
+
+  OwnCapnp(kj::Array<capnp::word> words)
+      : T::Reader(capnp::readMessageUnchecked<T>(words.begin())),
+        words(kj::mv(words)) {}
+
+  template <typename Reader>
+  friend OwnCapnp<capnp::FromReader<Reader>> newOwnCapnp(Reader value);
+};
+
+template <typename Reader>
+OwnCapnp<capnp::FromReader<Reader>> newOwnCapnp(Reader value) {
+  auto words = kj::heapArray<capnp::word>(value.totalSize().wordCount + 1);
+  memset(words.asBytes().begin(), 0, words.asBytes().size());
+  capnp::copyToUnchecked(value, words);
+  return OwnCapnp<capnp::FromReader<Reader>>(kj::mv(words));
+}
+
 }  // namespace sandstorm
 
 #endif // SANDSTORM_UTIL_H_


### PR DESCRIPTION
Commits 3acb128 through c970f29 implement the ability to *export* HTTP APIs from an http-bridge app. In the bridge config, the user may define a list of APIs the grain supports. (Currently these are singleton declarations -- the grain cannot implement multiple sub-objects. For most apps, this is probably fine, because grains themselves are usually the appropriate unit of export.)

Commits cd92c08 through 73bd11d implement the ability to *import* HTTP APIs in an http-bridge app. http-bridge is extended to export an HTTP proxy on localhost:15239. The `HTTP_PROXY` and `http_proxy` environment variables are set appropriately. A special route, `http://http-bridge/session/<session-id>/claim`, wraps the `SessionContext.claimRequest()` method, converting a request token obtained via a (client-side) powerbox request into an access token. The access token can be used in subsequent requests in the `Authorization: Bearer` header to make requests directly to the requested capability, which is assumed to be a `WebSession`.

Hence, it is now possible for apps to utilize the powerbox without interacting with Cap'n Proto at all.

The import half of this depends on the new KJ HTTP library: https://github.com/sandstorm-io/capnproto/pull/404