### PR TITLE
Update ssl.md, added a cleaner way to share the 443 port without sniproxy

### DIFF
--- a/docs/administering/ssl.md
+++ b/docs/administering/ssl.md
@@ -25,3 +25,10 @@ To share port 443 with other services on the same machine:
   443](https://xamar.sandcats.io/shared/Bqa9dftNbc1Ni06D-SgBdkFuM_iky8VHAlTw0Rk1lzN) between your
   existing server and Sandstorm so that Sandstorm can manage (and autorenew) its own certificates.
   This allows you to combine an **existing web server on port 443** with free sandcats.io HTTPS.
+  
+- You [can follow this guide]
+  (https://juanjoalvarez.net/es/detail/2017/jan/12/how-set-sandstorm-behind-reverse-proxy-keeping-you/)
+  that explains how to use a [cron script](https://github.com/juanjux/sandstorm-sandcats-cert-installer) 
+  to extract the certificates from your (sandcats.io enabled) Sandstorm installation to a location and 
+  format where your reverse proxy can use them so it can serve Sandstorm by HTTPS, keeping your 
+  sandcats.io domain and free auto-renewable certificates, along with any other services on your server.


### PR DESCRIPTION
Linked to an article + script I wrote providing a way to use HTTPS sandcats.io with your normal reverse proxy.