### PR TITLE
Don't include sandstorm-http-bridge-internal.capnp in installed capnp files.

### DIFF
--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -170,7 +170,7 @@ chmod u+w bundle/bin/*
 # Copy over capnp schemas.
 mkdir -p bundle/usr/include/{capnp,sandstorm}
 cp src/capnp/!(*test*).capnp bundle/usr/include/capnp
-cp src/sandstorm/*.capnp bundle/usr/include/sandstorm
+cp src/sandstorm/!(*-internal).capnp bundle/usr/include/sandstorm
 
 # Copy over node_modules.
 cp -r node_modules bundle


### PR DESCRIPTION
This file will be broken if installed because of the `embed` line. It appears that some tools or scripts or something try to parse all the capnp files in the directory even if not needed, for some reason.