### PR TITLE
Support comma-delimited emailDomain suffixes, optionally with leading "*."

### DIFF
--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1109,7 +1109,16 @@ _.extend(SandstormDb.prototype, {
     const ldapEnabled = orgMembership && orgMembership.ldap && orgMembership.ldap.enabled;
     const samlEnabled = orgMembership && orgMembership.saml && orgMembership.saml.enabled;
     if (emailEnabled && emailDomain && identity.services.email) {
-      if (identity.services.email.email.toLowerCase().split("@").pop() === emailDomain) {
+      if (/^\/(.*)\/$/.test(emailDomain)) {
+        try {
+          const emailDomainRegex = new RegExp(RegExp.$1);
+          if (emailDomainRegex.test(identity.services.email.email.toLowerCase().split("@").pop())) {
+            return true;
+          }
+        } catch (e) {
+          console.error("Invalid emain romain regex:", emailDomain);
+        }      
+      } else if (identity.services.email.email.toLowerCase().split("@").pop() === emailDomain) {
         return true;
       }
     } else if (ldapEnabled && identity.services.ldap) {

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1109,17 +1109,17 @@ _.extend(SandstormDb.prototype, {
     const ldapEnabled = orgMembership && orgMembership.ldap && orgMembership.ldap.enabled;
     const samlEnabled = orgMembership && orgMembership.saml && orgMembership.saml.enabled;
     if (emailEnabled && emailDomain && identity.services.email) {
-      if (/^\/(.*)\/$/.test(emailDomain)) {
-        try {
-          const emailDomainRegex = new RegExp(RegExp.$1);
-          if (emailDomainRegex.test(identity.services.email.email.toLowerCase().split("@").pop())) {
+      const domainSuffixes = emailDomain.split(/\s*,\s*/);
+      for (let i = 0; i < domainSuffixes.length; i++) {
+        const suffix = domainSuffixes[i];
+        const domain = identity.services.email.email.toLowerCase().split("@").pop();
+        if (suffix.startsWith("*.")) {
+          if (domain.endsWith(suffix.substr(2))) {
             return true;
           }
-        } catch (e) {
-          console.error("Invalid emain romain regex:", emailDomain);
-        }      
-      } else if (identity.services.email.email.toLowerCase().split("@").pop() === emailDomain) {
-        return true;
+        } else if (domain === suffix) {
+          return true;
+        }
       }
     } else if (ldapEnabled && identity.services.ldap) {
       return true;

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -2228,7 +2228,6 @@ if (Meteor.isServer) {
     // same data at the same time.
     first += Math.floor(intervalMs * computeStagger(replicaNumber));
 
-
     // If the stagger put us more than an interval away from now, back up.
     if (first > intervalMs) first -= intervalMs;
 

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -1114,7 +1114,7 @@ _.extend(SandstormDb.prototype, {
         const suffix = domainSuffixes[i];
         const domain = identity.services.email.email.toLowerCase().split("@").pop();
         if (suffix.startsWith("*.")) {
-          if (domain.endsWith(suffix.substr(2))) {
+          if (domain.endsWith(suffix.substr(1))) {
             return true;
           }
         } else if (domain === suffix) {
@@ -2227,6 +2227,7 @@ if (Meteor.isServer) {
     // Stagger cleanups across replicas so that we don't have all replicas trying to clean the
     // same data at the same time.
     first += Math.floor(intervalMs * computeStagger(replicaNumber));
+
 
     // If the stagger put us more than an interval away from now, back up.
     if (first > intervalMs) first -= intervalMs;


### PR DESCRIPTION
For example, in the gov.tw instance we need to allow all .gov.tw users using `/\.gov\.tw$/` in this field.

If this makes sense, we can change the description of `Users with an email address at this domain will be members of this server's organization.` to mention the regex syntax.