### PR TITLE
Upload/download backups on DDP host rather than main host.

### DIFF
--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -184,7 +184,7 @@ Template.grainBackupPopup.onCreated(function () {
       if (err) {
         _this._state.set({ error: "Backup failed: " + err });
       } else if (!_this._state.get().canceled) {
-        const origin = __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL || "";
+        const origin = __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL || "";  // jscs:ignore requireCamelCaseOrUpperCaseIdentifiers
         const url = origin + "/downloadBackup/" + id;
         const suggestedFilename = activeGrain.title() + ".zip";
         downloadFile(url, suggestedFilename);

--- a/shell/client/grain-client.js
+++ b/shell/client/grain-client.js
@@ -184,7 +184,8 @@ Template.grainBackupPopup.onCreated(function () {
       if (err) {
         _this._state.set({ error: "Backup failed: " + err });
       } else if (!_this._state.get().canceled) {
-        const url = "/downloadBackup/" + id;
+        const origin = __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL || "";
+        const url = origin + "/downloadBackup/" + id;
         const suggestedFilename = activeGrain.title() + ".zip";
         downloadFile(url, suggestedFilename);
 

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -794,7 +794,7 @@ restoreBackup = function (file) {
       console.error(err);
       alert(err.message);
     } else {
-      const origin = __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL || "";
+      const origin = __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL || "";  // jscs:ignore requireCamelCaseOrUpperCaseIdentifiers
       startUpload(file, origin + "/uploadBackup/" + token, function (response) {
         Session.set("uploadStatus", "Unpacking");
         const identityId = Accounts.getCurrentIdentityId();

--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -794,7 +794,8 @@ restoreBackup = function (file) {
       console.error(err);
       alert(err.message);
     } else {
-      startUpload(file, "/uploadBackup/" + token, function (response) {
+      const origin = __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL || "";
+      startUpload(file, origin + "/uploadBackup/" + token, function (response) {
         Session.set("uploadStatus", "Unpacking");
         const identityId = Accounts.getCurrentIdentityId();
         Meteor.call("restoreGrain", token, identityId, function (err, grainId) {

--- a/shell/server/backup.js
+++ b/shell/server/backup.js
@@ -249,6 +249,7 @@ Router.map(function () {
         if (!this.params.token || !token) {
           this.response.writeHead(403, {
             "Content-Type": "text/plain",
+            "Access-Control-Allow-Origin": "*",
           });
           this.response.write("Invalid upload token.");
           this.response.end();
@@ -271,16 +272,34 @@ Router.map(function () {
             });
           }));
 
-          this.response.writeHead(204);
+          this.response.writeHead(204, {
+            "Access-Control-Allow-Origin": "*",
+          });
           this.response.end();
         } catch (error) {
           console.error(error.stack);
           this.response.writeHead(500, {
             "Content-Type": "text/plain",
+            "Access-Control-Allow-Origin": "*",
           });
           this.response.write(error.stack);
           this.response.end();
         }
+      } else if (this.request.method == "OPTIONS") {
+        // Allow cross-origin posts to uploadBackup so that uploads can occur on the DDP host
+        // rather than the main host. In theory we could have Access-Control-Allow-Origin specify
+        // the main host rather than "*", but an uploadBackup request already requires a valid
+        // upload token, which is plenty of access control in itself.
+        const requestedHeaders = this.request.headers["access-control-request-headers"];
+        if (requestedHeaders) {
+          this.response.setHeader("Access-Control-Allow-Headers", requestedHeaders);
+        }
+        this.response.writeHead(204, {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "POST, OPTIONS",
+          "Access-Control-Max-Age": "3600",
+        });
+        this.response.end();
       } else {
         this.response.writeHead(405, {
           "Content-Type": "text/plain",

--- a/shell/server/backup.js
+++ b/shell/server/backup.js
@@ -294,6 +294,7 @@ Router.map(function () {
         if (requestedHeaders) {
           this.response.setHeader("Access-Control-Allow-Headers", requestedHeaders);
         }
+
         this.response.writeHead(204, {
           "Access-Control-Allow-Origin": "*",
           "Access-Control-Allow-Methods": "POST, OPTIONS",

--- a/shell/server/install-server.js
+++ b/shell/server/install-server.js
@@ -119,6 +119,7 @@ Router.map(function () {
       if (!this.params.token || !uploadTokens[this.params.token]) {
         this.response.writeHead(403, {
           "Content-Type": "text/plain",
+          "Access-Control-Allow-Origin": "*",
         });
         this.response.write("Invalid upload token.");
         this.response.end();
@@ -128,6 +129,7 @@ Router.map(function () {
           this.response.writeHead(200, {
             "Content-Length": packageId.length,
             "Content-Type": "text/plain",
+            "Access-Control-Allow-Origin": "*",
           });
           this.response.write(packageId);
           this.response.end();
@@ -137,13 +139,31 @@ Router.map(function () {
           console.error(error.stack);
           this.response.writeHead(500, {
             "Content-Type": "text/plain",
+            "Access-Control-Allow-Origin": "*",
           });
           this.response.write("Unpacking SPK failed; is it valid?");
           this.response.end();
         };
+      } else if (this.request.method == "OPTIONS") {
+        // Allow cross-origin posts to upload so that uploads can occur on the DDP host
+        // rather than the main host. In theory we could have Access-Control-Allow-Origin specify
+        // the main host rather than "*", but an upload request already requires a valid
+        // upload token, which is plenty of access control in itself.
+        const requestedHeaders = this.request.headers["access-control-request-headers"];
+        if (requestedHeaders) {
+          this.response.setHeader("Access-Control-Allow-Headers", requestedHeaders);
+        }
+
+        this.response.writeHead(204, {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "POST, OPTIONS",
+          "Access-Control-Max-Age": "3600",
+        });
+        this.response.end();
       } else {
         this.response.writeHead(405, {
           "Content-Type": "text/plain",
+          "Access-Control-Allow-Origin": "*",
         });
         this.response.write("You can only POST here.");
         this.response.end();


### PR DESCRIPTION
When a separate DDP host is specified, it should be used for all "dynamic" interaction, where the main host is used only for static content (e.g. static HTML, Javascript, CSS, images).

See also: https://sandstorm.io/news/2017-02-28-cloudbleed