### PR TITLE
Fix SAML login for Azure active directory accounts

### DIFF
--- a/shell/imports/server/accounts/saml-utils.js
+++ b/shell/imports/server/accounts/saml-utils.js
@@ -354,6 +354,11 @@ SAML.prototype.validateResponse = function (samlResponse, callback) {
           profile.email = microsoftEmail;
         }
 
+        const azureAdEmail = profile["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"];
+        if (!profile.email && azureAdEmail) {
+          profile.email = azureAdEmail;
+        }
+
         const microsoftDisplayName = profile["http://schemas.microsoft.com/identity/claims/displayname"];
         if (!profile.displayName && microsoftDisplayName) {
           profile.displayName = microsoftDisplayName;


### PR DESCRIPTION
When I  trying to logged in with Azure AD,  an error occurred with message `SAML profile did not contain an email address`  and I could not log in.
As far as I can see, this issue is caused by the field name of SAML response about email is different between Azure AD accounts and Microsoft accounts. (ref., https://onlinehelp.tableau.com/current/online/en-us/saml_config_azure_ad.htm)
This patch is fix of this issue.