### PR TITLE
Delete billing-prompt-on-account-creation experiment.

### DIFF
--- a/shell/client/shell-client.js
+++ b/shell/client/shell-client.js
@@ -593,63 +593,6 @@ Template.layout.helpers({
     return isStandalone();
   },
 
-  firstTimeBillingPromptState: function () {
-    // Should we show the first-time billing plan selector?
-
-    // Don't show if billing is not enabled.
-    if (!window.BlackrockPayments) return;
-
-    // Don't show on standalone domains.
-    if (isStandalone()) return;
-
-    const user = Meteor.user();
-
-    // Don't show if not logged in.
-    if (!user) return;
-
-    // Don't show if not in the experiment.
-    if (!user.experiments || user.experiments.firstTimeBillingPrompt !== "test") return;
-
-    // Don't show if the user has selected a plan already.
-    if (user.plan && !Session.get("firstTimeBillingPromptOpen")) return;
-
-    // Only show to account users (not identities).
-    if (!user.loginIdentities) return;
-
-    // Don't show to demo users.
-    if (user.expires) return;
-
-    // Don't show when viewing another user's grain. We don't want to scare people away from
-    // logging in to collaborate.
-    const route = Router.current().route.getName();
-    if (route === "shared") return;
-    if (route === "grain") {
-      if (_.some(globalGrains.getAll(), function (grain) {
-        return grain.isActive() && !grain.isOwner();
-      })) {
-
-        return;
-      }
-    }
-
-    // Don't show if user is trying to use a signup key. We're probably going to assign them
-    // a plan shortly.
-    if (route === "signup") return;
-
-    // Don't let the plan chooser disappear instantly once user.plan is set.
-    Session.set("firstTimeBillingPromptOpen", true);
-
-    // OK, show it.
-    return {
-      db: globalDb,
-      topbar: globalTopbar,
-      accountsUi: globalAccountsUi,
-      onComplete: function () {
-        Session.set("firstTimeBillingPromptOpen", false);
-      },
-    };
-  },
-
   demoModal: function () {
     return Session.get("globalDemoModal");
   },

--- a/shell/client/shell.html
+++ b/shell/client/shell.html
@@ -62,11 +62,6 @@ limitations under the License.
       {{> sandstormAccountsFirstSignIn accountSettingsUi}}
     </div>
   {{else}}
-  {{#with firstTimeBillingPromptState}}
-    <div class="first-sign-in-main-content {{#if hideNavbar}}hide-navbar{{else}}{{#if shrinkNavbar}}shrink-navbar{{/if}}{{/if}}">
-      {{> billingPromptFirstTime . }}
-    </div>
-  {{else}}
 
   {{!-- standard topbar items --}}
   {{#sandstormTopbarItem name="home-button" topbar=globalTopbar}}
@@ -118,7 +113,6 @@ limitations under the License.
     {{> Template.dynamic template=billingPromptTemplate}}
   {{/with}}
 
-  {{/with}} {{!-- firstTimeBillingPromptState --}}
   {{/if}} {{!-- firstLogin --}}
   {{/if}} {{!-- isAccountSuspended --}}
   {{/if}} {{!-- identityUser --}}
@@ -134,10 +128,8 @@ limitations under the License.
   {{#unless demoExpired}}
     {{#unless identityUser}}
       {{#unless firstLogin}}
-        {{#unless firstTimeBillingPromptState}}
-          {{> desktopNotifications "" }}
-          {{> yield}}
-        {{/unless}}
+        {{> desktopNotifications "" }}
+        {{> yield}}
       {{/unless}}
     {{/unless}}
   {{/unless}}

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -127,12 +127,7 @@ const collectionOptions = { defineMutationMethods: Meteor.isClient };
 //           experiment. Each experiment may define a point in time where users not already in the
 //           experiment may be added to it and assigned to a group (for example, at user creation
 //           time). Current experiments:
-//       firstTimeBillingPrompt: Value is "control" or "test". Users are assigned to groups at
-//               account creation on servers where billing is enabled (i.e. Oasis). Users in the
-//               test group will see a plan selection dialog and asked to make an explitic choice
-//               (possibly "free") before they can create grains (but not when opening someone
-//               else's shared grain). The goal of the experiment is to determine whether this
-//               prompt scares users away -- and also whether it increases paid signups.
+//       firstTimeBillingPrompt: OBSOLETE
 //       freeGrainLimit: Value is "control" or or a number indicating the grain limit that the
 //               user should receive when on the "free" plan, e.g. "Infinity".
 //   stashedOldUser: A complete copy of this user from before the accounts/identities migration.

--- a/shell/server/accounts/accounts-server.js
+++ b/shell/server/accounts/accounts-server.js
@@ -43,7 +43,6 @@ Accounts.onCreateUser(function (options, user) {
     if (globalDb.isReferralEnabled()) {
       user.experiments = user.experiments || {};
       user.experiments = {
-        firstTimeBillingPrompt: Math.random() < 0.5 ? "control" : "test",
         freeGrainLimit: Math.random() < 0.1 ? 100 : "control",
       };
       if (!("expires" in user)) {


### PR DESCRIPTION
This experiment caused 50% of Oasis users to see the billing plan chooser immediately upon logging in for the first time (with the option to choose the free plan), while the other 50% would default to a free account and only see the plan chooser once they had hit their quota limits.

Conclusion: Showing the billing prompt at account creation did not significantly affect any behavior that we attempted to measure. See: https://oasis.sandstorm.io/shared/LLFTfbhqQUHnTJ0_cKCn1yWk9Dcl-uP1pk0DfuJlJf9

However:
- The prompt was probably annoying.
- The prompt was responsible for numerous bugs over the time the experiment was active, in which the prompt would appear in inappropriate contexts.

Therefore, we will no longer show the billing prompt at account creation.