### PR TITLE
add 'connect-src wss: ws' so that Safari can use a websocket on the main host

### DIFF
--- a/shell/server/shell-server.js
+++ b/shell/server/shell-server.js
@@ -60,6 +60,8 @@ BrowserPolicy.content.allowImageOrigin(staticAssetHost);
 BrowserPolicy.content.allowScriptOrigin(staticAssetHost);
 BrowserPolicy.content.allowFontOrigin(staticAssetHost);
 BrowserPolicy.content.allowConnectOrigin(staticAssetHost);
+BrowserPolicy.content.allowConnectOrigin("wss:");
+BrowserPolicy.content.allowConnectOrigin("ws:");
 
 Meteor.publish("grainsMenu", function () {
   if (this.userId) {


### PR DESCRIPTION
Fixes #2578.

Our `connect-src` already includes `*`. According to [this document](https://webkit.org/blog/6830/a-refined-content-security-policy/), last year WebKit changed the meaning of the `*` in a backwards-incompatible way, such that now it only matches the scheme of the current page. So we still need to add a `ws` and/or `wss` scheme.

See also: https://github.com/meteor/meteor/issues/7772#issuecomment-265600327