### PR TITLE
fix errors reported by clang++ 4.0

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -2514,7 +2514,9 @@ public:
       sigset_t sigset;
       KJ_SYSCALL(sigemptyset(&sigset));
       KJ_SYSCALL(sigprocmask(SIG_SETMASK, &sigset, nullptr));
-      KJ_SYSCALL(signal(SIGPIPE, SIG_DFL));
+      if (signal(SIGPIPE, SIG_DFL) == SIG_ERR) {
+        KJ_FAIL_SYSCALL("signal(SIGPIPE, SIG_DFL)", errno);
+      }
 
       char* argv[command.size() + 1];
       for (uint i: kj::indices(command)) {

--- a/src/sandstorm/union-fs.c++
+++ b/src/sandstorm/union-fs.c++
@@ -631,8 +631,10 @@ kj::Own<fuse::Node> makeUnionFs(kj::StringPtr sourceDir, spk::SourceMap::Reader 
       struct stat stats;
       KJ_SYSCALL(lstat(sourcePath.cStr(), &stats), sourcePath);
       if (S_ISLNK(stats.st_mode)) {
-        char* real;
-        KJ_SYSCALL(real = realpath(sourcePath.cStr(), NULL));
+        char* real = realpath(sourcePath.cStr(), NULL);
+        if (real == NULL) {
+          KJ_FAIL_SYSCALL("realpath(sourcePath)", errno, sourcePath);
+        }
         KJ_DEFER(free(real));
         ownSourcePath = kj::str(real);
         sourcePath = ownSourcePath;
@@ -758,8 +760,10 @@ FileMapping mapFile(kj::StringPtr sourceDir, spk::SourceMap::Reader sourceMap, k
           struct stat stats;
           KJ_SYSCALL(lstat(candidate.cStr(), &stats));
           if (S_ISLNK(stats.st_mode)) {
-            char* real;
-            KJ_SYSCALL(real = realpath(candidate.cStr(), NULL));
+            char* real = realpath(candidate.cStr(), NULL);
+            if (real == NULL) {
+              KJ_FAIL_SYSCALL("realpath(candidate)", errno, candidate);
+            }
             KJ_DEFER(free(real));
             candidate = kj::str(real);
           }


### PR DESCRIPTION
`realpath()` and `signal()` return a pointer, but `KJ_SYSCALL()` expects a function that returns an integer.