### PR TITLE
don't start grains that are trashed

### DIFF
--- a/shell/imports/server/backend.js
+++ b/shell/imports/server/backend.js
@@ -115,6 +115,10 @@ class SandstormBackend {
       throw new Meteor.Error(404, "Grain Not Found", "Grain ID: " + grainId);
     }
 
+    if (grain.trashed) {
+      throw new Meteor.Error(403, "Grain is in the trash bin", "Grain ID: " + grainId);
+    }
+
     // If a DevPackage with the same app ID is currently active, we let it override the installed
     // package, so that the grain runs using the dev app.
     const devPackage = DevPackages.findOne({ appId: grain.appId });


### PR DESCRIPTION
When a grain provides a capability through a `SessionContext`, that capability will have a `permissionsHeld` `MembraneRequirement` attached to it that automatically revokes the capability when the grain gets trashed.

When a grain provides a capability directly through the `SandstormApi`, (e.g. a `Runnable` in https://github.com/sandstorm-io/sandstorm/pull/2922), no such requirement is added, and currently there is nothing stopping the capability from being restored even after the grain is trashed.

This pull request fixes that problem.

(Additionally, it might make sense to add a new kind of `MembraneRequirement` to handle this kind of situation. We can discuss such a change in a separate issue/pull request if it is desired.)