### PR TITLE
Correctly pass through error bodies for Powerbox HTTP requests

### DIFF
--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -377,6 +377,14 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
 
         descriptionHtml @8 :Text;
         # Optional extended description of the error, as an HTML document.
+        #
+        # If the response is not text/html, use nonHtmlContent.
+        #
+        # TODO(apibump): Get rid of this and use only nonHtmlContent.
+
+        nonHtmlBody @21 :ErrorBody;
+        # Response body, of a type that isn't text/html. If present, descriptionHtml should be
+        # ignored. However, older programs only know about descriptionHtml.
       }
 
       serverError :group {
@@ -387,6 +395,12 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
 
         descriptionHtml @9 :Text;
         # Optional extended description of the error, as an HTML document.
+        #
+        # TODO(apibump): Get rid of this and use only nonHtmlContent.
+
+        nonHtmlBody @22 :ErrorBody;
+        # Response body, of a type that isn't text/html. If present, descriptionHtml should be
+        # ignored. However, older programs only know about descriptionHtml.
       }
 
       # TODO(someday):  Return blob directly from storage, so data doesn't have to stream through
@@ -400,6 +414,13 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
     struct Header {
       name @0 :Text;  # lower-cased name
       value @1 :Text;
+    }
+
+    struct ErrorBody {
+      data @0 :Data;
+      encoding @1 :Text;  # Content-Encoding header (optional).
+      language @2 :Text;  # Content-Language header (optional).
+      mimeType @3 :Text;  # Content-Type header.
     }
 
     const headerWhitelist :List(Text) = [


### PR DESCRIPTION
Previously, error responses were replacing the response body with the error status name, e.g. "Not Found". For HTTP APIs, error bodies are often important.

Since HTTP APIs often want to return non-HTML error bodies, I extended web-session.capnp to be able to represent these.

However, I have not updated sandstorm-http-bridge or proxy.js to understand this protocol for now. I would like to rewrite sandstorm-http-bridge in terms of kj-http at some point, which would be a good time to update it.

This also fixes a bug: The content-type header on 200-OK responses wasn't being set correctly (it was clobbering the Content-Language header instead).