### PR TITLE
Send a notification warning affected users that identities are changing.

### DIFF
--- a/shell/client/accounts/account-settings.html
+++ b/shell/client/accounts/account-settings.html
@@ -28,6 +28,11 @@ limitations under the License.
 
     <h3 class="title-bar">Linked identities</h3>
 
+    {{#if affectedByIdentityRefactor}}
+    <p class="alert-identity-refactor">We're changing the way identities work. Your account may be affected.
+        <a href="https://sandstorm.io/news/2017-05-08-refactoring-identities">Learn more &raquo;</a></p>
+    {{/if}}
+
     {{#with actionCompleted}}
       {{#if success}}
         {{#focusingSuccessBox}}

--- a/shell/client/accounts/account-settings.js
+++ b/shell/client/accounts/account-settings.js
@@ -184,6 +184,24 @@ Template.sandstormAccountSettings.helpers({
   showDeleteButton: function () {
     return !Template.instance().data._db.isUserInOrganization(Meteor.user());
   },
+
+  affectedByIdentityRefactor: function () {
+    let previousName = null;
+    let needsNotification = false;
+
+    SandstormDb.getUserIdentityIds(Meteor.user())
+      .map((id) => Meteor.users.findOne({ _id: id }))
+      .filter((identity) => !!identity)
+      .forEach((identity) => {
+        const name = identity.profile && identity.profile.name;
+        if (!name || (previousName && previousName !== name)) {
+          needsNotification = true;
+        }
+        previousName = name;
+      });
+
+    return needsNotification;
+  },
 });
 
 GENDERS = { male: "male", female: "female", neutral: "neutral", robot: "robot" };

--- a/shell/client/accounts/account-settings.js
+++ b/shell/client/accounts/account-settings.js
@@ -197,6 +197,7 @@ Template.sandstormAccountSettings.helpers({
         if (!name || (previousName && previousName !== name)) {
           needsNotification = true;
         }
+
         previousName = name;
       });
 

--- a/shell/client/notifications-client.js
+++ b/shell/client/notifications-client.js
@@ -162,6 +162,11 @@ Template.notificationItem.helpers({
     const data = Template.currentData();
     return !!data.ongoing;
   },
+
+  isIdentityChanges() {
+    const data = Template.currentData();
+    return !!data.identityChanges;
+  },
 });
 
 Template.appUpdateNotificationItem.helpers({
@@ -245,6 +250,12 @@ Template.referralNotificationItem.helpers({
 Template.referralNotificationItem.events({
   "click button[type=button]"(evt) {
     evt.preventDefault();
+    Meteor.call("dismissNotification", this._id);
+  },
+});
+
+Template.identityChangesNotificationItem.events({
+  "click .notification-item"(evt) {
     Meteor.call("dismissNotification", this._id);
   },
 });

--- a/shell/client/notifications.html
+++ b/shell/client/notifications.html
@@ -116,6 +116,22 @@
   {{/linkTo}}
 </template>
 
+<template name="identityChangesNotificationItem">
+  <a href="https://sandstorm.io/news/2017-05-08-refactoring-identities" class="notification-item"
+     target="_blank">
+    <div class="notification-icon">
+      <img src="/sandstorm-gradient-logo.svg">
+    </div>
+
+    We're changing the way identities work in Sandstorm. Your account may be affected. Click here
+    to learn more.
+
+    <div class="notification-footer">
+      <span title="{{timestamp}}" class="notification-timestamp">{{dateString timestamp}}</span>
+    </div>
+  </a>
+</template>
+
 <template name="grainActivityNotificationItem">
   <a class="notification-item" href="{{notificationUrl}}">
     <div class="notification-icon">
@@ -158,7 +174,11 @@
   {{#if isOngoing }}
     {{> backgroundedGrainNotificationItem . }}
   {{else}}
+  {{#if isIdentityChanges }}
+    {{> identityChangesNotificationItem . }}
+  {{else}}
     {{> grainActivityNotificationItem . }}
+  {{/if}}
   {{/if}}
   {{/if}}
   {{/if}}

--- a/shell/client/styles/_account.scss
+++ b/shell/client/styles/_account.scss
@@ -492,6 +492,11 @@ body>.main-content>.account {
     padding: 5px;
   }
 
+  p.alert-identity-refactor {
+    color: red;
+    padding-left: 5px;
+  }
+
   .identities-and-editor {
     @media #{$not-mobile-only} {
       width: 660px;

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -807,11 +807,12 @@ function notifyIdentityChanges(db, backend) {
                     { fields: { loginIdentities: 1, nonloginIdentities: 1 } }).forEach(user => {
     let previousName = null;
     let needsNotification = false;
-    SandstormDb.getUserIdentityIds( user).forEach(identityId => {
+    SandstormDb.getUserIdentityIds(user).forEach(identityId => {
       const name = names[identityId];
       if (!name || (previousName && previousName !== name)) {
         needsNotification = true;
       }
+
       previousName = name;
     });
 

--- a/shell/packages/sandstorm-db/.npm/package/npm-shrinkwrap.json
+++ b/shell/packages/sandstorm-db/.npm/package/npm-shrinkwrap.json
@@ -3,7 +3,7 @@
     "content-type": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
-      "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+      "from": "content-type@1.0.1"
     }
   }
 }

--- a/shell/packages/sandstorm-db/db.js
+++ b/shell/packages/sandstorm-db/db.js
@@ -637,6 +637,8 @@ Notifications = new Mongo.Collection("notifications", collectionOptions);
 //   mailingListBonus: Like `referral`, but notify the user about the mailing list bonus. This is
 //                 a one-time notification only to Oasis users who existed when the bonus program
 //                 was implemented.
+//   identityChanges: If this boolean field is true, this notification should show a warning about
+//                 upcoming changes to the identity model.
 
 ActivitySubscriptions = new Mongo.Collection("activitySubscriptions", collectionOptions);
 // Activity events to which a user is subscribed.

--- a/shell/server/notifications-server.js
+++ b/shell/server/notifications-server.js
@@ -240,6 +240,13 @@ Meteor.methods({
       isUnread: true,
     });
 
+    Notifications.insert({
+      userId: this.userId,
+      identityChanges: true,
+      timestamp: new Date(),
+      isUnread: true,
+    });
+
     if (global.BlackrockPayments) {
       Notifications.insert({
         userId: this.userId,


### PR DESCRIPTION
See explanation here: https://github.com/sandstorm-io/sandstorm-website/pull/289

We send a bell notification to all users who have multiple identities where the display names of those identities are not all the same. We also show a warning on the accounts page for these users.

We specifically look for users with varying names on the assumption that if all the names are the same, then the user really only has one identity anyway, and the coming changes will be a strict improvement for them. I didn't feel it was necessary to compare profile pictures, handles, or preferred pronouns because if the display name is the same, it seems unlikely that the profiles vary significantly in these other factors.