### PR TITLE
Fixed forgotten rename in the setup wizard

### DIFF
--- a/shell/client/setup-wizard/wizard.html
+++ b/shell/client/setup-wizard/wizard.html
@@ -243,7 +243,7 @@
     Configure the identity provider or providers you wish to enable.
   </p>
 
-  {{> adminIdentityProviderTable idpData=idpData }}
+  {{> adminLoginProviderTable idpData=idpData }}
 
   {{#setupWizardButtonRow}}
     <button class="setup-next-button" {{nextHtmlDisabled}}>


### PR DESCRIPTION
Which caused the 'Begin Sandstorm Setup' button to not work after installation. 

Note, there might be more instances of stuff that needs renaming from Identity => Login, although I did a grep -ri on "adminProviderIdentityTable" and this was the only instance I could find.