### PR TITLE
spk.h: #include <sys/types.h>

### DIFF
--- a/src/sandstorm/spk.h
+++ b/src/sandstorm/spk.h
@@ -19,6 +19,7 @@
 
 #include "abstract-main.h"
 #include <fcntl.h>
+#include <sys/types.h>
 #include <sandstorm/package.capnp.h>
 
 namespace sandstorm {


### PR DESCRIPTION
Without this I get the following error:

```
compile: sandstorm/spk.c++
  In file included from /ekam-provider/canonical/sandstorm/spk.c++:19:
  /ekam-provider/canonical/sandstorm/spk.h:37:51: error: unknown type name 'uid_t'; did you mean 'pid_t'?
                                          kj::Maybe<uid_t> sandboxUid = nullptr);
                                                    ^~~~~
                                                    pid_t
  /usr/include/fcntl.h:69:17: note: 'pid_t' declared here
  typedef __pid_t pid_t;
                  ^
  1 error generated.
```

I assume this is dev-environment dependent in some way, since I can't
imagine it's just not building for anyone...