### PR TITLE
Update zh-TW.i18n.json

### DIFF
--- a/shell/i18n/zh-TW.i18n.json
+++ b/shell/i18n/zh-TW.i18n.json
@@ -1763,7 +1763,7 @@
   },
   "packages": {
     "topbar": {
-      "updated": "沙聚雲已有更新 &mdash; 點擊此處重新整理頁面",
+      "updated": "沙聚雲已有更新 — 點擊此處重新整理頁面",
       "apps": "應用程式",
       "grains": "沙粒",
       "oasis": "在 Oasis 上使用沙聚雲進行協作：",


### PR DESCRIPTION
Change &mdash; into unicode character; otherwise it's displayed doubly-escaped