### PR TITLE
Docs: Add build dependency

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -138,6 +138,7 @@ Please install the following:
 * `strace`
 * `curl`
 * `python`
+* `zlib1g-dev`
 * `cmake`
 * discount (markdown parser)
 * [Clang compiler](http://clang.llvm.org/) version 3.4 or better
@@ -146,7 +147,7 @@ Please install the following:
 On Debian or Ubuntu, you should be able to get all these with:
 
     sudo apt-get install build-essential libcap-dev xz-utils zip \
-        unzip strace curl clang discount git python
+        unzip strace curl clang discount git python zlib1g-dev
     curl https://install.meteor.com/ | sh
 
 ### Get the source code

--- a/docs/install.md
+++ b/docs/install.md
@@ -139,6 +139,7 @@ Please install the following:
 * `curl`
 * `python`
 * `zlib1g-dev`
+* `golang`
 * `cmake`
 * discount (markdown parser)
 * [Clang compiler](http://clang.llvm.org/) version 3.4 or better
@@ -147,7 +148,8 @@ Please install the following:
 On Debian or Ubuntu, you should be able to get all these with:
 
     sudo apt-get install build-essential libcap-dev xz-utils zip \
-        unzip strace curl clang discount git python zlib1g-dev
+        unzip strace curl clang discount git python zlib1g-dev \
+        golang
     curl https://install.meteor.com/ | sh
 
 ### Get the source code


### PR DESCRIPTION
Adds zlib1g-dev to the install list for building Sandstorm. (Removed the "fix" text since the Go dependency question isn't added yet.)