### PR TITLE
Added a DNS note.

### DIFF
--- a/docs/administering/wildcard.md
+++ b/docs/administering/wildcard.md
@@ -87,6 +87,12 @@ company behind Sandstorm) maintains `local.sandstorm.io` as a wildcard domain wh
 same as `localhost`. This allows you to run Sandstorm for development without needing to own a
 domain name or configure wildcard DNS for a subdomain.
 
+Note that sometimes DNS in routers and firewalls such as dnsmasq in DD-WRT can block the
+local.sandstorm.io name resolution to `127.0.0.1`.  In that case, for the machine developing
+Sandstorm please switch your DNS from using your router or firewall as a DNS server to using
+a public DNS service like Google's DNS (`8.8.8.8`, `8.8.4.4`) or OpenDNS (`208.67.222.222`,
+`208.67.220.220`), or adjust your DNS server to permit the `127.0.0.1` mapping.
+
 Within the `sandcats.io` DNS service, each domain is also a wildcard domain. This allows a
 self-hosted Sandstorm domain to operate correctly.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -333,6 +333,12 @@ In this configuration, Vagrant/VirtualBox manage TCP port forwarding, and Sandst
 http://local.sandstorm.io:6080/ by default. `local.sandstorm.io` is a DNS alias for localhost,
 indicating that the service is only visible on the computer where you ran Vagrant.
 
+Note that sometimes DNS in routers and firewalls such as dnsmasq in DD-WRT can block the
+local.sandstorm.io name resolution to `127.0.0.1`.  In that case, for the machine developing
+Sandstorm please switch your DNS from using your router or firewall as a DNS server to using
+a public DNS service like Google's DNS (`8.8.8.8`, `8.8.4.4`) or OpenDNS (`208.67.222.222`,
+`208.67.220.220`), or adjust your DNS server to permit the `127.0.0.1` mapping.
+
 We do recommend that you run Sandstorm on a native Linux system, but we understand that this isn't
 always an option. If you need further help making Sandstorm work with Vagrant or within
 virtualization generally, please email support@sandstorm.io.

--- a/docs/vagrant-spk/packaging-tutorial-meteor.md
+++ b/docs/vagrant-spk/packaging-tutorial-meteor.md
@@ -228,6 +228,12 @@ but it does mean that the domain name running Sandstorm needs
 DNS. You can rest assured that your interactions with
 `local.sandstorm.io` stay entirely on your computer.
 
+Note that sometimes DNS in routers and firewalls such as dnsmasq in DD-WRT can block the
+local.sandstorm.io name resolution to `127.0.0.1`.  In that case, for the machine developing
+Sandstorm please switch your DNS from using your router or firewall as a DNS server to using
+a public DNS service like Google's DNS (`8.8.8.8`, `8.8.4.4`) or OpenDNS (`208.67.222.222`,
+`208.67.220.220`), or adjust your DNS server to permit the `127.0.0.1` mapping.
+
 <!--(**Editor's note**: We should make localhost:6080 work, so that people don't have to learn about `local.sandstorm.io`.)-->
 
 Take a moment now to sign in. Choose **with a Dev account** and choose

--- a/docs/vagrant-spk/packaging-tutorial.md
+++ b/docs/vagrant-spk/packaging-tutorial.md
@@ -184,6 +184,12 @@ Some quick facts on how that works:
   local.sandstorm.io instead of `localhost` because all subdomains of local.sandstorm.io also point
   at the localhost IP address. You can read more about [wildcard DNS.](../administering/wildcard.md)
 
+- Note that sometimes DNS in routers and firewalls such as dnsmasq in DD-WRT can block the
+local.sandstorm.io name resolution to `127.0.0.1`.  In that case, for the machine developing
+Sandstorm please switch your DNS from using your router or firewall as a DNS server to using
+a public DNS service like Google's DNS (`8.8.8.8`, `8.8.4.4`) or OpenDNS (`208.67.222.222`,
+`208.67.220.220`), or adjust your DNS server to permit the `127.0.0.1` mapping.
+
 - Sandstorm uses port 6080 by default.
 
 Take a moment now to sign in by clicking on **Sign in** in the top-right corner.


### PR DESCRIPTION
I set up Sandstorm on a VM for testing, and the local.sandstorm.io
address would not work for me.  It took me a few hours to track
down the problem, and it would have been longer if not for
TimMc on IRC.  My DD-WRT router was running dnsmasq and
blocking the resolution to 127.0.0.1.  So I've added a note
in the hope that nobody else stumbles on the same problem.