### PR TITLE
Docs: Update PHP version in example

### DIFF
--- a/docs/vagrant-spk/customizing.md
+++ b/docs/vagrant-spk/customizing.md
@@ -139,7 +139,7 @@ See [packaging tutorial](packaging-tutorial.md) for details.
 
 ### Default setup
 
-Repo: https://github.com/paulproteus/php-app-to-package-for-sandstorm
+Repo: [https://github.com/paulproteus/php-app-to-package-for-sandstorm](https://github.com/paulproteus/php-app-to-package-for-sandstorm)
 
 This example shows how to setup a php + mysql app.
 
@@ -152,11 +152,11 @@ dependencies.
 
 `launcher.sh` creates a folder structure in `/var` for MySQL, nginx, and
 php5-fpm, creates MySQL tables, then launches the three daemons, checking that
-`mysqld` and `php5-fpm` are ready to accept requests before launching `nginx`,
+`mysqld` and `php7.0-fpm` are ready to accept requests before launching `nginx`,
 which will listen for requests on port 8000.
 
 ### Paperwork (php, mysql, composer, npm)
-Repo: https://github.com/JamborJan/paperwork
+Repo: [https://github.com/JamborJan/paperwork](https://github.com/JamborJan/paperwork)
 
 [`setup.sh`](https://github.com/JamborJan/paperwork/blob/master/.sandstorm/setup.sh)
 installs PHP, nginx, nodejs, and npm.  Additionally, it installs some


### PR DESCRIPTION
As per sandstorm-io/vagrant-spk#211. Also MkDocs isn't making these repo URLs into links, so I'm trying to force that.