### PR TITLE
Docs: Updated vagrant-spk platform stacks page with new stacks

### DIFF
--- a/docs/vagrant-spk/platform-stacks.md
+++ b/docs/vagrant-spk/platform-stacks.md
@@ -10,7 +10,10 @@ The following stacks exist:
 
 * `golang`: a stack for Go programs
 * `lemp`: a PHP-oriented software collection including nginx, MySQL, and PHP.
+* `lesp`: a similar take on the PHP stack using SQLite as the database.
 * `meteor`: a stack for [Meteor](https://meteor.com) apps, including MongoDB.
+* `node`: a Node stack on version 6.x, for legacy Node apps.
+* `node7`: a Node stack on version 7.x, for newer Node apps.
 * `static`: `nginx` configured to serve static files from `/opt/app`.
 * `uwsgi`: a Python-oriented stack including nginx and uwsgi.
 * `diy`: Create your own.


### PR DESCRIPTION
This reminds me that the Node stacks are probably really old. But descriptions of all the stacks should really be here.