### PR TITLE
Updated install docs for Fedora 27 packages

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -151,6 +151,14 @@ On Debian or Ubuntu, you should be able to get all these with:
         golang-go cmake
     curl https://install.meteor.com/ | sh
 
+On Fedora 27 you should be able to get them with (as root):
+
+   dnf install make libcap-devel libstdc++-devel libstdc++-static \
+       glibc-headers glibc-static glibc-locale-source xz zip \
+       unzip strace curl discount git python2 zlib-devel \
+       golang cmake
+    curl https://install.meteor.com/ | sh
+
 If you have trouble getting the build to work on your distro, we recommend trying in a virtual
 machine running the latest stable Debian release. This is easy to set up using Vagrant, like:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -153,7 +153,7 @@ On Debian or Ubuntu, you should be able to get all these with:
 
 On Fedora 27 you should be able to get them with (as root):
 
-   dnf install make libcap-devel libstdc++-devel libstdc++-static \
+    dnf install make libcap-devel libstdc++-devel libstdc++-static \
        glibc-headers glibc-static glibc-locale-source xz zip \
        unzip strace curl discount git python2 zlib-devel \
        golang cmake


### PR DESCRIPTION
These are all of the packages I needed to install for
a successful build of Sandstorm as of early March, 2018.