### PR TITLE
Depend on network-online.service instead of network.service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1528,8 +1528,9 @@ configure_systemd_init_system() {
   cat > /etc/systemd/system/$SYSTEMD_UNIT << __EOF__
 [Unit]
 Description=Sandstorm server
-After=local-fs.target remote-fs.target network.target
-Requires=local-fs.target remote-fs.target network.target
+After=local-fs.target remote-fs.target network-online.target
+Requires=local-fs.target remote-fs.target
+Wants=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
Ensures that resolv.conf is present on Sandstorm server startup.

I have tested this on my own self-hosted server running on Debian Stretch.

Fixes #3099