### PR TITLE
Fix typo in changelog for v0.240

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### v0.240 (2018-10-20) [bugfixes]
-- Updtaed dependencies.
+- Updated dependencies.
 - Added some clarification messages to Oasis UI regarding the [recent discontinuation of the free plan](https://sandstorm.io/news/2018-08-27-discontinuing-free-plan).
 
 ### v0.239 (2018-09-22)


### PR DESCRIPTION
## In brief

* Fix typo of `Updtaed` → `Updated`
  * Only applies to release version after next update