### PR TITLE
Fix typo of 'subtetx'

### DIFF
--- a/shell/client/admin/personalization.html
+++ b/shell/client/admin/personalization.html
@@ -26,7 +26,7 @@
         <input type="text" name="server-title" value="{{serverTitle}}" disabled="{{formDisabled}}"/>
       </label>
       <span class="form-subtext">
-        {{_ (con txt "serverTitle.subtetx")}}
+        {{_ (con txt "serverTitle.subtext")}}
       </span>
     </div>
 


### PR DESCRIPTION
I noticed this problem when I viewed the 'Admin / Personalization' page and saw the text `admin.personalization.newAdminPersonalization.serverTitle.subtetx` beneath the `Server title` form. This should've been a string, but the typo of `subtetx` instead of `subtext` prohibited this.