### PR TITLE
Remember user identities through "forget grain" and backup/restore

### DIFF
--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -30,7 +30,7 @@ const emailLinkWithInlineStyle = function (url, text) {
 // Force-shutdown dev apps whenever their packages change.
 Meteor.startup(() => {
   const shutdownApp = (appId) => {
-    Grains.find({ appId: appId }).forEach((grain) => {
+    Grains.find({ appId: appId }, {fields: {oldUsers: 0}}).forEach((grain) => {
       waitPromise(globalBackend.shutdownGrain(grain._id, grain.userId));
     });
   };
@@ -243,7 +243,7 @@ Meteor.publish("requestingAccess", function (grainId) {
 Meteor.publish("grainLog", function (grainId) {
   check(grainId, String);
   let id = 0;
-  const grain = Grains.findOne(grainId);
+  const grain = Grains.findOne(grainId, {fields: {oldUsers: 0}});
   if (!grain || !this.userId || grain.userId !== this.userId) {
     this.added("grainLog", id++, { text: "Only the grain owner can view the debug log." });
     this.ready();
@@ -354,7 +354,7 @@ Meteor.methods({
 
   shutdownGrain(grainId) {
     check(grainId, String);
-    const grain = Grains.findOne(grainId);
+    const grain = Grains.findOne(grainId, {fields: {oldUsers: 0}});
     if (!grain || !this.userId || grain.userId !== this.userId) {
       throw new Meteor.Error(403, "Unauthorized", "User is not the owner of this grain");
     }
@@ -366,7 +366,7 @@ Meteor.methods({
     check(grainId, String);
     check(newTitle, String);
     if (this.userId) {
-      const grain = Grains.findOne(grainId);
+      const grain = Grains.findOne(grainId, {fields: {oldUsers: 0}});
       if (grain) {
         if (grain.userId === this.userId) {
           Grains.update({ _id: grainId, userId: this.userId }, { $set: { title: newTitle } });
@@ -557,7 +557,7 @@ Meteor.methods({
         throw new Meteor.Error(403, "Must be logged in to request access.");
       }
 
-      const grain = Grains.findOne(grainId);
+      const grain = Grains.findOne(grainId, {fields: {oldUsers: 0}});
       if (!grain) {
         throw new Meteor.Error(404, "No such grain");
       }

--- a/shell/server/grain-server.js
+++ b/shell/server/grain-server.js
@@ -291,7 +291,7 @@ Meteor.publish("grainLog", function (grainId) {
 const GRAIN_DELETION_MS = 1000 * 60 * 60 * 24 * 30; // thirty days
 SandstormDb.periodicCleanup(86400000, () => {
   const trashExpiration = new Date(Date.now() - GRAIN_DELETION_MS);
-  globalDb.removeApiTokens({ trashed: { $lt: trashExpiration } });
+  globalDb.removeApiTokens({ trashed: { $lt: trashExpiration } }, true);
   globalDb.deleteGrains({ trashed: { $lt: trashExpiration } }, globalBackend, "grain");
 });
 

--- a/shell/server/install-server.js
+++ b/shell/server/install-server.js
@@ -119,7 +119,8 @@ Meteor.publish("packageInfo", function (packageId) {
     return [
       pkgCursor,
       db.collections.userActions.find({ userId: this.userId, appId: pkg.appId }),
-      db.collections.grains.find({ userId: this.userId, appId: pkg.appId }),
+      db.collections.grains.find(
+          { userId: this.userId, appId: pkg.appId }, {fields: {oldUsers: 0}}),
     ];
   } else {
     return pkgCursor;

--- a/shell/server/shell-server.js
+++ b/shell/server/shell-server.js
@@ -90,7 +90,7 @@ Meteor.publish("grainsMenu", function () {
 
     return [
       UserActions.find({ userId: this.userId }),
-      Grains.find({ userId: this.userId }),
+      Grains.find({ userId: this.userId }, {fields: {oldUsers: 0}}),
       ApiTokens.find({ "owner.user.accountId": this.userId }),
     ];
   } else {

--- a/shell/shared/grain-shared.js
+++ b/shell/shared/grain-shared.js
@@ -147,7 +147,7 @@ Meteor.methods({
     if (this.isSimulation) {
       ApiTokens.remove(query);
     } else {
-      globalDb.removeApiTokens(query);
+      globalDb.removeApiTokens(query, true);
     }
   },
 });

--- a/src/sandstorm/grain.capnp
+++ b/src/sandstorm/grain.capnp
@@ -620,8 +620,36 @@ struct GrainInfo {
 
   ownerIdentityId @3 :Text;
 
-  # TODO(someday): Record the whole sharing / capability graph including all users' identity IDs
-  #   so that they can be restored.
+  users @4 :List(User);
+  # Record of users with who had accessed this grain. This can be used to ensure that if a restored
+  # grain is shared with the same users, they receive the same identities, rather than appearing
+  # to be new people.
+
+  struct User {
+    identityId @0 :Text;
+    # Identity ID of this user within the app.
+
+    credentialIds @1 :List(Text);
+    # The user's login credential IDs. If a user with a matching credential visits the restored
+    # grain, they will regain the same identity. Credential IDs are consistent across differnt
+    # Sandstorm servers (as long as the same authentication mechanisms are used), so this can allow
+    # identities to be restored even on a new server.
+    #
+    # Non-login credentials are not included because those credentials could be shared by multiple
+    # users. However, non-login credentials could be used for matching when restoring identities
+    # later.
+
+    profile @2 :Identity.Profile;
+    # User's profile. Could be useful to allow the human owner of the restored grain to manually
+    # remap identities.
+  }
+
+  originalGrainId @5 :Text;
+  # The grain's original ID. With admin approval, grains could be allowed to receive the same IDs
+  # when restored on a new server.
+
+  # TODO(someday): Record the whole sharing / capability graph? This gets complicated since grains
+  #   may have been shared via other grains, etc.
 }
 
 # ========================================================================================


### PR DESCRIPTION
Two years ago, I [refactored the way identities work](https://sandstorm.io/news/2017-05-08-refactoring-identities).

Prior to that refactor, the "identity ID" that apps received identifying each user was exactly the ID of the credential they used to open the grain. These IDs were consistent across servers; e.g. if you used Google login on multiple Sandstorm servers using the same Google account, then you'd have the same identity ID in every app. (The identity ID was derived from taking a hash of the Google account ID.)

This had some problems:
* In theory, it meant that users could be tracked across grains and apps could know who a user is in advance (by having a database of known identities). This could be a privacy threat.
* With the identity refactor, users no longer chose a specific credential when opening a grain. Instead, a whole account was considered a single identity. An account can have multiple credentials, so it no longer made sense to use a credential ID as the identity ID, since there was no way to decide which one to use.

Therefore, in the identities refactor, I changed things so that identity IDs were randomly generated when an account first received access to a grain. The identity ID was stored on the ApiToken that granted the account access. (Typically, when sharing by link, this ApiToken is created when the user first visits the link and clicks the "reveal identity" button.)

But this created two regressions:
* If a user had a grain shared with them, used it, and then deleted it from their grain list, then the ApiToken that tracked their identity ID on that grain would be deleted. If the grain was later shared with the user again (or they re-opened the same sharing link and revealed their identity again), they would be assigned an all-new identity ID, and the app would treat them as an all-new user.
* When a grain was backed up and restored, all knowledge of identity IDs that had been assigned to users was lost (except for the owner's identity ID, which was handled explicitly). Hence, if a restored grain was shared with the same users, they would be treated as new users by the grain. This meant that using backup/restore to transfer grains between servers worked very poorly for multi-user grains.

This PR fixes both problems. We now store a record of users that historically had access to a grain, but no longer do. We also include such records in the metadata included in a grain backup. A new user opening a grain is considered to be the same user if any of the new user's credentials match one of the original user's login credentials.

When a grain is backed up and then restored to the same server, restoring user identities should "just work" the way it used to before the identity refactor.

When a grain is backed up and then restored on a _different_ server, the new logic should be superior to the original in one crucial way: Users on the new server do not need to use the same primary login mechanism as they did on the original. The only requirement is that whatever login credential they used on the original server is also associated with their account on the new server -- but on the new server, it can be listed as a secondary (non-login) credential.

**This should make it easier, for instance, to migrate from Oasis to a self-hosted server, where the self-hosted server uses LDAP or SAML as its primary authentication mechanism.**

We also store each user's provide in the grain backup metadata. This could perhaps be used to write tools or a UI that lets the grain owner manually associate each identity with a new user. However, at this time I don't plan to write any code that uses this.