### PR TITLE
docs(nginx-example): update ssl config

### DIFF
--- a/docs/administering/sample-config/nginx-example.conf
+++ b/docs/administering/sample-config/nginx-example.conf
@@ -47,6 +47,13 @@ server {
   # future then you should probably delete this line.
   add_header Strict-Transport-Security "max-age=63072000" always;
 
+  # OCSP stapling, requires Intermediate cert
+  #ssl_stapling on;
+  #ssl_stapling_verify on;
+
+  # verify chain of trust of OCSP response using Root CA and Intermediate certs
+  #ssl_trusted_certificate /path/to/root_CA_cert_plus_intermediates;
+
   location / {
     proxy_pass http://127.0.0.1:6080;
 

--- a/docs/administering/sample-config/nginx-example.conf
+++ b/docs/administering/sample-config/nginx-example.conf
@@ -27,7 +27,6 @@ server {
   listen 443 ssl http2;
   server_name example.com *.example.com;
 
-  ssl on;
   ssl_certificate /etc/nginx/ssl/sandstorm.crt;
   ssl_certificate_key /etc/nginx/ssl/sandstorm.key;
 

--- a/docs/administering/sample-config/nginx-example.conf
+++ b/docs/administering/sample-config/nginx-example.conf
@@ -23,6 +23,7 @@ server {
 
 # Configuration for Sandstorm shell and apps, over HTTPS.
 server {
+  # http2 requires Nginx >=1.9.5
   listen 443 ssl http2;
   server_name example.com *.example.com;
 
@@ -37,8 +38,8 @@ server {
   # Configure SSL with forward secrecy and other goodies.
   # Ciphersuite taken from https://wiki.mozilla.org/Security/Server_Side_TLS
   # "Intermediate compatibility" as of 2019-09-12
-  # https://ssl-config.mozilla.org/#server=nginx&server-version=1.10.3&config=intermediate&openssl-version=1.1.0k
-  ssl_protocols TLSv1.2;
+  # TLSv1.3 requires Nginx >=1.13.0 & OpenSSL >=1.1.1
+  ssl_protocols TLSv1.2 TLSv1.3;
   ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
   ssl_prefer_server_ciphers off;
 

--- a/docs/administering/sample-config/nginx-example.conf
+++ b/docs/administering/sample-config/nginx-example.conf
@@ -23,7 +23,7 @@ server {
 
 # Configuration for Sandstorm shell and apps, over HTTPS.
 server {
-  listen 443;
+  listen 443 ssl http2;
   server_name example.com *.example.com;
 
   ssl on;
@@ -31,18 +31,21 @@ server {
   ssl_certificate_key /etc/nginx/ssl/sandstorm.key;
 
   ssl_session_timeout 5m;
+  ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+  ssl_session_tickets off;
 
   # Configure SSL with forward secrecy and other goodies.
   # Ciphersuite taken from https://wiki.mozilla.org/Security/Server_Side_TLS
-  # "Intermediate compatibility" as of 2015-06-04
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-  ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
-  ssl_prefer_server_ciphers on;
+  # "Intermediate compatibility" as of 2019-09-12
+  # https://ssl-config.mozilla.org/#server=nginx&server-version=1.10.3&config=intermediate&openssl-version=1.1.0k
+  ssl_protocols TLSv1.2;
+  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+  ssl_prefer_server_ciphers off;
 
   # HSTS prevents attackers from tricking you into connecting via HTTP in the
   # future, but if you actually intend to access the server via non-SSL in the
   # future then you should probably delete this line.
-  add_header Strict-Transport-Security max-age=31536000;
+  add_header Strict-Transport-Security "max-age=63072000" always;
 
   location / {
     proxy_pass http://127.0.0.1:6080;

--- a/docs/administering/sample-config/nginx-example.conf
+++ b/docs/administering/sample-config/nginx-example.conf
@@ -35,6 +35,9 @@ server {
   ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
   ssl_session_tickets off;
 
+  # curl https://ssl-config.mozilla.org/ffdhe2048.txt > /path/to/dhparam.pem
+  ssl_dhparam /path/to/dhparam.pem;
+
   # Configure SSL with forward secrecy and other goodies.
   # Ciphersuite taken from https://wiki.mozilla.org/Security/Server_Side_TLS
   # "Intermediate compatibility" as of 2019-09-12


### PR DESCRIPTION
Prioritize newer recommendations and mention older ones if the platform uses older nginx+openssl.

Changes:
- Security:
  - Disable `ssl_session_tickets`
  - [`ssl_dhparam`](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam) to support EDH ciphers.
  - `ssl_ciphers` always use GCM mode for AES
  - Increase `Strict-Transport-Security` expiry to 2 years (from 1 year).
  - Retain `ssl_session_timeout 5m`; Mozilla [recommends](https://github.com/mozilla/server-side-tls/issues/198) 1d for performance and comes with security tradeoff.

- Performance:
  - Enable http/2
  - Enable `ssl_session_cache`

- Misc:
  - Remove [redundant](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl) `ssl on`
  - Disable `ssl_prefer_server_ciphers`. Not exactly security related, but it's more of respecting browser's choice, e.g. Chrome prefers `CHACHA20-POLY1305`.
  - [OCSP stapling](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_stapling) is mentioned but not enabled by default as it requires intermediate cert, which is not always present.

Ref: https://nginx.org/en/docs/http/ngx_http_ssl_module.html