### PR TITLE
docs(apache-example): update ssl config

### DIFF
--- a/docs/administering/sample-config/apache-virtualhost.conf
+++ b/docs/administering/sample-config/apache-virtualhost.conf
@@ -3,12 +3,15 @@
 # https://docs.sandstorm.io/en/latest/administering/
 # Any line containing example.com MUST be changed for this to work right.  All other lines
 # should work for an "out of the box" installation.
+#
+# Requires mod_ssl, mod_socache_shmcb, mod_rewrite, mod_headers, and mod_http2
 
 <VirtualHost *:80>
   # Use this VirtualHost for example.com and wildcards.
   ServerName example.com
   ServerAlias *.example.com
-  Redirect / https://example.com/
+  RewriteEngine On
+  RewriteRule ^(.*)$ https://%{HTTP_HOST}$1 [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>
@@ -16,10 +19,20 @@
   ServerAlias *.example.com
   SSLEngine on
   # The following paths will of course need to be replaced with the correct paths
-  SSLCertificateFile /etc/pki/tls/certs/example.com.crt
-  SSLCertificateKeyFile /etc/pki/tls/private/example.com.key
-  SSLCertificateChainFile /etc/pki/tls/certs/providedChainFileForexample.com.crt
-  Header always add Strict-Transport-Security "max-age=15768000; includeSubdomains"
+  # curl https://ssl-config.mozilla.org/ffdhe2048.txt >> /path/to/signed_cert_and_intermediate_certs_and_dhparams
+  SSLCertificateFile      /path/to/signed_cert_and_intermediate_certs_and_dhparams
+  SSLCertificateKeyFile   /path/to/private_key
+
+  # Apache >=2.4.8 supports full cert chain and obsoletes SSLCertificateChainFile
+  # Uncomment it if running older version
+  #SSLCertificateChainFile /etc/pki/tls/certs/providedChainFileForexample.com.crt
+
+  # Enable h2 (HTTP/2), if available
+  # h2 requires Apache >=2.4.17 and mod_http2
+  Protocols h2 http/1.1
+
+  # HTTP Strict Transport Security (mod_headers is required) (63072000 seconds)
+  Header always add Strict-Transport-Security "max-age=63072000; includeSubdomains"
 
   # Enable mod_rewrite so we can dispatch to ws:// vs. http:// based on HTTP Header. To make this
   # work, you might need to run:
@@ -49,39 +62,52 @@
   ProxyPreserveHost On
 </VirtualHost>
 
+# Configure SSL with forward secrecy and other goodies.
+# Ciphersuite taken from https://wiki.mozilla.org/Security/Server_Side_TLS
+# "Intermediate compatibility" as of 2019-09-17
+# TLSv1.3 requires Apache >=2.4.36 & OpenSSL >=1.1.1
+SSLProtocol             all -SSLv3 -TLSv1 -TLSv1.1
+SSLCipherSuite          ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+SSLHonorCipherOrder     off
+SSLSessionTickets       off
+
+# OCSP stapling, requires Intermediate cert
+#SSLUseStapling On
+#SSLStaplingCache "shmcb:logs/ssl_stapling(32768)"
+
 #  Uncomment the below section and remove the above section if SSL is not desired.
 #
 #  # This is a sample Apache reverse proxy configuration for use with Sandstorm. Read more:
 #  #
 #  # https://docs.sandstorm.io/en/latest/administering/
-#  
+#
 #  <VirtualHost *:80>
 #    # Use this VirtualHost for example.com and wildcards.
 #    ServerName example.com
 #    ServerAlias *.example.com
-#  
+#
 #    # Enable mod_rewrite so we can dispatch to ws:// vs. http:// based on HTTP Header. To make this
 #    # work, you might need to run:
 #    #
 #    # sudo a2enmod rewrite
 #    RewriteEngine On
-#  
+#
 #    # If this request wanted a websocket, then give it one. To make this work, you might need to run:
 #    #
 #    # sudo a2enmod proxy_wstunnel
 #    RewriteCond %{HTTP:Upgrade} =websocket
 #    RewriteRule /(.*)           ws://localhost:6080/$1 [P,L]
-#  
+#
 #    # If this request did not want a websocket, then give it http:// access to Sandstorm. To make this
 #    # work, you might need to run:
 #    #
 #    # sudo a2enmod proxy_http
 #    RewriteCond %{HTTP:Upgrade} !=websocket
 #    RewriteRule /(.*)           http://localhost:6080/$1 [P,L]
-#  
+#
 #    # By default, send all requests to Sandstorm over http://
 #    ProxyPass / http://localhost:6080/
-#  
+#
 #    # Preserve the inbound "Host: ..." header from the HTTP request. This is important so that
 #    # Sandstorm can detect which wildcard host is being requested.
 #    ProxyPreserveHost On


### PR DESCRIPTION
Prioritize newer recommendations and mention older ones when applicable.

Changes:
- Security:
  - Disable `SSLSessionTickets`
  - Mention dhparam in `SSLCertificateFile` to support EDH ciphers.
  - `SSLCipherSuite` always use GCM mode for AES
  - Increase `Strict-Transport-Security` expiry to 2 years (from 1 year)

- Performance:
  - Enable http/2

- Misc:
  - Comment out obsolete `SSLCertificateChainFile`
  - Disable `SSLHonorCipherOrder`. Not exactly security related, but it's more of respecting browser's choice, e.g. Chrome prefers `CHACHA20-POLY1305`
  - OCSP stapling is mentioned but not enabled by default as it requires intermediate cert, which is not always present.

Ref: https://httpd.apache.org/docs/2.4/mod/mod_ssl.html
Related PR: https://github.com/sandstorm-io/sandstorm/pull/3158