### PR TITLE
Spec out a solution to #3027

### DIFF
--- a/src/sandstorm/package.capnp
+++ b/src/sandstorm/package.capnp
@@ -230,7 +230,7 @@ struct BridgeConfig {
   # capability so that it can be fetched later using `SandstormHttpBridge.getSavedIdentity`. You
   # will probably want to enable this if your app supports notifications.
 
-  expectAppHooks @3 :Bool;
+  expectAppHooks @4 :Bool;
   # Set this to true if you are using sandstorm-http-bridge and want to do any of
   # the following:
   #

--- a/src/sandstorm/package.capnp
+++ b/src/sandstorm/package.capnp
@@ -230,6 +230,21 @@ struct BridgeConfig {
   # capability so that it can be fetched later using `SandstormHttpBridge.getSavedIdentity`. You
   # will probably want to enable this if your app supports notifications.
 
+  expectAppHooks @3 :Bool;
+  # Set this to true if you are using sandstorm-http-bridge and want to do any of
+  # the following:
+  #
+  # - Provide an implementation of getViewInfo() that generates its result dynamically,
+  #   rather than statically defining the result via `viewInfo` above.
+  # - Support exporting persistent capabilities other than the HTTP APIs specified by
+  #   PowerboxApi below.
+  #
+  # If this is true, the bridge will expect the application to establish a capnproto
+  # connection to the bridge via `/tmp/sandstorm-api`, and it will expect the app's
+  # bootstrap interface on this connection to implement `AppHooks`, defined in
+  # sandstorm-http-bridge.capnp. The methods described there can be used to
+  # implement the above functionality.
+
   powerboxApis @3 :List(PowerboxApi);
   struct PowerboxApi {
     # Defines an HTTP API which this application exports, to which other apps can request access

--- a/src/sandstorm/sandstorm-http-bridge-internal.capnp
+++ b/src/sandstorm/sandstorm-http-bridge-internal.capnp
@@ -30,9 +30,6 @@ struct BridgeObjectId {
   # Recall that Sandstorm obfuscates object IDs automatically, such that clients cannot see the
   # contents and the app can trust that the ID passed from Sandstorm is authentic. Hence, we can
   # put all the metadata we need directly in this structure and let Sandstorm store it.
-  #
-  # Note the AppHooks.BridgeObjectId defined in `sandstorm-http-bridge.capnp` is wire
-  # compatible with this, but exposes less information to apps.
 
   union {
     application @0 :AnyPointer;

--- a/src/sandstorm/sandstorm-http-bridge-internal.capnp
+++ b/src/sandstorm/sandstorm-http-bridge-internal.capnp
@@ -30,6 +30,9 @@ struct BridgeObjectId {
   # Recall that Sandstorm obfuscates object IDs automatically, such that clients cannot see the
   # contents and the app can trust that the ID passed from Sandstorm is authentic. Hence, we can
   # put all the metadata we need directly in this structure and let Sandstorm store it.
+  #
+  # Note the BridgeObjectId defined in `sandstorm-http-bridge.capnp` is wire compatible
+  # with this, but exposes less information to apps.
 
   union {
     application @0 :AnyPointer;

--- a/src/sandstorm/sandstorm-http-bridge-internal.capnp
+++ b/src/sandstorm/sandstorm-http-bridge-internal.capnp
@@ -31,8 +31,8 @@ struct BridgeObjectId {
   # contents and the app can trust that the ID passed from Sandstorm is authentic. Hence, we can
   # put all the metadata we need directly in this structure and let Sandstorm store it.
   #
-  # Note the BridgeObjectId defined in `sandstorm-http-bridge.capnp` is wire compatible
-  # with this, but exposes less information to apps.
+  # Note the AppHooks.BridgeObjectId defined in `sandstorm-http-bridge.capnp` is wire
+  # compatible with this, but exposes less information to apps.
 
   union {
     application @0 :AnyPointer;

--- a/src/sandstorm/sandstorm-http-bridge.capnp
+++ b/src/sandstorm/sandstorm-http-bridge.capnp
@@ -52,8 +52,8 @@ interface AppHooks (AppObjectId) {
   # objects exported by the app that implement Grain.AppPersistent.
 
   getViewInfo @0 () -> Grain.UiView.ViewInfo;
-  # Like Grain.UiView.GetViewInfo. If AppHooks is supplied, the bridge will
-  # delegate UiView.GetViewInfo to this method. If it raises unimplemented,
+  # Like Grain.UiView.getViewInfo. If AppHooks is supplied, the bridge will
+  # delegate UiView.getViewInfo to this method. If it raises unimplemented,
   # the bridge will fall back to reading the viewInfo from the bridgeConfig.
 
   restore @1 (objectId :AppObjectId) -> (cap :Capability);

--- a/src/sandstorm/sandstorm-http-bridge.capnp
+++ b/src/sandstorm/sandstorm-http-bridge.capnp
@@ -81,7 +81,7 @@ interface AppHooks (AppObjectId) {
       # The object ID is in a format understood by sandstorm-http-bridge. The bridge
       # will use this to manage persistent objects it implements itself (for example,
       # HTTP apis), but applications should not set this variant on objects they
-      # create, and the bridge will never pass this to `AppHooks.restore` or `drop`.
+      # create.
     }
   }
 }


### PR DESCRIPTION
This introduces additions to capnproto interfaces to allow
sandstorm-http-bridge to delegate MainView.restore/drop and
UiView.getViewInfo to the app, while still handling HTTP
translation.

Would like opinions on the design.

//cc @kentonv, @ocdtrekkie 