### PR TITLE
external-ui-view: Don't restrict GitHub to /users

### DIFF
--- a/shell/server/drivers/external-ui-view.js
+++ b/shell/server/drivers/external-ui-view.js
@@ -64,7 +64,7 @@ function getOAuthServiceInfo(url) {
       service: "google",
       endpoint: "https://www.googleapis.com/oauth2/v4/token",
     };
-  } else if (url.startsWith("https://api.github.com/users")) {
+  } else if (url.startsWith("https://api.github.com/")) {
     return {
       service: "github",
       endpoint: "https://github.com/login/oauth/access_token",


### PR DESCRIPTION
I don't understand why this was previously restricted to the /users
path on the GitHub api; this ought to match for the entire API.