### PR TITLE
Fix bug where some api-session requests had an extra / in the path.

### DIFF
--- a/shell/server/drivers/external-ui-view.js
+++ b/shell/server/drivers/external-ui-view.js
@@ -399,14 +399,16 @@ ExternalWebSession = class ExternalWebSession extends PersistentImpl {
         options.headers["user-agent"] = "sandstorm app";
       }
 
-      if (this.fromHackSession) {
-        // According to the specification of `WebSession`, `path` should not contain a
-        // leading slash, and therefore we need to prepend "/". However, for a long time
-        // this implementation did not in fact prepend a "/". Since some apps might rely on
-        // that behavior, we only prepend "/" if the path does not start with "/".
-        //
-        // TODO(soon): Once apps have updated, prepend "/" unconditionally.
-        options.path = path.startsWith("/") ? path : "/" + path;
+      // In theory, we should always prepend a slash to the path ourselves because,
+      // according to the specification of `WebSession`, `path` should not contain
+      // one, but in practice we need to be a little more flexible, for two reasons:
+      //
+      // 1. For a long time the `HackSession` implementation did not in fact
+      //    prepend a "/", so some apps may rely on that behavior.
+      // 2. If the session's path is at the root of a domain, it will have the
+      //    path set as "/" already, so we should not add another one.
+      if (this.path === "/" || path.startsWith("/")) {
+        options.path = this.path + path;
       } else {
         options.path = this.path + "/" + path;
       }


### PR DESCRIPTION
See the comment; if this.path is '/' then joining it and the rest of the
path with another '/' gives us a duplicate slash, which is not what we
want.

Note that there's a normative change to the comment here as well: I don't think it makes sense to plan remove the workaround for hack session down the line. I don't think being rigid about this really buys us anything, though it might cause trip up developers if they make the mistake of adding the slash themselves. I am willing to change the wording on the comment if you feel strongly though.

This turned out to be the real source of the problems I was seeing when I opened #3179; I have a demo using the GitHub api that will work once this and #3180 are merged.