### PR TITLE
Doc action

### DIFF
--- a/.github/workflows/doc-prod.yml
+++ b/.github/workflows/doc-prod.yml
@@ -1,0 +1,17 @@
+name: doc-prod
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'mkdocs.yml'
+      - 'docs/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      SANDSTORM_DOC_URL: ${{ secrets.doc_url_prod }}
+    steps:
+    - uses: actions/checkout@v2
+    - run: bash -x docs/generate.sh -s -p

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,12 +7,12 @@ https://docs.sandstorm.io/
 Run the following.
 
 ```
+# Get "dot" so we can render inline dot/graphviz
+sudo apt-get install -y graphviz virtualenv
 cd ~/projects/sandstorm
 virtualenv tmp/docs-virtualenv
 tmp/docs-virtualenv/bin/pip install mkdocs==1.0.4
 tmp/docs-virtualenv/bin/pip install markdown-inline-graphviz==1.0
-# Get "dot" so we can render inline dot/graphviz
-sudo apt-get install -y graphviz
 tmp/docs-virtualenv/bin/mkdocs serve
 ```
 


### PR DESCRIPTION
This PR, built atop my previous one, makes it possible to deploy the docs with a github push.

It extends the `generate.sh` script to fetch its dependencies and setup from scratch when given the `-s` option.
 
I created two "Workflow" files, one for staging and one for prod. The URL to the gitweb-pages grain, including its username and password, can be stored in Github Secrets. I was thinking that the flow could be to merge master to the doc-staging branch, wait for the action to complete, inspect the staging grain, and then merge master to the doc-prod branch. 

I tested this by pushing to my own repo and letting it deploy to my own staging grain.

Future work: use the github cache action to make it faster (setting up from scratch takes about 30sec). 

Example deployment log: https://github.com/abliss/sandstorm/commit/46e8493301901309c593459c2772efe22a7aef9e/checks?check_suite_id=408784600