### PR TITLE
Test suite: add an option for displaying the browser window.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -41,6 +41,14 @@ You can also run all test cases in a file:
 
     TESTCASE="tests/grain.js" make test
 
+## Displaying the browser's UI during tests
+
+By default the tests run against a mock X server, so the browser windows
+are not displayed. However, it can be helpful to display the browser
+windows when debugging. You can do this by setting `SHOW_BROWSER=true`:
+
+    SHOW_BROWSER=true make test
+
 ## How to dump the DOM for debugging
 
 Stick this in the test:

--- a/tests/run-local.sh
+++ b/tests/run-local.sh
@@ -19,7 +19,9 @@
 set -euo pipefail
 
 XVFB_PID=""
+SELENIUM_PID=""
 RUN_SELENIUM="${RUN_SELENIUM:-true}"
+SHOW_BROWSER="${SHOW_BROWSER:-false}"
 BUNDLE_PATH=""
 SANDSTORM_TESTAPP_PATH=""
 THIS_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
@@ -53,6 +55,9 @@ cleanExit () {
     # We don't actually know that PID, so we find it with pgrep.
     kill $(pgrep --parent $XVFB_PID node)
     wait $XVFB_PID
+  elif [ -n "$SELENIUM_PID" ] ; then
+    kill $SELENIUM_PID
+    wait $SELENIUM_PID
   fi
   exit $rc
 }
@@ -108,8 +113,13 @@ if [ "$RUN_SELENIUM" != "false" ] ; then
   checkInstalled java default-jre-headless
   checkInstalled xvfb-run Xvfb
   checkInstalled pgrep procps
-  xvfb-run --server-args="-screen 0, 1280x1024x24" node_modules/.bin/selenium-standalone start &
-  XVFB_PID=$!
+  if [ "$SHOW_BROWSER" != "false" ] ; then
+    node_modules/.bin/selenium-standalone start &
+    SELENIUM_PID=$!
+  else
+    xvfb-run --server-args="-screen 0, 1280x1024x24" node_modules/.bin/selenium-standalone start &
+    XVFB_PID=$!
+  fi
 fi
 
 export SANDSTORM_DIR=$THIS_DIR/tmp-sandstorm


### PR DESCRIPTION
Per the new section in the README, I've found this useful for debugging.