### PR TITLE
Update vagrant-spk stack list to reflect master

### DIFF
--- a/docs/vagrant-spk/platform-stacks.md
+++ b/docs/vagrant-spk/platform-stacks.md
@@ -12,8 +12,8 @@ The following stacks exist:
 * `lemp`: a PHP-oriented software collection including nginx, MySQL, and PHP.
 * `lesp`: a similar take on the PHP stack using SQLite as the database.
 * `meteor`: a stack for [Meteor](https://meteor.com) apps, including MongoDB.
-* `node`: a Node stack on version 6.x, for legacy Node apps.
-* `node7`: a Node stack on version 7.x, for newer Node apps.
+* `node`: a Node stack on version 10.x, for modern Node apps.
+* `node6`: a Node stack on version 6.x, for legacy Node apps.
 * `static`: `nginx` configured to serve static files from `/opt/app`.
 * `uwsgi`: a Python-oriented stack including nginx and uwsgi.
 * `diy`: Create your own.


### PR DESCRIPTION
We do tell people to use GitHub master by default, so we should update this in Docs immediately.