### PR TITLE
Fix typo in about page

### DIFF
--- a/shell/i18n/en.i18n.json
+++ b/shell/i18n/en.i18n.json
@@ -133,7 +133,7 @@
         "explanation": "These companies contributed heavily to Sandstorm's <a href=\"http://igg.me/at/sandstorm\">crowdfunding campaign</a>."
       },
       "individual": {
-        "title": "Key indivisual sponsors",
+        "title": "Key individual sponsors",
         "explanation": "These individuals contributed heavily to Sandstorm's <a href=\"http://igg.me/at/sandstorm\">crowdfunding campaign</a>."
       },
       "backers": {


### PR DESCRIPTION
This typo was introduced with i18n. Since it's a short string, my guess is someone hand-typed it instead of copy-pasting.