### PR TITLE
Fix Vagrantfile's Windows RAM calculation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,12 +56,8 @@ EOF
     cpus = `nproc`.to_i
     total_kB_ram = `grep MemTotal /proc/meminfo | awk '{print $2}'`.to_i
   elsif host =~ /mingw/
-    # powershell may not be available on Windows XP and Vista, so wrap this in a rescue block
-    begin
-      cpus = `powershell -Command "(Get-WmiObject Win32_Processor -Property NumberOfLogicalProcessors | Select-Object -Property NumberOfLogicalProcessors | Measure-Object NumberOfLogicalProcessors -Sum).Sum"`.to_i
-      total_kB_ram = `powershell -Command "[math]::Round((Get-WmiObject -Class Win32_ComputerSystem).TotalPhysicalMemory)"`.to_i / 1024
-    rescue
-    end
+    cpus = `powershell -Command "(Get-WmiObject Win32_Processor -Property NumberOfLogicalProcessors | Select-Object -Property NumberOfLogicalProcessors | Measure-Object NumberOfLogicalProcessors -Sum).Sum"`.to_i
+    total_kB_ram = `powershell -Command "[math]::Round((Get-WmiObject -Class Win32_ComputerSystem).TotalPhysicalMemory)"`.to_i / 1024
   end
 
   # Use the same number of CPUs within Vagrant as the system, with 1

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,7 +59,7 @@ EOF
     # powershell may not be available on Windows XP and Vista, so wrap this in a rescue block
     begin
       cpus = `powershell -Command "(Get-WmiObject Win32_Processor -Property NumberOfLogicalProcessors | Select-Object -Property NumberOfLogicalProcessors | Measure-Object NumberOfLogicalProcessors -Sum).Sum"`.to_i
-      total_kB_ram = `powershell -Command "Get-CimInstance -class cim_physicalmemory | % {$_.Capacity}"`.to_i / 1024
+      total_kB_ram = `powershell -Command "[math]::Round((Get-WmiObject -Class Win32_ComputerSystem).TotalPhysicalMemory)"`.to_i / 1024
     rescue
     end
   end


### PR DESCRIPTION
See https://github.com/sandstorm-io/vagrant-spk/pull/241 for the same fix on vagrant-spk, see https://github.com/sandstorm-io/vagrant-spk/pull/240 for details on how the existing command responds (listing half the RAM twice instead of providing a single valid amount of RAM).