### PR TITLE
Docs: Change vagrant-spk port to 6090

### DIFF
--- a/docs/developing/debugging.md
+++ b/docs/developing/debugging.md
@@ -26,9 +26,6 @@ Before using this procedure, you should know the following.
   commands you run in the shell will result in new files being accessed, and users don't need these
   debugging commands.
 
-- **You need version v0.164 or higher of vagrant-spk,** in which the
-  command was introduced. It was released during May 2016.
-
 - **Command-line interface subject to change:** Changes may be necessary in the future to take
   advantage of changes in Sandstorm, or to make the tool easier to integrate into automation.
 

--- a/docs/vagrant-spk/packaging-tutorial-meteor.md
+++ b/docs/vagrant-spk/packaging-tutorial-meteor.md
@@ -155,26 +155,6 @@ noise.
 Eventually, you will get your shell back. At this point, you can
 continue to the next step.
 
-**Troubleshooting note**: If the `vagrant-spk vm up` command fails, it
-could be because you already have Sandstorm installed on your
-laptop. You can recognize this error via the following red text:
-
-```bash
-Vagrant cannot forward the specified ports on this VM, since they
-would collide with some other application that is already listening
-on these ports. The forwarded port to 6080 is already in use
-on the host machine.
-```
-
-If you see that, run:
-
-```bash
-sudo service sandstorm stop
-```
-
-and halt any other `vagrant-spk` virtual machines you might be using
-to develop other apps.
-
 ## Connect your app to your local Sandstorm server
 
 Apps run differently in Sandstorm, compared to `meteor deploy`, so
@@ -212,7 +192,7 @@ App is now available from Sandstorm server. Ctrl+C to disconnect.
 
 When we visit the Sandstorm server, we'll see the app available. Open up
 this URL in your web browser:
-[http://local.sandstorm.io:6080/](http://local.sandstorm.io:6080/)
+[http://local.sandstorm.io:6090/](http://local.sandstorm.io:6090/)
 
 A note about `local.sandstorm.io`: This is the same as `localhost`,
 but in Sandstorm's security model, each session to the app uses a
@@ -223,8 +203,6 @@ but it does mean that the domain name running Sandstorm needs
 `local.sandstorm.io` as an alias for `localhost` and gave it wildcard
 DNS. You can rest assured that your interactions with
 `local.sandstorm.io` stay entirely on your computer.
-
-<!--(**Editor's note**: We should make localhost:6080 work, so that people don't have to learn about `local.sandstorm.io`.)-->
 
 Take a moment now to sign in. Choose **with a Dev account** and choose
 **Alice (admin)**. You will have to enter an email address; you can use
@@ -306,7 +284,7 @@ and change it to read:
 ```
 
 To refresh the information that shows up in
-[http://local.sandstorm.io:6080/](http://local.sandstorm.io:6080/),
+[http://local.sandstorm.io:6090/](http://local.sandstorm.io:6090/),
 find the terminal where you are running `vagrant-spk dev`. It should
 have this line at the end.
 
@@ -390,7 +368,7 @@ for other web frameworks, check out the **What's next** section below.
 
 With `vagrant-spk`, before you can develop a second app, you must stop
 the virtual machine created as part of developing the first one.  This
-is because the `vagrant-spk` virtual machine always uses port 6080.
+is because the `vagrant-spk` virtual machine always uses port 6090.
 
 In our case, we're done using the virtual machine running this app, so
 it's safe to stop it. Run this command:
@@ -402,7 +380,7 @@ vagrant-spk vm halt
 
 This shuts down the whole virtual machine used for developing your
 app's Sandstorm package, including the Sandstorm install specific to
-that app's packaging work. Now port 6080 is available for other app
+that app's packaging work. Now port 6090 is available for other app
 packaging projects.
 
 If you ever want to work on this app's packaging again, you can bring

--- a/docs/vagrant-spk/packaging-tutorial.md
+++ b/docs/vagrant-spk/packaging-tutorial.md
@@ -149,31 +149,12 @@ Eventually, you will see this mesage:
 
 and get your shell back. At this point, you can continue to the next step.
 
-**Troubleshooting note**: If you already have Sandstorm installed on your laptop,
-you might see the following red text:
-
-```bash
-Vagrant cannot forward the specified ports on this VM, since they
-would collide with some other application that is already listening
-on these ports. The forwarded port to 6080 is already in use
-on the host machine.
-```
-
-If you see that, run:
-
-```bash
-sudo service sandstorm stop
-```
-
-and halt any other `vagrant-spk` virtual machines you might be using to develop
-other apps.
-
 ## Examine the Sandstorm instance you will develop against
 
 Your system is now running a Sandstorm instance. You should visit it in your web browser now by
 opening this link.
 
-[http://local.sandstorm.io:6080/](http://local.sandstorm.io:6080/)
+[http://local.sandstorm.io:6090/](http://local.sandstorm.io:6090/)
 
 Some quick facts on how that works:
 
@@ -184,7 +165,7 @@ Some quick facts on how that works:
   local.sandstorm.io instead of `localhost` because all subdomains of local.sandstorm.io also point
   at the localhost IP address. You can read more about [wildcard DNS.](../administering/wildcard.md)
 
-- Sandstorm uses port 6080 by default.
+- Sandstorm uses port 6080 by default. vagrant-spk uses port 6090 by default.
 
 Take a moment now to sign in by clicking on **Sign in** in the top-right corner.
 Choose **Sign in with a Dev account** and choose **Alice (admin)** as the user
@@ -195,9 +176,6 @@ the experience of using your app as other users.
 
 Over the next few steps, we will prepare the app so that it is visible in that
 Sandstorm instance.
-
-<!--(**Editor's note**: We should make localhost:6080 work, so that people don't have to learn about `local.sandstorm.io`.)-->
-
 
 ## Use vagrant-spk to create a package definition file for your app
 
@@ -262,7 +240,7 @@ On the terminal, you will see a message like:
 App is now available from Sandstorm server. Ctrl+C to disconnect.
 ```
 
-Now you can visit the Sandstorm at http://local.sandstorm.io:6080/ and log in
+Now you can visit the Sandstorm at http://local.sandstorm.io:6090/ and log in
 as **Alice (admin)**. Your app name should appear in the list of apps.
 
 You can click **New showcase** and see the PHP code running.
@@ -329,7 +307,7 @@ for other web frameworks, check out the **What's next** section below.
 
 With `vagrant-spk`, before you can develop a second app, you must stop
 the virtual machine created as part of developing the first one.  This
-is because the `vagrant-spk` virtual machine always uses port 6080.
+is because the `vagrant-spk` virtual machine always uses port 6090.
 
 In our case, we're done using the virtual machine running this app, so
 it's safe to stop it. Run this command:
@@ -340,7 +318,7 @@ vagrant-spk vm halt
 
 (You should be running it from the `~/projects/php-app-to-package-for-sandstorm` directory.)
 
-Now port 6080 is available for other app packaging projects. If you ever want to work on
+Now port 6090 is available for other app packaging projects. If you ever want to work on
 this app's packaging again, you can bring it up by running:
 
 ```bash

--- a/docs/vagrant-spk/platform-stacks.md
+++ b/docs/vagrant-spk/platform-stacks.md
@@ -54,7 +54,7 @@ For a Meteor app, keep the following in mind:
 * Run `vagrant-spk setupvm meteor`
 * Run `vagrant-spk vm up`. Note this will print _lots_ of red text; sorry about that, then abruptly end.
 * Run `vagrant-spk init` and edit `.sandstorm/sandstorm-pkgdef.capnp`
-* Run `vagrant-spk dev` and make sure the app works OK at http://local.sandstorm.io:6080/
+* Run `vagrant-spk dev` and make sure the app works OK at http://local.sandstorm.io:6090/
 * Run `vagrant-spk pack ~/projects/meteor-package.spk` and you have a package file!
 
 **Troubleshooting**


### PR DESCRIPTION
This changes all the vagrant-spk tutorials to specify using port 6090 instead of port 6080, which should be true for new packages made after the merge of https://github.com/sandstorm-io/vagrant-spk/pull/260

I also drive-by-deleted a line about the minimum version of vagrant-spk required to use enter-grain, because that was four years ago and the Docs reflect the current state of vagrant-spk anyways, which is very much different than four years ago.