### PR TITLE
Actions: Don't upload every build, BUILD 0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           set -o pipefail
           # Currently these tests never pass.
           # TODO: When they are fixed, remove the || true
-          (make BUILD=${{ env.BUILD }} test |& tee testlog.txt; echo "Result: $?") || true
+          (make test |& tee testlog.txt; echo "Result: $?") || true
       - name: upload test log
         if: always()
         uses: actions/upload-artifact@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: build_and_test
 on: [push, pull_request]
 
 env:
-  BUILD: 9999
   CCACHE_DIR: ${{ github.workspace }}/.ccache"
   # TODO: remove this. See https://github.com/sandstorm-io/sandstorm/issues/3188
   SKIP_UNITTESTS: 1
@@ -58,11 +57,11 @@ jobs:
       #  with:
       #    name: ccache-debug.tar.gz
       #    path: ccache-debug.tar.gz
-      - name: upload sandstorm tarball
-        uses: actions/upload-artifact@v1
-        with:
-          name: sandstorm-${{ env.BUILD }}-fast.tar.xz
-          path: sandstorm-${{ env.BUILD }}-fast.tar.xz
+      #- name: upload sandstorm tarball
+      #  uses: actions/upload-artifact@v1
+      #  with:
+      #    name: sandstorm-${{ env.BUILD }}-fast.tar.xz
+      #    path: sandstorm-${{ env.BUILD }}-fast.tar.xz
       - name: test
         run: |
           set -o pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,8 +60,8 @@ jobs:
       #- name: upload sandstorm tarball
       #  uses: actions/upload-artifact@v1
       #  with:
-      #    name: sandstorm-${{ env.BUILD }}-fast.tar.xz
-      #    path: sandstorm-${{ env.BUILD }}-fast.tar.xz
+      #    name: sandstorm-0-fast.tar.xz
+      #    path: sandstorm-0-fast.tar.xz
       - name: test
         run: |
           set -o pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
             export CCACHE_SLOPPINESS="time_macros"
             export PATH=/usr/lib/ccache:$CLANGDIR:$PATH
 
-            make BUILD=${{ env.BUILD }} \
+            make \
               CC="$(which clang)" \
               CXX="$(which clang++)" \
               fast


### PR DESCRIPTION
As noted in reviews of #3208 it could be dangerous to install a build 9999, and the default behavior (build 0) is assumed to be a dev build. It's probably not super necessary to upload every single built Sandstorm test for every commit and PR either, but it's just commented out in case we want to restore it.

Side note: I haven't tested this, but creating a PR should test it?