### PR TITLE
Docs: Remove calls to email

### DIFF
--- a/docs/administering/active-directory.md
+++ b/docs/administering/active-directory.md
@@ -15,14 +15,14 @@ security benefit, the Sandstorm software never sees the user's passwords. This r
 support for SAML 2.0.
 
 This document provides textual advice as well as a great deal of screenshots to allow you to proceed
-with confidence. If you have questions, please email support@sandstorm.io. We want to help you
+with confidence. If you have questions, please [open an issue on GitHub](https://github.com/sandstorm-io/sandstorm/issues/new). We want to help you
 successfully set up Sandstorm!
 
 Note that you can also set up Sandstorm to integrate with Active Directory using LDAP bind to
 authenticate users. We recommend Active Directory Federation Services or Microsoft Azure AD Single
 Sign-On instead. Both of these products use SAML for authentication. If you must use LDAP bind for
 authentication instead, see the general [documentation about
-LDAP](for-work.md#authentication-provider-ldap) or email support@sandstorm.io.
+LDAP](for-work.md#authentication-provider-ldap).
 
 ## Windows Azure Active Directory
 

--- a/docs/administering/faq.md
+++ b/docs/administering/faq.md
@@ -424,7 +424,7 @@ to address the issue.
   the Sandstorm MongoDB instance, note that grain data is safely stored separately, so any grain data
   would not be affected.
 
-To get further help, please email support@sandstorm.io. Please include the most recent 100 lines
+To get further help, please [open an issue on GitHub](https://github.com/sandstorm-io/sandstorm/issues/new). Please include the most recent 100 lines
 from the MongoDB log file, if you can.
 
 ## Installing and running without root privileges
@@ -450,8 +450,7 @@ namespaces. If you use the userns-based sandbox, please be sure to keep up to da
 updates.
 
 - **People who don't know how to change a Linux kernel.** If you are a customer of a hosting
-  provider, please ask your hosting provider to read this page. They are also welcome to email the
-  Sandstorm team at [support@sandstorm.io.](mailto:support@sandstorm.io)
+  provider, please ask your hosting provider to read this page.
 
 - **Arch Linux users.** We suggest starting Sandstorm as root instead to avoid the dependency on
   user namespaces. In [#36969](https://bugs.archlinux.org/task/36969), the Arch Linux kernel
@@ -599,8 +598,8 @@ computer, we can suggest the following, though we haven't personally tried them.
   $130 at the time of writing.
 
 We are focusing on x86-64 because we only have so much time in the day. If you're a volunteer and
-interested in tackling the ARM/multi-architecture situation, then please email us at
-community@sandstorm.io.
+interested in tackling the ARM/multi-architecture situation, then please speak up on the
+[related issue](https://github.com/sandstorm-io/sandstorm/issues/2083).
 
 There are a few obstacles we'd need to overcome for Sandstorm to provide a good experience
 on ARM.

--- a/docs/administering/for-work.md
+++ b/docs/administering/for-work.md
@@ -137,7 +137,7 @@ Implementation notes for LDAP that may apply to your site:
   objects match the username. In this case, you probably need to add a custom **LDAP Search
   Filter** under "Additional LDAP filter criteria. Your search filter should typically take the form
   of `(&(something))` so that it is AND'd against the default Sandstorm LDAP query used when a user
-  is logging in. Contact us at support@sandstorm.io if you need help.
+  is logging in.
 
 - Some LDAP servers require authentication before permitting a search. In that case, you will need
   to configure an **Bind user DN** and **Bind user password**, a user and password for the search

--- a/docs/administering/guide.md
+++ b/docs/administering/guide.md
@@ -112,9 +112,8 @@ UPDATE_CHANNEL=none
 
 We intend to follow the Chrome update channels system, but for now we only have a `dev` channel.
 
-We strongly recommend that you keep automatic updates enabled. If you want to disable it, please
-email support@sandstorm.io so we can work with you to stay up to date some other way. We intend for
-our automatic updates to not cause any downtime.
+We strongly recommend that you keep automatic updates enabled. This is a work in progress, but
+we intend for our automatic updates to not cause any downtime.
 
 ### Sandstorm apps
 

--- a/docs/administering/reverse-proxy.md
+++ b/docs/administering/reverse-proxy.md
@@ -25,7 +25,7 @@ Sandstorm requires WebSockets support; to enable that, make sure to pay attentio
 `RewriteRule` stanzas in the example configuration.
 
 If you use a non-nginx, non-Apache2 reverse proxy, we'd love for you to
-[email us](mailto:community@sandstorm.io) so we can publish example configuration files.
+contribute a pull request with example configuration files.
 
 ### HTTPS or not: you choose
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -46,7 +46,7 @@ The Sandstorm ecosystem is full of people who want to promote your app, give you
 it.
 
 - **Free services from Sandstorm core team**: [Free Oasis service for app authors](https://sandstorm.io/news/2016-02-05-app-author-publicity-oasis)
-- **Getting help**: [Community feedback and Q&A](https://groups.google.com/d/forum/sandstorm-dev) | [Real-time IRC chat on freenode](https://kiwiirc.com/client/irc.freenode.net/?channel=#sandstorm) | [Watch presentations on the Sandstorm YouTube channel](https://www.youtube.com/channel/UC8xKZRW86Fa9W00uAppBXXg) | [Email the core team](mailto:community@sandstorm.io)
+- **Getting help**: [Community feedback and Q&A](https://groups.google.com/d/forum/sandstorm-dev) | [Real-time IRC chat on freenode](https://kiwiirc.com/client/irc.freenode.net/?channel=#sandstorm) | [Watch presentations on the Sandstorm YouTube channel](https://www.youtube.com/channel/UC8xKZRW86Fa9W00uAppBXXg)
 - **Publicity**: [Free icon design for your app](https://sandstorm.io/news/2015-11-10-icons-spks-for-everyone) | [Give a meetup/conference talk about your app](https://sandstorm.io/news/2015-12-17-community-talks) | [Public demo service for all Sandstorm apps](https://sandstorm.io/news/2015-02-06-app-demo) | [General publicity help](https://sandstorm.io/news/2016-02-05-app-author-publicity-oasis)
 - **Read more**: [All community resources](https://sandstorm.io/community)
 

--- a/docs/developing/handbook.md
+++ b/docs/developing/handbook.md
@@ -31,11 +31,6 @@ authoritative source of technical documentation. Within each section,
 we typically link to more detailed documentation. Those detailed
 documents provide further context on how stable each API is.
 
-# Change history
-
-* 2015-02-08: Some clarifications, particularly around access control.
-* 2015-02-06: Initial version.
-
 # A great Sandstorm app
 
 This section explains each brief bullet-point above in more depth.
@@ -397,9 +392,8 @@ Thanks for reading this far!
 Sandstorm is continuously evolving, and we are continuously developing
 it, so some of these details may change. We hope this has been a useful
 overview of the platform and helps you understand the platform's
-goals. We're always eager for feedback; email us at
-community@sandstorm.io. This handbook is very abbreviated; consider
-following the links in each section for more detail.
+goals. This handbook is very abbreviated; consider following the links
+in each section for more detail.
 
 To dig into the design of Sandstorm, read through the [Cap'n Proto
 protocols that govern how it
@@ -417,7 +411,3 @@ conveniently and safely. For example, it is OK to disable some
 features if the app still would be valuable to Sandstorm users. It's
 also OK to create a "monolithic" port if you believe it would be
 useful.
-
-Please check out our [Getting Involved
-page](https://github.com/sandstorm-io/sandstorm/wiki/Get-Involved), or
-send us an email at community@sandstorm.io!

--- a/docs/developing/publishing-apps.md
+++ b/docs/developing/publishing-apps.md
@@ -88,9 +88,7 @@ optional but highly recommended.
 
 ### Sign up with [Keybase.io](https://keybase.io)
 
-Currently, Keybase is invite-only. If you need an invite, you can
-contact [community@sandstorm.io](mailto:community@sandstorm.io). You
-should connect some of your public identites with your Keybase
+You should connect some of your public identities with your Keybase
 account, like Twitter and GitHub.
 
 Sandstorm app authors are verified using a PGP key linked to

--- a/docs/install.md
+++ b/docs/install.md
@@ -259,9 +259,7 @@ You can look at these examples as a starting-point:
 Note that this process uses Sandstorm's install.sh to download Sandstorm. Another option would be if
 Sandstorm provided an APT repository. However, at the time of writing (July 2016), there is no APT
 repository for Sandstorm because we have not yet examined fully how to retain Sandstorm's
-self-containerization and auto-updates in conjunction with an APT repository. If you're interested
-in that feature, please email support@sandstorm.io so we can use that information to prioritize it
-further.
+self-containerization and auto-updates in conjunction with an APT repository.
 
 ## Option 6: Using Sandstorm within Docker
 
@@ -317,10 +315,7 @@ This process uses Sandstorm's install.sh to download Sandstorm, and Sandstorm is
   container and its design currently assumes a single machine.
 
 We're hopeful that the above approach is useful, although we know that it is not the most idiomatic
-use of Docker. If your organization needs deeper integration with Docker, such as a Docker image
-maintained by the Sandstorm team that contains the latest version of Sandstorm, please send an email
-to support@sandstorm.io so we know that customers have a real need for it and can prioritize it
-accordingly.
+use of Docker.
 
 ## Option 7: Use Vagrant when deploying on Mac or Windows
 
@@ -349,7 +344,7 @@ indicating that the service is only visible on the computer where you ran Vagran
 
 We do recommend that you run Sandstorm on a native Linux system, but we understand that this isn't
 always an option. If you need further help making Sandstorm work with Vagrant or within
-virtualization generally, please email support@sandstorm.io.
+virtualization generally, please [open a GitHub issue](https://github.com/sandstorm-io/sandstorm/issues/new).
 
 ## Tips
 

--- a/docs/vagrant-spk/packaging-tutorial-meteor.md
+++ b/docs/vagrant-spk/packaging-tutorial-meteor.md
@@ -20,7 +20,7 @@ This tutorial assumes:
 
 **Windows users, please note**: This tutorial should work for you, but
 you might need to use slightly different commands to do things like
-create directories. Contact community@sandstorm.io if you need help.
+create directories.
 
 ## Overview of Sandstorm packages
 


### PR DESCRIPTION
Kenton stated that community@ is not monitored and is full of spam. And that we should probably not have calls to email support@ everywhere either, especially since people emailing Kenton solely may not get a response as quickly as people who reach out to the community.

In a couple instances, I put in a link that should invite someone to open a GitHub issue. In others, I dropped it entirely as it may not be a focus for us to collect certain requests, and we have enough places users can find a route to contact the community for help. Many of these email references were in old pages migrated from the wiki or the like.

I also fixed one typo, deleted a "changelog" for a file as the changelog is GitHub, and removed the claim Keybase is invite-only.