### PR TITLE
Have "send feedback" link to GitHub issues

### DIFF
--- a/shell/imports/client/accounts/login-buttons.html
+++ b/shell/imports/client/accounts/login-buttons.html
@@ -91,7 +91,7 @@ licenses, included in the LICENSES directory.
     {{/if}}
 
     {{#if showSendFeedback}}
-      <a href="mailto:support@sandstorm.io" target="_blank" role="menuitem">{{_ (con txt "sendFeedback")}}</a>
+      <a href="https://github.com/sandstorm-io/sandstorm/issues" target="_blank" role="menuitem">{{_ (con txt "sendFeedback")}}</a>
     {{/if}}
 
     {{#if referralsEnabled }}


### PR DESCRIPTION
We should have people open GitHub issues with problems/suggestions/feedback rather than emailing Kenton. As it was, I found this link irritating before (#775), because unexpected mailtos often launch unintended email clients in the days most people use webmail.

I chose to not use /new here like I did for Docs, because if you aren't logged into GitHub, that'll present a login screen. I think that's okay for my Docs PR, where the link text says "open an issue on GitHub", and hence, people clicking GitHub will expect to login. But for "Send feedback", sending them to the issues page is the cleanest solution.

docs.microsoft.com literally now just opens GitHub issues for any "feedback" on documentation pages, so this is a totally unheard of pattern, and the community can respond often faster than Kenton can.