### PR TITLE
Docs: Remove offers of services we don't offer

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -45,9 +45,8 @@ Not written yet:
 The Sandstorm ecosystem is full of people who want to promote your app, give you feedback, and use
 it.
 
-- **Free services from Sandstorm core team**: [Free Oasis service for app authors](https://sandstorm.io/news/2016-02-05-app-author-publicity-oasis)
 - **Getting help**: [Community feedback and Q&A](https://groups.google.com/d/forum/sandstorm-dev) | [Real-time IRC chat on freenode](https://kiwiirc.com/client/irc.freenode.net/?channel=#sandstorm) | [Watch presentations on the Sandstorm YouTube channel](https://www.youtube.com/channel/UC8xKZRW86Fa9W00uAppBXXg)
-- **Publicity**: [Free icon design for your app](https://sandstorm.io/news/2015-11-10-icons-spks-for-everyone) | [Give a meetup/conference talk about your app](https://sandstorm.io/news/2015-12-17-community-talks) | [Public demo service for all Sandstorm apps](https://sandstorm.io/news/2015-02-06-app-demo) | [General publicity help](https://sandstorm.io/news/2016-02-05-app-author-publicity-oasis)
+- **Publicity**: [Give a meetup/conference talk about your app](https://sandstorm.io/news/2015-12-17-community-talks) | [Public demo service for all Sandstorm apps](https://sandstorm.io/news/2015-02-06-app-demo)
 - **Read more**: [All community resources](https://sandstorm.io/community)
 
 ---


### PR DESCRIPTION
Since Asheesh is not here to help promote your app, Nena is not here to design your app icons, and Oasis is not here to provide free service to app developers, we should remove all of that. I think eventually community-sponsored initiatives can be added in here, but let's clean this out for now.