### PR TITLE
powerbox-server: dedup code from async-helpers.

### DIFF
--- a/shell/imports/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/imports/sandstorm-ui-powerbox/powerbox-server.js
@@ -14,21 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { waitPromise } from '../server/async-helpers.js';
+
 const Crypto = Npm.require("crypto");
 const Powerbox = Capnp.importSystem("sandstorm/powerbox.capnp");
 const Grain = Capnp.importSystem("sandstorm/grain.capnp");
-
-// TODO(cleanup): lift this out of a package so it can share with async-helpers.js
-const Future = Npm.require("fibers/future");
-const promiseToFuture = (promise) => {
-  const result = new Future();
-  promise.then(result.return.bind(result), result.throw.bind(result));
-  return result;
-};
-
-const waitPromise = (promise) => {
-  return promiseToFuture(promise).wait();
-};
 
 function encodePowerboxDescriptor(desc) {
   return Capnp.serializePacked(Powerbox.PowerboxDescriptor, desc)


### PR DESCRIPTION
Per the (now-deleted) comment, this previously wasn't this simple
because powerbox-server.js was inside of a meteor package, but @zarvox
did a recent refactoring that changed that, so we can just delete the
duplicate and import now.