### PR TITLE
Docs: Square off search box

### DIFF
--- a/docs/sandstorm_readthedocs_modified_theme/css/theme_extra.css
+++ b/docs/sandstorm_readthedocs_modified_theme/css/theme_extra.css
@@ -88,7 +88,7 @@ pre .cs, pre .c {
 
 form .search-query {
     width: 100%;
-    border-radius: 50px;
+    border-radius: 4px;
     padding: 6px 12px;  /* csslint allow: box-model */
     border-color: #D1D4D5;
 }


### PR DESCRIPTION
Sandstorm.io and the App Market have a very angular look, as does the Sandstorm UI itself. A 4px border-radius is common on sandstorm.io buttons, and I think it makes Docs a bit more fitting with the overall branding.