### PR TITLE
Mount a tmpfs at /dev/shm in the sandbox.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,9 @@ NODE_HEADERS=$(METEOR_DEV_BUNDLE)/include/node
 WARNINGS=-Wall -Wextra -Wglobal-constructors -Wno-sign-compare -Wno-unused-parameter
 CXXFLAGS2=-std=c++1z $(WARNINGS) $(CXXFLAGS) -DSANDSTORM_BUILD=$(BUILD) -DKJ_HAS_OPENSSL -DKJ_HAS_ZLIB -DKJ_HAS_LIBDL -pthread -fPIC -I$(NODE_HEADERS) -DKJ_STD_COMPAT
 CFLAGS2=$(CFLAGS) -pthread -fPIC -DKJ_STD_COMPAT
-LIBS2=$(LIBS) deps/libsodium/build/src/libsodium/.libs/libsodium.a deps/boringssl/build/ssl/libssl.a deps/boringssl/build/crypto/libcrypto.a -lz -ldl -pthread
+# -lrt is not used by sandstorm itself, but the test app uses it. It would be
+#  nice if we could not link everything against it.
+LIBS2=$(LIBS) deps/libsodium/build/src/libsodium/.libs/libsodium.a deps/boringssl/build/ssl/libssl.a deps/boringssl/build/crypto/libcrypto.a -lz -ldl -pthread -lrt
 
 define color
   printf '\033[0;34m==== $1 ====\033[0m\n'

--- a/src/sandstorm/test-app/test-app.html
+++ b/src/sandstorm/test-app/test-app.html
@@ -155,5 +155,7 @@ function doPowerboxRequest(desc) {
 
     <p><button onclick="postScheduledJob({shouldCancel: false, refStr: 'oneshot'})" id="do-schedule-oneshot">
       Schedule a one-shot job.</button></p>
+
+    <p><button onclick="doPost('/test-system-api', '')" id="do-test-system-api">Test the system api.</button></p>
   </body>
 </html>

--- a/tests/tests/system-api.js
+++ b/tests/tests/system-api.js
@@ -1,0 +1,47 @@
+// Sandstorm - Personal Cloud Sandbox
+// Copyright (c) 2020 Sandstorm Development Group, Inc. and contributors
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+"use strict";
+
+const { short_wait } = require('../utils');
+
+module.exports = {};
+
+module.exports["Test system api"] = function(browser) {
+  const selector = "#do-test-system-api";
+  browser
+    .init()
+    .loginDevAccount()
+    .uploadTestApp()
+    .assert.containsText("#grainTitle", "Untitled Sandstorm Test App instance")
+    // Start opening this now, so we don't have to wait for it later when we
+    // want to use it:
+    .click("#openDebugLog")
+    .grainFrame()
+    .waitForElementPresent(selector, short_wait)
+    .click(selector)
+    .pause(short_wait)
+    .windowHandles(windows => browser.switchWindow(windows.value[1]))
+    .waitForElementVisible(".grainlog-contents > pre", short_wait)
+    .assert.containsText(".grainlog-contents > pre", "testSystemApi() passed.")
+
+  // Close the grain log, and switch back to to the main window, to avoid
+  // confusing future tests:
+  browser.windowHandles(windows => {
+    browser.closeWindow()
+    browser.switchWindow(windows.value[0])
+  })
+}


### PR DESCRIPTION
...To get shm_open() and friends working.

Fixes #3196.

Note that the tests are currently *not* passing on my machine -- for some reason `shm_open` is returning `ENOSYS`. Based on the links @abliss posted at:

https://github.com/sandstorm-io/sandstorm/issues/3196#issuecomment-580909238

and the fact that there are two alternate implementations of `shm_open`, depending on build flags:

https://sourceware.org/git/?p=glibc.git;a=blob;f=rt/shm_open.c;h=b4623d3cdaf5a26e4fd795a866c12aa1b29eaa9a;hb=HEAD

...one possible explanation is that my system's glibc is built without support for this. So I'd be curious as to whether the tests pass for others. Grepping through the postgres source suggests it has some fallbacks if shm_open is not available, so another possibility is that the errors @orblivion saw re: `/dev/shm` weren't actually going through `shm_open`.

We should investigate and work out what's going on there before merging this.