### PR TITLE
Incremental frontend refactorings

### DIFF
--- a/shell/client/main.ts
+++ b/shell/client/main.ts
@@ -38,11 +38,7 @@
 
 // Load packages that the sandstorm shell depends on before sandstorm itself.
 
-// sandstorm-identicons.
-import "../imports/sandstorm-identicons/identicon.js";
-import "../imports/sandstorm-identicons/helpers.js";
-
-// sandstorm-db.  Depends on sandstorm-identicons.
+// sandstorm-db.
 import "../imports/sandstorm-db/db.js";
 import "../imports/sandstorm-db/profile.js";
 

--- a/shell/client/main.ts
+++ b/shell/client/main.ts
@@ -138,6 +138,7 @@ import "../imports/client/grain/grainlist-client.js";
 import "../imports/client/setup-wizard/wizard.js";
 import "../imports/client/vendor/ansi-up.js";
 import "../imports/client/widgets/widgets-client.js";
+import "../imports/db-deprecated.js";
 import "../imports/client/00-startup.js";
 import "../imports/client/admin-client.js";
 import "../imports/client/demo-client.js";

--- a/shell/imports/blackrock-payments/client/billingPrompt.js
+++ b/shell/imports/blackrock-payments/client/billingPrompt.js
@@ -14,7 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 var idCounter = 0;
 

--- a/shell/imports/blackrock-payments/client/billingSettings.js
+++ b/shell/imports/blackrock-payments/client/billingSettings.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { Template } from "meteor/templating";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 var messageListener = function (showPrompt, template, event) {
   if (event.origin !== window.location.protocol + "//" + makeWildcardHost("payments")) {

--- a/shell/imports/blackrock-payments/client/payments-api-client.js
+++ b/shell/imports/blackrock-payments/client/payments-api-client.js
@@ -14,6 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
+
 Template.stripePaymentAcceptorPowerboxConfiguration.events({
   "submit form"(event) {
     event.preventDefault();

--- a/shell/imports/blackrock-payments/server/payments-api-server.js
+++ b/shell/imports/blackrock-payments/server/payments-api-server.js
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Crypto from "crypto";
 const PaymentsRpc = Capnp.importSystem("sandstorm/payments.capnp");
-import Crypto from 'crypto';
 
 function wrapAsyncAsPromise(obj, func) {
   if (typeof func === "string") {

--- a/shell/imports/blackrock-payments/server/payments-api-server.js
+++ b/shell/imports/blackrock-payments/server/payments-api-server.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import Crypto from "crypto";
+import Capnp from "/imports/server/capnp.js";
 const PaymentsRpc = Capnp.importSystem("sandstorm/payments.capnp");
 
 function wrapAsyncAsPromise(obj, func) {

--- a/shell/imports/blackrock-payments/server/payments-server.js
+++ b/shell/imports/blackrock-payments/server/payments-server.js
@@ -26,6 +26,8 @@ import Crypto from "crypto";
 import Url from 'url';
 import StripeModule from "stripe";
 
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
+
 const ROOT_URL = process.env.ROOT_URL;
 const HOSTNAME = Url.parse(ROOT_URL).hostname;
 

--- a/shell/imports/blackrock-payments/server/payments-server.js
+++ b/shell/imports/blackrock-payments/server/payments-server.js
@@ -22,12 +22,14 @@
 //       mailingList: Boolean, true if user is subscribed to mailing list.
 //       metadata: A structure like plan.bonus but representing bonuses from Stripe metadata.
 
-var Crypto = Npm.require("crypto");
-var Url = Npm.require('url');
-var ROOT_URL = process.env.ROOT_URL;
-var HOSTNAME = Url.parse(ROOT_URL).hostname;
+import Crypto from "crypto";
+import Url from 'url';
+import StripeModule from "stripe";
 
-stripe = Npm.require("stripe")(Meteor.settings.stripeKey);
+const ROOT_URL = process.env.ROOT_URL;
+const HOSTNAME = Url.parse(ROOT_URL).hostname;
+
+stripe = StripeModule(Meteor.settings.stripeKey);
 
 BlackrockPayments = {};
 

--- a/shell/imports/client/00-startup.js
+++ b/shell/imports/client/00-startup.js
@@ -20,7 +20,6 @@ if ('serviceWorker' in navigator) {
   })
 }
 
-import "/imports/db-deprecated.js";
 import AccountsUi from "/imports/client/accounts/accounts-ui.js";
 import { GrainViewList } from "/imports/client/grain/grainview-list.js";
 

--- a/shell/imports/client/accounts/account-settings.js
+++ b/shell/imports/client/accounts/account-settings.js
@@ -14,9 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import { formatFutureTime } from "/imports/dates.js";
 import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants.js";
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 Template.sandstormAccountSettings.onCreated(function () {
   this.autorun(() => {

--- a/shell/imports/client/accounts/credentials/credentials-client.js
+++ b/shell/imports/client/accounts/credentials/credentials-client.js
@@ -14,6 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Mongo } from "meteor/mongo";
+import { check } from "meteor/check";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
+
 const LoginCredentialsOfLinkedAccounts = new Mongo.Collection("loginCredentialsOfLinkedAccounts");
 // Pseudocollection populated by the `accountsOfCredential(sourceCredentialId)` subscription. Contains
 // information about all login credentials for all accounts that have the "source credential" linked.

--- a/shell/imports/client/accounts/email-token/token-client.js
+++ b/shell/imports/client/accounts/email-token/token-client.js
@@ -14,10 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import {
   loginWithEmailToken,
   createAndEmailTokenForUser,
 } from "/imports/client/accounts/email-token/token-login-helpers.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 // Email token login routes.
 Router.route("/_emailLogin/:_email/:_token", function () {

--- a/shell/imports/client/accounts/login-buttons.js
+++ b/shell/imports/client/accounts/login-buttons.js
@@ -19,6 +19,9 @@
 // licenses, included in the LICENSES directory.
 // ====================================================================
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+import { Template } from "meteor/templating";
 import {
   loginWithEmailToken,
   createAndEmailTokenForUser,
@@ -27,6 +30,7 @@ import { GrainViewList } from '/imports/client/grain/grainview-list.js';
 import { loginWithLDAP } from "/imports/client/accounts/ldap/ldap-client.js";
 import { loginWithSaml } from "/imports/client/accounts/saml/saml-client.js";
 import AccountsUi from "/imports/client/accounts/accounts-ui.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 // for convenience
 const loginButtonsSession = Accounts._loginButtonsSession;

--- a/shell/imports/client/admin/network-capabilities-client.js
+++ b/shell/imports/client/admin/network-capabilities-client.js
@@ -1,3 +1,7 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
+
 function deriveIntroducer(cap) {
   // For a given ApiToken, determine the account ID of the user who should be attributed for
   // creating the token.

--- a/shell/imports/client/admin/stats-client.js
+++ b/shell/imports/client/admin/stats-client.js
@@ -1,3 +1,8 @@
+import { Meteor } from "meteor/meteor";
+import { Mongo } from "meteor/mongo";
+import { Template } from "meteor/templating";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
+
 // Pseudo-collection defined via publish.
 const RealTimeStats = new Mongo.Collection("realTimeStats");
 

--- a/shell/imports/client/admin/user-accounts-client.js
+++ b/shell/imports/client/admin/user-accounts-client.js
@@ -1,3 +1,7 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+import { SandstormDb } from "/imports/sandstorm-db/db.js"
+
 const matchesUser = function (searchKey, user) {
   // We match a user if we can find the searchKey in one of the following fields:
   //   * Account ID

--- a/shell/imports/client/admin/user-details-client.js
+++ b/shell/imports/client/admin/user-details-client.js
@@ -1,5 +1,8 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import { formatFutureTime } from "/imports/dates.js";
 import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 Template.newAdminUserDetailsCredentialTableRow.helpers({
   isOrganizationMember(credential) {

--- a/shell/imports/client/apps/app-details-client.js
+++ b/shell/imports/client/apps/app-details-client.js
@@ -1,4 +1,7 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import { iconSrcForPackage } from "/imports/sandstorm-identicons/helpers.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const latestPackageForAppId = function (db, appId) {
   // Dev apps mask current package version.

--- a/shell/imports/client/apps/app-details-client.js
+++ b/shell/imports/client/apps/app-details-client.js
@@ -1,3 +1,5 @@
+import { iconSrcForPackage } from "/imports/sandstorm-identicons/helpers.js";
+
 const latestPackageForAppId = function (db, appId) {
   // Dev apps mask current package version.
   const devPackage = db.collections.devPackages.findOne({ appId: appId });
@@ -125,7 +127,7 @@ Template.sandstormAppDetails.helpers({
   appIconSrc: function () {
     const ref = Template.instance().data;
     const pkg = ref.pkg;
-    return pkg && Identicon.iconSrcForPackage(pkg, "appGrid", window.location.protocol + "//" + ref.staticHost);
+    return pkg && iconSrcForPackage(pkg, "appGrid", window.location.protocol + "//" + ref.staticHost);
   },
 
   appId: function () {

--- a/shell/imports/client/apps/applist-client.js
+++ b/shell/imports/client/apps/applist-client.js
@@ -1,4 +1,5 @@
 import { introJs } from "intro.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 SandstormAppList = function (db, quotaEnforcer) {
   this._filter = new ReactiveVar("");

--- a/shell/imports/client/apps/install-client.js
+++ b/shell/imports/client/apps/install-client.js
@@ -1,3 +1,7 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
+
 const INSTALL_STEPS = ["download", "verify", "unpack", "analyze", "ready", "failed", "delete"];
 const checkStep = function (step) {
   if (INSTALL_STEPS.indexOf(step) === -1) throw new Error("Invalid step " + step + ".");

--- a/shell/imports/client/contacts.js
+++ b/shell/imports/client/contacts.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Mongo } from "meteor/mongo";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
+
 const transform = function (contact) {
   SandstormDb.fillInPictureUrl(contact);
   return contact;

--- a/shell/imports/client/demo-client.js
+++ b/shell/imports/client/demo-client.js
@@ -14,7 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
 import { allowDemo } from "/imports/demo.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 Meteor.loginWithDemo = function (options, callback) {
   Router.go("demo");

--- a/shell/imports/client/desktop-notifications-client.js
+++ b/shell/imports/client/desktop-notifications-client.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
+import { iconSrcForPackage, identiconForApp } from "/imports/sandstorm-identicons/helpers.js";
 
 // Test if localStorage is usable.
 // We can't use Meteor._localStorage for this because we need to be able to enumerate the elements
@@ -81,7 +82,7 @@ const showActivityDesktopNotification = (notif) => {
     const pkg = globalDb.collections.devPackages.findOne({ appId: grain.appId }) ||
                 globalDb.collections.packages.findOne({ _id: grain.packageId });
     if (pkg) {
-      appIcon = Identicon.iconSrcForPackage(pkg, "notification", staticPrefix);
+      appIcon = iconSrcForPackage(pkg, "notification", staticPrefix);
     }
 
     // We are the canonical title of this grain.
@@ -101,7 +102,7 @@ const showActivityDesktopNotification = (notif) => {
       if (meta && meta.icon && meta.icon.assetId) {
         appIcon = staticPrefix + "/" + meta.icon.assetId;
       } else {
-        appIcon = Identicon.identiconForApp((meta && meta.appId) || "00000000000000000000000000000000");
+        appIcon = identiconForApp((meta && meta.appId) || "00000000000000000000000000000000");
       }
 
       const titleObj = computeTitleFromTokenOwnerUser(tokenOwnerUser);

--- a/shell/imports/client/grain-client.js
+++ b/shell/imports/client/grain-client.js
@@ -16,12 +16,17 @@
 
 // This file implements /grain, i.e. the main view into an app.
 
+import { Meteor } from "meteor/meteor";
+import { Mongo } from "meteor/mongo";
+import { Match, check } from "meteor/check";
+import { Template } from "meteor/templating";
 import { introJs } from "intro.js";
 
 import downloadFile from "/imports/client/download-file.js";
 import { ContactProfiles } from "/imports/client/contacts.js";
 import { isStandalone } from "/imports/client/standalone.js";
 import { GrainView } from "/imports/client/grain/grainview.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 // Pseudo-collections.
 TokenInfo = new Mongo.Collection("tokenInfo");

--- a/shell/imports/client/grain/grainlist-client.js
+++ b/shell/imports/client/grain/grainlist-client.js
@@ -1,4 +1,5 @@
 import { introJs } from "intro.js";
+import { identiconForApp } from "/imports/sandstorm-identicons/helpers.js";
 
 SandstormGrainListPage = {};
 
@@ -41,7 +42,7 @@ SandstormGrainListPage.mapApiTokensToTemplateObject = function (apiTokens, stati
     // TODO(someday): use source sets and the dpi2x value
     const iconSrc = (grainInfo && grainInfo.icon && grainInfo.icon.assetId) ?
         (window.location.protocol + "//" + staticAssetHost + "/" + grainInfo.icon.assetId) :
-        Identicon.identiconForApp((grainInfo && grainInfo.appId) || "00000000000000000000000000000000");
+        identiconForApp((grainInfo && grainInfo.appId) || "00000000000000000000000000000000");
     const result = {
       _id: grainId,
       title: ownerData.title,

--- a/shell/imports/client/grain/grainlist-client.js
+++ b/shell/imports/client/grain/grainlist-client.js
@@ -1,5 +1,6 @@
 import { introJs } from "intro.js";
 import { identiconForApp } from "/imports/sandstorm-identicons/helpers.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 SandstormGrainListPage = {};
 

--- a/shell/imports/client/grain/grainview-list.js
+++ b/shell/imports/client/grain/grainview-list.js
@@ -16,6 +16,7 @@
 
 import { GrainView, onceConditionIsTrue } from "./grainview.js";
 import { isStandalone } from "/imports/client/standalone.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 class GrainViewList {
   constructor(db) {

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -14,10 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Match, check } from "meteor/check";
+import { Template } from "meteor/templating";
 import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
 import { isStandalone } from "/imports/client/standalone.js";
 import { GrainViewList } from "/imports/client/grain/grainview-list.js";
 import { identiconForApp, iconSrcForPackage } from "/imports/sandstorm-identicons/helpers.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 let counter = 0;
 

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -17,6 +17,7 @@
 import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
 import { isStandalone } from "/imports/client/standalone.js";
 import { GrainViewList } from "/imports/client/grain/grainview-list.js";
+import { identiconForApp, iconSrcForPackage } from "/imports/sandstorm-identicons/helpers.js";
 
 let counter = 0;
 
@@ -680,7 +681,7 @@ class GrainView {
 
   _fallbackIdenticon() {
     // identifier is SHA1('');
-    return Identicon.identiconForApp("da39a3ee5e6b4b0d3255bfef95601890afd80709", "grain");
+    return identiconForApp("da39a3ee5e6b4b0d3255bfef95601890afd80709", "grain");
   }
 
   _urlForAsset(assetId) {
@@ -699,7 +700,7 @@ class GrainView {
       if (grain) {
         const pkg = this._db.collections.devPackages.findOne({ appId: grain.appId }) ||
                   this._db.collections.packages.findOne({ _id: grain.packageId });
-        if (pkg) return Identicon.iconSrcForPackage(pkg, "grain", window.location.protocol + "//" + makeWildcardHost("static"));
+        if (pkg) return iconSrcForPackage(pkg, "grain", window.location.protocol + "//" + makeWildcardHost("static"));
       }
     } else if (!this._isUsingAnonymously()) {
       // Case 2
@@ -713,7 +714,7 @@ class GrainView {
       if (apiToken) {
         const meta = apiToken.owner.user.denormalizedGrainMetadata;
         if (meta && meta.icon && meta.icon.assetId) return this._urlForAsset(meta.icon.assetId);
-        if (meta && meta.appId) return Identicon.identiconForApp(meta.appId, "grain");
+        if (meta && meta.appId) return identiconForApp(meta.appId, "grain");
       }
     } else {
       // Case 3
@@ -721,7 +722,7 @@ class GrainView {
       if (tokenInfo && tokenInfo.grainMetadata) {
         const meta = tokenInfo.grainMetadata;
         if (meta.icon) return this._urlForAsset(meta.icon.assetId);
-        if (meta.appId) return Identicon.identiconForApp(meta.appId, "grain");
+        if (meta.appId) return identiconForApp(meta.appId, "grain");
       }
     }
 

--- a/shell/imports/client/notifications-client.js
+++ b/shell/imports/client/notifications-client.js
@@ -14,8 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
 import { iconSrcForPackage, iconSrcForDenormalizedGrainMetadata } from "/imports/sandstorm-identicons/helpers.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 testNotifications = () => {
   // Run on console to create some dummy notifications for the purpose of seeing what they look

--- a/shell/imports/client/notifications-client.js
+++ b/shell/imports/client/notifications-client.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
+import { iconSrcForPackage, iconSrcForDenormalizedGrainMetadata } from "/imports/sandstorm-identicons/helpers.js";
 
 testNotifications = () => {
   // Run on console to create some dummy notifications for the purpose of seeing what they look
@@ -96,11 +97,11 @@ Template.notificationsPopup.helpers({
           if (grain.packageId) {
             const pkg = Packages.findOne(grain.packageId);
             if (pkg) {
-              row.grainIcon = Identicon.iconSrcForPackage(pkg, usage, staticPrefix);
+              row.grainIcon = iconSrcForPackage(pkg, usage, staticPrefix);
             } else {
               const devPackage = DevPackages.findOne({ appId: grain.appId });
               if (devPackage) {
-                row.grainIcon = Identicon.iconSrcForPackage(devPackage, usage, staticPrefix);
+                row.grainIcon = iconSrcForPackage(devPackage, usage, staticPrefix);
               }
             }
           }
@@ -117,7 +118,7 @@ Template.notificationsPopup.helpers({
           if (apiToken) {
             const tokenOwnerUser = apiToken.owner.user;
             const meta = tokenOwnerUser.denormalizedGrainMetadata;
-            row.grainIcon = Identicon.iconSrcForDenormalizedGrainMetadata(meta, usage, staticPrefix);
+            row.grainIcon = iconSrcForDenormalizedGrainMetadata(meta, usage, staticPrefix);
 
             const titleObj = computeTitleFromTokenOwnerUser(tokenOwnerUser);
             row.grainTitle = titleObj.title;

--- a/shell/imports/client/shell-client.js
+++ b/shell/imports/client/shell-client.js
@@ -17,9 +17,12 @@
 // This file implements the common shell components such as the top bar.
 // It also covers the root page.
 
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import getBuildInfo from "/imports/client/build-info.js";
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
 import { isStandalone } from "/imports/client/standalone.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 // Subscribe to basic grain information first and foremost, since
 // without it we might e.g. redirect to the wrong place on login.

--- a/shell/imports/client/transfers-client.js
+++ b/shell/imports/client/transfers-client.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
+
 function isValidServerUrl(str) {
   let url;
   try {

--- a/shell/imports/db-deprecated.js
+++ b/shell/imports/db-deprecated.js
@@ -23,6 +23,9 @@
 //   the `globalDb` global should NOT go with it; the package should expect a SandstormDb to be
 //   passed in, thus allowing mocking the database for unit tests.
 
+import { Meteor } from "meteor/meteor";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
+
 let quotaManager;
 if (Meteor.isServer) {
   import { LDAP } from "/imports/server/accounts/ldap.js";
@@ -43,6 +46,7 @@ if (Meteor.isServer) {
   };
 }
 
+// TODO(cleanup) explicitly export all of these
 globalDb = new SandstormDb(quotaManager);
 
 Packages = globalDb.collections.packages;

--- a/shell/imports/sandstorm-accounts-packages/accounts.js
+++ b/shell/imports/sandstorm-accounts-packages/accounts.js
@@ -1,3 +1,6 @@
+import { Meteor } from "meteor/meteor";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
+
 if (Meteor.isClient) {
   Meteor.loginWithGoogle = function (options, callback) {
     // support a callback without options

--- a/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
+++ b/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
@@ -18,6 +18,7 @@
 // Figure out a new strategy for making sure we run tests.
 
 import Crypto from "crypto";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const globalDb = new SandstormDb();
 // TODO(cleanup): Use a lightweight fake (minimongo-based?) database here and construct a clean

--- a/shell/imports/sandstorm-db/db.js
+++ b/shell/imports/sandstorm-db/db.js
@@ -16,6 +16,8 @@
 
 // This file defines the database schema.
 
+import { iconSrcForPackage } from "/imports/sandstorm-identicons/helpers.js";
+
 // Useful for debugging: Set the env variable LOG_MONGO_QUERIES to have the server write every
 // query it makes, so you can see if it's doing queries too often, etc.
 if (Meteor.isServer && process.env.LOG_MONGO_QUERIES) {
@@ -1457,7 +1459,7 @@ _.extend(SandstormDb.prototype, {
   },
 
   iconSrcForPackage(pkg, usage) {
-    return Identicon.iconSrcForPackage(pkg, usage, httpProtocol + "//" + this.makeWildcardHost("static"));
+    return iconSrcForPackage(pkg, usage, httpProtocol + "//" + this.makeWildcardHost("static"));
   },
 
   getDenormalizedGrainInfo(grainId) {

--- a/shell/imports/sandstorm-db/db.js
+++ b/shell/imports/sandstorm-db/db.js
@@ -16,6 +16,9 @@
 
 // This file defines the database schema.
 
+import { Meteor } from "meteor/meteor";
+import { Mongo } from "meteor/mongo";
+import { Match, check } from "meteor/check";
 import { iconSrcForPackage } from "/imports/sandstorm-identicons/helpers.js";
 
 // Useful for debugging: Set the env variable LOG_MONGO_QUERIES to have the server write every
@@ -152,7 +155,7 @@ Meteor.users.ensureIndexOnServer("services.google.id", { unique: 1, sparse: 1 })
 Meteor.users.ensureIndexOnServer("services.github.id", { unique: 1, sparse: 1 });
 Meteor.users.ensureIndexOnServer("suspended.willDelete", { sparse: 1 });
 
-Packages = new Mongo.Collection("packages", collectionOptions);
+const Packages = new Mongo.Collection("packages", collectionOptions);
 // Packages which are installed or downloading.
 //
 // Each contains:
@@ -174,7 +177,7 @@ Packages = new Mongo.Collection("packages", collectionOptions);
 //   authorPgpKeyFingerprint: Verified PGP key fingerprint (SHA-1, hex, all-caps) of the app
 //     packager.
 
-DevPackages = new Mongo.Collection("devpackages", collectionOptions);
+const DevPackages = new Mongo.Collection("devpackages", collectionOptions);
 // List of packages currently made available via the dev tools running on the local machine.
 // This is normally empty; the only time it is non-empty is when a developer is using the spk tool
 // on the local machine to publish an under-development app to this server. That should only ever
@@ -196,7 +199,7 @@ DevPackages = new Mongo.Collection("devpackages", collectionOptions);
 //   manifest:  The app's manifest, as with Packages.manifest.
 //   mountProc: True if the supervisor should mount /proc.
 
-UserActions = new Mongo.Collection("userActions", collectionOptions);
+const UserActions = new Mongo.Collection("userActions", collectionOptions);
 // List of actions that each user has installed which create new grains.  Each app may install
 // some number of actions (usually, one).
 //
@@ -215,7 +218,7 @@ UserActions = new Mongo.Collection("userActions", collectionOptions);
 //   nounPhrase: JSON-encoded LocalizedText describing what is created when this action is run.
 //   command:  Manifest.Command to run this action (see package.capnp).
 
-Grains = new Mongo.Collection("grains", collectionOptions);
+const Grains = new Mongo.Collection("grains", collectionOptions);
 // Grains belonging to users.
 //
 // Each contains:
@@ -258,12 +261,12 @@ Grains = new Mongo.Collection("grains", collectionOptions);
 Grains.ensureIndexOnServer("userId");
 Grains.ensureIndexOnServer("cachedViewInfo.matchRequests.tags.id", { sparse: 1 });
 
-RoleAssignments = new Mongo.Collection("roleAssignments", collectionOptions);
+const RoleAssignments = new Mongo.Collection("roleAssignments", collectionOptions);
 // *OBSOLETE* Before `user` was a variant of ApiTokenOwner, this collection was used to store edges
 // in the permissions sharing graph. This functionality has been subsumed by the ApiTokens
 // collection.
 
-Contacts = new Mongo.Collection("contacts", collectionOptions);
+const Contacts = new Mongo.Collection("contacts", collectionOptions);
 // Edges in the social graph.
 //
 // If Alice has Bob as a contact, then she is allowed to see Bob's profile information and Bob
@@ -280,7 +283,7 @@ Contacts = new Mongo.Collection("contacts", collectionOptions);
 //   created: Date when this contact was created.
 //   accountId: The `_id` of the acount whose contact info this contains.
 
-Sessions = new Mongo.Collection("sessions", collectionOptions);
+const Sessions = new Mongo.Collection("sessions", collectionOptions);
 // UI sessions open to particular grains.  A new session is created each time a user opens a grain.
 //
 // The existence of a Session does NOT prove that the user has permission to access the grain. A
@@ -337,7 +340,7 @@ Sessions = new Mongo.Collection("sessions", collectionOptions);
 //       to enforce security; its purpose is only to assist in showing a helpful error message in
 //       the case that the user's access has been blocked by other means.
 
-SignupKeys = new Mongo.Collection("signupKeys", collectionOptions);
+const SignupKeys = new Mongo.Collection("signupKeys", collectionOptions);
 // Invite keys which may be used by users to get access to Sandstorm.
 //
 // Each contains:
@@ -346,7 +349,7 @@ SignupKeys = new Mongo.Collection("signupKeys", collectionOptions);
 //   note:  Text note assigned when creating key, to keep track of e.g. whom the key was for.
 //   email: If this key was sent as an email invite, the email address to which it was sent.
 
-ActivityStats = new Mongo.Collection("activityStats", collectionOptions);
+const ActivityStats = new Mongo.Collection("activityStats", collectionOptions);
 // Contains usage statistics taken on a regular interval. Each entry is a data point.
 //
 // Each contains:
@@ -370,7 +373,7 @@ ActivityStats = new Mongo.Collection("activityStats", collectionOptions);
 //       demoed: Number of demo grains created and expired.
 //       appDemoUsers: Number of app demos initiated with this app.
 
-DeleteStats = new Mongo.Collection("deleteStats", collectionOptions);
+const DeleteStats = new Mongo.Collection("deleteStats", collectionOptions);
 // Contains records of objects that were deleted, for stat-keeping purposes.
 //
 // Each contains:
@@ -380,7 +383,7 @@ DeleteStats = new Mongo.Collection("deleteStats", collectionOptions);
 //     arrived to demo. For others, undefined.
 //   experiments: The experiments the user (or owner of the grain) was in. See user.experiments.
 
-FileTokens = new Mongo.Collection("fileTokens", collectionOptions);
+const FileTokens = new Mongo.Collection("fileTokens", collectionOptions);
 // Tokens corresponding to backup files that are currently stored on the server. A user receives
 // a token when they create a backup file (either by uploading it, or by backing up one of their
 // grains) and may use the token to read the file (either to download it, or to restore a new
@@ -391,14 +394,14 @@ FileTokens = new Mongo.Collection("fileTokens", collectionOptions);
 //   name:      Suggested filename.
 //   timestamp: File creation time. Used to figure out when the token and file should be wiped.
 
-SpkTokens = new Mongo.Collection("spkTokens", collectionOptions);
+const SpkTokens = new Mongo.Collection("spkTokens", collectionOptions);
 // A lot like FileTokens, but for SPK uploads.
 //
 // Each contains:
 //   _id:       The unguessable token string.
 //   timestamp: Creation time. Used to figure out when the token should be wiped.
 
-ApiTokens = new Mongo.Collection("apiTokens", collectionOptions);
+const ApiTokens = new Mongo.Collection("apiTokens", collectionOptions);
 // Access tokens for APIs exported by apps.
 //
 // Originally API tokens were only used by external users through the HTTP API endpoint. However,
@@ -600,7 +603,7 @@ ApiTokens.ensureIndexOnServer("grainId", { sparse: 1 });
 ApiTokens.ensureIndexOnServer("owner.user.accountId", { sparse: 1 });
 ApiTokens.ensureIndexOnServer("frontendRef.emailVerifier.id", { sparse: 1 });
 
-ApiHosts = new Mongo.Collection("apiHosts", collectionOptions);
+const ApiHosts = new Mongo.Collection("apiHosts", collectionOptions);
 // Allows defining some limited static behavior for an API host when accessed unauthenticated. This
 // mainly exists to allow backwards-compatibility with client applications that expect to be able
 // to probe an API host without authentication to determine capabilities such as DAV protocols
@@ -625,7 +628,7 @@ ApiHosts = new Mongo.Collection("apiHosts", collectionOptions);
 //     encoding:   Content-Encoding.
 //     body:       Entity-body as a string or buffer.
 
-Notifications = new Mongo.Collection("notifications", collectionOptions);
+const Notifications = new Mongo.Collection("notifications", collectionOptions);
 // Notifications for a user.
 //
 // Each contains:
@@ -666,7 +669,7 @@ Notifications = new Mongo.Collection("notifications", collectionOptions);
 //                 changes to the identity model described in:
 //                 https://sandstorm.io/news/2017-05-08-refactoring-identities
 
-ActivitySubscriptions = new Mongo.Collection("activitySubscriptions", collectionOptions);
+const ActivitySubscriptions = new Mongo.Collection("activitySubscriptions", collectionOptions);
 // Activity events to which a user is subscribed.
 //
 // Each contains:
@@ -686,7 +689,7 @@ ActivitySubscriptions = new Mongo.Collection("activitySubscriptions", collection
 ActivitySubscriptions.ensureIndexOnServer("accountId");
 ActivitySubscriptions.ensureIndexOnServer({ "grainId": 1, "threadPath": 1 });
 
-StatsTokens = new Mongo.Collection("statsTokens", collectionOptions);
+const StatsTokens = new Mongo.Collection("statsTokens", collectionOptions);
 // Access tokens for the Stats collection
 //
 // These tokens are used for accessing the ActivityStats collection remotely
@@ -695,7 +698,7 @@ StatsTokens = new Mongo.Collection("statsTokens", collectionOptions);
 // Each contains:
 //   _id:       The token. At least 128 bits entropy (Random.id(22)).
 
-Misc = new Mongo.Collection("misc", collectionOptions);
+const Misc = new Mongo.Collection("misc", collectionOptions);
 // Miscellaneous configuration and other settings
 //
 // This table is currently only used for persisting BASE_URL from one session to the next,
@@ -705,7 +708,7 @@ Misc = new Mongo.Collection("misc", collectionOptions);
 //   _id:       The name of the setting. eg. "BASE_URL"
 //   value:     The value of the setting.
 
-Settings = new Mongo.Collection("settings", collectionOptions);
+const Settings = new Mongo.Collection("settings", collectionOptions);
 // Settings for this Sandstorm instance go here. They are configured through the adminSettings
 // route. This collection differs from misc in that any admin user can update it through the admin
 // interface.
@@ -725,13 +728,13 @@ Settings = new Mongo.Collection("settings", collectionOptions);
 //
 //   potentially other fields that are unique to the setting
 
-Migrations = new Mongo.Collection("migrations", collectionOptions);
+const Migrations = new Mongo.Collection("migrations", collectionOptions);
 // This table tracks which migrations we have applied to this instance.
 // It contains a single entry:
 //   _id:       "migrations_applied"
 //   value:     The number of migrations this instance has successfully completed.
 
-StaticAssets = new Mongo.Collection("staticAssets", collectionOptions);
+const StaticAssets = new Mongo.Collection("staticAssets", collectionOptions);
 // Collection of static assets served up from the Sandstorm server's "static" host. We only
 // support relatively small assets: under 1MB each.
 //
@@ -745,7 +748,7 @@ StaticAssets = new Mongo.Collection("staticAssets", collectionOptions);
 //       have transactions, this needs to bias towards over-counting; a backup GC could be used
 //       to catch leaked assets, although it's probably not a big deal in practice.
 
-AssetUploadTokens = new Mongo.Collection("assetUploadTokens", collectionOptions);
+const AssetUploadTokens = new Mongo.Collection("assetUploadTokens", collectionOptions);
 // Collection of tokens representing a single-use permission to upload an asset, such as a new
 // profile picture.
 //
@@ -756,7 +759,7 @@ AssetUploadTokens = new Mongo.Collection("assetUploadTokens", collectionOptions)
 //           userId: Account ID of user whose picture shall be replaced.
 //   expires:   Time when this token will go away if unused.
 
-Plans = new Mongo.Collection("plans", collectionOptions);
+const Plans = new Mongo.Collection("plans", collectionOptions);
 // Subscription plans, which determine quota.
 //
 // Each contains:
@@ -770,14 +773,14 @@ Plans = new Mongo.Collection("plans", collectionOptions);
 //       allowed to switch away.
 //   title: Title from display purposes. If missing, default to capitalizing _id.
 
-AppIndex = new Mongo.Collection("appIndex", collectionOptions);
+const AppIndex = new Mongo.Collection("appIndex", collectionOptions);
 // A mirror of the data from the App Market index
 //
 // Each contains:
 //   _id: the appId of the app
 //  The rest of the fields are defined in src/sandstorm/app-index/app-index.capnp:AppIndexForMarket
 
-KeybaseProfiles = new Mongo.Collection("keybaseProfiles", collectionOptions);
+const KeybaseProfiles = new Mongo.Collection("keybaseProfiles", collectionOptions);
 // Cache of Keybase profile information. The profile for a user is re-fetched every time a package
 // by that user is installed, as well as if the keybase profile is requested and not already
 // present for some reason.
@@ -797,12 +800,12 @@ KeybaseProfiles = new Mongo.Collection("keybaseProfiles", collectionOptions);
 //     WARNING: Currently verification is NOT IMPLEMENTED, so all proofs will be "unverified"
 //       for now and we just trust Keybase.
 
-FeatureKey = new Mongo.Collection("featureKey", collectionOptions);
+const FeatureKey = new Mongo.Collection("featureKey", collectionOptions);
 // OBSOLETE: This was used to implement the Sandstorm for Work paywall, which has been removed.
 //   Collection object still defined because it could have old data in it, for servers that used
 //   to have a feature key.
 
-SetupSession = new Mongo.Collection("setupSession", collectionOptions);
+const SetupSession = new Mongo.Collection("setupSession", collectionOptions);
 // Responsible for storing information about setup sessions.  Contains a single document with three
 // keys:
 //
@@ -875,7 +878,7 @@ const ScheduledJobs = new Mongo.Collection("scheduledJobs", collectionOptions);
 //     type:         The "kjType" of the error. One of "failed", "disconnected", "overloaded", or
 //                   "unimplemented".
 //     message:      A string message associated with the error.
-IncomingTransfers = new Mongo.Collection("incomingTransfers", collectionOptions);
+const IncomingTransfers = new Mongo.Collection("incomingTransfers", collectionOptions);
 // Contains records of grains scheduled to be transferred to this server.
 //
 // Each contains:
@@ -902,7 +905,7 @@ IncomingTransfers = new Mongo.Collection("incomingTransfers", collectionOptions)
 IncomingTransfers.ensureIndexOnServer("userId", { sparse: 1 });
 IncomingTransfers.ensureIndexOnServer("downloading", { sparse: 1 });
 
-OutgoingTransfers = new Mongo.Collection("outgoingTransfers", collectionOptions);
+const OutgoingTransfers = new Mongo.Collection("outgoingTransfers", collectionOptions);
 // Contains records of authorized outgoing mass grain transfers.
 //
 // Each contains:
@@ -974,7 +977,7 @@ const calculateReferralBonus = function (user) {
   }
 };
 
-isAdmin = function () {
+function isAdmin() {
   // Returns true if the user is the administrator.
 
   const user = Meteor.user();
@@ -983,9 +986,9 @@ isAdmin = function () {
   } else {
     return false;
   }
-};
+}
 
-isAdminById = function (id) {
+function isAdminById(id) {
   // Returns true if the user's id is the administrator.
 
   const user = Meteor.users.findOne({ _id: id }, { fields: { isAdmin: 1 } });
@@ -994,9 +997,9 @@ isAdminById = function (id) {
   } else {
     return false;
   }
-};
+}
 
-findAdminUserForToken = function (token) {
+function findAdminUserForToken(token) {
   if (!token.requirements) {
     return;
   }
@@ -1014,7 +1017,7 @@ findAdminUserForToken = function (token) {
   }
 
   return requirements[0].userIsAdmin;
-};
+}
 
 const wildcardHost = Meteor.settings.public.wildcardHost.toLowerCase().split("*");
 
@@ -1022,7 +1025,7 @@ if (wildcardHost.length != 2) {
   throw new Error("Wildcard host must contain exactly one asterisk.");
 }
 
-matchWildcardHost = function (host) {
+function matchWildcardHost(host) {
   // See if the hostname is a member of our wildcard. If so, extract the ID.
 
   // We remove everything after the first ":" character so that our
@@ -1041,24 +1044,24 @@ matchWildcardHost = function (host) {
   }
 
   return null;
-};
+}
 
-makeWildcardHost = function (id) {
+function makeWildcardHost(id) {
   return wildcardHost[0] + id + wildcardHost[1];
-};
+}
 
-const isApiHostId = function (hostId) {
+function isApiHostId(hostId) {
   if (hostId) {
     const split = hostId.split("-");
     if (split[0] === "api") return split[1] || "*";
   }
 
   return false;
-};
+}
 
-const isTokenSpecificHostId = function (hostId) {
+function isTokenSpecificHostId(hostId) {
   return hostId.lastIndexOf("api-", 0) === 0;
-};
+}
 
 let apiHostIdHashForToken;
 if (Meteor.isServer) {
@@ -1084,13 +1087,13 @@ if (Meteor.isServer) {
   };
 }
 
-const apiHostIdForToken = function (token) {
+function apiHostIdForToken(token) {
   return "api-" + apiHostIdHashForToken(token);
-};
+}
 
-const makeApiHost = function (token) {
+function makeApiHost(token) {
   return makeWildcardHost(apiHostIdForToken(token));
-};
+}
 
 if (Meteor.isServer) {
   const Url = Npm.require("url");
@@ -1113,7 +1116,7 @@ if (Meteor.isServer) {
   };
 }
 
-SandstormDb = function (quotaManager) {
+function SandstormDb(quotaManager) {
   // quotaManager is an object with the following method:
   //   updateUserQuota: It is provided two arguments
   //     db: This SandstormDb object
@@ -2305,7 +2308,7 @@ SandstormDb.escapeMongoKey = (key) => {
   return key.replace(".", "\uFF0E").replace("$", "\uFF04");
 };
 
-const appNameFromPackage = function (packageObj) {
+function appNameFromPackage(packageObj) {
   // This function takes a Package object from Mongo and returns an
   // app title.
   const manifest = packageObj.manifest;
@@ -2314,9 +2317,9 @@ const appNameFromPackage = function (packageObj) {
   appName = (manifest.appTitle && manifest.appTitle.defaultText) ||
     appNameFromActionName(action.title.defaultText);
   return appName;
-};
+}
 
-const appNameFromActionName = function (name) {
+function appNameFromActionName(name) {
   // Hack: Historically we only had action titles, like "New Etherpad Document", not app
   //   titles. But for this UI we want app titles. As a transitionary measure, try to
   //   derive the app title from the action title.
@@ -2339,15 +2342,15 @@ const appNameFromActionName = function (name) {
   }
 
   return name;
-};
+}
 
-const appShortDescriptionFromPackage = function (pkg) {
+function appShortDescriptionFromPackage(pkg) {
   return pkg && pkg.manifest && pkg.manifest.metadata &&
          pkg.manifest.metadata.shortDescription &&
          pkg.manifest.metadata.shortDescription.defaultText;
-};
+}
 
-const nounPhraseForActionAndAppTitle = function (action, appTitle) {
+function nounPhraseForActionAndAppTitle(action, appTitle) {
   // A hack to deal with legacy apps not including fields in their manifests.
   // I look forward to the day I can remove most of this code.
   // Attempt to figure out the appropriate noun that this action will create.
@@ -2378,15 +2381,15 @@ const nounPhraseForActionAndAppTitle = function (action, appTitle) {
   } else {
     return "grain";
   }
-};
+}
 
 // Static methods on SandstormDb that don't need an instance.
 // Largely things that deal with backwards-compatibility.
 _.extend(SandstormDb, {
-  appNameFromActionName: appNameFromActionName,
-  appNameFromPackage: appNameFromPackage,
-  appShortDescriptionFromPackage: appShortDescriptionFromPackage,
-  nounPhraseForActionAndAppTitle: nounPhraseForActionAndAppTitle,
+  appNameFromActionName,
+  appNameFromPackage,
+  appShortDescriptionFromPackage,
+  nounPhraseForActionAndAppTitle,
 });
 
 if (Meteor.isServer) {
@@ -3145,3 +3148,5 @@ Meteor.methods({
     }
   },
 });
+
+export { SandstormDb };

--- a/shell/imports/sandstorm-db/profile.js
+++ b/shell/imports/sandstorm-db/profile.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Identicon from "/imports/sandstorm-identicons/identicon.js";
+
 let makeIdenticon;
 let httpProtocol;
 

--- a/shell/imports/sandstorm-db/profile.js
+++ b/shell/imports/sandstorm-db/profile.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import Identicon from "/imports/sandstorm-identicons/identicon.js";
+import { SandstormDb } from "./db.js";
 
 let makeIdenticon;
 let httpProtocol;

--- a/shell/imports/sandstorm-db/scheduled-jobs-db.js
+++ b/shell/imports/sandstorm-db/scheduled-jobs-db.js
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Crypto from 'crypto';
+import Crypto from "crypto";
 
 const MINIMUM_SCHEDULING_SLACK_NANO = Capnp.importSystem("sandstorm/grain.capnp").minimumSchedulingSlack;
 

--- a/shell/imports/sandstorm-db/scheduled-jobs-db.js
+++ b/shell/imports/sandstorm-db/scheduled-jobs-db.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import Crypto from "crypto";
+import Capnp from "/imports/server/capnp.js";
 
 const MINIMUM_SCHEDULING_SLACK_NANO = Capnp.importSystem("sandstorm/grain.capnp").minimumSchedulingSlack;
 

--- a/shell/imports/sandstorm-db/scheduled-jobs-db.js
+++ b/shell/imports/sandstorm-db/scheduled-jobs-db.js
@@ -16,6 +16,7 @@
 
 import Crypto from "crypto";
 import Capnp from "/imports/server/capnp.js";
+import { SandstormDb } from "./db.js";
 
 const MINIMUM_SCHEDULING_SLACK_NANO = Capnp.importSystem("sandstorm/grain.capnp").minimumSchedulingSlack;
 

--- a/shell/imports/sandstorm-identicons/helpers.js
+++ b/shell/imports/sandstorm-identicons/helpers.js
@@ -1,9 +1,11 @@
+import Identicon from "./identicon.js";
+
 const VALID_USAGES = ["appGrid", "grain", "notification"];
-const checkUsage = function (usage) {
+function checkUsage(usage) {
   if (VALID_USAGES.indexOf(usage) === -1) throw new Error("Invalid icon usage.");
 };
 
-const iconFromManifest = function (manifest, usage) {
+function iconFromManifest(manifest, usage) {
   // TODO: select by usage location, rather than assuming appGrid
   const icons = manifest && manifest.metadata && manifest.metadata.icons ?
       manifest.metadata.icons : undefined;
@@ -18,7 +20,7 @@ const iconFromManifest = function (manifest, usage) {
   return undefined;
 };
 
-Identicon.hashAppIdForIdenticon = function (id) {
+function hashAppIdForIdenticon(id) {
   // "Hash" an app ID to a 32-digit hex string for the purpose of
   // producing an identicon. Since app IDs are already high-
   // entropy base32 strings, we simply turn each of the first
@@ -39,7 +41,7 @@ Identicon.hashAppIdForIdenticon = function (id) {
 // Keep a static global cache of all app identicons produced in this way.
 // If memory usage is excessive, we can revisit this decision.
 const cachedIdenticons = {};
-const cachedIdenticon = function (hashedAppId, size) {
+function cachedIdenticon(hashedAppId, size) {
   const cacheKey = hashedAppId + "-" + size;
   if (!cachedIdenticons[cacheKey]) {
     const data = new Identicon(hashedAppId, size).toString();
@@ -49,12 +51,12 @@ const cachedIdenticon = function (hashedAppId, size) {
   return cachedIdenticons[cacheKey];
 };
 
-const identiconForApp = function (appId, usage) {
+function identiconForApp(appId, usage) {
   const size = (usage === "appGrid" ? 128 : 24);
-  return cachedIdenticon(Identicon.hashAppIdForIdenticon(appId), size);
+  return cachedIdenticon(hashAppIdForIdenticon(appId), size);
 };
 
-const bytesToBase64 = function (bytes) {
+function bytesToBase64(bytes) {
   const arr = new Array(bytes.length);
   for (let i = 0; i < bytes.length; i++) {
     arr[i] = String.fromCharCode(bytes[i]);
@@ -64,7 +66,7 @@ const bytesToBase64 = function (bytes) {
   return result;
 };
 
-const iconSrcFor = function (appId, iconObj, staticPrefix, usage) {
+function iconSrcFor(appId, iconObj, staticPrefix, usage) {
   if (iconObj === undefined || iconObj === null) {
     // Return a identicon src based on hashing appId instead.
     // (We hash the appID even though it's already a hash because it's not hex)
@@ -99,11 +101,7 @@ const iconSrcFor = function (appId, iconObj, staticPrefix, usage) {
   return identiconForApp(appId, usage);
 };
 
-Identicon.identiconForApp = function (appId, usage) {
-  return identiconForApp(appId, usage);
-};
-
-Identicon.iconSrcForPackage = function (pkg, usage, staticPrefix) {
+function iconSrcForPackage(pkg, usage, staticPrefix) {
   // Works for regular packages and dev packages.
 
   checkUsage(usage);
@@ -111,6 +109,13 @@ Identicon.iconSrcForPackage = function (pkg, usage, staticPrefix) {
   return iconSrcFor(pkg.appId, iconObj, staticPrefix, usage);
 };
 
-Identicon.iconSrcForDenormalizedGrainMetadata = function (metadata, usage, staticPrefix) {
+function iconSrcForDenormalizedGrainMetadata(metadata, usage, staticPrefix) {
   return iconSrcFor(metadata.appId, metadata.icon, staticPrefix, usage);
+};
+
+export {
+    hashAppIdForIdenticon,
+    identiconForApp,
+    iconSrcForPackage,
+    iconSrcForDenormalizedGrainMetadata,
 };

--- a/shell/imports/sandstorm-identicons/identicon-server.js
+++ b/shell/imports/sandstorm-identicons/identicon-server.js
@@ -1,0 +1,22 @@
+import { Meteor } from "meteor/meteor";
+import Zlib from "zlib";
+import Identicon from "./identicon.js";
+
+const gzipSync = Meteor.wrapAsync(Zlib.gzip, Zlib);
+
+// Because identicons are so simple, we can save a lot of bandwidth by applying compression
+// before sending them from the server to the client. The PNG format has built-in support for
+// lossless compression, but indenticon.js does not take advantage of it. We could work around
+// that fact by roundtripping the PNGs through a more complete library like pngjs, or we could
+// just apply gzip on top of the suboptimal PNG. We opt for the latter approach.
+class ServerIdenticon extends Identicon {
+  asAsset() {
+    return {
+      mimeType: "image/svg+xml",
+      content: gzipSync(new Buffer(this.render())),
+      encoding: "gzip",
+    };
+  }
+}
+
+export default ServerIdenticon;

--- a/shell/imports/sandstorm-identicons/identicon.js
+++ b/shell/imports/sandstorm-identicons/identicon.js
@@ -11,7 +11,7 @@
 // Trivially modified for Meteor context by Kenton Varda.
 // Later modified to produce an SVG rather than a PNG.
 
-Identicon = class Identicon {
+class Identicon {
   constructor(hash, size, margin) {
     this.hash   = hash;
     this.size   = size   || 64;
@@ -82,20 +82,4 @@ Identicon = class Identicon {
   }
 };
 
-if (Meteor.isServer) {
-  // Because identicons are so simple, we can save a lot of bandwidth by applying compression
-  // before sending them from the server to the client. The PNG format has built-in support for
-  // lossless compression, but indenticon.js does not take advantage of it. We could work around
-  // that fact by roundtripping the PNGs through a more complete library like pngjs, or we could
-  // just apply gzip on top of the suboptimal PNG. We opt for the latter approach.
-  const Zlib = Npm.require("zlib");
-  const gzipSync = Meteor.wrapAsync(Zlib.gzip, Zlib);
-
-  Identicon.prototype.asAsset = function () {
-    return {
-      mimeType: "image/svg+xml",
-      content: gzipSync(new Buffer(this.render())),
-      encoding: "gzip",
-    };
-  };
-}
+export default Identicon;

--- a/shell/imports/sandstorm-permissions/permissions.js
+++ b/shell/imports/sandstorm-permissions/permissions.js
@@ -15,6 +15,9 @@
 // limitations under the License.
 
 import Crypto from "crypto";
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 SandstormPermissions = {};
 

--- a/shell/imports/sandstorm-permissions/permissions.js
+++ b/shell/imports/sandstorm-permissions/permissions.js
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Crypto from 'crypto';
+import Crypto from "crypto";
 
 SandstormPermissions = {};
 

--- a/shell/imports/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/imports/sandstorm-ui-powerbox/powerbox-client.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { identiconForApp } from "/imports/sandstorm-identicons/helpers.js";
+
 const PowerboxOptions = new Mongo.Collection("powerboxOptions");
 
 SandstormPowerboxRequest = class SandstormPowerboxRequest {
@@ -186,7 +188,7 @@ SandstormPowerboxRequest = class SandstormPowerboxRequest {
             (grainInfo && grainInfo.appTitle && grainInfo.appTitle.defaultText) || "",
         iconSrc: (grainInfo && grainInfo.icon && grainInfo.icon.assetId) ?
             (window.location.protocol + "//" + staticAssetHost + "/" + grainInfo.icon.assetId) :
-            Identicon.identiconForApp(
+            identiconForApp(
                 (grainInfo && grainInfo.appId) || "00000000000000000000000000000000"),
         lastUsed: apiToken.lastUsed || apiToken.created,
         apiTokenId: apiToken._id,

--- a/shell/imports/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/imports/sandstorm-ui-powerbox/powerbox-client.js
@@ -14,7 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Mongo } from "meteor/mongo";
+import { Template } from "meteor/templating";
 import { identiconForApp } from "/imports/sandstorm-identicons/helpers.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const PowerboxOptions = new Mongo.Collection("powerboxOptions");
 

--- a/shell/imports/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/imports/sandstorm-ui-powerbox/powerbox-server.js
@@ -14,9 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Crypto from "crypto";
+import Future from "fibers/future";
+
 import { waitPromise } from '../server/async-helpers.js';
 
-const Crypto = Npm.require("crypto");
 const Powerbox = Capnp.importSystem("sandstorm/powerbox.capnp");
 const Grain = Capnp.importSystem("sandstorm/grain.capnp");
 

--- a/shell/imports/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/imports/sandstorm-ui-powerbox/powerbox-server.js
@@ -16,6 +16,7 @@
 
 import Crypto from "crypto";
 import Future from "fibers/future";
+import Capnp from "/imports/server/capnp.js";
 
 import { waitPromise } from '../server/async-helpers.js';
 

--- a/shell/imports/server/00-startup.js
+++ b/shell/imports/server/00-startup.js
@@ -14,7 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import "/imports/db-deprecated.js";
 import { FrontendRefRegistry } from "/imports/server/frontend-ref.js";
 import { PersistentImpl } from "/imports/server/persistent.js";
 import { migrateToLatest } from "/imports/server/migrations.js";

--- a/shell/imports/server/00-startup.js
+++ b/shell/imports/server/00-startup.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { FrontendRefRegistry } from "/imports/server/frontend-ref.js";
 import { PersistentImpl } from "/imports/server/persistent.js";
 import { migrateToLatest } from "/imports/server/migrations.js";

--- a/shell/imports/server/account-suspension.js
+++ b/shell/imports/server/account-suspension.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { send } from "/imports/server/email.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 function sendDeletionEmails(db, deletedUserId, byAdminUserId, feedback) {
   const deletedUser = db.getUser(deletedUserId);

--- a/shell/imports/server/accounts/accounts-server.js
+++ b/shell/imports/server/accounts/accounts-server.js
@@ -17,8 +17,8 @@
 import { Accounts } from "meteor/accounts-base";
 import { fetchPicture, userPictureUrl } from "/imports/server/accounts/picture.js";
 
-const Crypto = Npm.require("crypto");
-const Future = Npm.require("fibers/future");
+import Crypto from "crypto";
+import Future from "fibers/future";
 
 const ValidHandle = Match.Where(function (handle) {
   check(handle, String);

--- a/shell/imports/server/accounts/accounts-server.js
+++ b/shell/imports/server/accounts/accounts-server.js
@@ -16,6 +16,7 @@
 
 import { Accounts } from "meteor/accounts-base";
 import { fetchPicture, userPictureUrl } from "/imports/server/accounts/picture.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 import Crypto from "crypto";
 import Future from "fibers/future";

--- a/shell/imports/server/accounts/accounts-ui-methods.js
+++ b/shell/imports/server/accounts/accounts-ui-methods.js
@@ -17,6 +17,8 @@
 // This file contains method definitions which are available on both client and server (on the
 // client for prediction purposes, on the server for actual execution).
 
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
+
 const ValidHandle = Match.Where(function (handle) {
   check(handle, String);
   return !!handle.match(/^[a-z_][a-z0-9_]*$/);

--- a/shell/imports/server/accounts/credentials/credentials-server.js
+++ b/shell/imports/server/accounts/credentials/credentials-server.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { SandstormBackend } from "/imports/server/backend.js";
 
 const linkCredentialToAccountInternal = function (db, backend, credentialId, accountId, allowLogin) {

--- a/shell/imports/server/accounts/email-token/token-server.js
+++ b/shell/imports/server/accounts/email-token/token-server.js
@@ -1,8 +1,8 @@
 import crypto from "crypto";
+import Url from "url";
 
 import { send as sendEmail } from "/imports/server/email.js";
 
-const Url = Npm.require("url");
 
 const V1_ROUNDS = 4096; // Selected to take ~5msec at creation time (2016) on a developer's laptop.
 const V1_KEYSIZE = 32; // 256 bits / 8 bits/byte = 32 bytes

--- a/shell/imports/server/accounts/email-token/token-server.js
+++ b/shell/imports/server/accounts/email-token/token-server.js
@@ -1,8 +1,8 @@
 import crypto from "crypto";
 import Url from "url";
 
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { send as sendEmail } from "/imports/server/email.js";
-
 
 const V1_ROUNDS = 4096; // Selected to take ~5msec at creation time (2016) on a developer's laptop.
 const V1_KEYSIZE = 32; // 256 bits / 8 bits/byte = 32 bytes

--- a/shell/imports/server/accounts/ldap.js
+++ b/shell/imports/server/accounts/ldap.js
@@ -1,4 +1,4 @@
-const Future = Npm.require("fibers/future");
+import Future from "fibers/future";
 import ldapjs from "ldapjs";
 
 // At a minimum, set up LDAP_DEFAULTS.url and .dn according to

--- a/shell/imports/server/accounts/saml/saml-server.js
+++ b/shell/imports/server/accounts/saml/saml-server.js
@@ -2,8 +2,8 @@ import Url from "url";
 import zlib from "zlib";
 import { SAML } from "/imports/server/accounts/saml-utils.js";
 
-const Fiber = Npm.require("fibers");
-const BodyParser = Npm.require("body-parser");
+import Fiber from "fibers";
+import BodyParser from "body-parser";
 
 if (!Accounts.saml) {
   Accounts.saml = {};

--- a/shell/imports/server/accounts/saml/saml-server.js
+++ b/shell/imports/server/accounts/saml/saml-server.js
@@ -1,6 +1,7 @@
 import Url from "url";
 import zlib from "zlib";
 import { SAML } from "/imports/server/accounts/saml-utils.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 import Fiber from "fibers";
 import BodyParser from "body-parser";

--- a/shell/imports/server/admin-server.js
+++ b/shell/imports/server/admin-server.js
@@ -22,6 +22,7 @@ import { SANDSTORM_LOGDIR } from "/imports/server/constants.js";
 import { clearAdminToken, checkAuth, tokenIsValid, tokenIsSetupSession } from "/imports/server/auth.js";
 import { send as sendEmail } from "/imports/server/email.js";
 import { fillUndefinedForChangedDoc } from "/imports/server/observe-helpers.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const publicAdminSettings = [
   "google", "github", "ldap", "saml", "emailToken", "splashUrl", "signupDialog",

--- a/shell/imports/server/async-helpers.js
+++ b/shell/imports/server/async-helpers.js
@@ -1,6 +1,5 @@
 import { Meteor } from "meteor/meteor";
-
-const Future = Npm.require("fibers/future");
+import Future from "fibers/future";
 
 let inMeteorListener = undefined;
 const onInMeteor = (callback) => {

--- a/shell/imports/server/backend.js
+++ b/shell/imports/server/backend.js
@@ -14,11 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Crypto from "crypto";
 import { SANDSTORM_ALTHOME } from "/imports/server/constants.js";
 import { inMeteor, promiseToFuture, waitPromise } from "/imports/server/async-helpers.js";
 
 const Backend = Capnp.importSystem("sandstorm/backend.capnp").Backend;
-const Crypto = Npm.require("crypto");
 
 let storageUsageUnimplemented = false;
 

--- a/shell/imports/server/backend.js
+++ b/shell/imports/server/backend.js
@@ -17,6 +17,7 @@
 import Crypto from "crypto";
 import { SANDSTORM_ALTHOME } from "/imports/server/constants.js";
 import { inMeteor, promiseToFuture, waitPromise } from "/imports/server/async-helpers.js";
+import Capnp from "/imports/server/capnp.js";
 
 const Backend = Capnp.importSystem("sandstorm/backend.capnp").Backend;
 

--- a/shell/imports/server/backup.js
+++ b/shell/imports/server/backup.js
@@ -16,8 +16,8 @@
 
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 
-const ChildProcess = Npm.require("child_process");
-const Future = Npm.require("fibers/future");
+import ChildProcess from "child_process";
+import Future from "fibers/future";
 
 const GrainInfo = Capnp.importSystem("sandstorm/grain.capnp").GrainInfo;
 

--- a/shell/imports/server/backup.js
+++ b/shell/imports/server/backup.js
@@ -18,6 +18,7 @@ import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 
 import ChildProcess from "child_process";
 import Future from "fibers/future";
+import Capnp from "/imports/server/capnp.js";
 
 const GrainInfo = Capnp.importSystem("sandstorm/grain.capnp").GrainInfo;
 

--- a/shell/imports/server/backup.js
+++ b/shell/imports/server/backup.js
@@ -19,6 +19,7 @@ import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import ChildProcess from "child_process";
 import Future from "fibers/future";
 import Capnp from "/imports/server/capnp.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const GrainInfo = Capnp.importSystem("sandstorm/grain.capnp").GrainInfo;
 

--- a/shell/imports/server/capnp.js
+++ b/shell/imports/server/capnp.js
@@ -21,19 +21,23 @@
 // in: https://github.com/meteor/meteor/pull/9095
 
 import fs from "fs";
+
 const pathParts = process.cwd().split("/");
 
+let Capnp;
 for (;;) {
-  var path = pathParts.join("/");
+  const path = pathParts.join("/");
 
-  if (fs.existsSync(path + "/node_modules/capnp.node")) {
-    Capnp = Npm.require(path + "/node_modules/capnp.js");
+  if (fs.existsSync(`${path}/node_modules/capnp.node`)) {
+    Capnp = Npm.require(`${path}/node_modules/capnp.js`);
     break;
   }
 
-  if (pathParts.length == 0) {
-    throw new Error("Can't find capnp.node, starting from: " + process.cwd());
+  if (pathParts.length === 0) {
+    throw new Error(`Can't find capnp.node, starting from: ${process.cwd()}`);
   }
 
   pathParts.pop();
 }
+
+export default Capnp;

--- a/shell/imports/server/capnp.js
+++ b/shell/imports/server/capnp.js
@@ -20,7 +20,7 @@
 // We used to use Npm.require() for this, but Meteor disabled the "search up the tree" behavior
 // in: https://github.com/meteor/meteor/pull/9095
 
-const fs = Npm.require("fs");
+import fs from "fs";
 const pathParts = process.cwd().split("/");
 
 for (;;) {

--- a/shell/imports/server/core.js
+++ b/shell/imports/server/core.js
@@ -14,9 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Crypto from "crypto";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { StaticAssetImpl, IdenticonStaticAssetImpl } from "/imports/server/static-asset.js";
-const Crypto = Npm.require("crypto");
 import { PersistentImpl, hashSturdyRef, generateSturdyRef, checkRequirements,
          fetchApiToken, insertApiToken } from "/imports/server/persistent.js";
 import { SandstormBackend } from "/imports/server/backend.js";

--- a/shell/imports/server/core.js
+++ b/shell/imports/server/core.js
@@ -21,6 +21,7 @@ import { PersistentImpl, hashSturdyRef, generateSturdyRef, checkRequirements,
          fetchApiToken, insertApiToken } from "/imports/server/persistent.js";
 import { SandstormBackend } from "/imports/server/backend.js";
 import { hashAppIdForIdenticon } from "/imports/sandstorm-identicons/helpers.js";
+import Capnp from "/imports/server/capnp.js";
 
 const PersistentHandle = Capnp.importSystem("sandstorm/supervisor.capnp").PersistentHandle;
 const SandstormCore = Capnp.importSystem("sandstorm/supervisor.capnp").SandstormCore;

--- a/shell/imports/server/core.js
+++ b/shell/imports/server/core.js
@@ -20,6 +20,7 @@ const Crypto = Npm.require("crypto");
 import { PersistentImpl, hashSturdyRef, generateSturdyRef, checkRequirements,
          fetchApiToken, insertApiToken } from "/imports/server/persistent.js";
 import { SandstormBackend } from "/imports/server/backend.js";
+import { hashAppIdForIdenticon } from "/imports/sandstorm-identicons/helpers.js";
 
 const PersistentHandle = Capnp.importSystem("sandstorm/supervisor.capnp").PersistentHandle;
 const SandstormCore = Capnp.importSystem("sandstorm/supervisor.capnp").SandstormCore;
@@ -251,7 +252,7 @@ class PersistentUiViewImpl extends PersistentImpl {
           viewInfo.grainIcon = new Capnp.Capability(new StaticAssetImpl(grainIcon.assetId),
                                                     StaticAsset);
         } else {
-          const hash = Identicon.hashAppIdForIdenticon(pkg.appId);
+          const hash = hashAppIdForIdenticon(pkg.appId);
           viewInfo.grainIcon = new Capnp.Capability(new IdenticonStaticAssetImpl(hash, 24),
                                                     StaticAsset);
         }

--- a/shell/imports/server/demo-server.js
+++ b/shell/imports/server/demo-server.js
@@ -16,6 +16,7 @@
 
 import { waitPromise } from "/imports/server/async-helpers.js";
 import { allowDemo } from "/imports/demo.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const DEMO_EXPIRATION_MS = 60 * 60 * 1000;
 const DEMO_GRACE_MS = 10 * 60 * 1000;  // time between expiration and deletion

--- a/shell/imports/server/desktop-notifications-server.js
+++ b/shell/imports/server/desktop-notifications-server.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 SandstormDb.periodicCleanup(120000, () => {
   // Remove old desktop notfications regularly.

--- a/shell/imports/server/dev-accounts-server.js
+++ b/shell/imports/server/dev-accounts-server.js
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Crypto from 'crypto';
+import Crypto from "crypto";
 
 Meteor.methods({
   createDevAccount: function (displayName, isAdmin, profile, unverifiedEmail) {

--- a/shell/imports/server/drivers/external-ui-view.js
+++ b/shell/imports/server/drivers/external-ui-view.js
@@ -19,10 +19,10 @@ import { ssrfSafeLookup } from "/imports/server/networking.js";
 import { REQUEST_HEADER_WHITELIST, RESPONSE_HEADER_WHITELIST }
     from "/imports/server/header-whitelist.js";
 
-const Future = Npm.require("fibers/future");
-const Url = Npm.require("url");
-const Http = Npm.require("http");
-const Https = Npm.require("https");
+import Future from "fibers/future";
+import Url from "url";
+import Http from "http";
+import Https from "https";
 const ApiSession = Capnp.importSystem("sandstorm/api-session.capnp").ApiSession;
 const PersistentApiSession =
     Capnp.importSystem("sandstorm/api-session-impl.capnp").PersistentApiSession;

--- a/shell/imports/server/drivers/external-ui-view.js
+++ b/shell/imports/server/drivers/external-ui-view.js
@@ -23,6 +23,7 @@ import Future from "fibers/future";
 import Url from "url";
 import Http from "http";
 import Https from "https";
+import Capnp from "/imports/server/capnp.js";
 const ApiSession = Capnp.importSystem("sandstorm/api-session.capnp").ApiSession;
 const PersistentApiSession =
     Capnp.importSystem("sandstorm/api-session-impl.capnp").PersistentApiSession;

--- a/shell/imports/server/drivers/ip.js
+++ b/shell/imports/server/drivers/ip.js
@@ -20,6 +20,7 @@ import Future from "fibers/future";
 import Net from "net";
 import Tls from "tls";
 import Dgram from "dgram";
+import Capnp from "/imports/server/capnp.js";
 
 const IpRpc = Capnp.importSystem("sandstorm/ip.capnp");
 

--- a/shell/imports/server/drivers/ip.js
+++ b/shell/imports/server/drivers/ip.js
@@ -16,10 +16,10 @@
 
 import Bignum from "bignum";
 import { PersistentImpl } from "/imports/server/persistent.js";
-const Future = Npm.require("fibers/future");
-const Net = Npm.require("net");
-const Tls = Npm.require("tls");
-const Dgram = Npm.require("dgram");
+import Future from "fibers/future";
+import Net from "net";
+import Tls from "tls";
+import Dgram from "dgram";
 
 const IpRpc = Capnp.importSystem("sandstorm/ip.capnp");
 

--- a/shell/imports/server/drivers/mail.js
+++ b/shell/imports/server/drivers/mail.js
@@ -22,16 +22,15 @@ import { rawSend } from "/imports/server/email.js";
 import { shouldRestartGrain } from "/imports/server/backend.js";
 import { inMeteor } from "/imports/server/async-helpers.js";
 
-const Crypto = Npm.require("crypto");
-const Future = Npm.require("fibers/future");
+import Crypto from "crypto";
+import Future from "fibers/future";
+import Url from "url";
 
 const EmailRpc = Capnp.importSystem("sandstorm/email.capnp");
 const EmailImpl = Capnp.importSystem("sandstorm/email-impl.capnp");
 const HackSessionContext = Capnp.importSystem("sandstorm/hack-session.capnp").HackSessionContext;
 const Supervisor = Capnp.importSystem("sandstorm/supervisor.capnp").Supervisor;
 const EmailSendPort = EmailRpc.EmailSendPort;
-
-const Url = Npm.require("url");
 
 const ROOT_URL = Url.parse(process.env.ROOT_URL);
 const HOSTNAME = ROOT_URL.hostname;

--- a/shell/imports/server/drivers/mail.js
+++ b/shell/imports/server/drivers/mail.js
@@ -25,6 +25,7 @@ import { inMeteor } from "/imports/server/async-helpers.js";
 import Crypto from "crypto";
 import Future from "fibers/future";
 import Url from "url";
+import Capnp from "/imports/server/capnp.js";
 
 const EmailRpc = Capnp.importSystem("sandstorm/email.capnp");
 const EmailImpl = Capnp.importSystem("sandstorm/email-impl.capnp");

--- a/shell/imports/server/drivers/mail.js
+++ b/shell/imports/server/drivers/mail.js
@@ -17,6 +17,7 @@
 import { SMTPServer } from "smtp-server";
 import { MailParser } from "mailparser";
 
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { PersistentImpl } from "/imports/server/persistent.js";
 import { rawSend } from "/imports/server/email.js";
 import { shouldRestartGrain } from "/imports/server/backend.js";

--- a/shell/imports/server/email.js
+++ b/shell/imports/server/email.js
@@ -1,8 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import nodemailer from "nodemailer";
 import smtpPool from "nodemailer-smtp-pool";
-
-const Future = Npm.require("fibers/future");
+import Future from "fibers/future";
 
 const getSmtpConfig = function () {
   const config = Settings.findOne({ _id: "smtpConfig" });

--- a/shell/imports/server/gateway-router.js
+++ b/shell/imports/server/gateway-router.js
@@ -14,15 +14,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
+import Crypto from "crypto";
+import Dns from "dns";
+
 const GatewayRouter = Capnp.importSystem("sandstorm/backend.capnp").GatewayRouter;
 const ApiSession = Capnp.importSystem("sandstorm/api-session.capnp").ApiSession;
 const WebSession = Capnp.importSystem("sandstorm/web-session.capnp").WebSession;
 const SystemPersistent = Capnp.importSystem("sandstorm/supervisor.capnp").SystemPersistent;
 const Powerbox = Capnp.importSystem("sandstorm/powerbox.capnp");
-
-import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
-const Crypto = Npm.require("crypto");
-const Dns = Npm.require("dns");
 
 const SESSION_PROXY_TIMEOUT = 60000;
 const DNS_CACHE_TTL_SECONDS = 30;

--- a/shell/imports/server/gateway-router.js
+++ b/shell/imports/server/gateway-router.js
@@ -17,6 +17,7 @@
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import Crypto from "crypto";
 import Dns from "dns";
+import Capnp from "/imports/server/capnp.js";
 
 const GatewayRouter = Capnp.importSystem("sandstorm/backend.capnp").GatewayRouter;
 const ApiSession = Capnp.importSystem("sandstorm/api-session.capnp").ApiSession;

--- a/shell/imports/server/gateway-router.js
+++ b/shell/imports/server/gateway-router.js
@@ -18,6 +18,7 @@ import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import Crypto from "crypto";
 import Dns from "dns";
 import Capnp from "/imports/server/capnp.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const GatewayRouter = Capnp.importSystem("sandstorm/backend.capnp").GatewayRouter;
 const ApiSession = Capnp.importSystem("sandstorm/api-session.capnp").ApiSession;

--- a/shell/imports/server/grain-server.js
+++ b/shell/imports/server/grain-server.js
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const Crypto = Npm.require("crypto");
+import Crypto from "crypto";
 import { send as sendEmail } from "/imports/server/email.js";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 

--- a/shell/imports/server/grain-server.js
+++ b/shell/imports/server/grain-server.js
@@ -17,6 +17,7 @@
 import Crypto from "crypto";
 import { send as sendEmail } from "/imports/server/email.js";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const ROOT_URL = process.env.ROOT_URL;
 

--- a/shell/imports/server/hack-session.js
+++ b/shell/imports/server/hack-session.js
@@ -14,11 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const Crypto = Npm.require("crypto");
-const Http = Npm.require("http");
-const Https = Npm.require("https");
-const Net = Npm.require("net");
-const Dgram = Npm.require("dgram");
+import Crypto from "crypto";
+import Http from "http";
+import Https from "https";
+import Net from "net";
+import Dgram from "dgram";
+import Url from "url";
 import { hashSturdyRef, checkRequirements, fetchApiToken } from "/imports/server/persistent.js";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { ssrfSafeLookup } from "/imports/server/networking.js";
@@ -32,7 +33,6 @@ const EmailSendPort = EmailRpc.EmailSendPort;
 const Grain = Capnp.importSystem("sandstorm/grain.capnp");
 const Powerbox = Capnp.importSystem("sandstorm/powerbox.capnp");
 
-const Url = Npm.require("url");
 
 ROOT_URL = Url.parse(process.env.ROOT_URL);
 HOSTNAME = ROOT_URL.hostname;

--- a/shell/imports/server/hack-session.js
+++ b/shell/imports/server/hack-session.js
@@ -24,6 +24,7 @@ import { hashSturdyRef, checkRequirements, fetchApiToken } from "/imports/server
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { ssrfSafeLookup } from "/imports/server/networking.js";
 import Capnp from "/imports/server/capnp.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const EmailRpc = Capnp.importSystem("sandstorm/email.capnp");
 const HackSessionContext = Capnp.importSystem("sandstorm/hack-session.capnp").HackSessionContext;

--- a/shell/imports/server/hack-session.js
+++ b/shell/imports/server/hack-session.js
@@ -23,6 +23,7 @@ import Url from "url";
 import { hashSturdyRef, checkRequirements, fetchApiToken } from "/imports/server/persistent.js";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { ssrfSafeLookup } from "/imports/server/networking.js";
+import Capnp from "/imports/server/capnp.js";
 
 const EmailRpc = Capnp.importSystem("sandstorm/email.capnp");
 const HackSessionContext = Capnp.importSystem("sandstorm/hack-session.capnp").HackSessionContext;

--- a/shell/imports/server/header-whitelist.js
+++ b/shell/imports/server/header-whitelist.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Capnp from "/imports/server/capnp.js";
 const WebSession = Capnp.importSystem("sandstorm/web-session.capnp").WebSession;
 
 class HeaderWhitelist {

--- a/shell/imports/server/identity.js
+++ b/shell/imports/server/identity.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { PersistentImpl } from "/imports/server/persistent.js";
 import { StaticAssetImpl, IdenticonStaticAssetImpl } from "/imports/server/static-asset.js";
 import Capnp from "/imports/server/capnp.js";

--- a/shell/imports/server/identity.js
+++ b/shell/imports/server/identity.js
@@ -14,10 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const IdentityRpc = Capnp.importSystem("sandstorm/identity-impl.capnp");
-const Identity = Capnp.importSystem("sandstorm/identity.capnp").Identity;
 import { PersistentImpl } from "/imports/server/persistent.js";
 import { StaticAssetImpl, IdenticonStaticAssetImpl } from "/imports/server/static-asset.js";
+import Capnp from "/imports/server/capnp.js";
+
+const IdentityRpc = Capnp.importSystem("sandstorm/identity-impl.capnp");
+const Identity = Capnp.importSystem("sandstorm/identity.capnp").Identity;
 const StaticAsset = Capnp.importSystem("sandstorm/util.capnp").StaticAsset;
 
 class IdentityImpl extends PersistentImpl {

--- a/shell/imports/server/install-server.js
+++ b/shell/imports/server/install-server.js
@@ -17,6 +17,7 @@
 import { allowDemo } from "/imports/demo.js";
 import { isSafeDemoAppUrl } from "/imports/install.js"
 import { promiseToFuture } from "/imports/server/async-helpers.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const TOKEN_CLEANUP_MINUTES = 120;  // Give enough time for large uploads on slow connections.
 const TOKEN_CLEANUP_TIMER = TOKEN_CLEANUP_MINUTES * 60 * 1000;

--- a/shell/imports/server/installer.js
+++ b/shell/imports/server/installer.js
@@ -22,6 +22,7 @@ import Url from "url";
 
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { ssrfSafeLookupOrProxy } from "/imports/server/networking.js";
+import Capnp from "/imports/server/capnp.js";
 
 const Request = HTTPInternals.NpmModules.request.module;
 

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -10,6 +10,7 @@ import { Match } from "meteor/check";
 import { userPictureUrl, fetchPicture } from "/imports/server/accounts/picture.js";
 import { waitPromise } from "/imports/server/async-helpers.js";
 import { PRIVATE_IPV4_ADDRESSES, PRIVATE_IPV6_ADDRESSES } from "/imports/constants.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 import Future from "fibers/future";
 import Url from "url";

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -11,9 +11,9 @@ import { userPictureUrl, fetchPicture } from "/imports/server/accounts/picture.j
 import { waitPromise } from "/imports/server/async-helpers.js";
 import { PRIVATE_IPV4_ADDRESSES, PRIVATE_IPV6_ADDRESSES } from "/imports/constants.js";
 
-const Future = Npm.require("fibers/future");
-const Url = Npm.require("url");
-const Crypto = Npm.require("crypto");
+import Future from "fibers/future";
+import Url from "url";
+import Crypto from "crypto";
 
 const updateLoginStyleToRedirect = function (db, backend) {
   const configurations = Package["service-configuration"].ServiceConfiguration.configurations;

--- a/shell/imports/server/networking.js
+++ b/shell/imports/server/networking.js
@@ -14,11 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { SPECIAL_IPV4_ADDRESSES, SPECIAL_IPV6_ADDRESSES } from "/imports/constants.js";
+import { Meteor } from "meteor/meteor";
+import Dns from "dns";
+import Ip from "ip";
+import Url from "url";
 
-const Dns = Npm.require("dns");
-const Ip = Npm.require("ip");
-const Url = Npm.require("url");
+import { SPECIAL_IPV4_ADDRESSES, SPECIAL_IPV6_ADDRESSES } from "/imports/constants.js";
 
 const lookupInFiber = Meteor.wrapAsync(Dns.lookup, Dns);
 

--- a/shell/imports/server/notifications-server.js
+++ b/shell/imports/server/notifications-server.js
@@ -17,6 +17,7 @@
 import { waitPromise } from "/imports/server/async-helpers.js";
 import { createAppActivityDesktopNotification } from "/imports/server/desktop-notifications.js";
 import Capnp from "/imports/server/capnp.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const SupervisorCapnp = Capnp.importSystem("sandstorm/supervisor.capnp");
 const SystemPersistent = SupervisorCapnp.SystemPersistent;

--- a/shell/imports/server/notifications-server.js
+++ b/shell/imports/server/notifications-server.js
@@ -16,6 +16,7 @@
 
 import { waitPromise } from "/imports/server/async-helpers.js";
 import { createAppActivityDesktopNotification } from "/imports/server/desktop-notifications.js";
+import Capnp from "/imports/server/capnp.js";
 
 const SupervisorCapnp = Capnp.importSystem("sandstorm/supervisor.capnp");
 const SystemPersistent = SupervisorCapnp.SystemPersistent;

--- a/shell/imports/server/persistent.js
+++ b/shell/imports/server/persistent.js
@@ -16,7 +16,7 @@
 
 import { inMeteor } from "/imports/server/async-helpers.js";
 
-const Crypto = Npm.require("crypto");
+import Crypto from "crypto";
 
 const privateDb = Symbol("PersistentImpl.db");
 const privateTemplate = Symbol("PersistentImpl.template");

--- a/shell/imports/server/persistent.js
+++ b/shell/imports/server/persistent.js
@@ -14,9 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { inMeteor } from "/imports/server/async-helpers.js";
-
 import Crypto from "crypto";
+import { inMeteor } from "/imports/server/async-helpers.js";
+import Capnp from "/imports/server/capnp.js";
 
 const privateDb = Symbol("PersistentImpl.db");
 const privateTemplate = Symbol("PersistentImpl.template");

--- a/shell/imports/server/pre-meteor.js
+++ b/shell/imports/server/pre-meteor.js
@@ -24,6 +24,7 @@ import Fs from "fs";
 import Dns from "dns";
 import Future from "fibers/future";
 import Http from "http";
+import Capnp from "/imports/server/capnp.js";
 const ByteStream = Capnp.importSystem("sandstorm/util.capnp").ByteStream;
 
 const HOSTNAME = Url.parse(process.env.ROOT_URL).hostname;

--- a/shell/imports/server/pre-meteor.js
+++ b/shell/imports/server/pre-meteor.js
@@ -18,6 +18,7 @@
 // including routing of requests to proxies and handling of static web publishing.
 
 import { inMeteor } from "/imports/server/async-helpers.js";
+import ServerIdenticon from "/imports/sandstorm-identicons/identicon-server.js";
 const Url = Npm.require("url");
 const Fs = Npm.require("fs");
 const Dns = Npm.require("dns");
@@ -92,7 +93,7 @@ function serveStaticAsset(req, res, hostId) {
       let asset;
       if (pathname.startsWith("identicon/")) {
         const size = parseInt((url.query || {}).s);
-        asset = new Identicon(pathname.slice("identicon/".length), size).asAsset();
+        asset = new ServerIdenticon(pathname.slice("identicon/".length), size).asAsset();
       } else if (pathname.indexOf("/") == -1) {
         asset = globalDb.getStaticAsset(pathname);
       }

--- a/shell/imports/server/pre-meteor.js
+++ b/shell/imports/server/pre-meteor.js
@@ -19,11 +19,11 @@
 
 import { inMeteor } from "/imports/server/async-helpers.js";
 import ServerIdenticon from "/imports/sandstorm-identicons/identicon-server.js";
-const Url = Npm.require("url");
-const Fs = Npm.require("fs");
-const Dns = Npm.require("dns");
-const Future = Npm.require("fibers/future");
-const Http = Npm.require("http");
+import Url from "url";
+import Fs from "fs";
+import Dns from "dns";
+import Future from "fibers/future";
+import Http from "http";
 const ByteStream = Capnp.importSystem("sandstorm/util.capnp").ByteStream;
 
 const HOSTNAME = Url.parse(process.env.ROOT_URL).hostname;

--- a/shell/imports/server/sandcats.js
+++ b/shell/imports/server/sandcats.js
@@ -18,11 +18,11 @@ Sandcats = {};
 
 import { inMeteor } from "/imports/server/async-helpers.js";
 import { pki, asn1 } from "node-forge";
-const querystring = Npm.require("querystring");
-const https = Npm.require("https");
-const fs = Npm.require("fs");
-const dgram = Npm.require("dgram");
-const Url = Npm.require("url");
+import querystring from "querystring";
+import https from "https";
+import fs from "fs";
+import dgram from "dgram";
+import Url from "url";
 
 import { SANDSTORM_ALTHOME } from "/imports/server/constants.js";
 

--- a/shell/imports/server/scheduled-job.js
+++ b/shell/imports/server/scheduled-job.js
@@ -15,9 +15,11 @@
 // limitations under the License.
 
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
+import { PersistentImpl, fetchApiToken } from "/imports/server/persistent.js";
+import Capnp from "/imports/server/capnp.js";
+
 const ScheduledJob = Capnp.importSystem("sandstorm/grain.capnp").ScheduledJob;
 const SystemPersistent = Capnp.importSystem("sandstorm/supervisor.capnp").SystemPersistent;
-import { PersistentImpl, fetchApiToken } from "/imports/server/persistent.js";
 
 const MINIMUM_SCHEDULING_SLACK_NANO = Capnp.importSystem("sandstorm/grain.capnp").minimumSchedulingSlack;
 const MINIMUM_SCHEDULING_SLACK_MILLIS = MINIMUM_SCHEDULING_SLACK_NANO / 1e6;

--- a/shell/imports/server/scheduled-job.js
+++ b/shell/imports/server/scheduled-job.js
@@ -17,6 +17,7 @@
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { PersistentImpl, fetchApiToken } from "/imports/server/persistent.js";
 import Capnp from "/imports/server/capnp.js";
+import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const ScheduledJob = Capnp.importSystem("sandstorm/grain.capnp").ScheduledJob;
 const SystemPersistent = Capnp.importSystem("sandstorm/supervisor.capnp").SystemPersistent;

--- a/shell/imports/server/static-asset.js
+++ b/shell/imports/server/static-asset.js
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const Url = Npm.require("url");
+import Url from "url";
 const StaticAsset = Capnp.importSystem("sandstorm/grain.capnp").StaticAsset;
 
 const PROTOCOL = Url.parse(process.env.ROOT_URL).protocol;

--- a/shell/imports/server/static-asset.js
+++ b/shell/imports/server/static-asset.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import Url from "url";
+import Capnp from "/imports/server/capnp.js";
 const StaticAsset = Capnp.importSystem("sandstorm/grain.capnp").StaticAsset;
 
 const PROTOCOL = Url.parse(process.env.ROOT_URL).protocol;

--- a/shell/imports/server/transfers-server.js
+++ b/shell/imports/server/transfers-server.js
@@ -14,10 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const URL = Npm.require("url").URL;
-const Crypto = Npm.require("crypto");
-const NodeHttp = Npm.require("http");
-const NodeHttps = Npm.require("https");
+import { URL } from "url";
+import Crypto from "crypto";
+import NodeHttp from "http";
+import NodeHttps from "https";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 
 function isValidServerUrl(str) {

--- a/shell/npm-shrinkwrap.json
+++ b/shell/npm-shrinkwrap.json
@@ -543,6 +543,11 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -766,6 +771,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fibers": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.2.tgz",
+      "integrity": "sha512-FhICi1K4WZh9D6NC18fh2ODF3EWy1z0gzIdV9P7+s2pRjfRBnCkMDJ6x3bV1DkVymKH8HGrQa/FNOBjYvnJ/tQ==",
+      "requires": {
+        "detect-libc": "^1.0.3"
+      }
     },
     "figures": {
       "version": "3.2.0",

--- a/shell/package.json
+++ b/shell/package.json
@@ -20,6 +20,7 @@
     "bignum": "^0.13.0",
     "body-parser": "^1.19.0",
     "content-type": "^1.0.4",
+    "fibers": "^4.0.2",
     "heapdump": "^0.3.15",
     "intro.js": "git+https://github.com/sandstorm-io/intro.js.git#8e1c7604f251ec874bf4ae4d7b4f11a14cee697e",
     "ldapjs": "^1.0.2",

--- a/shell/server/main.ts
+++ b/shell/server/main.ts
@@ -77,6 +77,7 @@ import "../imports/server/admin/system-status-server.js";
 import "../imports/server/drivers/external-ui-view.js";
 import "../imports/server/drivers/ip.js";
 import "../imports/server/drivers/mail.js";
+import "../imports/db-deprecated.js";
 import "../imports/server/00-startup.js";
 import "../imports/server/account-suspension.js";
 import "../imports/server/admin-server.js";

--- a/shell/server/main.ts
+++ b/shell/server/main.ts
@@ -38,14 +38,10 @@
 
 // Import packages that sandstorm depends on.
 
-// sandstorm-identicons.
-import "../imports/sandstorm-identicons/identicon.js";
-import "../imports/sandstorm-identicons/helpers.js";
-
 // sandstorm-capnp.
 import "../imports/server/capnp.js";
 
-// sandstorm-db.  Depends on sandstorm-capnp and sandstorm-identicons.
+// sandstorm-db.  Depends on sandstorm-capnp.
 import "../imports/sandstorm-db/db.js";
 import "../imports/sandstorm-db/profile.js";
 import "../imports/sandstorm-db/scheduled-jobs-db.js";

--- a/shell/server/main.ts
+++ b/shell/server/main.ts
@@ -38,10 +38,7 @@
 
 // Import packages that sandstorm depends on.
 
-// sandstorm-capnp.
-import "../imports/server/capnp.js";
-
-// sandstorm-db.  Depends on sandstorm-capnp.
+// sandstorm-db.
 import "../imports/sandstorm-db/db.js";
 import "../imports/sandstorm-db/profile.js";
 import "../imports/sandstorm-db/scheduled-jobs-db.js";
@@ -55,10 +52,10 @@ import "../imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
 // sandstorm-accounts-packages
 import "../imports/sandstorm-accounts-packages/accounts.js";
 
-// sandstorm-ui-powerbox.  Depends on sandstorm-capnp
+// sandstorm-ui-powerbox.
 import "../imports/sandstorm-ui-powerbox/powerbox-server.js";
 
-// blackrock-payments.  Depends on sandstorm-db and sandstorm-capnp.
+// blackrock-payments.  Depends on sandstorm-db
 import "../imports/blackrock-payments/constants.js";
 import "../imports/blackrock-payments/server/payments-server.js";
 import "../imports/blackrock-payments/server/payments-api-server.js";


### PR DESCRIPTION
I started going through the files imported in `main.ts` from the top and converting them from side-effect-ful imports to explicit imports and exports.  If you want to review this, going commit-by-commit is probably the way to go.  With the exception of the final commit (with a fix for what appears to be a long-standing bug), I believe this patch series does not change any behavior.

Identicons were first.  We largely used Identicon as a namespace; I've taken to flattening things out into just the bare functions when we're not instantiating a class or doing anything stateful.

I moved our dependency on fibers to be explicit in package.json, and moved several other things we used to pull in via `Npm.require` to `import` statements.  There's still a few `Npm.require`s floating around in conditional branches; I'm inclined to split things apart into separate client and server packages where appropriate.  There's whole swaths of methods on SandstormDb that are only implemented on client or on server, and plenty more that expose the same interface but have separate implementations.

I moved Capnp to explicit imports.  The style I've been trying to take for ordering imports is:

* imports from Meteor
* imports from npm packages, alphabetically
* imports from /imports

My position is that Capnp imports like `const Whatever = Capnp.importSystem(...)` should go after all the JS module imports.

Since almost all of our code uses double-quotes for strings today, I changed a couple instances of single-quotes introduced in recent patches to double-quotes for consistency.

I moved the side-effect-ful import of `db-deprecated.js` up from `00-startup.js` (where, before imports were available, we dumped things we needed to be loaded first for their side-effects) so that all side-effect-ful imports live in `main.ts`.

I moved `SandstormDb` to explicit imports and exports.

Lastly, I made some small cleanups to db.js including fixing what I believe is a bug in `refStaticAsset`, where we would incorrectly specify a query for the object for which we wanted to increment the refcount.