### PR TITLE
Remove spacejam dependency from tests/

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -21,7 +21,6 @@
     "mailparser": "0.5.1",
     "selenium-standalone": "^6.15.4",
     "simplesmtp": "0.3.35",
-    "spacejam": "1.2.2",
     "underscore": "^1.9.1"
   }
 }


### PR DESCRIPTION
The tests that use this are broken anyway (#3188) and fixing them
probably means moving to a different testing framework. Meanwhile,
spacejam pulls in phantomjs, which is unmaintained and seems to be
broken on node 12, so this breaks the whole CI system.

Hopefully fixes #3277