### PR TITLE
admin panel: add an explanation for network capabilities.

### DIFF
--- a/shell/i18n/en.i18n.json
+++ b/shell/i18n/en.i18n.json
@@ -1202,6 +1202,7 @@
     "networkCapabilities": {
       "name": "Network capabilities",
       "subtext": "Manage direct network access for grains.",
+      "explanation": "This page displays network capabilities granted to grains. By default, grains have very limited network access. A grain can request full network access while it is being used. Only an admin can approve the request, which grants a \"network capability\" to the grain.",
       "newAdminNetworkCapabilitiesTableCapabilityRow": {
         "adminAccount": "Admin account %s",
         "unknownGranter": "Unknown granter",

--- a/shell/imports/client/admin/network-capabilities.html
+++ b/shell/imports/client/admin/network-capabilities.html
@@ -142,6 +142,8 @@
   </ul>
 </h1>
 
+<p>{{_ "admin.networkCapabilities.explanation"}}</p>
+
 <h2>{{_ (con txt "networkCaps")}}</h2>
 {{>newAdminNetworkCapabilitiesSection caps=ipNetworkCaps}}
 


### PR DESCRIPTION
Fixes #2039

@kentonv mentioned on that issue that the page is likely to cover other types of capabilities at some point. I am of the opinion that it makes sense to wait until that actually happens to update the explanation; otherwise I think it will just seem overly abstract (especially without other examples).

This will need translation (cc @xet7, who else?). (It would be nice if we had a team for translators so when submitting prs that change UI text we could just cc @sandstorm-io/translators or something).