### PR TITLE
Adopt & fix most of the rules from eslint:recommended

### DIFF
--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -17,4 +17,3 @@ rules:
   no-unused-vars: ["off"]
   no-empty: ["off"]
   no-inner-declarations: ["off"]
-  no-useless-escape: ["off"]

--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -17,6 +17,5 @@ rules:
   no-unused-vars: ["off"]
   no-empty: ["off"]
   no-inner-declarations: ["off"]
-  no-extra-boolean-cast: ["off"]
   no-useless-escape: ["off"]
   no-unexpected-multiline: ["off"]

--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -11,7 +11,7 @@ parserOptions:
 reportUnusedDisableDirectives: true
 extends: "eslint:recommended"
 rules:
-  # These are implied by eslint:recommended, but we havent' gotten around to
+  # These are implied by eslint:recommended, but we haven't gotten around to
   # fixing them yet:
   no-undef: ["off"]
   no-unused-vars: ["off"]

--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -9,7 +9,16 @@ parserOptions:
   # *has* to be conditional, so tell eslint to allow this:
   allowImportExportEverywhere: true
 reportUnusedDisableDirectives: true
+extends: "eslint:recommended"
 rules:
-  no-extra-semi: ["error"]
-  no-self-assign: ["error"]
-  no-prototype-builtins: ["error"]
+  # These are implied by eslint:recommended, but we havent' gotten around to
+  # fixing them yet:
+  no-undef: ["off"]
+  no-unused-vars: ["off"]
+  no-empty: ["off"]
+  no-inner-declarations: ["off"]
+  no-extra-boolean-cast: ["off"]
+  no-constant-condition: ["off"]
+  no-useless-escape: ["off"]
+  no-case-declarations: ["off"]
+  no-unexpected-multiline: ["off"]

--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -11,3 +11,4 @@ parserOptions:
 reportUnusedDisableDirectives: true
 rules:
   no-extra-semi: ["error"]
+  no-self-assign: ["error"]

--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -9,3 +9,5 @@ parserOptions:
   # *has* to be conditional, so tell eslint to allow this:
   allowImportExportEverywhere: true
 reportUnusedDisableDirectives: true
+rules:
+  no-extra-semi: ["error"]

--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -20,5 +20,4 @@ rules:
   no-extra-boolean-cast: ["off"]
   no-constant-condition: ["off"]
   no-useless-escape: ["off"]
-  no-case-declarations: ["off"]
   no-unexpected-multiline: ["off"]

--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -18,4 +18,3 @@ rules:
   no-empty: ["off"]
   no-inner-declarations: ["off"]
   no-useless-escape: ["off"]
-  no-unexpected-multiline: ["off"]

--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -18,6 +18,5 @@ rules:
   no-empty: ["off"]
   no-inner-declarations: ["off"]
   no-extra-boolean-cast: ["off"]
-  no-constant-condition: ["off"]
   no-useless-escape: ["off"]
   no-unexpected-multiline: ["off"]

--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -12,3 +12,4 @@ reportUnusedDisableDirectives: true
 rules:
   no-extra-semi: ["error"]
   no-self-assign: ["error"]
+  no-prototype-builtins: ["error"]

--- a/shell/imports/blackrock-payments/client/payments-client.js
+++ b/shell/imports/blackrock-payments/client/payments-client.js
@@ -32,7 +32,7 @@ updateStripeData = function (cb) {
         sources = data.sources;
         for (var i = 0; i < sources.length; i++) {
           StripeCards.upsert({_id: sources[i].id}, sources[i]);
-        };
+        }
       }
       if (cb) {
         cb();

--- a/shell/imports/blackrock-payments/server/payments-server.js
+++ b/shell/imports/blackrock-payments/server/payments-server.js
@@ -193,8 +193,9 @@ function sendEmail(db, user, mailSubject, mailText, mailHtml, config) {
   if (email) {
     email = email.email;
   } else {
-    email = Meteor.wrapAsync(stripe.customers.retrieve.bind(stripe.customers))
-        (user.payments.id).email;
+    email = Meteor.wrapAsync(stripe.customers.retrieve.bind(stripe.customers))(
+      user.payments.id
+    ).email;
   }
 
   if (email) {
@@ -896,8 +897,9 @@ function getStripeBonus(user, paymentsBonuses) {
   var bonus = {};
 
   if (user.payments && user.payments.id) {
-    var customer = Meteor.wrapAsync(stripe.customers.retrieve.bind(stripe.customers))
-        (user.payments.id);
+    var customer = Meteor.wrapAsync(stripe.customers.retrieve.bind(stripe.customers))(
+      user.payments.id
+    );
 
     var meta = customer.metadata;
     if (meta) {

--- a/shell/imports/client/accounts/account-settings.js
+++ b/shell/imports/client/accounts/account-settings.js
@@ -125,7 +125,7 @@ Template.sandstormAccountSettings.helpers({
           const input = instance.find("input[name='email']");
           if (input) {
             input.value = "";
-          };
+          }
 
           instance._actionCompleted.set({ success: "credential added" });
         },

--- a/shell/imports/client/download-file.js
+++ b/shell/imports/client/download-file.js
@@ -16,6 +16,6 @@ function downloadFile(url, suggestedFilename) {
   } else {
     window.location = url;
   }
-};
+}
 
 export default downloadFile;

--- a/shell/imports/client/grain-client.js
+++ b/shell/imports/client/grain-client.js
@@ -1292,7 +1292,7 @@ Template.emailInviteTab.events({
     const emails = instance.find("input.emails");
     const emailsValue = emails.value;
     if (emailsValue) {
-      if (emailsValue.match(/.+\@.+\..+/)) {
+      if (emailsValue.match(/.+@.+\..+/)) {
         contacts.push({
           _id: emailsValue,
           profile: {
@@ -1598,8 +1598,8 @@ Meteor.startup(function () {
         // grainTitleSlug is the grain title with url-unsafe characters replaced
         let grainTitleSlug = grainTitle.toLowerCase().trim();
         grainTitleSlug = grainTitleSlug.replace(/\s+/g, "-")
-                                       .replace(/[^\w\-]+/g, "")
-                                       .replace(/\-\-+/g, "-")
+                                       .replace(/[^\w-]+/g, "")
+                                       .replace(/--+/g, "-")
                                        .replace(/^-+/, "")
                                        .replace(/-+$/, "");
         const renderedTemplate = template.replace(/\$API_TOKEN/g, tokenId)

--- a/shell/imports/client/grain-client.js
+++ b/shell/imports/client/grain-client.js
@@ -242,6 +242,10 @@ Template.grainRestartButton.events({
         for (let i = 0; i < frames.length; i++) {
           const frame = frames[i];
           if (frame.dataset.grainid == grainId) {
+            // Re-assign frame.src; this causes the browser to refresh the
+            // iframe's contents.
+            //
+            // eslint-disable-next-line no-self-assign
             frame.src = frame.src;
           }
         }

--- a/shell/imports/client/grain/grainview-list.js
+++ b/shell/imports/client/grain/grainview-list.js
@@ -268,7 +268,7 @@ class GrainViewList {
       this._grains.set(newGrains);
     }
   }
-};
+}
 
 export { GrainViewList };
 

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -862,7 +862,7 @@ class GrainView {
     return this._db.collections.notifications.find(
         { grainId: this._grainId, ongoing: { $exists: false } }).count();
   }
-};
+}
 
 const onceConditionIsTrue = (condition, continuation) => {
   Tracker.nonreactive(() => {

--- a/shell/imports/dates.js
+++ b/shell/imports/dates.js
@@ -33,6 +33,6 @@ function formatFutureTime(diff) {
 
   // We're within a second of the countdown, or past it.
   return "any moment";
-};
+}
 
 export { formatFutureTime };

--- a/shell/imports/install.js
+++ b/shell/imports/install.js
@@ -22,6 +22,6 @@ function isSafeDemoAppUrl(url) {
       url.lastIndexOf("https://sandstorm.io/", 0) === 0 ||
       url.lastIndexOf("https://alpha-j7uny7u376jnimcsx34c.sandstorm.io/", 0) === 0 ||
       url.lastIndexOf("https://app-index.sandstorm.io/", 0) === 0;
-};
+}
 
 export { isSafeDemoAppUrl };

--- a/shell/imports/sandstorm-db/db.js
+++ b/shell/imports/sandstorm-db/db.js
@@ -1150,7 +1150,7 @@ function SandstormDb(quotaManager) {
     incomingTransfers: IncomingTransfers,
     outgoingTransfers: OutgoingTransfers,
   };
-};
+}
 
 // TODO(cleanup): These methods should not be defined freestanding and should use collection
 //   objects created in SandstormDb's constructor rather than globals.

--- a/shell/imports/sandstorm-identicons/helpers.js
+++ b/shell/imports/sandstorm-identicons/helpers.js
@@ -3,7 +3,7 @@ import Identicon from "./identicon.js";
 const VALID_USAGES = ["appGrid", "grain", "notification"];
 function checkUsage(usage) {
   if (VALID_USAGES.indexOf(usage) === -1) throw new Error("Invalid icon usage.");
-};
+}
 
 function iconFromManifest(manifest, usage) {
   // TODO: select by usage location, rather than assuming appGrid
@@ -18,7 +18,7 @@ function iconFromManifest(manifest, usage) {
   }
 
   return undefined;
-};
+}
 
 function hashAppIdForIdenticon(id) {
   // "Hash" an app ID to a 32-digit hex string for the purpose of
@@ -36,7 +36,7 @@ function hashAppIdForIdenticon(id) {
   }
 
   return result.join("");
-};
+}
 
 // Keep a static global cache of all app identicons produced in this way.
 // If memory usage is excessive, we can revisit this decision.
@@ -49,12 +49,12 @@ function cachedIdenticon(hashedAppId, size) {
   }
 
   return cachedIdenticons[cacheKey];
-};
+}
 
 function identiconForApp(appId, usage) {
   const size = (usage === "appGrid" ? 128 : 24);
   return cachedIdenticon(hashAppIdForIdenticon(appId), size);
-};
+}
 
 function bytesToBase64(bytes) {
   const arr = new Array(bytes.length);
@@ -64,7 +64,7 @@ function bytesToBase64(bytes) {
   // Note that btoa is not available in IE9.  We may want to polyfill this.
   const result = btoa(arr.join(""));
   return result;
-};
+}
 
 function iconSrcFor(appId, iconObj, staticPrefix, usage) {
   if (iconObj === undefined || iconObj === null) {
@@ -99,7 +99,7 @@ function iconSrcFor(appId, iconObj, staticPrefix, usage) {
   }
   // We should never reach here, but do something sensible anyway
   return identiconForApp(appId, usage);
-};
+}
 
 function iconSrcForPackage(pkg, usage, staticPrefix) {
   // Works for regular packages and dev packages.
@@ -107,11 +107,11 @@ function iconSrcForPackage(pkg, usage, staticPrefix) {
   checkUsage(usage);
   const iconObj = iconFromManifest(pkg.manifest, usage);
   return iconSrcFor(pkg.appId, iconObj, staticPrefix, usage);
-};
+}
 
 function iconSrcForDenormalizedGrainMetadata(metadata, usage, staticPrefix) {
   return iconSrcFor(metadata.appId, metadata.icon, staticPrefix, usage);
-};
+}
 
 export {
     hashAppIdForIdenticon,

--- a/shell/imports/sandstorm-identicons/identicon.js
+++ b/shell/imports/sandstorm-identicons/identicon.js
@@ -80,6 +80,6 @@ class Identicon {
   toString() {
     return this.render();
   }
-};
+}
 
 export default Identicon;

--- a/shell/imports/sandstorm-permissions/permissions.js
+++ b/shell/imports/sandstorm-permissions/permissions.js
@@ -865,7 +865,7 @@ class Context {
       } else if (req.tokenValid) {
         // Active the token and all of its transitive parents.
         let currentTokenId = req.tokenValid;
-        while (true) {
+        for(;;) {
           let currentToken = this.tokensById[currentTokenId];
           if (!currentToken && db) {
             currentToken = db.collections.apiTokens.findOne({
@@ -932,7 +932,7 @@ class Context {
     }
 
     this.activateRelevantTokens(grainId, vertexId);
-    while (true) {
+    for(;;) {
       const result = this.runForwardChaining(grainId, vertexId, permissionSet);
       if (result && permissionSet.isSubsetOf(result)) {
         return result;

--- a/shell/imports/server/accounts/credentials/credentials-server.js
+++ b/shell/imports/server/accounts/credentials/credentials-server.js
@@ -182,7 +182,7 @@ Meteor.methods({
     } else if (user.expires) {
       // Demo user.
       newUser.expires = user.expires;
-      if (!!user.appDemoId) {
+      if (user.appDemoId) {
         newUser.appDemoId = user.appDemoId;
       }
     }

--- a/shell/imports/server/accounts/ldap.js
+++ b/shell/imports/server/accounts/ldap.js
@@ -44,8 +44,10 @@ LDAP.prototype.ldapCheck = function (db, options) {
 
   options = options || {};
 
-  if ((options.hasOwnProperty("username") && options.hasOwnProperty("ldapPass")) ||
-      options.hasOwnProperty("searchUsername")) {
+  const hasOwnProperty = Object.prototype.hasOwnProperty.call
+
+  if ((hasOwnProperty(options, "username") && hasOwnProperty(options, "ldapPass")) ||
+      hasOwnProperty(options, "searchUsername")) {
     _this.options.base = db.getLdapBase();
     _this.options.url = db.getLdapUrl();
     _this.options.searchBeforeBind = {};
@@ -94,7 +96,7 @@ LDAP.prototype.ldapCheck = function (db, options) {
     let username = options.username;
     let domain = _this.options.defaultDomain;
 
-    if (!options.hasOwnProperty("searchUsername")) {
+    if (!hasOwnProperty(options, "searchUsername")) {
       // Slide @xyz.whatever from username if it was passed in
       // and replace it with the domain specified in defaults
       let emailSliceIndex = options.username.indexOf("@");
@@ -165,7 +167,7 @@ LDAP.prototype.ldapCheck = function (db, options) {
 
         retObject.searchResults = _.omit(entry.object, "userPassword");
 
-        if (options.hasOwnProperty("searchUsername")) {
+        if (hasOwnProperty(options, "searchUsername")) {
           // This was only a search, return immediately
           resolved = true;
           ldapAsyncFut.return(retObject);

--- a/shell/imports/server/accounts/ldap.js
+++ b/shell/imports/server/accounts/ldap.js
@@ -26,7 +26,7 @@ LDAP_DEFAULTS = {
 function LDAP() {
   // Set options
   this.options = _.clone(LDAP_DEFAULTS);
-};
+}
 
 /**
  * Attempt to bind (authenticate) ldap

--- a/shell/imports/server/accounts/saml-utils.js
+++ b/shell/imports/server/accounts/saml-utils.js
@@ -288,7 +288,7 @@ SAML.prototype.validateResponse = function (samlResponse, callback) {
       const conditions = _this.getElement(assertion[0], "Conditions")[0];
       if (conditions) {
         for (const key in conditions) {
-          if (conditions.hasOwnProperty(key)) {
+          if (Object.prototype.hasOwnProperty.call(conditions, key)) {
             const value = conditions[key];
             if (key === "$") {
               const nowMs = Date.now();

--- a/shell/imports/server/backend.js
+++ b/shell/imports/server/backend.js
@@ -215,6 +215,6 @@ class SandstormBackend {
       }
     }
   }
-};
+}
 
 export { SandstormBackend, shouldRestartGrain };

--- a/shell/imports/server/core.js
+++ b/shell/imports/server/core.js
@@ -502,7 +502,7 @@ class DummyObserver {
       revoker.close();
     }
   }
-};
+}
 
 restoreInternal = (db, originalToken, ownerPattern, requirements, originalTokenInfo,
                    currentTokenId, currentTokenKey) => {
@@ -683,7 +683,7 @@ class SandstormCoreFactoryImpl {
 
 function makeSandstormCoreFactory(db) {
   return new Capnp.Capability(new SandstormCoreFactoryImpl(db), SandstormCoreFactory);
-};
+}
 
 // Start up the backend.
 const sandstormCoreFactory = makeSandstormCoreFactory(globalDb);

--- a/shell/imports/server/drivers/external-ui-view.js
+++ b/shell/imports/server/drivers/external-ui-view.js
@@ -511,7 +511,7 @@ ExternalWebSession = class ExternalWebSession extends PersistentImpl {
               }
 
               switch (statusInfo ? statusInfo.type : resp.statusCode) {
-                case "content":
+                case "content": {
                   const content = {};
                   rpcResponse.content = content;
 
@@ -541,7 +541,8 @@ ExternalWebSession = class ExternalWebSession extends PersistentImpl {
 
                   resolve(rpcResponse);
                   break;
-                case "noContent":
+                }
+                case "noContent": {
                   const noContent = {};
                   rpcResponse.noContent = noContent;
                   noContent.setShouldResetForm = statusInfo.shouldResetForm;
@@ -551,7 +552,8 @@ ExternalWebSession = class ExternalWebSession extends PersistentImpl {
 
                   resolve(rpcResponse);
                   break;
-                case "redirect":
+                }
+                case "redirect": {
                   const redirect = {};
                   rpcResponse.redirect = redirect;
                   redirect.isPermanent = statusInfo.isPermanent;
@@ -559,7 +561,8 @@ ExternalWebSession = class ExternalWebSession extends PersistentImpl {
                   if ("location" in resp.headers) redirect.location = resp.headers.location;
                   resolve(rpcResponse);
                   break;
-                case "clientError":
+                }
+                case "clientError": {
                   const clientError = {};
                   rpcResponse.clientError = clientError;
                   clientError.statusCode = statusInfo.clientErrorCode;
@@ -567,13 +570,15 @@ ExternalWebSession = class ExternalWebSession extends PersistentImpl {
                   fillInErrorBody(clientError);
                   resolve(rpcResponse);
                   break;
-                case "serverError":
+                }
+                case "serverError": {
                   const serverError = {};
                   rpcResponse.serverError = serverError;
                   fillInErrorBody(serverError);
                   resolve(rpcResponse);
                   break;
-                case "preconditionFailed":
+                }
+                case "preconditionFailed": {
                   const preconditionFailed = {};
                   rpcResponse.preconditionFailed = preconditionFailed;
                   if (resp.headers.etag) {
@@ -586,11 +591,14 @@ ExternalWebSession = class ExternalWebSession extends PersistentImpl {
                 // TODO(soon): Handle token-expired errors by throwing DISCONNECTED -- this will
                 //   force the client to reload the capability which will refresh the token.
 
-                default: // ???
+                }
+                default: {
+                  // ???
                   const err = new Error(
                       "Invalid status code " + resp.statusCode + " received in response.");
                   reject(err);
                   break;
+                }
               }
             } catch (err) {
               reject(err);

--- a/shell/imports/server/drivers/ip.js
+++ b/shell/imports/server/drivers/ip.js
@@ -120,7 +120,7 @@ class IpInterfaceImpl extends PersistentImpl {
       });
     });
   }
-};
+}
 
 // TODO(cleanup): Meteor.startup() needed because 00-startup.js runs *after* code in subdirectories
 //   (ugh).
@@ -254,7 +254,7 @@ class IpNetworkImpl extends PersistentImpl {
   getRemoteHostByName(address) {
     return { host: new IpRemoteHostImpl(address, this.tls) };
   }
-};
+}
 
 // TODO(cleanup): Meteor.startup() needed because 00-startup.js runs *after* code in subdirectories
 //   (ugh).
@@ -332,7 +332,7 @@ class IpRemoteHostImpl {
 
     return { port: new UdpPortImpl(this.address, portNum) };
   }
-};
+}
 
 TcpPortImpl = class TcpPortImpl {
   constructor(address, portNum, tls) {

--- a/shell/imports/server/drivers/mail.js
+++ b/shell/imports/server/drivers/mail.js
@@ -344,7 +344,7 @@ class EmailVerifierImpl extends PersistentImpl {
       return verification.address;
     });
   }
-};
+}
 
 class VerifiedEmailImpl extends PersistentImpl {
   constructor(db, saveTemplate) {
@@ -436,7 +436,7 @@ Meteor.startup(() => {
             cardTemplate: "emailVerifierPowerboxCard",
           });
         }
-      };
+      }
 
       return results;
     },

--- a/shell/imports/server/gateway-router.js
+++ b/shell/imports/server/gateway-router.js
@@ -94,7 +94,7 @@ class PermissionsObserver {
   whenRevoked(callback) {
     this.invalidatedPromise.then(callback);
   }
-};
+}
 
 function boolListToBuffer(bools) {
   const numBytes = Math.ceil(bools.length / 8);
@@ -150,7 +150,7 @@ function validateWebkey(apiToken, refreshedExpiration) {
   if (apiToken.objectId || apiToken.frontendRef) {
     throw new Meteor.Error(403, "ApiToken refers to a non-webview Capability.");
   }
-};
+}
 
 function getUiViewAndUserInfo(grainId, vertex, accountId, identityId, sessionId, observer) {
   if (!accountId && globalDb.getOrganizationDisallowGuests()) {
@@ -614,7 +614,7 @@ function storeReferralProgramInfoApiTokenCreated(db, accountId, apiTokenAccountI
   Meteor.users.update(
     { _id: bobAccountId, referredBy: { $exists: false } },
     { $set: { referredBy: aliceAccountId } });
-};
+}
 
 function referralProgramLogSharingTokenUse(db, bobAccountId) {
   // Hooray! The sharing token is valid! Someone (let's call them Charlie) is going to get a UiView

--- a/shell/imports/server/header-whitelist.js
+++ b/shell/imports/server/header-whitelist.js
@@ -39,7 +39,7 @@ class HeaderWhitelist {
       if (header.startsWith(this._prefixes[i])) {
         return true;
       }
-    };
+    }
 
     return false;
   }

--- a/shell/imports/server/identity.js
+++ b/shell/imports/server/identity.js
@@ -50,7 +50,7 @@ class IdentityImpl extends PersistentImpl {
 
     return { profile: profile };
   }
-};
+}
 
 // TODO(cleanup): Find a better home for this.
 const MembraneRequirement = Match.OneOf(

--- a/shell/imports/server/install-server.js
+++ b/shell/imports/server/install-server.js
@@ -162,7 +162,7 @@ Router.map(function () {
           });
           this.response.write("Unpacking SPK failed; is it valid?");
           this.response.end();
-        };
+        }
       } else if (this.request.method == "OPTIONS") {
         // Allow cross-origin posts to upload so that uploads can occur on the DDP host
         // rather than the main host. In theory we could have Access-Control-Allow-Origin specify

--- a/shell/imports/server/persistent.js
+++ b/shell/imports/server/persistent.js
@@ -89,7 +89,7 @@ class PersistentImpl {
 
 function hashSturdyRef(sturdyRef) {
   return Crypto.createHash("sha256").update(sturdyRef).digest("base64");
-};
+}
 
 function generateSturdyRef() {
   return Random.secret();
@@ -245,7 +245,7 @@ function checkRequirements(db, requirements) {
       throw new Meteor.Error(403, "Unknown requirement type.");
     }
   });
-};
+}
 
 export {
   PersistentImpl, hashSturdyRef, generateSturdyRef, checkRequirements,

--- a/shell/imports/server/sandcats.js
+++ b/shell/imports/server/sandcats.js
@@ -327,4 +327,4 @@ Sandcats.initializeSandcats = () => {
 
 if (SANDCATS_HOSTNAME) {
   Meteor.startup(Sandcats.initializeSandcats);
-};
+}

--- a/shell/imports/server/shell-server.js
+++ b/shell/imports/server/shell-server.js
@@ -259,7 +259,7 @@ Meteor.publish("referralInfoPseudo", function () {
         // If the handle doesn't show up in the new list of referredAccountIds, then remove
         // info from the client & stop it on the server & make it null.
         const handleForProfileName = handleForProfileNameByAccountId[accountId];
-        if (referredAccountIdsAsObject.hasOwnProperty(accountId)) {
+        if (Object.prototype.hasOwnProperty.call(referredAccountIdsAsObject, accountId)) {
           stopWatchingAccount(accountId);
         }
       });

--- a/shell/imports/server/startup.js
+++ b/shell/imports/server/startup.js
@@ -37,7 +37,7 @@ Meteor.startup(() => {
     if (resetOAuth) {
       console.log("resetting oauth");
       Settings.find({ _id: { $in: ["google", "github"] } }).forEach((setting) => {
-        if (!!setting.value) {
+        if (setting.value) {
           Settings.update({ _id: setting._id },
                           { $set: { value: false,
                                     automaticallyReset: { baseUrlChangedFrom: baseUrlRow.value }, }, });

--- a/shell/imports/server/static-asset.js
+++ b/shell/imports/server/static-asset.js
@@ -30,7 +30,7 @@ class StaticAssetImpl {
   getUrl() {
     return { protocol: this._protocol, hostPath: this._hostPath, };
   }
-};
+}
 
 class IdenticonStaticAssetImpl {
   constructor(hash, size) {
@@ -43,6 +43,6 @@ class IdenticonStaticAssetImpl {
   getUrl() {
     return { protocol: this._protocol, hostPath: this._hostPath, };
   }
-};
+}
 
 export { StaticAssetImpl, IdenticonStaticAssetImpl };

--- a/shell/imports/server/transfers-server.js
+++ b/shell/imports/server/transfers-server.js
@@ -489,7 +489,7 @@ class Downloader {
       }
     }
   }
-};
+}
 
 if (!Meteor.settings.replicaNumber) {
   Meteor.startup(() => {


### PR DESCRIPTION
This adds `extends: "eslint:recommended"` to our eslint config, removes a couple rules explicitly, and fixes violations of the rest.

It's probably easiest to understand the diff by looking at the individual commits.
