### PR TITLE
Explicitly import a bunch of stuff.

### DIFF
--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -1,4 +1,12 @@
 ---
+env:
+  # Assume standard globals. TODO: Ideally we'd only allow
+  # `node` from server/ and only allow `browser` from client,
+  # but I(zenhack) am not sure how to get eslint to use different
+  # options per subtree:
+  browser: true
+  node: true
+  es6: true
 parser: "babel-eslint"
 parserOptions:
   ecmaVersion: 2020

--- a/shell/imports/blackrock-payments/client/billingPrompt.js
+++ b/shell/imports/blackrock-payments/client/billingPrompt.js
@@ -16,6 +16,9 @@
 
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { _ } from "meteor/underscore";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 var idCounter = 0;

--- a/shell/imports/blackrock-payments/client/billingSettings.js
+++ b/shell/imports/blackrock-payments/client/billingSettings.js
@@ -14,7 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { _ } from "meteor/underscore";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 var messageListener = function (showPrompt, template, event) {

--- a/shell/imports/blackrock-payments/client/payments-api-client.js
+++ b/shell/imports/blackrock-payments/client/payments-api-client.js
@@ -16,6 +16,9 @@
 
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { _ } from "meteor/underscore";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 Template.stripePaymentAcceptorPowerboxConfiguration.events({

--- a/shell/imports/blackrock-payments/client/payments-client.js
+++ b/shell/imports/blackrock-payments/client/payments-client.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Mongo } from "meteor/mongo";
+
 StripeCustomerData = new Mongo.Collection(null);  // see getStripeData for where this is produced
 StripeCards = new Mongo.Collection(null);
 

--- a/shell/imports/blackrock-payments/server/payments-api-server.js
+++ b/shell/imports/blackrock-payments/server/payments-api-server.js
@@ -15,6 +15,8 @@
 // limitations under the License.
 
 import Crypto from "crypto";
+import { Meteor } from "meteor/meteor";
+
 import Capnp from "/imports/server/capnp.js";
 const PaymentsRpc = Capnp.importSystem("sandstorm/payments.capnp");
 

--- a/shell/imports/blackrock-payments/server/payments-server.js
+++ b/shell/imports/blackrock-payments/server/payments-server.js
@@ -27,6 +27,7 @@ import Url from 'url';
 import StripeModule from "stripe";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const ROOT_URL = process.env.ROOT_URL;
 const HOSTNAME = Url.parse(ROOT_URL).hostname;

--- a/shell/imports/blackrock-payments/server/payments-server.js
+++ b/shell/imports/blackrock-payments/server/payments-server.js
@@ -26,6 +26,12 @@ import Crypto from "crypto";
 import Url from 'url';
 import StripeModule from "stripe";
 
+import { Meteor } from "meteor/meteor";
+import { Mongo } from "meteor/mongo";
+import { check } from "meteor/check";
+import { Random } from "meteor/random";
+import { _ } from "meteor/underscore";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/00-startup.js
+++ b/shell/imports/client/00-startup.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { globalDb } from "/imports/db-deprecated.js";
+
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', function() {
     navigator.serviceWorker.register('/pwa-service-worker.js')

--- a/shell/imports/client/00-startup.js
+++ b/shell/imports/client/00-startup.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+
 import { globalDb } from "/imports/db-deprecated.js";
 
 if ('serviceWorker' in navigator) {

--- a/shell/imports/client/accounts/account-settings.js
+++ b/shell/imports/client/accounts/account-settings.js
@@ -15,7 +15,11 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { _ } from "meteor/underscore";
+
 import { formatFutureTime } from "/imports/dates.js";
 import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants.js";
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";

--- a/shell/imports/client/accounts/accounts-testing.js
+++ b/shell/imports/client/accounts/accounts-testing.js
@@ -1,3 +1,5 @@
+import { Meteor } from "meteor/meteor";
+
 window.testFirstSignup = function () {
   Meteor.call("testFirstSignup");
 };

--- a/shell/imports/client/accounts/credentials/credentials-client.js
+++ b/shell/imports/client/accounts/credentials/credentials-client.js
@@ -18,6 +18,11 @@ import { Meteor } from "meteor/meteor";
 import { Mongo } from "meteor/mongo";
 import { check } from "meteor/check";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Router } from "meteor/iron:router";
+import { Accounts } from "meteor/accounts-base"
+import { _ } from "meteor/underscore";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const LoginCredentialsOfLinkedAccounts = new Mongo.Collection("loginCredentialsOfLinkedAccounts");

--- a/shell/imports/client/accounts/credentials/credentials-client.js
+++ b/shell/imports/client/accounts/credentials/credentials-client.js
@@ -17,6 +17,7 @@
 import { Meteor } from "meteor/meteor";
 import { Mongo } from "meteor/mongo";
 import { check } from "meteor/check";
+import { Template } from "meteor/templating";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const LoginCredentialsOfLinkedAccounts = new Mongo.Collection("loginCredentialsOfLinkedAccounts");

--- a/shell/imports/client/accounts/email-token/token-client.js
+++ b/shell/imports/client/accounts/email-token/token-client.js
@@ -16,6 +16,9 @@
 
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Router } from "meteor/iron:router";
+
 import {
   loginWithEmailToken,
   createAndEmailTokenForUser,

--- a/shell/imports/client/accounts/email-token/token-login-helpers.js
+++ b/shell/imports/client/accounts/email-token/token-login-helpers.js
@@ -1,6 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { Accounts } from "meteor/accounts-base";
-import { check } from "meteor/check";
+import { Match, check } from "meteor/check";
 
 /**
  * @summary Log the user in with a one-time-use token.

--- a/shell/imports/client/accounts/ldap/ldap-client.js
+++ b/shell/imports/client/accounts/ldap/ldap-client.js
@@ -1,3 +1,6 @@
+import { Match, check } from "meteor/check";
+import { Accounts } from "meteor/accounts-base";
+
 const loginWithLDAP = function (user, password, callback) {
   check(user, String);
   check(password, String);

--- a/shell/imports/client/accounts/login-buttons-session.js
+++ b/shell/imports/client/accounts/login-buttons-session.js
@@ -29,6 +29,9 @@
 // licenses, included in the LICENSES directory.
 // ====================================================================
 
+import { Accounts } from "meteor/accounts-base";
+import { _ } from "meteor/underscore";
+
 const VALID_KEYS = [
   "dropdownVisible",
   "inSignupFlow",

--- a/shell/imports/client/accounts/login-buttons.js
+++ b/shell/imports/client/accounts/login-buttons.js
@@ -31,6 +31,7 @@ import { loginWithLDAP } from "/imports/client/accounts/ldap/ldap-client.js";
 import { loginWithSaml } from "/imports/client/accounts/saml/saml-client.js";
 import AccountsUi from "/imports/client/accounts/accounts-ui.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 // for convenience
 const loginButtonsSession = Accounts._loginButtonsSession;

--- a/shell/imports/client/accounts/login-buttons.js
+++ b/shell/imports/client/accounts/login-buttons.js
@@ -22,6 +22,10 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Accounts } from "meteor/accounts-base";
+import { _ } from "meteor/underscore";
+
 import {
   loginWithEmailToken,
   createAndEmailTokenForUser,

--- a/shell/imports/client/accounts/saml/saml-client-pt2.js
+++ b/shell/imports/client/accounts/saml/saml-client-pt2.js
@@ -1,4 +1,5 @@
 import { Meteor } from "meteor/meteor";
+import { Router } from "meteor/iron:router";
 
 import { loginWithSaml } from "/imports/client/accounts/saml/saml-client.js";
 

--- a/shell/imports/client/accounts/saml/saml-client-pt2.js
+++ b/shell/imports/client/accounts/saml/saml-client-pt2.js
@@ -1,3 +1,5 @@
+import { Meteor } from "meteor/meteor";
+
 import { loginWithSaml } from "/imports/client/accounts/saml/saml-client.js";
 
 // Reexported for use in shared/admin.js.  We should probably break that up into

--- a/shell/imports/client/accounts/saml/saml-client.js
+++ b/shell/imports/client/accounts/saml/saml-client.js
@@ -1,3 +1,5 @@
+import { Meteor } from "meteor/meteor";
+
 const initiateLogin = function (options, callback, dimensions) {
   // default dimensions that worked well for facebook and google
   const popup = openCenteredPopup(

--- a/shell/imports/client/accounts/saml/saml-client.js
+++ b/shell/imports/client/accounts/saml/saml-client.js
@@ -1,4 +1,6 @@
 import { Meteor } from "meteor/meteor";
+import { Random } from "meteor/random";
+import { Accounts } from "meteor/accounts-base";
 
 const initiateLogin = function (options, callback, dimensions) {
   // default dimensions that worked well for facebook and google

--- a/shell/imports/client/admin-client.js
+++ b/shell/imports/client/admin-client.js
@@ -15,6 +15,8 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { Tracker } from "meteor/tracker";
+import { Router } from "meteor/iron:router";
 
 Meteor.subscribe("publicAdminSettings");
 

--- a/shell/imports/client/admin-client.js
+++ b/shell/imports/client/admin-client.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+
 Meteor.subscribe("publicAdminSettings");
 
 const newAdminRoute = RouteController.extend({

--- a/shell/imports/client/admin/admin-new-client.js
+++ b/shell/imports/client/admin/admin-new-client.js
@@ -1,3 +1,5 @@
+import { Template } from "meteor/templating";
+
 import { globalDb } from "/imports/db-deprecated";
 
 Template.newAdmin.helpers({

--- a/shell/imports/client/admin/admin-new-client.js
+++ b/shell/imports/client/admin/admin-new-client.js
@@ -1,3 +1,5 @@
+import { globalDb } from "/imports/db-deprecated";
+
 Template.newAdmin.helpers({
   setDocumentTitle: function () {
     document.title = "Admin panel · " + globalDb.getServerTitle();

--- a/shell/imports/client/admin/admin-new-client.js
+++ b/shell/imports/client/admin/admin-new-client.js
@@ -1,4 +1,5 @@
 import { Template } from "meteor/templating";
+import { Router } from "meteor/iron:router";
 
 import { globalDb } from "/imports/db-deprecated";
 

--- a/shell/imports/client/admin/app-sources-client.js
+++ b/shell/imports/client/admin/app-sources-client.js
@@ -1,3 +1,6 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+
 import { globalDb } from "/imports/db-deprecated.js";
 
 const DEFAULT_APP_MARKET_URL = "https://apps.sandstorm.io";

--- a/shell/imports/client/admin/app-sources-client.js
+++ b/shell/imports/client/admin/app-sources-client.js
@@ -1,3 +1,5 @@
+import { globalDb } from "/imports/db-deprecated.js";
+
 const DEFAULT_APP_MARKET_URL = "https://apps.sandstorm.io";
 const DEFAULT_APP_UPDATES_ENABLED = true;
 const DEFAULT_APP_INDEX_URL = "https://app-index.sandstorm.io";

--- a/shell/imports/client/admin/app-sources-client.js
+++ b/shell/imports/client/admin/app-sources-client.js
@@ -1,5 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
 
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/admin/email-config-client.js
+++ b/shell/imports/client/admin/email-config-client.js
@@ -1,4 +1,4 @@
-/* globals globalDb */
+import { globalDb } from '/imports/db-deprecated.js';
 
 Template.newAdminEmailConfig.onCreated(function () {
   const c = globalDb.getSmtpConfig();

--- a/shell/imports/client/admin/email-config-client.js
+++ b/shell/imports/client/admin/email-config-client.js
@@ -1,3 +1,5 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import { globalDb } from '/imports/db-deprecated.js';
 
 Template.newAdminEmailConfig.onCreated(function () {

--- a/shell/imports/client/admin/email-config-client.js
+++ b/shell/imports/client/admin/email-config-client.js
@@ -1,5 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+
 import { globalDb } from '/imports/db-deprecated.js';
 
 Template.newAdminEmailConfig.onCreated(function () {

--- a/shell/imports/client/admin/hosting-management-client.js
+++ b/shell/imports/client/admin/hosting-management-client.js
@@ -1,3 +1,6 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+
 import { globalDb } from "/imports/db-deprecated.js";
 
 const DEFAULT_QUOTA_ENABLED = false;

--- a/shell/imports/client/admin/hosting-management-client.js
+++ b/shell/imports/client/admin/hosting-management-client.js
@@ -1,3 +1,5 @@
+import { globalDb } from "/imports/db-deprecated.js";
+
 const DEFAULT_QUOTA_ENABLED = false;
 const DEFAULT_QUOTA_LDAP_ATTRIBUTE = "quota";
 const DEFAULT_BILLING_PROMPT_URL = "";

--- a/shell/imports/client/admin/hosting-management-client.js
+++ b/shell/imports/client/admin/hosting-management-client.js
@@ -1,5 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
 
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/admin/login-providers.js
+++ b/shell/imports/client/admin/login-providers.js
@@ -1,4 +1,5 @@
 /* global Settings */
+import { globalDb } from "/imports/db-deprecated.js";
 
 const idpData = function (configureCallback) {
   const emailTokenEnabled = globalDb.getSettingWithFallback("emailToken", false);

--- a/shell/imports/client/admin/login-providers.js
+++ b/shell/imports/client/admin/login-providers.js
@@ -1,4 +1,6 @@
 /* global Settings */
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import { globalDb } from "/imports/db-deprecated.js";
 
 const idpData = function (configureCallback) {

--- a/shell/imports/client/admin/login-providers.js
+++ b/shell/imports/client/admin/login-providers.js
@@ -1,6 +1,8 @@
 /* global Settings */
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+
 import { globalDb } from "/imports/db-deprecated.js";
 
 const idpData = function (configureCallback) {

--- a/shell/imports/client/admin/maintenance-message-client.js
+++ b/shell/imports/client/admin/maintenance-message-client.js
@@ -1,3 +1,5 @@
+import { globalDb } from "/imports/db-deprecated.js";
+
 Template.newAdminMaintenance.onCreated(function () {
   const messageText = globalDb.getSettingWithFallback("adminAlert", "");
   const maintenanceTime = globalDb.getSettingWithFallback("adminAlertTime", "");

--- a/shell/imports/client/admin/maintenance-message-client.js
+++ b/shell/imports/client/admin/maintenance-message-client.js
@@ -1,5 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
 
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/admin/maintenance-message-client.js
+++ b/shell/imports/client/admin/maintenance-message-client.js
@@ -1,3 +1,6 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+
 import { globalDb } from "/imports/db-deprecated.js";
 
 Template.newAdminMaintenance.onCreated(function () {

--- a/shell/imports/client/admin/network-capabilities-client.js
+++ b/shell/imports/client/admin/network-capabilities-client.js
@@ -1,5 +1,8 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { _ } from "meteor/underscore";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/admin/network-capabilities-client.js
+++ b/shell/imports/client/admin/network-capabilities-client.js
@@ -1,6 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 function deriveIntroducer(cap) {
   // For a given ApiToken, determine the account ID of the user who should be attributed for

--- a/shell/imports/client/admin/networking-client.js
+++ b/shell/imports/client/admin/networking-client.js
@@ -16,6 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
 
 import { PRIVATE_IPV4_ADDRESSES, PRIVATE_IPV6_ADDRESSES } from "/imports/constants.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/client/admin/networking-client.js
+++ b/shell/imports/client/admin/networking-client.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+
 import { PRIVATE_IPV4_ADDRESSES, PRIVATE_IPV6_ADDRESSES } from "/imports/constants.js";
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/admin/networking-client.js
+++ b/shell/imports/client/admin/networking-client.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { PRIVATE_IPV4_ADDRESSES, PRIVATE_IPV6_ADDRESSES } from "/imports/constants.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const DEFAULT_IP_BLACKLIST = PRIVATE_IPV4_ADDRESSES.concat(PRIVATE_IPV6_ADDRESSES).join("\n");
 

--- a/shell/imports/client/admin/organization-client.js
+++ b/shell/imports/client/admin/organization-client.js
@@ -1,5 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { Tracker } from "meteor/tracker";
+import { ReactiveVar } from "meteor/reactive-var";
 
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/admin/organization-client.js
+++ b/shell/imports/client/admin/organization-client.js
@@ -1,3 +1,6 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+
 import { globalDb } from "/imports/db-deprecated.js";
 
 Template.newAdminOrganization.onCreated(function () {

--- a/shell/imports/client/admin/organization-client.js
+++ b/shell/imports/client/admin/organization-client.js
@@ -1,3 +1,5 @@
+import { globalDb } from "/imports/db-deprecated.js";
+
 Template.newAdminOrganization.onCreated(function () {
   const emailChecked = globalDb.getOrganizationEmailEnabled() || false;
   const gappsChecked = globalDb.getOrganizationGoogleEnabled() || false;

--- a/shell/imports/client/admin/personalization-client.js
+++ b/shell/imports/client/admin/personalization-client.js
@@ -1,5 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+
 import { DEFAULT_SIGNUP_DIALOG } from "/imports/client/personalization.js";
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/admin/personalization-client.js
+++ b/shell/imports/client/admin/personalization-client.js
@@ -1,3 +1,5 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import { DEFAULT_SIGNUP_DIALOG } from "/imports/client/personalization.js";
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/admin/personalization-client.js
+++ b/shell/imports/client/admin/personalization-client.js
@@ -1,4 +1,5 @@
 import { DEFAULT_SIGNUP_DIALOG } from "/imports/client/personalization.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 Template.newAdminPersonalization.onCreated(function () {
   this.serverTitle = new ReactiveVar(globalDb.getSettingWithFallback("serverTitle", ""));

--- a/shell/imports/client/admin/preinstalled-apps-client.js
+++ b/shell/imports/client/admin/preinstalled-apps-client.js
@@ -1,3 +1,5 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import { globalDb } from "/imports/db-deprecated.js";
 
 const APP_LIMIT = 10;

--- a/shell/imports/client/admin/preinstalled-apps-client.js
+++ b/shell/imports/client/admin/preinstalled-apps-client.js
@@ -1,5 +1,9 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { Tracker } from "meteor/tracker";
+import { ReactiveVar } from "meteor/reactive-var";
+import { _ } from "meteor/underscore";
+
 import { globalDb } from "/imports/db-deprecated.js";
 
 const APP_LIMIT = 10;

--- a/shell/imports/client/admin/preinstalled-apps-client.js
+++ b/shell/imports/client/admin/preinstalled-apps-client.js
@@ -1,3 +1,5 @@
+import { globalDb } from "/imports/db-deprecated.js";
+
 const APP_LIMIT = 10;
 
 Template.newAdminPreinstalledApps.onCreated(function () {

--- a/shell/imports/client/admin/stats-client.js
+++ b/shell/imports/client/admin/stats-client.js
@@ -1,6 +1,9 @@
 import { Meteor } from "meteor/meteor";
 import { Mongo } from "meteor/mongo";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { _ } from "meteor/underscore";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 // Pseudo-collection defined via publish.

--- a/shell/imports/client/admin/user-accounts-client.js
+++ b/shell/imports/client/admin/user-accounts-client.js
@@ -1,6 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { SandstormDb } from "/imports/sandstorm-db/db.js"
+import { globalDb } from "/imports/db-deprecated.js";
 
 const matchesUser = function (searchKey, user) {
   // We match a user if we can find the searchKey in one of the following fields:

--- a/shell/imports/client/admin/user-accounts-client.js
+++ b/shell/imports/client/admin/user-accounts-client.js
@@ -1,5 +1,9 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Router } from "meteor/iron:router";
+import { _ } from "meteor/underscore";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js"
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/admin/user-details-client.js
+++ b/shell/imports/client/admin/user-details-client.js
@@ -1,5 +1,8 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Router } from "meteor/iron:router";
+
 import { formatFutureTime } from "/imports/dates.js";
 import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";

--- a/shell/imports/client/admin/user-details-client.js
+++ b/shell/imports/client/admin/user-details-client.js
@@ -3,6 +3,7 @@ import { Template } from "meteor/templating";
 import { formatFutureTime } from "/imports/dates.js";
 import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 Template.newAdminUserDetailsCredentialTableRow.helpers({
   isOrganizationMember(credential) {

--- a/shell/imports/client/admin/user-invite-client.js
+++ b/shell/imports/client/admin/user-invite-client.js
@@ -1,3 +1,5 @@
+import { globalDb } from "/imports/db-deprecated.js";
+
 Template.newAdminUserInviteLink.onCreated(function () {
   this.formState = new ReactiveVar("default");
   this.generatedLink = new ReactiveVar(undefined);

--- a/shell/imports/client/admin/user-invite-client.js
+++ b/shell/imports/client/admin/user-invite-client.js
@@ -1,3 +1,6 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+
 import { globalDb } from "/imports/db-deprecated.js";
 
 Template.newAdminUserInviteLink.onCreated(function () {

--- a/shell/imports/client/admin/user-invite-client.js
+++ b/shell/imports/client/admin/user-invite-client.js
@@ -1,5 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Router } from "meteor/iron:router";
 
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/apps/app-details-client.js
+++ b/shell/imports/client/apps/app-details-client.js
@@ -1,5 +1,9 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Router } from "meteor/iron:router";
+import { _ } from "meteor/underscore";
+
 import { iconSrcForPackage } from "/imports/sandstorm-identicons/helpers.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 

--- a/shell/imports/client/apps/applist-client.js
+++ b/shell/imports/client/apps/applist-client.js
@@ -1,5 +1,9 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Router } from "meteor/iron:router";
+import { _ } from "meteor/underscore";
+
 import { introJs } from "intro.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 

--- a/shell/imports/client/apps/applist-client.js
+++ b/shell/imports/client/apps/applist-client.js
@@ -1,3 +1,5 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import { introJs } from "intro.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 

--- a/shell/imports/client/apps/install-client.js
+++ b/shell/imports/client/apps/install-client.js
@@ -1,5 +1,8 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Router } from "meteor/iron:router";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const INSTALL_STEPS = ["download", "verify", "unpack", "analyze", "ready", "failed", "delete"];

--- a/shell/imports/client/billing/billingPromptLocal-client.js
+++ b/shell/imports/client/billing/billingPromptLocal-client.js
@@ -1,3 +1,4 @@
+import { Template } from "meteor/templating";
 import { globalDb } from "/imports/db-deprecated.js";
 
 Template.billingPromptLocal.helpers({

--- a/shell/imports/client/billing/billingPromptLocal-client.js
+++ b/shell/imports/client/billing/billingPromptLocal-client.js
@@ -1,3 +1,5 @@
+import { globalDb } from "/imports/db-deprecated.js";
+
 Template.billingPromptLocal.helpers({
   onDismiss: function () {
     return () => {

--- a/shell/imports/client/demo-client.js
+++ b/shell/imports/client/demo-client.js
@@ -15,6 +15,9 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { Tracker } from "meteor/tracker";
+import { Router } from "meteor/iron:router";
+
 import { allowDemo } from "/imports/demo.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 

--- a/shell/imports/client/desktop-notifications-client.js
+++ b/shell/imports/client/desktop-notifications-client.js
@@ -16,6 +16,8 @@
 
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { Random } from "meteor/random";
+import { Router } from "meteor/iron:router";
 
 import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
 import { iconSrcForPackage, identiconForApp } from "/imports/sandstorm-identicons/helpers.js";

--- a/shell/imports/client/desktop-notifications-client.js
+++ b/shell/imports/client/desktop-notifications-client.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+
 import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
 import { iconSrcForPackage, identiconForApp } from "/imports/sandstorm-identicons/helpers.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/client/desktop-notifications-client.js
+++ b/shell/imports/client/desktop-notifications-client.js
@@ -16,6 +16,7 @@
 
 import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
 import { iconSrcForPackage, identiconForApp } from "/imports/sandstorm-identicons/helpers.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 // Test if localStorage is usable.
 // We can't use Meteor._localStorage for this because we need to be able to enumerate the elements

--- a/shell/imports/client/dev-accounts-client.js
+++ b/shell/imports/client/dev-accounts-client.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Accounts } from "meteor/accounts-base";
+import { Router } from "meteor/iron:router";
+
 loginDevAccount = function (displayName, isAdmin, callback) {
   Accounts.callLoginMethod({
     methodName: "createDevAccount",

--- a/shell/imports/client/globals.js
+++ b/shell/imports/client/globals.js
@@ -17,6 +17,9 @@
 // This file provides some helper functions that are used in multiple places
 // by client-side code.
 
+import { Tracker } from "meteor/tracker";
+import { ReactiveVar } from "meteor/reactive-var";
+
 getOrigin = function () {
   return document.location.protocol + "//" + document.location.host;
 };

--- a/shell/imports/client/grain-client.js
+++ b/shell/imports/client/grain-client.js
@@ -20,6 +20,12 @@ import { Meteor } from "meteor/meteor";
 import { Mongo } from "meteor/mongo";
 import { Match, check } from "meteor/check";
 import { Template } from "meteor/templating";
+import { Tracker } from "meteor/tracker";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Router } from "meteor/iron:router";
+import { _ } from "meteor/underscore";
+import { $ } from "meteor/jquery";
+
 import { introJs } from "intro.js";
 
 import downloadFile from "/imports/client/download-file.js";

--- a/shell/imports/client/grain-client.js
+++ b/shell/imports/client/grain-client.js
@@ -27,6 +27,7 @@ import { ContactProfiles } from "/imports/client/contacts.js";
 import { isStandalone } from "/imports/client/standalone.js";
 import { GrainView } from "/imports/client/grain/grainview.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 // Pseudo-collections.
 TokenInfo = new Mongo.Collection("tokenInfo");

--- a/shell/imports/client/grain/contact-autocomplete.js
+++ b/shell/imports/client/grain/contact-autocomplete.js
@@ -1,3 +1,5 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import { ContactProfiles } from "/imports/client/contacts.js";
 
 const generateAutoCompleteContacts = function (template) {

--- a/shell/imports/client/grain/contact-autocomplete.js
+++ b/shell/imports/client/grain/contact-autocomplete.js
@@ -1,5 +1,9 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Random } from "meteor/random";
+import { _ } from "meteor/underscore";
+
 import { ContactProfiles } from "/imports/client/contacts.js";
 
 const generateAutoCompleteContacts = function (template) {

--- a/shell/imports/client/grain/grainlist-client.js
+++ b/shell/imports/client/grain/grainlist-client.js
@@ -1,3 +1,7 @@
+
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+
 import { introJs } from "intro.js";
 import { identiconForApp } from "/imports/sandstorm-identicons/helpers.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";

--- a/shell/imports/client/grain/grainlist-client.js
+++ b/shell/imports/client/grain/grainlist-client.js
@@ -1,6 +1,10 @@
 
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { ReactiveDict } from "meteor/reactive-dict";
+import { Router } from "meteor/iron:router";
+import { _ } from "meteor/underscore";
 
 import { introJs } from "intro.js";
 import { identiconForApp } from "/imports/sandstorm-identicons/helpers.js";

--- a/shell/imports/client/grain/grainview-list.js
+++ b/shell/imports/client/grain/grainview-list.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
 import { GrainView, onceConditionIsTrue } from "./grainview.js";
 import { isStandalone } from "/imports/client/standalone.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";

--- a/shell/imports/client/grain/grainview-list.js
+++ b/shell/imports/client/grain/grainview-list.js
@@ -15,6 +15,12 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+import { Tracker } from "meteor/tracker";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Router } from "meteor/iron:router";
+import { Accounts } from "meteor/accounts-base";
+
 import { GrainView, onceConditionIsTrue } from "./grainview.js";
 import { isStandalone } from "/imports/client/standalone.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -17,6 +17,12 @@
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { Template } from "meteor/templating";
+import { Tracker } from "meteor/tracker";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Random } from "meteor/random";
+import { Router } from "meteor/iron:router";
+import { _ } from "meteor/underscore";
+
 import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
 import { isStandalone } from "/imports/client/standalone.js";
 import { GrainViewList } from "/imports/client/grain/grainview-list.js";

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { Template } from "meteor/templating";
 import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -21,6 +21,7 @@ import { isStandalone } from "/imports/client/standalone.js";
 import { GrainViewList } from "/imports/client/grain/grainview-list.js";
 import { identiconForApp, iconSrcForPackage } from "/imports/sandstorm-identicons/helpers.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 let counter = 0;
 

--- a/shell/imports/client/install-client.js
+++ b/shell/imports/client/install-client.js
@@ -16,6 +16,7 @@
 
 import { allowDemo } from "/imports/demo.js";
 import { isSafeDemoAppUrl } from "/imports/install.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 Router.map(function () {
   this.route("install", {

--- a/shell/imports/client/install-client.js
+++ b/shell/imports/client/install-client.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+
 import { allowDemo } from "/imports/demo.js";
 import { isSafeDemoAppUrl } from "/imports/install.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/client/install-client.js
+++ b/shell/imports/client/install-client.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { Router } from "meteor/iron:router";
 
 import { allowDemo } from "/imports/demo.js";
 import { isSafeDemoAppUrl } from "/imports/install.js";

--- a/shell/imports/client/notifications-client.js
+++ b/shell/imports/client/notifications-client.js
@@ -19,6 +19,7 @@ import { Template } from "meteor/templating";
 import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
 import { iconSrcForPackage, iconSrcForDenormalizedGrainMetadata } from "/imports/sandstorm-identicons/helpers.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 testNotifications = () => {
   // Run on console to create some dummy notifications for the purpose of seeing what they look

--- a/shell/imports/client/notifications-client.js
+++ b/shell/imports/client/notifications-client.js
@@ -16,6 +16,9 @@
 
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { Tracker } from "meteor/tracker";
+import { _ } from "meteor/underscore";
+
 import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
 import { iconSrcForPackage, iconSrcForDenormalizedGrainMetadata } from "/imports/sandstorm-identicons/helpers.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";

--- a/shell/imports/client/powerbox-builtins.js
+++ b/shell/imports/client/powerbox-builtins.js
@@ -16,6 +16,9 @@
 
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { _ } from "meteor/underscore";
+import { Accounts } from "meteor/accounts-base";
 
 const prepareViewInfoForDisplay = function (viewInfo) {
   const result = _.clone(viewInfo || {});

--- a/shell/imports/client/powerbox-builtins.js
+++ b/shell/imports/client/powerbox-builtins.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+
 const prepareViewInfoForDisplay = function (viewInfo) {
   const result = _.clone(viewInfo || {});
   if (result.permissions) indexElements(result.permissions);

--- a/shell/imports/client/setup-wizard/wizard.js
+++ b/shell/imports/client/setup-wizard/wizard.js
@@ -1,6 +1,7 @@
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
 import AccountsUi from "/imports/client/accounts/accounts-ui.js";
 import downloadFile from "/imports/client/download-file.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 // Pseudocollection telling the client if there's an admin user yet.
 HasAdmin = new Mongo.Collection("hasAdmin");

--- a/shell/imports/client/setup-wizard/wizard.js
+++ b/shell/imports/client/setup-wizard/wizard.js
@@ -1,3 +1,6 @@
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
 import AccountsUi from "/imports/client/accounts/accounts-ui.js";
 import downloadFile from "/imports/client/download-file.js";

--- a/shell/imports/client/setup-wizard/wizard.js
+++ b/shell/imports/client/setup-wizard/wizard.js
@@ -1,5 +1,10 @@
 import { Meteor } from "meteor/meteor";
+import { Mongo } from "meteor/mongo";
 import { Template } from "meteor/templating";
+import { Tracker } from "meteor/tracker";
+import { ReactiveVar } from "meteor/reactive-var";
+import { _ } from "meteor/underscore";
+import { Router } from "meteor/iron:router";
 
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
 import AccountsUi from "/imports/client/accounts/accounts-ui.js";

--- a/shell/imports/client/shell-client.js
+++ b/shell/imports/client/shell-client.js
@@ -23,6 +23,7 @@ import getBuildInfo from "/imports/client/build-info.js";
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
 import { isStandalone } from "/imports/client/standalone.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 // Subscribe to basic grain information first and foremost, since
 // without it we might e.g. redirect to the wrong place on login.

--- a/shell/imports/client/shell-client.js
+++ b/shell/imports/client/shell-client.js
@@ -18,7 +18,13 @@
 // It also covers the root page.
 
 import { Meteor } from "meteor/meteor";
+import { Mongo } from "meteor/mongo";
 import { Template } from "meteor/templating";
+import { Tracker } from "meteor/tracker";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Accounts } from "meteor/accounts-base";
+import { Router } from "meteor/iron:router";
+
 import getBuildInfo from "/imports/client/build-info.js";
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
 import { isStandalone } from "/imports/client/standalone.js";

--- a/shell/imports/client/signup-client.js
+++ b/shell/imports/client/signup-client.js
@@ -16,6 +16,8 @@
 
 // This file covers the client side of the invite key workflow.
 
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import { DEFAULT_SIGNUP_DIALOG } from "/imports/client/personalization.js";
 
 Template.signup.helpers({

--- a/shell/imports/client/styleguide.js
+++ b/shell/imports/client/styleguide.js
@@ -1,3 +1,5 @@
+import { Template } from "meteor/templating";
+
 Template.styleguide.events({
   "submit form"(evt) {
     evt.preventDefault();

--- a/shell/imports/client/transfers-client.js
+++ b/shell/imports/client/transfers-client.js
@@ -16,6 +16,8 @@
 
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { Router } from "meteor/iron:router";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/transfers-client.js
+++ b/shell/imports/client/transfers-client.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/transfers-client.js
+++ b/shell/imports/client/transfers-client.js
@@ -16,6 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 function isValidServerUrl(str) {
   let url;

--- a/shell/imports/client/widgets/widgets-client.js
+++ b/shell/imports/client/widgets/widgets-client.js
@@ -1,3 +1,5 @@
+import { Template } from "meteor/templating";
+
 Template.modalDialogWithBackdrop.onCreated(function () {
   // This keypress event listener which closes the dialog when Escape is pressed should be scoped to
   // the browser window, not this template.

--- a/shell/imports/db-deprecated.js
+++ b/shell/imports/db-deprecated.js
@@ -46,9 +46,9 @@ if (Meteor.isServer) {
   };
 }
 
-// TODO(cleanup) explicitly export all of these
-globalDb = new SandstormDb(quotaManager);
+export const globalDb = new SandstormDb(quotaManager);
 
+// TODO(cleanup) explicitly export all of these
 Packages = globalDb.collections.packages;
 DevPackages = globalDb.collections.devPackages;
 UserActions = globalDb.collections.userActions;

--- a/shell/imports/sandstorm-accounts-packages/accounts.js
+++ b/shell/imports/sandstorm-accounts-packages/accounts.js
@@ -1,4 +1,6 @@
 import { Meteor } from "meteor/meteor";
+import { Accounts } from "meteor/accounts-base";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 if (Meteor.isClient) {

--- a/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
+++ b/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
@@ -18,6 +18,10 @@
 // Figure out a new strategy for making sure we run tests.
 
 import Crypto from "crypto";
+
+import { Meteor } from "meteor/meteor";
+import { Accounts } from "meteor/accounts-base";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const globalDb = new SandstormDb();

--- a/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps.js
+++ b/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+
 SandstormAutoupdateApps = {};
 
 SandstormAutoupdateApps.updateAppIndex = function (db) {

--- a/shell/imports/sandstorm-db/profile.js
+++ b/shell/imports/sandstorm-db/profile.js
@@ -14,6 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+import { Accounts } from "meteor/accounts-base";
+import { _ } from "meteor/underscore";
+
 import Identicon from "/imports/sandstorm-identicons/identicon.js";
 import { SandstormDb } from "./db.js";
 import { Settings } from "/imports/db-deprecated.js";

--- a/shell/imports/sandstorm-db/profile.js
+++ b/shell/imports/sandstorm-db/profile.js
@@ -16,6 +16,7 @@
 
 import Identicon from "/imports/sandstorm-identicons/identicon.js";
 import { SandstormDb } from "./db.js";
+import { Settings } from "/imports/db-deprecated.js";
 
 let makeIdenticon;
 let httpProtocol;

--- a/shell/imports/sandstorm-db/scheduled-jobs-db.js
+++ b/shell/imports/sandstorm-db/scheduled-jobs-db.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import Crypto from "crypto";
+import { Match, check } from "meteor/check";
 import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "./db.js";
 

--- a/shell/imports/sandstorm-permissions/permissions-tests.js
+++ b/shell/imports/sandstorm-permissions/permissions-tests.js
@@ -18,6 +18,8 @@
 // Figure out a new strategy for making sure we run tests.
 
 import Crypto from "crypto";
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
 
 const globalDb = new SandstormDb();
 // TODO(cleanup): Use a lightweight fake (minimongo-based?) database here and construct a clean

--- a/shell/imports/sandstorm-permissions/permissions.js
+++ b/shell/imports/sandstorm-permissions/permissions.js
@@ -17,6 +17,9 @@
 import Crypto from "crypto";
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { Random } from "meteor/random";
+import { _ } from "meteor/underscore";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 SandstormPermissions = {};

--- a/shell/imports/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/imports/sandstorm-ui-powerbox/powerbox-client.js
@@ -14,8 +14,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+import { Random } from "meteor/random";
 import { Mongo } from "meteor/mongo";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
+import { _ } from "meteor/underscore";
+
 import { identiconForApp } from "/imports/sandstorm-identicons/helpers.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 

--- a/shell/imports/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/imports/sandstorm-ui-powerbox/powerbox-server.js
@@ -16,6 +16,11 @@
 
 import Crypto from "crypto";
 import Future from "fibers/future";
+
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+import { _ } from "meteor/underscore";
+
 import Capnp from "/imports/server/capnp.js";
 
 import { waitPromise } from '../server/async-helpers.js';

--- a/shell/imports/sandstorm-ui-topbar/topbar.js
+++ b/shell/imports/sandstorm-ui-topbar/topbar.js
@@ -14,7 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
 import { Template } from "meteor/templating";
+import { Tracker } from "meteor/tracker";
+import { ReactiveVar } from "meteor/reactive-var";
+import { Router } from "meteor/iron:router";
+import { _ } from "meteor/underscore";
 
 let reloadBlockingCount = 0;
 const blockedReload = new ReactiveVar(null);

--- a/shell/imports/sandstorm-ui-topbar/topbar.js
+++ b/shell/imports/sandstorm-ui-topbar/topbar.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Template } from "meteor/templating";
+
 let reloadBlockingCount = 0;
 const blockedReload = new ReactiveVar(null);
 let explicitlyUnblocked = false;

--- a/shell/imports/server/00-startup.js
+++ b/shell/imports/server/00-startup.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 import { FrontendRefRegistry } from "/imports/server/frontend-ref.js";
 import { PersistentImpl } from "/imports/server/persistent.js";
 import { migrateToLatest } from "/imports/server/migrations.js";

--- a/shell/imports/server/00-startup.js
+++ b/shell/imports/server/00-startup.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 import { FrontendRefRegistry } from "/imports/server/frontend-ref.js";

--- a/shell/imports/server/account-suspension.js
+++ b/shell/imports/server/account-suspension.js
@@ -16,6 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
+import { _ } from "meteor/underscore";
 
 import { send } from "/imports/server/email.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";

--- a/shell/imports/server/account-suspension.js
+++ b/shell/imports/server/account-suspension.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+
 import { send } from "/imports/server/email.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 

--- a/shell/imports/server/accounts/accounts-server.js
+++ b/shell/imports/server/accounts/accounts-server.js
@@ -17,6 +17,7 @@
 import { Accounts } from "meteor/accounts-base";
 import { fetchPicture, userPictureUrl } from "/imports/server/accounts/picture.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 import Crypto from "crypto";
 import Future from "fibers/future";

--- a/shell/imports/server/accounts/accounts-server.js
+++ b/shell/imports/server/accounts/accounts-server.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
 import { Accounts } from "meteor/accounts-base";
 import { fetchPicture, userPictureUrl } from "/imports/server/accounts/picture.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";

--- a/shell/imports/server/accounts/accounts-server.js
+++ b/shell/imports/server/accounts/accounts-server.js
@@ -17,6 +17,8 @@
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { Accounts } from "meteor/accounts-base";
+import { _ } from "meteor/underscore";
+
 import { fetchPicture, userPictureUrl } from "/imports/server/accounts/picture.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/server/accounts/accounts-ui-methods.js
+++ b/shell/imports/server/accounts/accounts-ui-methods.js
@@ -19,6 +19,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { _ } from "meteor/underscore";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 

--- a/shell/imports/server/accounts/accounts-ui-methods.js
+++ b/shell/imports/server/accounts/accounts-ui-methods.js
@@ -17,6 +17,9 @@
 // This file contains method definitions which are available on both client and server (on the
 // client for prediction purposes, on the server for actual execution).
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 
 const ValidHandle = Match.Where(function (handle) {

--- a/shell/imports/server/accounts/accounts-ui-server.js
+++ b/shell/imports/server/accounts/accounts-ui-server.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
+import { Meteor } from "meteor/meteor";
+
 // Meteor permits users to modify their own profile by default, for some reason.
 Meteor.users.deny({
   insert: function () { return true; },

--- a/shell/imports/server/accounts/credentials/credentials-server.js
+++ b/shell/imports/server/accounts/credentials/credentials-server.js
@@ -16,6 +16,9 @@
 
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
+import { Accounts } from "meteor/accounts-base";
+import { _ } from "meteor/underscore";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { SandstormBackend } from "/imports/server/backend.js";
 

--- a/shell/imports/server/accounts/email-token/token-server.js
+++ b/shell/imports/server/accounts/email-token/token-server.js
@@ -1,6 +1,9 @@
 import crypto from "crypto";
 import Url from "url";
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 import { send as sendEmail } from "/imports/server/email.js";

--- a/shell/imports/server/accounts/email-token/token-server.js
+++ b/shell/imports/server/accounts/email-token/token-server.js
@@ -3,6 +3,8 @@ import Url from "url";
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { Random } from "meteor/random";
+import { Accounts } from "meteor/accounts-base";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/server/accounts/email-token/token-server.js
+++ b/shell/imports/server/accounts/email-token/token-server.js
@@ -2,6 +2,7 @@ import crypto from "crypto";
 import Url from "url";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 import { send as sendEmail } from "/imports/server/email.js";
 
 const V1_ROUNDS = 4096; // Selected to take ~5msec at creation time (2016) on a developer's laptop.

--- a/shell/imports/server/accounts/ldap.js
+++ b/shell/imports/server/accounts/ldap.js
@@ -2,6 +2,7 @@ import Future from "fibers/future";
 import ldapjs from "ldapjs";
 
 import { Meteor } from "meteor/meteor";
+import { _ } from "meteor/underscore";
 
 // At a minimum, set up LDAP_DEFAULTS.url and .dn according to
 // your needs. url should appear as 'ldap://your.url.here'

--- a/shell/imports/server/accounts/ldap.js
+++ b/shell/imports/server/accounts/ldap.js
@@ -1,6 +1,8 @@
 import Future from "fibers/future";
 import ldapjs from "ldapjs";
 
+import { Meteor } from "meteor/meteor";
+
 // At a minimum, set up LDAP_DEFAULTS.url and .dn according to
 // your needs. url should appear as 'ldap://your.url.here'
 // dn should appear in normal ldap format of comma separated attribute=value

--- a/shell/imports/server/accounts/ldap/ldap-server.js
+++ b/shell/imports/server/accounts/ldap/ldap-server.js
@@ -1,5 +1,8 @@
 import { LDAP } from "/imports/server/accounts/ldap.js";
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+
 // Register login handler with Meteor
 Accounts.registerLoginHandler("ldap", function (loginRequest) {
   // If 'ldap' isn't set in loginRequest object,

--- a/shell/imports/server/accounts/ldap/ldap-server.js
+++ b/shell/imports/server/accounts/ldap/ldap-server.js
@@ -2,6 +2,7 @@ import { LDAP } from "/imports/server/accounts/ldap.js";
 
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
+import { Accounts } from "meteor/accounts-base";
 
 // Register login handler with Meteor
 Accounts.registerLoginHandler("ldap", function (loginRequest) {

--- a/shell/imports/server/accounts/saml-utils.js
+++ b/shell/imports/server/accounts/saml-utils.js
@@ -7,6 +7,8 @@ import xmlCrypto from "xml-crypto";
 import xmldom from "xmldom";
 import zlib from "zlib";
 
+import { Meteor } from "meteor/meteor";
+
 const HOSTNAME = Url.parse(process.env.ROOT_URL).hostname;
 
 const SAML = function (options) {

--- a/shell/imports/server/accounts/saml/saml-server.js
+++ b/shell/imports/server/accounts/saml/saml-server.js
@@ -1,5 +1,9 @@
 import Url from "url";
 import zlib from "zlib";
+
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+
 import { SAML } from "/imports/server/accounts/saml-utils.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 

--- a/shell/imports/server/accounts/saml/saml-server.js
+++ b/shell/imports/server/accounts/saml/saml-server.js
@@ -3,6 +3,8 @@ import zlib from "zlib";
 
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
+import { _ } from "meteor/underscore";
+import { Accounts } from "meteor/accounts-base";
 
 import { SAML } from "/imports/server/accounts/saml-utils.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";

--- a/shell/imports/server/admin-server.js
+++ b/shell/imports/server/admin-server.js
@@ -23,6 +23,7 @@ import { clearAdminToken, checkAuth, tokenIsValid, tokenIsSetupSession } from "/
 import { send as sendEmail } from "/imports/server/email.js";
 import { fillUndefinedForChangedDoc } from "/imports/server/observe-helpers.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const publicAdminSettings = [
   "google", "github", "ldap", "saml", "emailToken", "splashUrl", "signupDialog",

--- a/shell/imports/server/admin-server.js
+++ b/shell/imports/server/admin-server.js
@@ -16,6 +16,10 @@
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { _ } from "meteor/underscore";
+import { Accounts } from "meteor/accounts-base";
+import { Random } from "meteor/random";
+
 import Fs from "fs";
 import Crypto from "crypto";
 import Heapdump from "heapdump";

--- a/shell/imports/server/admin-server.js
+++ b/shell/imports/server/admin-server.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
 import Fs from "fs";
 import Crypto from "crypto";
 import Heapdump from "heapdump";

--- a/shell/imports/server/admin/admin-user-invite.js
+++ b/shell/imports/server/admin/admin-user-invite.js
@@ -1,3 +1,5 @@
+import { Meteor } from "meteor/meteor";
+
 Meteor.publish("allInviteTokens", function () {
   const db = this.connection.sandstormDb;
   if (!db.isAdminById(this.userId)) {

--- a/shell/imports/server/admin/personalization-server.js
+++ b/shell/imports/server/admin/personalization-server.js
@@ -1,6 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { checkAuth } from "/imports/server/auth.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const personalizationMessageShape = {
   serverTitle: String,

--- a/shell/imports/server/admin/system-status-server.js
+++ b/shell/imports/server/admin/system-status-server.js
@@ -1,6 +1,8 @@
 import { Meteor } from "meteor/meteor";
 import { Router } from "meteor/iron:router";
 import { Random } from "meteor/random";
+import { _ } from "meteor/underscore";
+
 import Crypto from "crypto";
 import Fs from "fs";
 import { checkAuth } from "/imports/server/auth.js";

--- a/shell/imports/server/auth.js
+++ b/shell/imports/server/auth.js
@@ -3,7 +3,7 @@ import { Match, check } from "meteor/check";
 import Crypto from "crypto";
 import Fs from "fs";
 import { SANDSTORM_VARDIR } from "/imports/server/constants.js";
-// TODO(cleanup): globalDb is still an unbound global, but extracting it is Hard.
+import { globalDb } from "/imports/db-deprecated.js";
 
 const ADMIN_TOKEN_EXPIRATION_TIME = 60 * 60 * 1000;
 const SANDSTORM_ADMIN_TOKEN = SANDSTORM_VARDIR + "/adminToken";

--- a/shell/imports/server/backend.js
+++ b/shell/imports/server/backend.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import Crypto from "crypto";
+import { Meteor } from "meteor/meteor";
 import { SANDSTORM_ALTHOME } from "/imports/server/constants.js";
 import { inMeteor, promiseToFuture, waitPromise } from "/imports/server/async-helpers.js";
 import Capnp from "/imports/server/capnp.js";

--- a/shell/imports/server/backup.js
+++ b/shell/imports/server/backup.js
@@ -16,6 +16,9 @@
 
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
+import { _ } from "meteor/underscore";
+import { Random } from "meteor/random";
+import { Router } from "meteor/iron:router";
 
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 

--- a/shell/imports/server/backup.js
+++ b/shell/imports/server/backup.js
@@ -20,6 +20,7 @@ import ChildProcess from "child_process";
 import Future from "fibers/future";
 import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const GrainInfo = Capnp.importSystem("sandstorm/grain.capnp").GrainInfo;
 

--- a/shell/imports/server/backup.js
+++ b/shell/imports/server/backup.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 
 import ChildProcess from "child_process";

--- a/shell/imports/server/contacts-server.js
+++ b/shell/imports/server/contacts-server.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+
 Meteor.publish("contactProfiles", function (showAll) {
   const db = this.connection.sandstormDb;
   const _this = this;

--- a/shell/imports/server/contacts-server.js
+++ b/shell/imports/server/contacts-server.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { _ } from "meteor/underscore";
 
 Meteor.publish("contactProfiles", function (showAll) {
   const db = this.connection.sandstormDb;

--- a/shell/imports/server/core.js
+++ b/shell/imports/server/core.js
@@ -16,6 +16,8 @@
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { _ } from "meteor/underscore";
+
 import Crypto from "crypto";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { StaticAssetImpl, IdenticonStaticAssetImpl } from "/imports/server/static-asset.js";

--- a/shell/imports/server/core.js
+++ b/shell/imports/server/core.js
@@ -21,6 +21,7 @@ import { PersistentImpl, hashSturdyRef, generateSturdyRef, checkRequirements,
          fetchApiToken, insertApiToken } from "/imports/server/persistent.js";
 import { SandstormBackend } from "/imports/server/backend.js";
 import { hashAppIdForIdenticon } from "/imports/sandstorm-identicons/helpers.js";
+import { globalDb } from "/imports/db-deprecated.js";
 import Capnp from "/imports/server/capnp.js";
 
 const PersistentHandle = Capnp.importSystem("sandstorm/supervisor.capnp").PersistentHandle;

--- a/shell/imports/server/core.js
+++ b/shell/imports/server/core.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
 import Crypto from "crypto";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { StaticAssetImpl, IdenticonStaticAssetImpl } from "/imports/server/static-asset.js";

--- a/shell/imports/server/demo-server.js
+++ b/shell/imports/server/demo-server.js
@@ -17,6 +17,7 @@
 import { waitPromise } from "/imports/server/async-helpers.js";
 import { allowDemo } from "/imports/demo.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const DEMO_EXPIRATION_MS = 60 * 60 * 1000;
 const DEMO_GRACE_MS = 10 * 60 * 1000;  // time between expiration and deletion

--- a/shell/imports/server/demo-server.js
+++ b/shell/imports/server/demo-server.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+
 import { waitPromise } from "/imports/server/async-helpers.js";
 import { allowDemo } from "/imports/demo.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";

--- a/shell/imports/server/desktop-notifications-server.js
+++ b/shell/imports/server/desktop-notifications-server.js
@@ -16,6 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 SandstormDb.periodicCleanup(120000, () => {
   // Remove old desktop notfications regularly.

--- a/shell/imports/server/desktop-notifications.js
+++ b/shell/imports/server/desktop-notifications.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { Match, check } from "meteor/check";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const createAppActivityDesktopNotification = (options) => {
   check(options, {

--- a/shell/imports/server/dev-accounts-server.js
+++ b/shell/imports/server/dev-accounts-server.js
@@ -15,6 +15,8 @@
 // limitations under the License.
 
 import Crypto from "crypto";
+import { Meteor } from "meteor/meteor";
+import { Match, check }  from "meteor/check";
 
 Meteor.methods({
   createDevAccount: function (displayName, isAdmin, profile, unverifiedEmail) {

--- a/shell/imports/server/dev-accounts-server.js
+++ b/shell/imports/server/dev-accounts-server.js
@@ -17,6 +17,7 @@
 import Crypto from "crypto";
 import { Meteor } from "meteor/meteor";
 import { Match, check }  from "meteor/check";
+import { Accounts } from "meteor/accounts-base";
 
 Meteor.methods({
   createDevAccount: function (displayName, isAdmin, profile, unverifiedEmail) {

--- a/shell/imports/server/drivers/external-ui-view.js
+++ b/shell/imports/server/drivers/external-ui-view.js
@@ -18,6 +18,7 @@ import { PersistentImpl } from "/imports/server/persistent.js";
 import { ssrfSafeLookup } from "/imports/server/networking.js";
 import { REQUEST_HEADER_WHITELIST, RESPONSE_HEADER_WHITELIST }
     from "/imports/server/header-whitelist.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 import Future from "fibers/future";
 import Url from "url";

--- a/shell/imports/server/drivers/external-ui-view.js
+++ b/shell/imports/server/drivers/external-ui-view.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+
 import { PersistentImpl } from "/imports/server/persistent.js";
 import { ssrfSafeLookup } from "/imports/server/networking.js";
 import { REQUEST_HEADER_WHITELIST, RESPONSE_HEADER_WHITELIST }

--- a/shell/imports/server/drivers/external-ui-view.js
+++ b/shell/imports/server/drivers/external-ui-view.js
@@ -16,6 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { _ } from "meteor/underscore";
 
 import { PersistentImpl } from "/imports/server/persistent.js";
 import { ssrfSafeLookup } from "/imports/server/networking.js";

--- a/shell/imports/server/drivers/ip.js
+++ b/shell/imports/server/drivers/ip.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+
 import Bignum from "bignum";
 import { PersistentImpl } from "/imports/server/persistent.js";
 import Future from "fibers/future";

--- a/shell/imports/server/drivers/mail.js
+++ b/shell/imports/server/drivers/mail.js
@@ -18,6 +18,7 @@ import { SMTPServer } from "smtp-server";
 import { MailParser } from "mailparser";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 import { PersistentImpl } from "/imports/server/persistent.js";
 import { rawSend } from "/imports/server/email.js";
 import { shouldRestartGrain } from "/imports/server/backend.js";

--- a/shell/imports/server/drivers/mail.js
+++ b/shell/imports/server/drivers/mail.js
@@ -16,6 +16,9 @@
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { _ } from "meteor/underscore";
+import { Random } from "meteor/random";
+import { Accounts } from "meteor/accounts-base";
 
 import { SMTPServer } from "smtp-server";
 import { MailParser } from "mailparser";

--- a/shell/imports/server/drivers/mail.js
+++ b/shell/imports/server/drivers/mail.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+
 import { SMTPServer } from "smtp-server";
 import { MailParser } from "mailparser";
 

--- a/shell/imports/server/email.js
+++ b/shell/imports/server/email.js
@@ -1,5 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
+import { _ } from "meteor/underscore";
+
 import nodemailer from "nodemailer";
 import smtpPool from "nodemailer-smtp-pool";
 import Future from "fibers/future";

--- a/shell/imports/server/email.js
+++ b/shell/imports/server/email.js
@@ -1,4 +1,5 @@
 import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
 import nodemailer from "nodemailer";
 import smtpPool from "nodemailer-smtp-pool";
 import Future from "fibers/future";

--- a/shell/imports/server/gateway-router.js
+++ b/shell/imports/server/gateway-router.js
@@ -19,6 +19,7 @@ import Crypto from "crypto";
 import Dns from "dns";
 import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const GatewayRouter = Capnp.importSystem("sandstorm/backend.capnp").GatewayRouter;
 const ApiSession = Capnp.importSystem("sandstorm/api-session.capnp").ApiSession;

--- a/shell/imports/server/gateway-router.js
+++ b/shell/imports/server/gateway-router.js
@@ -17,6 +17,10 @@
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import Crypto from "crypto";
 import Dns from "dns";
+
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+
 import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/server/gateway-router.js
+++ b/shell/imports/server/gateway-router.js
@@ -20,6 +20,8 @@ import Dns from "dns";
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { _ } from "meteor/underscore";
+import { Random } from "meteor/random";
 
 import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";

--- a/shell/imports/server/grain-server.js
+++ b/shell/imports/server/grain-server.js
@@ -18,6 +18,7 @@ import Crypto from "crypto";
 import { send as sendEmail } from "/imports/server/email.js";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const ROOT_URL = process.env.ROOT_URL;
 

--- a/shell/imports/server/grain-server.js
+++ b/shell/imports/server/grain-server.js
@@ -15,6 +15,10 @@
 // limitations under the License.
 
 import Crypto from "crypto";
+
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+
 import { send as sendEmail } from "/imports/server/email.js";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";

--- a/shell/imports/server/grain-server.js
+++ b/shell/imports/server/grain-server.js
@@ -18,6 +18,8 @@ import Crypto from "crypto";
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { _ } from "meteor/underscore";
+import { Random } from "meteor/random";
 
 import { send as sendEmail } from "/imports/server/email.js";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";

--- a/shell/imports/server/hack-session.js
+++ b/shell/imports/server/hack-session.js
@@ -25,6 +25,7 @@ import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { ssrfSafeLookup } from "/imports/server/networking.js";
 import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const EmailRpc = Capnp.importSystem("sandstorm/email.capnp");
 const HackSessionContext = Capnp.importSystem("sandstorm/hack-session.capnp").HackSessionContext;

--- a/shell/imports/server/hack-session.js
+++ b/shell/imports/server/hack-session.js
@@ -20,6 +20,10 @@ import Https from "https";
 import Net from "net";
 import Dgram from "dgram";
 import Url from "url";
+
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+
 import { hashSturdyRef, checkRequirements, fetchApiToken } from "/imports/server/persistent.js";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { ssrfSafeLookup } from "/imports/server/networking.js";

--- a/shell/imports/server/hack-session.js
+++ b/shell/imports/server/hack-session.js
@@ -23,6 +23,8 @@ import Url from "url";
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { _ } from "meteor/underscore";
+import { Random } from "meteor/random";
 
 import { hashSturdyRef, checkRequirements, fetchApiToken } from "/imports/server/persistent.js";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";

--- a/shell/imports/server/identity.js
+++ b/shell/imports/server/identity.js
@@ -16,6 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { _ } from "meteor/underscore";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/server/identity.js
+++ b/shell/imports/server/identity.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 import { PersistentImpl } from "/imports/server/persistent.js";

--- a/shell/imports/server/identity.js
+++ b/shell/imports/server/identity.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 import { PersistentImpl } from "/imports/server/persistent.js";
 import { StaticAssetImpl, IdenticonStaticAssetImpl } from "/imports/server/static-asset.js";
 import Capnp from "/imports/server/capnp.js";

--- a/shell/imports/server/install-server.js
+++ b/shell/imports/server/install-server.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+
 import { allowDemo } from "/imports/demo.js";
 import { isSafeDemoAppUrl } from "/imports/install.js"
 import { promiseToFuture } from "/imports/server/async-helpers.js";

--- a/shell/imports/server/install-server.js
+++ b/shell/imports/server/install-server.js
@@ -18,6 +18,7 @@ import { allowDemo } from "/imports/demo.js";
 import { isSafeDemoAppUrl } from "/imports/install.js"
 import { promiseToFuture } from "/imports/server/async-helpers.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const TOKEN_CLEANUP_MINUTES = 120;  // Give enough time for large uploads on slow connections.
 const TOKEN_CLEANUP_TIMER = TOKEN_CLEANUP_MINUTES * 60 * 1000;

--- a/shell/imports/server/install-server.js
+++ b/shell/imports/server/install-server.js
@@ -16,6 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { Random } from "meteor/random";
 
 import { allowDemo } from "/imports/demo.js";
 import { isSafeDemoAppUrl } from "/imports/install.js"

--- a/shell/imports/server/installer.js
+++ b/shell/imports/server/installer.js
@@ -22,6 +22,7 @@ import Url from "url";
 
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { ssrfSafeLookupOrProxy } from "/imports/server/networking.js";
+import { globalDb } from "/imports/db-deprecated.js";
 import Capnp from "/imports/server/capnp.js";
 
 const Request = HTTPInternals.NpmModules.request.module;

--- a/shell/imports/server/installer.js
+++ b/shell/imports/server/installer.js
@@ -20,6 +20,8 @@ import Crypto from "crypto";
 import ChildProcess from "child_process";
 import Url from "url";
 
+import { Meteor } from "meteor/meteor";
+
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { ssrfSafeLookupOrProxy } from "/imports/server/networking.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/server/installer.js
+++ b/shell/imports/server/installer.js
@@ -21,6 +21,8 @@ import ChildProcess from "child_process";
 import Url from "url";
 
 import { Meteor } from "meteor/meteor";
+import { _ } from "meteor/underscore";
+import { Random } from "meteor/random";
 
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { ssrfSafeLookupOrProxy } from "/imports/server/networking.js";

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -5,6 +5,7 @@
 // idempotent and safe to accidentally run multiple times.
 
 import { Meteor } from "meteor/meteor";
+import { Mongo } from "meteor/mongo";
 import { _ } from "meteor/underscore";
 import { Match } from "meteor/check";
 import { userPictureUrl, fetchPicture } from "/imports/server/accounts/picture.js";

--- a/shell/imports/server/notifications-server.js
+++ b/shell/imports/server/notifications-server.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
+
 import { waitPromise } from "/imports/server/async-helpers.js";
 import { createAppActivityDesktopNotification } from "/imports/server/desktop-notifications.js";
 import Capnp from "/imports/server/capnp.js";

--- a/shell/imports/server/notifications-server.js
+++ b/shell/imports/server/notifications-server.js
@@ -16,6 +16,8 @@
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { _ } from "meteor/underscore";
+import { Random } from "meteor/random";
 
 import { waitPromise } from "/imports/server/async-helpers.js";
 import { createAppActivityDesktopNotification } from "/imports/server/desktop-notifications.js";

--- a/shell/imports/server/notifications-server.js
+++ b/shell/imports/server/notifications-server.js
@@ -18,6 +18,7 @@ import { waitPromise } from "/imports/server/async-helpers.js";
 import { createAppActivityDesktopNotification } from "/imports/server/desktop-notifications.js";
 import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const SupervisorCapnp = Capnp.importSystem("sandstorm/supervisor.capnp");
 const SystemPersistent = SupervisorCapnp.SystemPersistent;

--- a/shell/imports/server/persistent.js
+++ b/shell/imports/server/persistent.js
@@ -16,6 +16,8 @@
 
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
+import { _ } from "meteor/underscore";
+import { Random } from "meteor/random";
 
 import Crypto from "crypto";
 import { inMeteor } from "/imports/server/async-helpers.js";

--- a/shell/imports/server/persistent.js
+++ b/shell/imports/server/persistent.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+
 import Crypto from "crypto";
 import { inMeteor } from "/imports/server/async-helpers.js";
 import Capnp from "/imports/server/capnp.js";

--- a/shell/imports/server/pre-meteor.js
+++ b/shell/imports/server/pre-meteor.js
@@ -17,6 +17,9 @@
 // This file implements logic that we place in front of our main Meteor application,
 // including routing of requests to proxies and handling of static web publishing.
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+
 import { inMeteor } from "/imports/server/async-helpers.js";
 import { globalDb } from "/imports/db-deprecated.js";
 import ServerIdenticon from "/imports/sandstorm-identicons/identicon-server.js";

--- a/shell/imports/server/pre-meteor.js
+++ b/shell/imports/server/pre-meteor.js
@@ -18,6 +18,7 @@
 // including routing of requests to proxies and handling of static web publishing.
 
 import { inMeteor } from "/imports/server/async-helpers.js";
+import { globalDb } from "/imports/db-deprecated.js";
 import ServerIdenticon from "/imports/sandstorm-identicons/identicon-server.js";
 import Url from "url";
 import Fs from "fs";

--- a/shell/imports/server/sandcats.js
+++ b/shell/imports/server/sandcats.js
@@ -25,6 +25,7 @@ import dgram from "dgram";
 import Url from "url";
 
 import { SANDSTORM_ALTHOME } from "/imports/server/constants.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const SANDCATS_HOSTNAME = (Meteor.settings && Meteor.settings.public &&
                            Meteor.settings.public.sandcatsHostname);

--- a/shell/imports/server/sandcats.js
+++ b/shell/imports/server/sandcats.js
@@ -18,6 +18,7 @@ Sandcats = {};
 
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
+import { Random } from "meteor/random";
 
 import { inMeteor } from "/imports/server/async-helpers.js";
 import { pki, asn1 } from "node-forge";

--- a/shell/imports/server/sandcats.js
+++ b/shell/imports/server/sandcats.js
@@ -16,6 +16,9 @@
 
 Sandcats = {};
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+
 import { inMeteor } from "/imports/server/async-helpers.js";
 import { pki, asn1 } from "node-forge";
 import querystring from "querystring";

--- a/shell/imports/server/scheduled-job.js
+++ b/shell/imports/server/scheduled-job.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { PersistentImpl, fetchApiToken } from "/imports/server/persistent.js";
 import Capnp from "/imports/server/capnp.js";

--- a/shell/imports/server/scheduled-job.js
+++ b/shell/imports/server/scheduled-job.js
@@ -18,6 +18,7 @@ import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { PersistentImpl, fetchApiToken } from "/imports/server/persistent.js";
 import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const ScheduledJob = Capnp.importSystem("sandstorm/grain.capnp").ScheduledJob;
 const SystemPersistent = Capnp.importSystem("sandstorm/supervisor.capnp").SystemPersistent;

--- a/shell/imports/server/shell-server.js
+++ b/shell/imports/server/shell-server.js
@@ -34,6 +34,7 @@
 //   user, so maybe it's not a big deal...
 
 import { inMeteor } from "/imports/server/async-helpers.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 BrowserPolicy.framing.disallow();  // Disallow framing of the UI.
 Meteor.startup(() => {

--- a/shell/imports/server/shell-server.js
+++ b/shell/imports/server/shell-server.js
@@ -33,6 +33,8 @@
 //   with encoded URLs to an evil server. Although, this attack would be very detectable to the
 //   user, so maybe it's not a big deal...
 
+import { Meteor } from "meteor/meteor";
+
 import { inMeteor } from "/imports/server/async-helpers.js";
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/server/signup-server.js
+++ b/shell/imports/server/signup-server.js
@@ -17,6 +17,9 @@
 // This file covers creation and consumption of invite keys (i.e. to invite people to become
 // users of the Sandstorm server).
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+
 Meteor.publish("signupKey", function (key) {
   check(key, String);
   return SignupKeys.find(key);

--- a/shell/imports/server/standalone-server.js
+++ b/shell/imports/server/standalone-server.js
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+
 import { globalDb } from "/imports/db-deprecated.js";
 
 Meteor.publish("standaloneDomain", function (domain) {

--- a/shell/imports/server/standalone-server.js
+++ b/shell/imports/server/standalone-server.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { globalDb } from "/imports/db-deprecated.js";
+
 Meteor.publish("standaloneDomain", function (domain) {
   check(domain, String);
 

--- a/shell/imports/server/startup.js
+++ b/shell/imports/server/startup.js
@@ -16,6 +16,8 @@
 
 // This file is for various startup code that doesn't fit neatly anywhere else
 
+import { Meteor } from "meteor/meteor";
+
 const ROOT_URL = process.env.ROOT_URL;
 
 Meteor.startup(() => {

--- a/shell/imports/server/static-asset.js
+++ b/shell/imports/server/static-asset.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import Url from "url";
+import { Match, check } from "meteor/check";
 import Capnp from "/imports/server/capnp.js";
 const StaticAsset = Capnp.importSystem("sandstorm/grain.capnp").StaticAsset;
 

--- a/shell/imports/server/stats-server.js
+++ b/shell/imports/server/stats-server.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+
 import { allowDemo } from "/imports/demo.js";
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/server/stats-server.js
+++ b/shell/imports/server/stats-server.js
@@ -15,6 +15,10 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { Mongo } from "meteor/mongo";
+import { _ } from "meteor/underscore";
+import { Random } from "meteor/random";
+import { Router } from "meteor/iron:router";
 
 import { allowDemo } from "/imports/demo.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/server/stats-server.js
+++ b/shell/imports/server/stats-server.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { allowDemo } from "/imports/demo.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 

--- a/shell/imports/server/transfers-server.js
+++ b/shell/imports/server/transfers-server.js
@@ -18,6 +18,8 @@ import { URL } from "url";
 import Crypto from "crypto";
 import NodeHttp from "http";
 import NodeHttps from "https";
+import { Meteor } from "meteor/meteor";
+import { Match, check } from "meteor/check";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/server/transfers-server.js
+++ b/shell/imports/server/transfers-server.js
@@ -18,8 +18,11 @@ import { URL } from "url";
 import Crypto from "crypto";
 import NodeHttp from "http";
 import NodeHttps from "https";
+
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { Router } from "meteor/iron:router";
+
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/server/transfers-server.js
+++ b/shell/imports/server/transfers-server.js
@@ -19,6 +19,7 @@ import Crypto from "crypto";
 import NodeHttp from "http";
 import NodeHttps from "https";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 function isValidServerUrl(str) {
   let url;

--- a/shell/imports/shared/admin.js
+++ b/shell/imports/shared/admin.js
@@ -20,6 +20,7 @@
 // initiateLogin and loginTemplate are only used on client
 
 import { Meteor } from "meteor/meteor";
+import { Accounts } from "meteor/accounts-base";
 
 function serviceEnabled(name) {
   const setting = Settings.findOne({ _id: name });

--- a/shell/imports/shared/admin.js
+++ b/shell/imports/shared/admin.js
@@ -19,6 +19,8 @@
 // getLoginId is only used on server
 // initiateLogin and loginTemplate are only used on client
 
+import { Meteor } from "meteor/meteor";
+
 function serviceEnabled(name) {
   const setting = Settings.findOne({ _id: name });
   return setting && !!setting.value;

--- a/shell/imports/shared/dev-accounts.js
+++ b/shell/imports/shared/dev-accounts.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Accounts } from "meteor/accounts-base";
+
 import { globalDb } from "/imports/db-deprecated.js";
 
 Accounts.loginServices.dev = {

--- a/shell/imports/shared/dev-accounts.js
+++ b/shell/imports/shared/dev-accounts.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { globalDb } from "/imports/db-deprecated.js";
+
 Accounts.loginServices.dev = {
   isEnabled: function () {
     return globalDb.allowDevAccounts();

--- a/shell/imports/shared/grain-shared.js
+++ b/shell/imports/shared/grain-shared.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { globalDb } from "/imports/db-deprecated.js";
+
 Meteor.methods({
   // Methods defined in this file have meaningful latency compensation (client-side prediction)
   // potential.

--- a/shell/imports/shared/grain-shared.js
+++ b/shell/imports/shared/grain-shared.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
 import { globalDb } from "/imports/db-deprecated.js";
 
 Meteor.methods({

--- a/shell/imports/shared/testing.js
+++ b/shell/imports/shared/testing.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
 import { globalDb } from "/imports/db-deprecated.js";
 
 const isTesting = Meteor.settings && Meteor.settings.public &&

--- a/shell/imports/shared/testing.js
+++ b/shell/imports/shared/testing.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { globalDb } from "/imports/db-deprecated.js";
+
 const isTesting = Meteor.settings && Meteor.settings.public &&
                   Meteor.settings.public.isTesting;
 


### PR DESCRIPTION
This is some work on the refactoring that @zarvox started; it adds explicit import statements for many things that we were previously relying on being in global scope from side effects. Most of these are things imported from meteor packages.

Additionally, this makes the `globalDb` variable an explicit export; when I started I was planning to do that with more variables.

Also, this tweaks the eslint config so it assumes the existence of globals provided by the browser and/or node.

There is still a fair amount to do, but this gets rid of about 75% of the undefined variable warnings.