### PR TITLE
Fix LDAP hasOwnProperty breakage.

### DIFF
--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -17,4 +17,3 @@ rules:
   no-unused-vars: ["off"]
   no-empty: ["off"]
   no-inner-declarations: ["off"]
-  no-prototype-builtins: ["off"]

--- a/shell/imports/server/accounts/ldap.js
+++ b/shell/imports/server/accounts/ldap.js
@@ -44,8 +44,10 @@ LDAP.prototype.ldapCheck = function (db, options) {
 
   options = options || {};
 
-  if ((options.hasOwnProperty("username") && options.hasOwnProperty("ldapPass")) ||
-      options.hasOwnProperty("searchUsername")) {
+  const hasOwnProperty = Object.prototype.hasOwnProperty.call
+
+  if ((hasOwnProperty(options, "username") && hasOwnProperty(options, "ldapPass")) ||
+      hasOwnProperty(options, "searchUsername")) {
     _this.options.base = db.getLdapBase();
     _this.options.url = db.getLdapUrl();
     _this.options.searchBeforeBind = {};
@@ -94,7 +96,7 @@ LDAP.prototype.ldapCheck = function (db, options) {
     let username = options.username;
     let domain = _this.options.defaultDomain;
 
-    if (!options.hasOwnProperty("searchUsername")) {
+    if (!hasOwnProperty(options, "searchUsername")) {
       // Slide @xyz.whatever from username if it was passed in
       // and replace it with the domain specified in defaults
       let emailSliceIndex = options.username.indexOf("@");
@@ -165,7 +167,7 @@ LDAP.prototype.ldapCheck = function (db, options) {
 
         retObject.searchResults = _.omit(entry.object, "userPassword");
 
-        if (options.hasOwnProperty("searchUsername")) {
+        if (hasOwnProperty(options, "searchUsername")) {
           // This was only a search, return immediately
           resolved = true;
           ldapAsyncFut.return(retObject);

--- a/shell/imports/server/accounts/ldap.js
+++ b/shell/imports/server/accounts/ldap.js
@@ -44,7 +44,8 @@ LDAP.prototype.ldapCheck = function (db, options) {
 
   options = options || {};
 
-  const hasOwnProperty = Object.prototype.hasOwnProperty.call
+  let hasOwnProperty = Object.prototype.hasOwnProperty;
+  hasOwnProperty = hasOwnProperty.call.bind(hasOwnProperty);
 
   if ((hasOwnProperty(options, "username") && hasOwnProperty(options, "ldapPass")) ||
       hasOwnProperty(options, "searchUsername")) {

--- a/shell/imports/server/accounts/saml-utils.js
+++ b/shell/imports/server/accounts/saml-utils.js
@@ -288,7 +288,7 @@ SAML.prototype.validateResponse = function (samlResponse, callback) {
       const conditions = _this.getElement(assertion[0], "Conditions")[0];
       if (conditions) {
         for (const key in conditions) {
-          if (conditions.hasOwnProperty(key)) {
+          if (Object.prototype.hasOwnProperty.call(conditions, key)) {
             const value = conditions[key];
             if (key === "$") {
               const nowMs = Date.now();

--- a/shell/imports/server/shell-server.js
+++ b/shell/imports/server/shell-server.js
@@ -259,7 +259,7 @@ Meteor.publish("referralInfoPseudo", function () {
         // If the handle doesn't show up in the new list of referredAccountIds, then remove
         // info from the client & stop it on the server & make it null.
         const handleForProfileName = handleForProfileNameByAccountId[accountId];
-        if (referredAccountIdsAsObject.hasOwnProperty(accountId)) {
+        if (Object.prototype.hasOwnProperty.call(referredAccountIdsAsObject, accountId)) {
           stopWatchingAccount(accountId);
         }
       });


### PR DESCRIPTION
This should fix the errors described in the commit message for 932214aa0604fce54ff061d1555262242269047c; presumably hasOwnProperty.call is making use of `this` somehow.