### PR TITLE
Fix many places we fail eslint's `no-undef` rule

### DIFF
--- a/shell/imports/blackrock-payments/client/billingPrompt.js
+++ b/shell/imports/blackrock-payments/client/billingPrompt.js
@@ -20,6 +20,7 @@ import { ReactiveVar } from "meteor/reactive-var";
 import { _ } from "meteor/underscore";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { MAILING_LIST_BONUS } from "/imports/blackrock-payments/constants.js";
 
 var idCounter = 0;
 

--- a/shell/imports/blackrock-payments/client/payments-client.js
+++ b/shell/imports/blackrock-payments/client/payments-client.js
@@ -56,8 +56,6 @@ BlackrockPayments.processOptins = function (form) {
   }
 };
 
-BlackrockPayments.MAILING_LIST_BONUS = MAILING_LIST_BONUS;
-
 // Client-side method simulations.
 Meteor.methods({
   unsubscribeMailingList: function () {

--- a/shell/imports/blackrock-payments/constants.js
+++ b/shell/imports/blackrock-payments/constants.js
@@ -14,4 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-MAILING_LIST_BONUS = 1e9;   // 1GB bonus for subscribing to mailing list.
+const MAILING_LIST_BONUS = 1e9;   // 1GB bonus for subscribing to mailing list.
+
+export { MAILING_LIST_BONUS };

--- a/shell/imports/blackrock-payments/server/payments-api-server.js
+++ b/shell/imports/blackrock-payments/server/payments-api-server.js
@@ -16,6 +16,7 @@
 
 import Crypto from "crypto";
 import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
 
 import Capnp from "/imports/server/capnp.js";
 const PaymentsRpc = Capnp.importSystem("sandstorm/payments.capnp");
@@ -251,7 +252,7 @@ BlackrockPayments.registerPaymentsApi =
         if (user) {
           sendInvoice(this._db, user, this._invoice, this._config);
         } else {
-          console.error("Stripe charge didn't match any user: " + chrage.id);
+          console.error("Stripe charge didn't match any user: " + charge.id);
         }
       }, err => {
         // The error could be because the charge was already captured, but the only indication

--- a/shell/imports/blackrock-payments/server/payments-server.js
+++ b/shell/imports/blackrock-payments/server/payments-server.js
@@ -34,6 +34,7 @@ import { _ } from "meteor/underscore";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
+import { MAILING_LIST_BONUS } from "/imports/blackrock-payments/constants.js";
 
 const ROOT_URL = process.env.ROOT_URL;
 const HOSTNAME = Url.parse(ROOT_URL).hostname;

--- a/shell/imports/client/00-startup.js
+++ b/shell/imports/client/00-startup.js
@@ -16,6 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { Session } from "meteor/session";
 
 import { globalDb } from "/imports/db-deprecated.js";
 
@@ -29,6 +30,7 @@ import AccountsUi from "/imports/client/accounts/accounts-ui.js";
 import { GrainViewList } from "/imports/client/grain/grainview-list.js";
 
 Session.setDefault("shrink-navbar", false);
+// window.globalGrains is used by test code and must remain exported.
 globalGrains = new GrainViewList(globalDb);
 
 // If Meteor._localStorage disappears, we'll have to write our own localStorage wrapper, I guess.

--- a/shell/imports/client/accounts/account-settings-ui.js
+++ b/shell/imports/client/accounts/account-settings-ui.js
@@ -1,7 +1,7 @@
-SandstormAccountSettingsUi = function (topbar, db, staticHost) {
+function SandstormAccountSettingsUi(topbar, db, staticHost) {
   this._topbar = topbar;
   this._db = db;
   this._staticHost = staticHost;
-};
+}
 
 export default SandstormAccountSettingsUi;

--- a/shell/imports/client/accounts/account-settings.js
+++ b/shell/imports/client/accounts/account-settings.js
@@ -18,6 +18,7 @@ import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
+import { Session } from "meteor/session";
 import { _ } from "meteor/underscore";
 
 import { formatFutureTime } from "/imports/dates.js";
@@ -184,7 +185,8 @@ Template.sandstormAccountSettings.helpers({
   },
 });
 
-GENDERS = { male: "male", female: "female", neutral: "neutral", robot: "robot" };
+// TODO: dedupe with sandstorm-db/profile.js
+const GENDERS = { male: "male", female: "female", neutral: "neutral", robot: "robot" };
 
 Template._accountProfileEditor.helpers({
   profile: function () {

--- a/shell/imports/client/accounts/accounts-ui.js
+++ b/shell/imports/client/accounts/accounts-ui.js
@@ -1,8 +1,8 @@
-AccountsUi = function (db) {
+function AccountsUi(db) {
   // Object implementing the accounts UI. Must be passed as the data context for the `loginButtons`
   // and `loginButtonsPopup` templates.
 
   this._db = db;
-};
+}
 
 export default AccountsUi;

--- a/shell/imports/client/accounts/credentials/credentials-client.js
+++ b/shell/imports/client/accounts/credentials/credentials-client.js
@@ -19,6 +19,7 @@ import { Mongo } from "meteor/mongo";
 import { check } from "meteor/check";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
+import { Session } from "meteor/session";
 import { Router } from "meteor/iron:router";
 import { Accounts } from "meteor/accounts-base"
 import { _ } from "meteor/underscore";

--- a/shell/imports/client/accounts/login-buttons-session.js
+++ b/shell/imports/client/accounts/login-buttons-session.js
@@ -30,6 +30,7 @@
 // ====================================================================
 
 import { Accounts } from "meteor/accounts-base";
+import { Session } from "meteor/session";
 import { _ } from "meteor/underscore";
 
 const VALID_KEYS = [

--- a/shell/imports/client/accounts/login-buttons.js
+++ b/shell/imports/client/accounts/login-buttons.js
@@ -25,6 +25,7 @@ import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { Accounts } from "meteor/accounts-base";
 import { _ } from "meteor/underscore";
+import { Router } from "meteor/iron:router";
 
 import {
   loginWithEmailToken,

--- a/shell/imports/client/admin-client.js
+++ b/shell/imports/client/admin-client.js
@@ -15,6 +15,8 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { Random } from "meteor/random";
+import { Session } from "meteor/session";
 import { Tracker } from "meteor/tracker";
 import { Router } from "meteor/iron:router";
 

--- a/shell/imports/client/admin/admin-new-client.js
+++ b/shell/imports/client/admin/admin-new-client.js
@@ -1,5 +1,6 @@
 import { Template } from "meteor/templating";
 import { Router } from "meteor/iron:router";
+import { Session } from "meteor/session";
 
 import { globalDb } from "/imports/db-deprecated";
 

--- a/shell/imports/client/admin/login-providers.js
+++ b/shell/imports/client/admin/login-providers.js
@@ -2,6 +2,7 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
+import { TAPi18n } from "meteor/tap:i18n";
 
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/admin/network-capabilities-client.js
+++ b/shell/imports/client/admin/network-capabilities-client.js
@@ -37,7 +37,7 @@ const capDetails = function (cap) {
 
   if (cap.owner.grain !== undefined) {
     const grainId = cap.owner.grain.grainId;
-    const grain = Grains.findOne(grainId);
+    const grain = globalDb.collections.grains.findOne(grainId);
     if (!grain) {
       // Grain was deleted.  Don't show anything.
       return undefined;
@@ -75,7 +75,7 @@ Template.newAdminNetworkCapabilities.onCreated(function () {
   this.adminApiTokensSub = this.subscribe("adminApiTokens", undefined);
 
   this.autorun(() => {
-    const apiTokens = ApiTokens.find({
+    const apiTokens = globalDb.collections.apiTokens.find({
       $and: [
         {
           $or: [
@@ -91,7 +91,7 @@ Template.newAdminNetworkCapabilities.onCreated(function () {
     const grainIds = apiTokens.map(token => token.owner.grain.grainId);
     this.subscribe("adminGrains", grainIds);
 
-    const packageIds = Grains.find({
+    const packageIds = globalDb.collections.grains.find({
       _id: {
         $in: grainIds,
       },
@@ -111,7 +111,7 @@ Template.newAdminNetworkCapabilities.onCreated(function () {
 
 Template.newAdminNetworkCapabilities.helpers({
   ipNetworkCaps() {
-    return ApiTokens.find({
+    return globalDb.collections.apiTokens.find({
       "frontendRef.ipNetwork": { $exists: true },
       $or: [
         { "frontendRef.ipNetwork.encryption": { $exists: false } },
@@ -123,7 +123,7 @@ Template.newAdminNetworkCapabilities.helpers({
   },
 
   ipNetworkCapsTls() {
-    return ApiTokens.find({
+    return globalDb.collections.apiTokens.find({
       "frontendRef.ipNetwork.encryption.tls": { $exists: true },
       "owner.clientPowerboxRequest": { $exists: false },
     }).map(capDetails)
@@ -131,7 +131,7 @@ Template.newAdminNetworkCapabilities.helpers({
   },
 
   ipInterfaceCaps() {
-    return ApiTokens.find({
+    return globalDb.collections.apiTokens.find({
       "frontendRef.ipInterface": { $exists: true },
     }).map(capDetails)
       .filter((item) => !!item);

--- a/shell/imports/client/apps/applist-client.js
+++ b/shell/imports/client/apps/applist-client.js
@@ -1,11 +1,14 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
+import { Session } from "meteor/session";
 import { Router } from "meteor/iron:router";
 import { _ } from "meteor/underscore";
+import { TAPi18n } from "meteor/tap:i18n";
 
 import { introJs } from "intro.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 SandstormAppList = function (db, quotaEnforcer) {
   this._filter = new ReactiveVar("");
@@ -170,7 +173,7 @@ Template.sandstormAppListPage.helpers({
   },
 
   appMarketUrl: function () {
-    const appMarket = Settings.findOne({ _id: "appMarketUrl" });
+    const appMarket = globalDb.collections.settings.findOne({ _id: "appMarketUrl" });
     if (!appMarket) {
       return "#";
     }

--- a/shell/imports/client/demo-client.js
+++ b/shell/imports/client/demo-client.js
@@ -15,11 +15,14 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { Session } from "meteor/session";
 import { Tracker } from "meteor/tracker";
 import { Router } from "meteor/iron:router";
+import { Accounts } from "meteor/accounts-base";
 
 import { allowDemo } from "/imports/demo.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 Meteor.loginWithDemo = function (options, callback) {
   Router.go("demo");
@@ -112,7 +115,7 @@ Router.map(function () {
         if (!splashShown) {
           // find the newest (highest version, so "first" when sorting by
           // inverse order) matching package.
-          const thisPackage = Packages.findOne({
+          const thisPackage = globalDb.collections.packages.findOne({
             appId: this.params.appId,
           }, {
             sort: { "manifest.appVersion": -1 },
@@ -153,13 +156,13 @@ Router.map(function () {
           // First, find the package ID, since that is what
           // addUserActions takes. Choose the package ID with
           // highest version number.
-          const packageId = Packages.findOne(
+          const packageId = globalDb.collections.packages.findOne(
             { appId: appId },
             { sort: { "manifest.appVersion": -1 } }
           )._id;
 
           // 3. Install this app for the user, if needed.
-          if (UserActions.find({ appId: appId, userId: Meteor.userId() }).count() == 0) {
+          if (globalDb.collections.userActions.find({ appId: appId, userId: Meteor.userId() }).count() == 0) {
             Meteor.call("addUserActions", packageId);
           }
 

--- a/shell/imports/client/globals.js
+++ b/shell/imports/client/globals.js
@@ -19,6 +19,7 @@
 
 import { Tracker } from "meteor/tracker";
 import { ReactiveVar } from "meteor/reactive-var";
+import { Router } from "meteor/iron:router";
 
 getOrigin = function () {
   return document.location.protocol + "//" + document.location.host;

--- a/shell/imports/client/grain/grainlist-client.js
+++ b/shell/imports/client/grain/grainlist-client.js
@@ -3,8 +3,10 @@ import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { ReactiveDict } from "meteor/reactive-dict";
+import { Session } from "meteor/session";
 import { Router } from "meteor/iron:router";
 import { _ } from "meteor/underscore";
+import { TAPi18n } from "meteor/tap:i18n";
 
 import { introJs } from "intro.js";
 import { identiconForApp } from "/imports/sandstorm-identicons/helpers.js";

--- a/shell/imports/client/grain/grainview-list.js
+++ b/shell/imports/client/grain/grainview-list.js
@@ -20,6 +20,7 @@ import { Tracker } from "meteor/tracker";
 import { ReactiveVar } from "meteor/reactive-var";
 import { Router } from "meteor/iron:router";
 import { Accounts } from "meteor/accounts-base";
+import { SHA256 } from "meteor/sha";
 
 import { GrainView, onceConditionIsTrue } from "./grainview.js";
 import { isStandalone } from "/imports/client/standalone.js";

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -17,6 +17,7 @@
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { Template } from "meteor/templating";
+import { Blaze } from "meteor/blaze";
 import { Tracker } from "meteor/tracker";
 import { ReactiveVar } from "meteor/reactive-var";
 import { Random } from "meteor/random";
@@ -372,7 +373,7 @@ class GrainView {
       return true;
     }
 
-    const session = Sessions.findOne({ _id: this._sessionId });
+    const session = globalDb.collections.sessions.findOne({ _id: this._sessionId });
     // TODO(soon): this is a hack to cache hasLoaded. Consider moving it to an autorun.
     this._hasLoaded = session && session.hasLoaded;
 
@@ -533,7 +534,7 @@ class GrainView {
     const _this = this;
     const sessionId = this._sessionId;
     _this._sessionSub = Meteor.subscribe("sessions", sessionId, params);
-    _this._sessionObserver = Sessions.find({ _id: sessionId }).observe({
+    _this._sessionObserver = globalDb.collections.sessions.find({ _id: sessionId }).observe({
       removed(session) {
         _this._sessionSub.stop();
         _this._sessionSub = undefined;
@@ -796,7 +797,7 @@ class GrainView {
 
   showPowerboxOffer() {
     this._dep.depend();
-    const session = Sessions.findOne({
+    const session = globalDb.collections.sessions.findOne({
       _id: this._sessionId,
     }, {
       fields: {
@@ -809,7 +810,7 @@ class GrainView {
   powerboxOfferData() {
     this._dep.depend();
     const sessionId = this._sessionId;
-    const session = Sessions.findOne({
+    const session = globalDb.collections.sessions.findOne({
       _id: sessionId,
     }, {
       fields: {

--- a/shell/imports/client/install-client.js
+++ b/shell/imports/client/install-client.js
@@ -41,7 +41,7 @@ Router.map(function () {
       const packageUrl = this.params.query && this.params.query.url;
       const handle = new SandstormAppInstall(packageId, packageUrl, globalDb);
 
-      const pkg = Packages.findOne(packageId);
+      const pkg = globalDb.collections.packages.findOne(packageId);
       if (!Meteor.userId()) {
         if (allowDemo && isSafeDemoAppUrl(packageUrl)) {
           if (pkg && pkg.status === "ready") {

--- a/shell/imports/client/signup-client.js
+++ b/shell/imports/client/signup-client.js
@@ -18,11 +18,13 @@
 
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { Router } from "meteor/iron:router";
 import { DEFAULT_SIGNUP_DIALOG } from "/imports/client/personalization.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 Template.signup.helpers({
   signupDialog: function () {
-    const setting = Settings.findOne("signupDialog");
+    const setting = globalDb.collections.settings.findOne("signupDialog");
     return (setting && setting.value) || DEFAULT_SIGNUP_DIALOG;
   },
 });
@@ -39,7 +41,7 @@ Router.map(function () {
     },
 
     data: function () {
-      const keyInfo = SignupKeys.findOne(this.params.key);
+      const keyInfo = globalDb.collections.signupKeys.findOne(this.params.key);
       const user = Meteor.user();
 
       const result = {

--- a/shell/imports/client/styleguide.js
+++ b/shell/imports/client/styleguide.js
@@ -1,4 +1,5 @@
 import { Template } from "meteor/templating";
+import { Router } from "meteor/iron:router";
 
 Template.styleguide.events({
   "submit form"(evt) {

--- a/shell/imports/client/transfers-client.js
+++ b/shell/imports/client/transfers-client.js
@@ -17,6 +17,7 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { Router } from "meteor/iron:router";
+import { TAPi18n } from "meteor/tap:i18n";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/demo.js
+++ b/shell/imports/demo.js
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Meteor } from "meteor/meteor";
+
 const allowDemo = Meteor.settings && Meteor.settings.public &&
                   Meteor.settings.public.allowDemoAccounts;
 

--- a/shell/imports/sandstorm-db/scheduled-jobs-db.js
+++ b/shell/imports/sandstorm-db/scheduled-jobs-db.js
@@ -160,7 +160,7 @@ SandstormDb.prototype.scheduledJobIncrementRetries = function (id) {
   check(id, String);
 
   this.collections.scheduledJobs.update(
-    { _id: job._id },
+    { _id: id },
     { $inc: { retries: 1 },
       $unset: { lastKeepAlive: true },
     });

--- a/shell/imports/sandstorm-identicons/helpers.js
+++ b/shell/imports/sandstorm-identicons/helpers.js
@@ -28,7 +28,7 @@ function hashAppIdForIdenticon(id) {
 
   if (!id) return "00000000000000000000000000000000";
 
-  result = [];
+  const result = [];
   const digits16 = "0123456789abcdef";
   const digits32 = "0123456789acdefghjkmnpqrstuvwxyz";
   for (let i = 0; i < 32; i++) {

--- a/shell/imports/sandstorm-ui-topbar/topbar.js
+++ b/shell/imports/sandstorm-ui-topbar/topbar.js
@@ -17,6 +17,8 @@
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { Template } from "meteor/templating";
+import { Blaze } from "meteor/blaze";
+import { Reload } from "meteor/reload";
 import { Tracker } from "meteor/tracker";
 import { ReactiveVar } from "meteor/reactive-var";
 import { Router } from "meteor/iron:router";

--- a/shell/imports/server/accounts/email-token/token-server.js
+++ b/shell/imports/server/accounts/email-token/token-server.js
@@ -5,6 +5,7 @@ import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { Random } from "meteor/random";
 import { Accounts } from "meteor/accounts-base";
+import { SHA256 } from "meteor/sha";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/server/accounts/ldap.js
+++ b/shell/imports/server/accounts/ldap.js
@@ -8,7 +8,7 @@ import { _ } from "meteor/underscore";
 // your needs. url should appear as 'ldap://your.url.here'
 // dn should appear in normal ldap format of comma separated attribute=value
 // e.g. 'uid=someuser,cn=users,dc=somevalue'
-LDAP_DEFAULTS = {
+const LDAP_DEFAULTS = {
   url: false,
   port: "389",
   dn: false,

--- a/shell/imports/server/accounts/saml-utils.js
+++ b/shell/imports/server/accounts/saml-utils.js
@@ -229,7 +229,7 @@ SAML.prototype.validateResponse = function (samlResponse, callback) {
         return callback(new Error("Missing SAML assertion"), null, false, xml);
       }
 
-      profile = {};
+      const profile = {};
 
       if (response.$ && response.$.InResponseTo) {
         profile.inResponseToId = response.$.InResponseTo;

--- a/shell/imports/server/backend.js
+++ b/shell/imports/server/backend.js
@@ -19,6 +19,7 @@ import { Meteor } from "meteor/meteor";
 import { SANDSTORM_ALTHOME } from "/imports/server/constants.js";
 import { inMeteor, promiseToFuture, waitPromise } from "/imports/server/async-helpers.js";
 import Capnp from "/imports/server/capnp.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const Backend = Capnp.importSystem("sandstorm/backend.capnp").Backend;
 
@@ -47,7 +48,7 @@ class SandstormBackend {
 
   shutdownGrain(grainId, ownerId, keepSessions) {
     if (!keepSessions) {
-      Sessions.remove({ grainId: grainId });
+      globalDb.collections.sessions.remove({ grainId: grainId });
     }
 
     const grain = this._backendCap.getGrain(ownerId, grainId).supervisor;
@@ -97,7 +98,7 @@ class SandstormBackend {
   }
 
   continueGrain(grainId) {
-    const grain = Grains.findOne(grainId);
+    const grain = globalDb.collections.grains.findOne(grainId);
     if (!grain) {
       throw new Meteor.Error(404, "Grain Not Found", "Grain ID: " + grainId);
     }
@@ -108,7 +109,7 @@ class SandstormBackend {
 
     // If a DevPackage with the same app ID is currently active, we let it override the installed
     // package, so that the grain runs using the dev app.
-    const devPackage = DevPackages.findOne({ appId: grain.appId });
+    const devPackage = globalDb.collections.devPackages.findOne({ appId: grain.appId });
     let isDev;
     let mountProc;
     let pkg;
@@ -117,7 +118,7 @@ class SandstormBackend {
       pkg = devPackage;
       mountProc = pkg.mountProc;
     } else {
-      pkg = Packages.findOne(grain.packageId);
+      pkg = globalDb.collections.packages.findOne(grain.packageId);
       if (!pkg || pkg.status !== "ready") {
         throw new Meteor.Error(500, "Grain's package not installed",
                                "Package ID: " + grain.packageId);
@@ -177,7 +178,7 @@ class SandstormBackend {
     let storagePromise = undefined;
     let ownerId = undefined;
     if (this._db.isQuotaEnabled() && !storageUsageUnimplemented) {
-      let grain = Grains.findOne(grainId);
+      let grain = globalDb.collections.grains.findOne(grainId);
       if (!grain) return;  // must have been deleted
       ownerId = grain.userId;
       storagePromise = this._backendCap.getUserStorageUsage(ownerId);
@@ -187,7 +188,7 @@ class SandstormBackend {
     }
 
     const now = new Date();
-    if (Grains.update(grainId, { $set: { lastUsed: now } }) === 0) {
+    if (globalDb.collections.grains.update(grainId, { $set: { lastUsed: now } }) === 0) {
       // Grain must have been deleted. Ignore.
       return;
     }
@@ -196,7 +197,7 @@ class SandstormBackend {
       Meteor.users.update(userId, { $set: { lastActive: now } });
 
       // Update any API tokens that match this user/grain pairing as well
-      ApiTokens.update({ grainId: grainId, "owner.user.accountId": userId },
+      globalDb.collections.apiTokens.update({ grainId: grainId, "owner.user.accountId": userId },
                        { $set: { lastUsed: now } },
                        { multi: true });
     }

--- a/shell/imports/server/core.js
+++ b/shell/imports/server/core.js
@@ -241,7 +241,7 @@ class PersistentUiViewImpl extends PersistentImpl {
       }
 
       let pkg = this._db.getPackage(grain.packageId) ||
-        DevPackages.findOne({ appId: grain.appId }) ||
+        globalDb.collections.devPackages.findOne({ appId: grain.appId }) ||
         {};
 
       const manifest = pkg.manifest || {};
@@ -723,7 +723,7 @@ unwrapFrontendCap = (cap, type, callback) => {
       let tokenInfo = fetchApiToken(globalDb, saveResult.sturdyRef.toString("utf8"));
 
       // Delete the token now since it's not needed.
-      ApiTokens.remove(tokenInfo._id);
+      globalDb.collections.apiTokens.remove(tokenInfo._id);
 
       for (;;) {
         if (!tokenInfo) throw new Error("missing token?");
@@ -733,7 +733,7 @@ unwrapFrontendCap = (cap, type, callback) => {
         } else {
           // Hmm, parentTokenKey doesn't exist or is still encrypted. We can't decrypt the parent
           // but we can still fetch it in encrypted format.
-          tokenInfo = ApiTokens.findOne(tokenInfo.parentToken);
+          tokenInfo = globalDb.collections.apiTokens.findOne(tokenInfo.parentToken);
         }
       }
 

--- a/shell/imports/server/demo-server.js
+++ b/shell/imports/server/demo-server.js
@@ -16,6 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { Accounts } from "meteor/accounts-base";
 
 import { waitPromise } from "/imports/server/async-helpers.js";
 import { allowDemo } from "/imports/demo.js";
@@ -75,7 +76,7 @@ function cleanupExpiredUsers() {
       record.experiments = user.experiments;
     }
 
-    DeleteStats.insert(record);
+    globalDb.collections.deleteStats.insert(record);
   });
 
   // All demo credentials should have been deleted as part of deleting the demo users, but just in
@@ -144,7 +145,7 @@ if (allowDemo) {
       if (userId) {
         return [
           packageCursor,
-          UserActions.find({ userId: userId, appId: appId }),
+          globalDb.collections.userActions.find({ userId: userId, appId: appId }),
         ];
       }
 
@@ -155,7 +156,7 @@ if (allowDemo) {
     // that package isn't installed, store the version number so we can filter on it later.
     let packageQuery = {};
     if (appIndexData) {
-      let appIndexPackageQuery = Packages.find({ _id: appIndexData.packageId });
+      let appIndexPackageQuery = globalDb.collections.packages.find({ _id: appIndexData.packageId });
       if (appIndexPackageQuery.count() > 0) {
         return packageCursorAndMaybeUserActions(this.userId, appId, appIndexPackageQuery);
       }
@@ -169,7 +170,7 @@ if (allowDemo) {
     // If the specific package from the app index isn't installed, or the app isn't there at all, do
     // our best.
     packageQuery.appId = appId;
-    const packageCursor = Packages.find(
+    const packageCursor = globalDb.collections.packages.find(
       packageQuery,
       { sort: { "manifest.appVersion": -1 },
         limit: 1,

--- a/shell/imports/server/drivers/external-ui-view.js
+++ b/shell/imports/server/drivers/external-ui-view.js
@@ -18,6 +18,7 @@ import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { _ } from "meteor/underscore";
 
+import { inMeteor } from "/imports/server/async-helpers.js";
 import { PersistentImpl } from "/imports/server/persistent.js";
 import { ssrfSafeLookup } from "/imports/server/networking.js";
 import { REQUEST_HEADER_WHITELIST, RESPONSE_HEADER_WHITELIST }
@@ -335,7 +336,7 @@ function parseETag(input) {
   }
 }
 
-ExternalWebSession = class ExternalWebSession extends PersistentImpl {
+class ExternalWebSession extends PersistentImpl {
   constructor(url, options, db, saveTemplate) {
     super(db, saveTemplate);
 
@@ -620,7 +621,7 @@ ExternalWebSession = class ExternalWebSession extends PersistentImpl {
 
       req.setTimeout(15000, () => {
         req.abort();
-        err = new Error("Request timed out.");
+        const err = new Error("Request timed out.");
         err.kjType = "overloaded";
         reject(err);
       });
@@ -632,4 +633,4 @@ ExternalWebSession = class ExternalWebSession extends PersistentImpl {
       }
     });
   }
-};
+}

--- a/shell/imports/server/drivers/ip.js
+++ b/shell/imports/server/drivers/ip.js
@@ -27,7 +27,7 @@ import Capnp from "/imports/server/capnp.js";
 
 const IpRpc = Capnp.importSystem("sandstorm/ip.capnp");
 
-ByteStreamConnection = class ByteStreamConnection{
+class ByteStreamConnection {
   constructor(connection) {
     this.connection = connection;
   }
@@ -42,7 +42,7 @@ ByteStreamConnection = class ByteStreamConnection{
 
   // expectSize not implemented
   // expectSize(size) { }
-};
+}
 
 class IpInterfaceImpl extends PersistentImpl {
   constructor(db, saveTemplate) {
@@ -167,7 +167,7 @@ Meteor.startup(() => {
   });
 });
 
-BoundUdpPortImpl = class BoundUdpPortImpl {
+class BoundUdpPortImpl {
   constructor(server, address, port) {
     this.server = server;
     this.address = address;
@@ -180,7 +180,7 @@ BoundUdpPortImpl = class BoundUdpPortImpl {
     // their raw physical address/port, and using that here
     this.server.send(message, 0, message.length, this.port, this.address);
   }
-};
+}
 
 const bits16 = Bignum(1).shiftLeft(16).sub(1);
 const bits32 = Bignum(1).shiftLeft(32).sub(1);
@@ -337,7 +337,7 @@ class IpRemoteHostImpl {
   }
 }
 
-TcpPortImpl = class TcpPortImpl {
+class TcpPortImpl {
   constructor(address, portNum, tls) {
     this.address = address;
     this.port = portNum;
@@ -376,13 +376,13 @@ TcpPortImpl = class TcpPortImpl {
       });
     });
   }
-};
+}
 
 const errorWrite = (data) => {
   throw new Error("error occurred in connection");
 };
 
-UdpPortImpl = class UdpPortImpl {
+class UdpPortImpl {
   constructor(address, portNum) {
     this.address = address;
     this.port = portNum;
@@ -412,5 +412,5 @@ UdpPortImpl = class UdpPortImpl {
 
     // TODO(someday): use callback to catch errors and do something with them
   }
-};
+}
 

--- a/shell/imports/server/drivers/mail.js
+++ b/shell/imports/server/drivers/mail.js
@@ -160,7 +160,7 @@ Meteor.startup(function () {
             const tryDeliver = (retryCount) => {
               let grainId;
               return inMeteor(() => {
-                const grain = Grains.findOne({ publicId: publicId }, { fields: {} });
+                const grain = globalDb.collections.grains.findOne({ publicId: publicId }, { fields: {} });
                 if (grain) {
                   grainId = grain._id;
                   return globalBackend.continueGrain(grainId, retryCount > 0);
@@ -311,7 +311,7 @@ hackSendEmail = (session, email) => {
       options.attachments = attachments;
     }
 
-    const grain = Grains.findOne(session.grainId);
+    const grain = globalDb.collections.grains.findOne(session.grainId);
     if (!grain) throw new Error("Grain does not exist.");
     globalDb.incrementDailySentMailCount(grain.userId);
 

--- a/shell/imports/server/email.js
+++ b/shell/imports/server/email.js
@@ -6,8 +6,10 @@ import nodemailer from "nodemailer";
 import smtpPool from "nodemailer-smtp-pool";
 import Future from "fibers/future";
 
+import { globalDb } from "/imports/db-deprecated.js";
+
 const getSmtpConfig = function () {
-  const config = Settings.findOne({ _id: "smtpConfig" });
+  const config = globalDb.collections.settings.findOne({ _id: "smtpConfig" });
   return config && config.value;
 };
 
@@ -47,7 +49,7 @@ let pool;
 let configured = false;
 
 Meteor.startup(function () {
-  Settings.find({ _id: "smtpConfig" }).observeChanges({
+  globalDb.collections.settings.find({ _id: "smtpConfig" }).observeChanges({
     removed: function () {
       configured = false;
     },

--- a/shell/imports/server/install-server.js
+++ b/shell/imports/server/install-server.js
@@ -17,12 +17,14 @@
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { Random } from "meteor/random";
+import { Router } from "meteor/iron:router";
 
 import { allowDemo } from "/imports/demo.js";
 import { isSafeDemoAppUrl } from "/imports/install.js"
-import { promiseToFuture } from "/imports/server/async-helpers.js";
+import { promiseToFuture, waitPromise } from "/imports/server/async-helpers.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
+import { cancelDownload } from "/imports/server/installer.js";
 
 const TOKEN_CLEANUP_MINUTES = 120;  // Give enough time for large uploads on slow connections.
 const TOKEN_CLEANUP_TIMER = TOKEN_CLEANUP_MINUTES * 60 * 1000;
@@ -99,7 +101,7 @@ Meteor.methods({
           "This Sandstorm server requires you to get an invite before installing apps.");
     }
 
-    const pkg = Packages.findOne(packageId);
+    const pkg = globalDb.collections.packages.findOne(packageId);
 
     if (!pkg || pkg.status !== "ready") {
       if (!this.userId || isDemoUser() || globalDb.isUninvitedFreeUser()) {

--- a/shell/imports/server/networking.js
+++ b/shell/imports/server/networking.js
@@ -71,7 +71,7 @@ function parseCidr(cidr) {
   }
 }
 
-SPECIAL_FILTERS = SPECIAL_IPV4_ADDRESSES.concat(SPECIAL_IPV6_ADDRESSES).map(parseCidr);
+const SPECIAL_FILTERS = SPECIAL_IPV4_ADDRESSES.concat(SPECIAL_IPV6_ADDRESSES).map(parseCidr);
 
 function ssrfSafeLookup(db, url) {
   // Given an HTTP/HTTPS URL, look up the hostname, verify it doesn't point to a blacklisted IP,

--- a/shell/imports/server/sandcats.js
+++ b/shell/imports/server/sandcats.js
@@ -14,8 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-Sandcats = {};
-
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Random } from "meteor/random";
@@ -34,6 +32,8 @@ import { globalDb } from "/imports/db-deprecated.js";
 const SANDCATS_HOSTNAME = (Meteor.settings && Meteor.settings.public &&
                            Meteor.settings.public.sandcatsHostname);
 const SANDCATS_VARDIR = (SANDSTORM_ALTHOME || "") + "/var/sandcats";
+
+const Sandcats = {};
 
 // Figure out what IP address to send Sandcats requests from. For machines with multiple IPs, it
 // is important to use the IP to which we're binding. However, some people set BIND_IP to 127.0.0.1
@@ -67,7 +67,7 @@ const pingUdp = () => {
   const socket = dgram.createSocket("udp4");
   const secret = Random.secret(16);
 
-  message = new Buffer(SANDCATS_NAME + " " + secret);
+  const message = new Buffer(SANDCATS_NAME + " " + secret);
   socket.on("message", (buf) => {
     if (buf.toString() === secret) {
       updateSandcatsIp();

--- a/shell/imports/server/shell-server.js
+++ b/shell/imports/server/shell-server.js
@@ -34,6 +34,7 @@
 //   user, so maybe it's not a big deal...
 
 import { Meteor } from "meteor/meteor";
+import { BrowserPolicy } from "meteor/browser-policy";
 
 import { inMeteor } from "/imports/server/async-helpers.js";
 import { globalDb } from "/imports/db-deprecated.js";
@@ -82,7 +83,7 @@ Meteor.publish("grainsMenu", function () {
         if (err.kjType === "unimplemented") {
           // Compute based on sum of grain sizes instead.
           let total = 0;
-          Grains.find({ userId: userId }, { fields: { size: 1 } })
+          globalDb.collections.grains.find({ userId: userId }, { fields: { size: 1 } })
               .forEach(grain => total += (grain.size || 0));
           Meteor.users.update(userId, { $set: { storageUsage: total } });
         } else {
@@ -92,9 +93,9 @@ Meteor.publish("grainsMenu", function () {
     }
 
     return [
-      UserActions.find({ userId: this.userId }),
-      Grains.find({ userId: this.userId }, {fields: {oldUsers: 0}}),
-      ApiTokens.find({ "owner.user.accountId": this.userId }),
+      globalDb.collections.userActions.find({ userId: this.userId }),
+      globalDb.collections.grains.find({ userId: this.userId }, {fields: {oldUsers: 0}}),
+      globalDb.collections.apiTokens.find({ "owner.user.accountId": this.userId }),
     ];
   } else {
     return [];
@@ -102,7 +103,7 @@ Meteor.publish("grainsMenu", function () {
 });
 
 Meteor.publish("devPackages", function () {
-  return DevPackages.find();
+  return globalDb.collections.devPackages.find();
 });
 
 Meteor.publish("hasUsers", function () {

--- a/shell/imports/server/signup-server.js
+++ b/shell/imports/server/signup-server.js
@@ -19,10 +19,11 @@
 
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
+import { globalDb } from "/imports/db-deprecated.js";
 
 Meteor.publish("signupKey", function (key) {
   check(key, String);
-  return SignupKeys.find(key);
+  return globalDb.collections.signupKeys.find(key);
 });
 
 Meteor.methods({
@@ -49,7 +50,7 @@ Meteor.methods({
       return;
     }
 
-    const keyInfo = SignupKeys.findOne(key);
+    const keyInfo = globalDb.collections.signupKeys.findOne(key);
     if (!keyInfo || keyInfo.used) {
       throw new Meteor.Error(403, "Invalid key or already used.");
     }
@@ -60,7 +61,7 @@ Meteor.methods({
       // probably now have two payment accounts. Mark this invite as used but also add a special
       // flag so we can find it later and cancel the dupe payment account. Record who tried to
       // use it so that we can transfer credits over if needed.
-      SignupKeys.update(key, { $set: { used: true, rejectedBy: this.userId } });
+      globalDb.collections.signupKeys.update(key, { $set: { used: true, rejectedBy: this.userId } });
       return;
     }
 
@@ -85,6 +86,6 @@ Meteor.methods({
     }
 
     Meteor.users.update(this.userId, { $set: userFields });
-    SignupKeys.update(key, { $set: { used: true } });
+    globalDb.collections.signupKeys.update(key, { $set: { used: true } });
   },
 });

--- a/shell/imports/server/startup.js
+++ b/shell/imports/server/startup.js
@@ -17,16 +17,17 @@
 // This file is for various startup code that doesn't fit neatly anywhere else
 
 import { Meteor } from "meteor/meteor";
+import { globalDb } from "/imports/db-deprecated.js";
 
 const ROOT_URL = process.env.ROOT_URL;
 
 Meteor.startup(() => {
-  let baseUrlRow = Misc.findOne({ _id: "BASE_URL" });
+  let baseUrlRow = globalDb.collections.misc.findOne({ _id: "BASE_URL" });
 
   if (!baseUrlRow) {
     // Fill data with current value in the case this is a first run
     baseUrlRow = { _id: "BASE_URL", value: ROOT_URL };
-    Misc.insert(baseUrlRow);
+    globalDb.collections.misc.insert(baseUrlRow);
   } else if (baseUrlRow.value !== ROOT_URL) {
     // If the only thing that happened is some trailing slashes got removed, then don't reset OAuth
     // providers.
@@ -38,9 +39,9 @@ Meteor.startup(() => {
 
     if (resetOAuth) {
       console.log("resetting oauth");
-      Settings.find({ _id: { $in: ["google", "github"] } }).forEach((setting) => {
+      globalDb.collections.settings.find({ _id: { $in: ["google", "github"] } }).forEach((setting) => {
         if (setting.value) {
-          Settings.update({ _id: setting._id },
+          globalDb.collections.settings.update({ _id: setting._id },
                           { $set: { value: false,
                                     automaticallyReset: { baseUrlChangedFrom: baseUrlRow.value }, }, });
         }
@@ -48,6 +49,6 @@ Meteor.startup(() => {
     }
 
     baseUrlRow = { _id: "BASE_URL", value: ROOT_URL };
-    Misc.update({ _id: "BASE_URL" }, { $set: { value: ROOT_URL } });
+    globalDb.collections.misc.update({ _id: "BASE_URL" }, { $set: { value: ROOT_URL } });
   }
 });

--- a/shell/imports/server/static-asset.js
+++ b/shell/imports/server/static-asset.js
@@ -17,6 +17,8 @@
 import Url from "url";
 import { Match, check } from "meteor/check";
 import Capnp from "/imports/server/capnp.js";
+import { globalDb } from "/imports/db-deprecated.js";
+
 const StaticAsset = Capnp.importSystem("sandstorm/grain.capnp").StaticAsset;
 
 const PROTOCOL = Url.parse(process.env.ROOT_URL).protocol;
@@ -25,7 +27,7 @@ class StaticAssetImpl {
   constructor(assetId) {
     check(assetId, String);
     this._protocol = PROTOCOL.slice(0, -1);
-    this._hostPath = makeWildcardHost("static") + "/" + assetId;
+    this._hostPath = globalDb.makeWildcardHost("static") + "/" + assetId;
   }
 
   getUrl() {
@@ -38,7 +40,7 @@ class IdenticonStaticAssetImpl {
     check(hash, String);
     check(size, Match.Integer);
     this._protocol = PROTOCOL.slice(0, -1);
-    this._hostPath =  makeWildcardHost("static") + "/identicon/" + hash + "?s=" + size;
+    this._hostPath =  globalDb.makeWildcardHost("static") + "/identicon/" + hash + "?s=" + size;
   }
 
   getUrl() {

--- a/shell/imports/shared/admin.js
+++ b/shell/imports/shared/admin.js
@@ -21,9 +21,10 @@
 
 import { Meteor } from "meteor/meteor";
 import { Accounts } from "meteor/accounts-base";
+import { globalDb } from "/imports/db-deprecated.js";
 
 function serviceEnabled(name) {
-  const setting = Settings.findOne({ _id: name });
+  const setting = globalDb.collections.settings.findOne({ _id: name });
   return setting && !!setting.value;
 }
 

--- a/shell/imports/shared/testing.js
+++ b/shell/imports/shared/testing.js
@@ -26,13 +26,13 @@ if (isTesting) {
     import { runDueJobs } from '/imports/server/scheduled-job.js';
 
     function clearUser(id) {
-      UserActions.remove({ userId: id });
+      globalDb.collections.userActions.remove({ userId: id });
       globalDb.removeApiTokens({ userId: id });
-      Grains.find({ userId: id }).forEach(function (grain) {
+      globalDb.collections.grains.find({ userId: id }).forEach(function (grain) {
         globalBackend.deleteGrain(grain._id);
       });
 
-      Grains.remove({ userId: id });
+      globalDb.collections.grains.remove({ userId: id });
       Meteor.users.remove({ _id: id });
     }
 


### PR DESCRIPTION
I mostly went for things that were trivial to find/replace with `globalDb`, but
there's a few typos fixed, missing `const`s, and a couple of places where it
looks like we have been naming the wrong variable for some time.

This brings us down to 706 no-undef lint failures from >1000.  There are still
many failures that will require more in-depth refactoring, but at least this
helps reduce the noise so we can find them more easily.

I believe this should make no behavior changes, besides fixing existing
brokenness around the few typos.