### PR TITLE
Fix more `no-undef` eslint warnings.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,3 +79,9 @@ jobs:
         with:
           name: testlog.txt
           path: testlog.txt
+      - name: upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v1
+        with:
+          name: screenshots
+          path: tests/screenshots

--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -21,7 +21,7 @@ extends: "eslint:recommended"
 rules:
   # These are implied by eslint:recommended, but we haven't gotten around to
   # fixing them yet:
-  no-undef: ["off"]
+  no-undef: ["warn"]
   no-unused-vars: ["off"]
   no-empty: ["off"]
   no-inner-declarations: ["off"]

--- a/shell/imports/blackrock-payments/server/payments-server.js
+++ b/shell/imports/blackrock-payments/server/payments-server.js
@@ -30,6 +30,7 @@ import { Meteor } from "meteor/meteor";
 import { Mongo } from "meteor/mongo";
 import { check } from "meteor/check";
 import { Random } from "meteor/random";
+import { HTTP } from "meteor/http";
 import { _ } from "meteor/underscore";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";

--- a/shell/imports/client/00-startup.js
+++ b/shell/imports/client/00-startup.js
@@ -19,6 +19,7 @@ import { Template } from "meteor/templating";
 import { Session } from "meteor/session";
 
 import { globalDb } from "/imports/db-deprecated.js";
+import { SandstormTopbar } from "/imports/sandstorm-ui-topbar/topbar.js";
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', function() {

--- a/shell/imports/client/accounts/account-settings.js
+++ b/shell/imports/client/accounts/account-settings.js
@@ -19,6 +19,7 @@ import { check } from "meteor/check";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { Session } from "meteor/session";
+import { HTTP } from "meteor/http";
 import { _ } from "meteor/underscore";
 
 import { formatFutureTime } from "/imports/dates.js";

--- a/shell/imports/client/admin-client.js
+++ b/shell/imports/client/admin-client.js
@@ -19,6 +19,7 @@ import { Random } from "meteor/random";
 import { Session } from "meteor/session";
 import { Tracker } from "meteor/tracker";
 import { Router } from "meteor/iron:router";
+import { HTTP } from "meteor/http";
 
 Meteor.subscribe("publicAdminSettings");
 

--- a/shell/imports/client/admin/login-providers.js
+++ b/shell/imports/client/admin/login-providers.js
@@ -3,6 +3,7 @@ import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { TAPi18n } from "meteor/tap:i18n";
+import { Iron } from "meteor/iron:router";
 
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/admin/personalization-client.js
+++ b/shell/imports/client/admin/personalization-client.js
@@ -1,6 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
+import { HTTP } from "meteor/http";
 
 import { DEFAULT_SIGNUP_DIALOG } from "/imports/client/personalization.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/client/setup-wizard/wizard.js
+++ b/shell/imports/client/setup-wizard/wizard.js
@@ -4,7 +4,7 @@ import { Template } from "meteor/templating";
 import { Tracker } from "meteor/tracker";
 import { ReactiveVar } from "meteor/reactive-var";
 import { _ } from "meteor/underscore";
-import { Router } from "meteor/iron:router";
+import { Iron, Router } from "meteor/iron:router";
 
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
 import AccountsUi from "/imports/client/accounts/accounts-ui.js";

--- a/shell/imports/client/shell-client.js
+++ b/shell/imports/client/shell-client.js
@@ -26,6 +26,7 @@ import { Accounts } from "meteor/accounts-base";
 import { Session } from "meteor/session";
 import { Router } from "meteor/iron:router";
 import { TAPi18n } from "meteor/tap:i18n";
+import { HTTP } from "meteor/http";
 
 import getBuildInfo from "/imports/client/build-info.js";
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";

--- a/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
+++ b/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
@@ -23,6 +23,7 @@ import { Meteor } from "meteor/meteor";
 import { Accounts } from "meteor/accounts-base";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SandstormAutoUpdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
 
 const globalDb = new SandstormDb();
 // TODO(cleanup): Use a lightweight fake (minimongo-based?) database here and construct a clean

--- a/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
+++ b/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
@@ -24,7 +24,7 @@ import { Accounts } from "meteor/accounts-base";
 import { HTTP } from "meteor/http";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { SandstormAutoUpdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
+import { SandstormAutoupdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
 
 const globalDb = new SandstormDb();
 // TODO(cleanup): Use a lightweight fake (minimongo-based?) database here and construct a clean

--- a/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
+++ b/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
@@ -21,6 +21,7 @@ import Crypto from "crypto";
 
 import { Meteor } from "meteor/meteor";
 import { Accounts } from "meteor/accounts-base";
+import { HTTP } from "meteor/http";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { SandstormAutoUpdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";

--- a/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps.js
+++ b/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps.js
@@ -17,7 +17,7 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 
-SandstormAutoupdateApps = {};
+export const SandstormAutoupdateApps = {};
 
 SandstormAutoupdateApps.updateAppIndex = function (db) {
   db.updateAppIndex();

--- a/shell/imports/sandstorm-ui-topbar/topbar.js
+++ b/shell/imports/sandstorm-ui-topbar/topbar.js
@@ -333,7 +333,7 @@ Template.sandstormTopbarItem.onDestroyed(function () {
 // =======================================================================================
 // Public interface
 
-SandstormTopbar = function (db, expandedVar, grainsVar, shrinkNavbarVar) {
+export const SandstormTopbar = function (db, expandedVar, grainsVar, shrinkNavbarVar) {
   // `expandedVar` is an optional object that behaves like a `ReactiveVar` and will be used to
   // track which popup is currently open. (The caller may wish to back this with a Session
   // variable.)

--- a/shell/imports/server/00-startup.js
+++ b/shell/imports/server/00-startup.js
@@ -24,6 +24,7 @@ import { migrateToLatest } from "/imports/server/migrations.js";
 import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants.js";
 import { onInMeteor } from "/imports/server/async-helpers.js";
 import { monkeyPatchHttp } from "/imports/server/networking.js";
+import { SandstormAutoUpdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
 let url = require("url");
 
 process.on('unhandledRejection', (reason, p) => {

--- a/shell/imports/server/00-startup.js
+++ b/shell/imports/server/00-startup.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
+import { HTTP } from "meteor/http";
 
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/server/00-startup.js
+++ b/shell/imports/server/00-startup.js
@@ -25,7 +25,7 @@ import { migrateToLatest } from "/imports/server/migrations.js";
 import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants.js";
 import { onInMeteor } from "/imports/server/async-helpers.js";
 import { monkeyPatchHttp } from "/imports/server/networking.js";
-import { SandstormAutoUpdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
+import { SandstormAutoupdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
 let url = require("url");
 
 process.on('unhandledRejection', (reason, p) => {

--- a/shell/imports/server/backup.js
+++ b/shell/imports/server/backup.js
@@ -50,7 +50,7 @@ Meteor.startup(() => {
   });
 });
 
-createGrainBackup = (userId, grainId, async) => {
+export const createGrainBackup = (userId, grainId, async) => {
   check(grainId, String);
   const grain = globalDb.collections.grains.findOne(grainId);
   if (!grain || !userId || grain.userId !== userId) {

--- a/shell/imports/server/backup.js
+++ b/shell/imports/server/backup.js
@@ -115,7 +115,7 @@ export const createGrainBackup = (userId, grainId, async) => {
   return token._id;
 };
 
-createBackupToken = () => {
+export const createBackupToken = () => {
   const token = {
     _id: Random.id(),
     timestamp: new Date(),
@@ -126,7 +126,7 @@ createBackupToken = () => {
   return token._id;
 };
 
-restoreGrainBackup = (tokenId, user, transferInfo) => {
+export const restoreGrainBackup = (tokenId, user, transferInfo) => {
   check(tokenId, String);
   const token = globalDb.collections.fileTokens.findOne(tokenId);
   if (!token) {
@@ -321,7 +321,7 @@ downloadGrainBackup = (tokenId, response, retryCount = 0) => {
   cleanupToken(tokenId);
 }
 
-storeGrainBackup = (tokenId, inputStream) => {
+export const storeGrainBackup = (tokenId, inputStream) => {
   const stream = globalBackend.cap().uploadBackup(tokenId).stream;
 
   waitPromise(new Promise((resolve, reject) => {

--- a/shell/imports/server/core.js
+++ b/shell/imports/server/core.js
@@ -26,6 +26,7 @@ import { PersistentImpl, hashSturdyRef, generateSturdyRef, checkRequirements,
 import { SandstormBackend } from "/imports/server/backend.js";
 import { hashAppIdForIdenticon } from "/imports/sandstorm-identicons/helpers.js";
 import { globalDb } from "/imports/db-deprecated.js";
+import { schedulePeriodic, scheduleOneShot } from "/imports/server/scheduled-job.js";
 import Capnp from "/imports/server/capnp.js";
 
 const PersistentHandle = Capnp.importSystem("sandstorm/supervisor.capnp").PersistentHandle;

--- a/shell/imports/server/drivers/external-ui-view.js
+++ b/shell/imports/server/drivers/external-ui-view.js
@@ -16,6 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
+import { HTTP } from "meteor/http";
 import { _ } from "meteor/underscore";
 
 import { inMeteor } from "/imports/server/async-helpers.js";

--- a/shell/imports/server/drivers/mail.js
+++ b/shell/imports/server/drivers/mail.js
@@ -29,6 +29,7 @@ import { PersistentImpl } from "/imports/server/persistent.js";
 import { rawSend } from "/imports/server/email.js";
 import { shouldRestartGrain } from "/imports/server/backend.js";
 import { inMeteor } from "/imports/server/async-helpers.js";
+import { makeHackSessionContext } from "/imports/server/hack-session.js";
 
 import Crypto from "crypto";
 import Future from "fibers/future";

--- a/shell/imports/server/drivers/mail.js
+++ b/shell/imports/server/drivers/mail.js
@@ -33,6 +33,7 @@ import { makeHackSessionContext } from "/imports/server/hack-session.js";
 
 import Crypto from "crypto";
 import Future from "fibers/future";
+import Net from "net";
 import Url from "url";
 import Capnp from "/imports/server/capnp.js";
 
@@ -72,7 +73,7 @@ if (process.env.HTTP_GATEWAY === "local" &&
     pipe.open(fd);
     pipe.onread = function (size, buf, handle) {
       if (handle) {
-        cb(new net.Socket({ handle: handle }));
+        cb(new Net.Socket({ handle: handle }));
       }
     };
     pipe.readStart();

--- a/shell/imports/server/gateway-router.js
+++ b/shell/imports/server/gateway-router.js
@@ -27,6 +27,8 @@ import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 
+import { makeHackSessionContext } from "/imports/server/hack-session.js";
+
 const GatewayRouter = Capnp.importSystem("sandstorm/backend.capnp").GatewayRouter;
 const ApiSession = Capnp.importSystem("sandstorm/api-session.capnp").ApiSession;
 const WebSession = Capnp.importSystem("sandstorm/web-session.capnp").WebSession;

--- a/shell/imports/server/hack-session.js
+++ b/shell/imports/server/hack-session.js
@@ -531,7 +531,7 @@ class HackSessionContextImpl extends SessionContextImpl {
   }
 }
 
-makeHackSessionContext = (grainId, sessionId, accountId, tabId) => {
+export const makeHackSessionContext = (grainId, sessionId, accountId, tabId) => {
   // TODO(security): Ensure that the session context is revoked if the session is revoked.
   return new Capnp.Capability(new HackSessionContextImpl(grainId, sessionId, accountId, tabId),
                               HackSessionContext);

--- a/shell/imports/server/scheduled-job.js
+++ b/shell/imports/server/scheduled-job.js
@@ -28,7 +28,7 @@ const SystemPersistent = Capnp.importSystem("sandstorm/supervisor.capnp").System
 const MINIMUM_SCHEDULING_SLACK_NANO = Capnp.importSystem("sandstorm/grain.capnp").minimumSchedulingSlack;
 const MINIMUM_SCHEDULING_SLACK_MILLIS = MINIMUM_SCHEDULING_SLACK_NANO / 1e6;
 
-scheduleOneShot = (db, grainId, name, callback, when, slack) => {
+export const scheduleOneShot = (db, grainId, name, callback, when, slack) => {
   callback.castAs(SystemPersistent).save({ frontend: null }).then((result) => {
     db.addOneShotScheduledJob(
       grainId,
@@ -40,7 +40,7 @@ scheduleOneShot = (db, grainId, name, callback, when, slack) => {
   })
 }
 
-schedulePeriodic = (db, grainId, name, callback, period) => {
+export const schedulePeriodic = (db, grainId, name, callback, period) => {
   callback.castAs(SystemPersistent).save({ frontend: null }).then((result) => {
     db.addPeriodicScheduledJob(
       grainId,

--- a/shell/imports/server/stats-server.js
+++ b/shell/imports/server/stats-server.js
@@ -19,6 +19,7 @@ import { Mongo } from "meteor/mongo";
 import { _ } from "meteor/underscore";
 import { Random } from "meteor/random";
 import { Router } from "meteor/iron:router";
+import { HTTP } from "meteor/http";
 
 import { allowDemo } from "/imports/demo.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/server/transfers-server.js
+++ b/shell/imports/server/transfers-server.js
@@ -25,7 +25,8 @@ import { Router } from "meteor/iron:router";
 
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { globalDb } from "/imports/db-deprecated.js";
-import { createGrainBackup } from "/imports/server/backup.js";
+import { createGrainBackup, createBackupToken, restoreGrainBackup, storeGrainBackup }
+  from "/imports/server/backup.js";
 
 function isValidServerUrl(str) {
   let url;

--- a/shell/imports/server/transfers-server.js
+++ b/shell/imports/server/transfers-server.js
@@ -22,6 +22,7 @@ import NodeHttps from "https";
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { Router } from "meteor/iron:router";
+import { HTTP } from "meteor/http";
 
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/server/transfers-server.js
+++ b/shell/imports/server/transfers-server.js
@@ -25,6 +25,7 @@ import { Router } from "meteor/iron:router";
 
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { globalDb } from "/imports/db-deprecated.js";
+import { createGrainBackup } from "/imports/server/backup.js";
 
 function isValidServerUrl(str) {
   let url;

--- a/shell/imports/shared/testing.js
+++ b/shell/imports/shared/testing.js
@@ -16,6 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { globalDb } from "/imports/db-deprecated.js";
+import { SandstormAutoUpdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
 
 const isTesting = Meteor.settings && Meteor.settings.public &&
                   Meteor.settings.public.isTesting;

--- a/shell/imports/shared/testing.js
+++ b/shell/imports/shared/testing.js
@@ -16,7 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { globalDb } from "/imports/db-deprecated.js";
-import { SandstormAutoUpdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
+import { SandstormAutoupdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
 
 const isTesting = Meteor.settings && Meteor.settings.public &&
                   Meteor.settings.public.isTesting;

--- a/tests/apps/schedule.js
+++ b/tests/apps/schedule.js
@@ -53,6 +53,7 @@ function common({browser, refStr, firstWaitDuration, shouldRepeat}) {
     .waitForElementPresent(selector, short_wait)
     .click(selector)
     .frameParent()
+    .pause(short_wait)
     .execute('Meteor.call("runDueJobsAt", ' + firstCheck.toString() + ');')
     .pause(short_wait)
     .windowHandles(windows => browser.switchWindow(windows.value[1]))


### PR DESCRIPTION
This gets rid of about 70 of them. I also set the warning to `"warn"` in the config, so it won't fail CI but we can still see the output.