### PR TITLE
Fix flakiness from race condition in installApp test helper

### DIFF
--- a/tests/commands/installApp.js
+++ b/tests/commands/installApp.js
@@ -29,7 +29,16 @@ exports.command = function(url, packageId, appId, dontStartGrain, callback) {
   var ret = browser
     .init()
     .url(this.launch_url + "/install/" + packageId + "?url=" + url)
-    .waitForElementVisible("#step-confirm", very_long_wait)
+    .waitForElementVisible("#step-confirm", very_long_wait);
+
+  if (!dontStartGrain) {
+    ret = ret
+      // The introjs overlay often doesn't destroy itself fast enough and intercepts
+      // clicks that we don't want it to intercept. So we manually disable it here.
+      .disableGuidedTour();
+  }
+
+  ret = ret
     .click("#confirmInstall")
     .url(this.launch_url + "/apps")
     .waitForElementVisible(".app-list", medium_wait)
@@ -37,9 +46,6 @@ exports.command = function(url, packageId, appId, dontStartGrain, callback) {
 
   if (!dontStartGrain) {
     ret = ret
-      // The introjs overlay often doesn't destroy itself fast enough and intercepts
-      // clicks that we don't want it to intercept. So we manually disable it here.
-      .disableGuidedTour()
       .click(appSelector(appId))
       .waitForElementVisible(actionSelector, short_wait)
       .click(actionSelector)


### PR DESCRIPTION
When navigating to /apps, it's possible that the introjs overlay will make the
.app-list element not "visible" (because the overlay is blocking the entirety
of the page).

It's also possible that we'll win that race, but then once we navigate to the
grain list page, we'll lose a race against a different introjs overlay.

Additionally, the introjs overlay does not appear to get reactively removed
when we mark that it's no longer needed in the Session.  So we need to catch
things early.

Making the call to `disableGuidedTour()` *before* navigating to any of the
pages that feature introjs helpers should help ensure that they never render
and never cause test failures.

It's possible we should rethink how we manage introjs and testing -- perhaps we
should disable the overlays earlier for testing purpose, like in user login.
There's only two tests that actually bother interacting with the introjs
overlays, and perhaps they could use a different login method (or pass a
parameter to decline disabling all introjs overlays).

I believe this patch may fix the flakiness around `apps/collections` that we're
seeing in the checks for #3293.