### PR TITLE
Use es6 modules in the Sandcats ACME.js plugin.

### DIFF
--- a/acme-dns-01-sandcats/index.js
+++ b/acme-dns-01-sandcats/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const https = require("https");
-const querystring = require("querystring");
-const dns = require("dns");
+import https from "https";
+import querystring from "querystring";
+import dns from "dns";
 
 class Challenge {
   constructor(options) {
@@ -125,8 +125,6 @@ class Challenge {
   }
 };
 
-module.exports = {
-  create(options) {
-    return new Challenge(options);
-  }
-};
+export function create(options) {
+  return new Challenge(options);
+}

--- a/acme-dns-01-sandcats/package.json
+++ b/acme-dns-01-sandcats/package.json
@@ -1,5 +1,6 @@
 {
   "name": "acme-dns-01-sandcats",
+  "type": "module",
   "version": "0.1.0",
   "engines": {
     "node": ">=12.0"

--- a/acme-dns-01-sandcats/test.js
+++ b/acme-dns-01-sandcats/test.js
@@ -1,10 +1,11 @@
 'use strict';
 
-const sandcatsChallenge = require("./index.js");
-const fs = require("fs");
-const tester = require("acme-dns-01-test");
+import * as sandcatsChallenge from "./index.js";
+import fs from "fs";
+import tester from "acme-dns-01-test";
+import { setServers } from "dns";
 
-require("dns").setServers(["104.197.28.173"]);
+setServers(["104.197.28.173"])
 
 async function run() {
   let challenger = sandcatsChallenge.create({


### PR DESCRIPTION
@kentonv, the magic seems to be to put `"type": "module"` in package.json, but I had to actually pop it open and try it to figure it out, so I figured I'd just send a pr rather than make you replicate it.

...it would be nice if it were possible for other people to run these tests somehow.