### PR TITLE
Fix bitrot in install docs.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -142,14 +142,14 @@ Please install the following:
 * `golang-go`
 * `cmake`
 * discount (markdown parser)
-* [Meteor](http://meteor.com)
+* [Meteor](http://meteor.com) version 1.8.2
 
 On Debian or Ubuntu, you should be able to get all these with:
 
     sudo apt-get install build-essential libcap-dev xz-utils zip \
         unzip strace curl discount git python zlib1g-dev \
         golang-go cmake
-    curl https://install.meteor.com/ | sh
+    curl https://install.meteor.com/?release=1.8.2 | sh
 
 On Fedora 27 you should be able to get them with (as root):
 
@@ -157,7 +157,7 @@ On Fedora 27 you should be able to get them with (as root):
        glibc-headers glibc-static glibc-locale-source xz zip \
        unzip strace curl discount git python2 zlib-devel \
        golang cmake
-    curl https://install.meteor.com/ | sh
+    curl https://install.meteor.com/?release=1.8.2 | sh
 
 If you have trouble getting the build to work on your distro, we recommend trying in a virtual
 machine running the latest stable Debian release. This is easy to set up using Vagrant, like:


### PR DESCRIPTION
Per comments in the Makefile and the GitHub action, we actually need to
install specifically meteor 1.8.2, to work around a problem with font
generation (ick). The installing from source docs were never updated
when the workaround became necessary however; this patch does that.

See also #3303, where someone tripped on this getting set up to hack on
things.