### PR TITLE
find-meteor-dev-bundle: don't use empty cache

### DIFF
--- a/find-meteor-dev-bundle.sh
+++ b/find-meteor-dev-bundle.sh
@@ -43,7 +43,7 @@ METEOR_RELEASE=${1:-$(<.meteor/release)}
 CACHE_FILE="../tmp/$METEOR_RELEASE.location"
 
 mkdir -p ../tmp
-if [ -e "$CACHE_FILE" ]; then
+if [ -s "$CACHE_FILE" ]; then
   cat "$CACHE_FILE"
   exit
 fi


### PR DESCRIPTION
When this script fails (e.g. because the requested meteor version is not installed), it writes an empty cache file. Later, that empty value would be reported as success, and so the makefile would blithely continue on with an empty path.