### PR TITLE
Clean up a bunch of c++ compiler warnings.

### DIFF
--- a/src/sandstorm/app-index/indexer.c++
+++ b/src/sandstorm/app-index/indexer.c++
@@ -526,7 +526,7 @@ kj::String Indexer::getReviewQueueJson() {
 
 // =======================================================================================
 
-class Indexer::UploadStreamImpl: public AppIndex::UploadStream::Server {
+class Indexer::UploadStreamImpl final: public AppIndex::UploadStream::Server {
 public:
   UploadStreamImpl()
       : spkFile("/var/tmp") {}

--- a/src/sandstorm/backend.h
+++ b/src/sandstorm/backend.h
@@ -30,7 +30,7 @@ namespace kj {
 
 namespace sandstorm {
 
-class BackendImpl: public Backend::Server, private kj::TaskSet::ErrorHandler {
+class BackendImpl final: public Backend::Server, private kj::TaskSet::ErrorHandler {
 public:
   BackendImpl(kj::LowLevelAsyncIoProvider& ioProvider, kj::Network& network,
               SandstormCoreFactory::Client&& sandstormCoreFactory,

--- a/src/sandstorm/backup.h
+++ b/src/sandstorm/backup.h
@@ -23,7 +23,7 @@
 
 namespace sandstorm {
 
-class BackupMain: public AbstractMain {
+class BackupMain final: public AbstractMain {
   // The main class for the "backup" command, which creates or restores a grain backup.
 public:
   BackupMain(kj::ProcessContext& context);

--- a/src/sandstorm/gateway.c++
+++ b/src/sandstorm/gateway.c++
@@ -952,7 +952,7 @@ void GatewayTlsManager::unsetKeys() {
   readyFulfiller->fulfill();
 }
 
-class GatewayTlsManager::TlsKeyCallbackImpl: public GatewayRouter::TlsKeyCallback::Server {
+class GatewayTlsManager::TlsKeyCallbackImpl final: public GatewayRouter::TlsKeyCallback::Server {
 public:
   TlsKeyCallbackImpl(GatewayTlsManager& parent): parent(parent) {}
 
@@ -1021,11 +1021,10 @@ kj::Promise<void> GatewayTlsManager::listenSmtpsLoop(kj::ConnectionReceiver& por
   return port.accept().then([this, &port](kj::Own<kj::AsyncIoStream>&& stream) {
     KJ_IF_MAYBE(t, currentTls) {
       auto tls = kj::addRef(**t);
-      auto& tlsRef = tls->tls;
       tasks.add(tls->tls.wrapServer(kj::mv(stream))
-          .then([this,&tlsRef](kj::Own<kj::AsyncIoStream>&& encrypted) {
+          .then([this](kj::Own<kj::AsyncIoStream>&& encrypted) {
         return smtpServer.connect()
-            .then([this,&tlsRef,encrypted=kj::mv(encrypted)]
+            .then([encrypted=kj::mv(encrypted)]
                   (kj::Own<kj::AsyncIoStream>&& server) mutable {
           return pumpDuplex(kj::mv(encrypted), kj::mv(server));
         });

--- a/src/sandstorm/gateway.c++
+++ b/src/sandstorm/gateway.c++
@@ -645,7 +645,7 @@ kj::Own<kj::HttpService> GatewayService::getApiBridge(
         // On error, invalidate the cached session immediately.
         apiHosts.erase(key);
       }));
-      return result;
+      return kj::mv(result);
     });
 
     ApiHostEntry entry {

--- a/src/sandstorm/gateway.h
+++ b/src/sandstorm/gateway.h
@@ -233,7 +233,7 @@ private:
   class TlsKeyCallbackImpl;
 };
 
-class RealIpService: public kj::HttpService {
+class RealIpService final: public kj::HttpService {
   // Wrapper that should be instantiated for each connection to capture IP address in X-Real-IP.
 
 public:
@@ -250,7 +250,7 @@ private:
   bool trustClient = false;
 };
 
-class AltPortService: public kj::HttpService {
+class AltPortService final: public kj::HttpService {
   // Wrapper that should be exported on ports other than the main port. This will redirect
   // clients to the main port where appropriate.
 

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -156,7 +156,7 @@ const HeaderWhitelist REQUEST_HEADER_WHITELIST(*WebSession::Context::HEADER_WHIT
 const HeaderWhitelist RESPONSE_HEADER_WHITELIST(*WebSession::Response::HEADER_WHITELIST);
 #pragma clang diagnostic pop
 
-class HttpParser: public sandstorm::Handle::Server,
+class HttpParser final: public sandstorm::Handle::Server,
                   private http_parser,
                   private kj::TaskSet::ErrorHandler {
 public:
@@ -1622,7 +1622,7 @@ public:
     context.releaseParams();
 
     return serverAddr.connect().then(
-        [this, KJ_MVCAP(httpRequest), KJ_MVCAP(clientStream), responseStream, context]
+        [KJ_MVCAP(httpRequest), KJ_MVCAP(clientStream), responseStream, context]
         (kj::Own<kj::AsyncIoStream>&& stream) mutable {
       kj::ArrayPtr<const byte> httpRequestRef = httpRequest;
       auto& streamRef = *stream;
@@ -1941,7 +1941,7 @@ private:
     });
   }
 
-  class IgnoreStream: public ByteStream::Server {
+  class IgnoreStream final: public ByteStream::Server {
   protected:
     kj::Promise<void> write(WriteContext context) override { return kj::READY_NOW; }
     kj::Promise<void> done(DoneContext context) override { return kj::READY_NOW; }
@@ -2297,7 +2297,7 @@ private:
   kj::ArrayPtr<const char> suffix;
 };
 
-class SandstormHttpBridgeImpl: public SandstormHttpBridge::Server {
+class SandstormHttpBridgeImpl final: public SandstormHttpBridge::Server {
 public:
   explicit SandstormHttpBridgeImpl(SandstormApi<BridgeObjectId>::Client&& apiCap,
                                    BridgeContext& bridgeContext)
@@ -2809,7 +2809,7 @@ public:
                                 kj::Timer& timer,
                                 bool loggedSlowStartupMessage,
                                 int numTriesSoFar) {
-    return address->connect().then([this, loggedSlowStartupMessage](auto x) -> void {
+    return address->connect().then([loggedSlowStartupMessage](auto x) -> void {
       if (loggedSlowStartupMessage) {
         KJ_LOG(WARNING, "App successfully started listening for TCP connections!");
       }

--- a/src/sandstorm/smtp-proxy.c++
+++ b/src/sandstorm/smtp-proxy.c++
@@ -20,7 +20,7 @@ namespace sandstorm {
 
 namespace {
 
-class AsyncLineReader: public kj::AsyncIoStream {
+class AsyncLineReader final: public kj::AsyncIoStream {
 public:
   AsyncLineReader(kj::Own<kj::AsyncIoStream> inner): inner(kj::mv(inner)) {}
 

--- a/src/sandstorm/spk.c++
+++ b/src/sandstorm/spk.c++
@@ -157,7 +157,7 @@ private:
   bool committed = false;
 };
 
-class SpkTool: public AbstractMain {
+class SpkTool final: public AbstractMain {
   // Main class for the Sandstorm spk tool.
 
 public:

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1917,7 +1917,7 @@ public:
     auto grainOwner = req.getSealFor().initGrain();
     grainOwner.setGrainId(grainId);
     grainOwner.setSaveLabel(args.getLabel());
-    return req.send().then([this, context](auto args) mutable -> void {
+    return req.send().then([context](auto args) mutable -> void {
       context.getResults().setToken(args.getSturdyRef());
     });
   }
@@ -2257,7 +2257,7 @@ private:
     }
   }
 
-  class LogWatcher: public Handle::Server, private kj::TaskSet::ErrorHandler {
+  class LogWatcher final: public Handle::Server, private kj::TaskSet::ErrorHandler {
   public:
     explicit LogWatcher(kj::UnixEventPort& eventPort, kj::StringPtr logPath,
                         kj::AutoCloseFd logFileParam, ByteStream::Client stream)

--- a/src/sandstorm/supervisor.h
+++ b/src/sandstorm/supervisor.h
@@ -27,7 +27,7 @@
 
 namespace sandstorm {
 
-class SupervisorMain: public AbstractMain {
+class SupervisorMain final: public AbstractMain {
   // Main class for the Sandstorm supervisor.  This program:
   // - Sets up a sandbox for a grain.
   // - Executes the grain in the sandbox.

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -460,7 +460,7 @@ private:
   kj::OneOf<Passive, Active> state;
 };
 
-class TwoPartyServerWithClientBootstrap: private kj::TaskSet::ErrorHandler {
+class TwoPartyServerWithClientBootstrap final: private kj::TaskSet::ErrorHandler {
   // Similar to TwoPartyServer, but it can take a redirector for a client bootstrap as an argument
   // and/or allows you to call getBootstrap to get the client bootstrap.
 


### PR DESCRIPTION
I was working on something else and got tired of ekam cutting off compiler output before the actual error, so I decided to fix a big pile of warnings. Most of these are either unused lambda captures or non-final classes with no virtual dtor. There is only one (in the second commit) that should have any functional impact; it removes an unnecessary copy caught by the compiler.

There are still a few warnings left regarding use of a couple deprecated functions and one about getaddrinfo in statically linked executables. Fixing those is less mechanical though, and this makes the output a lot less noisy.