### PR TITLE
Use es6 modules in the Sandcats ACME.js plugin (again).

### DIFF
--- a/acme-dns-01-sandcats/index.js
+++ b/acme-dns-01-sandcats/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const https = require("https");
-const querystring = require("querystring");
-const dns = require("dns");
+import https from "https";
+import querystring from "querystring";
+import dns from "dns";
 
 class Challenge {
   constructor(options) {
@@ -125,8 +125,6 @@ class Challenge {
   }
 };
 
-module.exports = {
-  create(options) {
-    return new Challenge(options);
-  }
-};
+export function create(options) {
+  return new Challenge(options);
+}

--- a/acme-dns-01-sandcats/package.json
+++ b/acme-dns-01-sandcats/package.json
@@ -1,5 +1,6 @@
 {
   "name": "acme-dns-01-sandcats",
+  "type": "module",
   "version": "0.1.0",
   "engines": {
     "node": ">=12.0"

--- a/acme-dns-01-sandcats/test.js
+++ b/acme-dns-01-sandcats/test.js
@@ -1,10 +1,11 @@
 'use strict';
 
-const sandcatsChallenge = require("./index.js");
-const fs = require("fs");
-const tester = require("acme-dns-01-test");
+import * as sandcatsChallenge from "./index.js";
+import fs from "fs";
+import tester from "acme-dns-01-test";
+import { setServers } from "dns";
 
-require("dns").setServers(["104.197.28.173"]);
+setServers(["104.197.28.173"])
 
 async function run() {
   let challenger = sandcatsChallenge.create({


### PR DESCRIPTION
This apparently didn't land on master, because @kentonv merged #3299 into master before merging #3302 into the `lets-encrypt-sandcats` feature branch. So, new pr for the same patch.