### PR TITLE
Docs: Add sniproxy guide to share TLS port

### DIFF
--- a/docs/administering/sniproxy.md
+++ b/docs/administering/sniproxy.md
@@ -2,36 +2,13 @@
 
 The purpose of this tutorial is to set up sniproxy so it’s possible to use regular https:// URLs for your main web server, like nginx or Apache, as well as Sandstorm, which has its own HTTPS handling. To make that work, they will need to share port 443.
 
-## Introduction
-
-The purpose of this tutorial is to set up sniproxy so it's possible to use Sandstorm-verified TLS encryption while coexisting with another web server that also uses TLS and share port 443 with it.
-
-The main reason is to allow users to connect with your Sandstorm instance in the standard HTTPS port (443) and keep using that port also for any other web apps.
-
-This action is going to change the BASE_URL of Sandstorm, presumably, so you'll end up erasing the OAuth configuration. To fix that, you will need to follow the "How do I log in, if there's a problem with logging in via the web?" section of [the FAQ](faq.md).
-
 This document assumes the server is running Debian or one of its derivatives (e.g. Ubuntu). If your server is not, you might need to adjust some steps. Note that there will be some downtime in this process so you might want to do it when your server is not very busy.
+
+We are also going to assume you are using the Sandcats DNS/HTTPS service in this example, however this will work with any Sandstorm-managed TLS setup, provided the pattern is distinct from your other web services on the server.
 
 ## Install sniproxy
 
-If you're lucky, the package `sniproxy` might be present on your GNU/Linux distro; otherwise, you'll have to install it yourself. Follow the instructions at [the sniproxy homepage](https://github.com/dlundquist/sniproxy) for your operating system and install it.
-
-In this example, on Ubuntu 10.04, the instructions were:
-
-```bash
-# Install required packages
-sudo apt-get install autotools-dev cdbs debhelper dh-autoreconf dpkg-dev gettext libev-dev libpcre3-dev libudns-dev pkg-config fakeroot git
-
-# Clone sniproxy repo from Github
-git clone https://github.com/dlundquist/sniproxy.git
-
-# Compile and create the package
-cd sniproxy
-./autogen.sh && dpkg-buildpackage
-
-# Install the package
-sudo dpkg -i ../sniproxy_*_*.deb
-```
+It is likely the package `sniproxy` is present on your Linux distro and you can install it through your package manager. Otherwise, follow the instructions at [the sniproxy homepage](https://github.com/dlundquist/sniproxy) for your operating system to install it manually.
 
 ## Setting up sniproxy
 
@@ -79,7 +56,15 @@ table https_hosts {
 
 ### Startup
 
-We'll have to ensure sniproxy starts when the system is rebooted. For that we'll need to ensure it is enabled in ```/etc/default/sniproxy``` (```ENABLED=1```). You may also need to run this command to make sure sniproxy will automatically start on boot up:
+We'll have to ensure sniproxy starts when the system is rebooted. For that we'll need to ensure it is enabled in ```/etc/default/sniproxy``` (```ENABLED=1```).
+
+The command to instruct your machine to start sniproxy on boot depends on your distro, but it is likely systemd-based, upon which you can run:
+
+```bash
+sudo systemctl enable sniproxy
+```
+
+Otherwise, if you have a sysvinit-based distribution, you may need to run:
 
 ```bash
 sudo update-rc.d sniproxy enable
@@ -131,12 +116,6 @@ sudo service sandstorm stop
 sudo service sniproxy start
 sudo service sandstorm start
 sudo service nginx start
-```
-
-You probably have to fix the Sandstorm administrator OAuth token. Run the following and follow the instructions that it prints out:
-
-```bash
-sudo sandstorm admin-token
 ```
 
 Now you can test by trying to get to your Sandstorm instance. In a web browser, visit https://example.sandcats.io (replace "example" with your sandcats domain) to make sure Sandstorm works. Next, test any other HTTPS service you had before (something like https://service.yourdomain.com).

--- a/docs/administering/sniproxy.md
+++ b/docs/administering/sniproxy.md
@@ -1,10 +1,10 @@
-# sniproxy for sharing a TLS port 443 with Sandstorm
+# Sharing the HTTPS Port with sniproxy
 
 The purpose of this tutorial is to set up sniproxy so it’s possible to use regular https:// URLs for your main web server, like nginx or Apache, as well as Sandstorm, which has its own HTTPS handling. To make that work, they will need to share port 443.
 
 ## Introduction
 
-The purpose of this tutorial is to set up *sniproxy* so it's possible to use Sandstorm-verified TLS encryption while coexisting with another web server that also uses TLS and share port 443 with it.
+The purpose of this tutorial is to set up sniproxy so it's possible to use Sandstorm-verified TLS encryption while coexisting with another web server that also uses TLS and share port 443 with it.
 
 The main reason is to allow users to connect with your Sandstorm instance in the standard HTTPS port (443) and keep using that port also for any other web apps.
 
@@ -14,7 +14,7 @@ This document assumes the server is running Debian or one of its derivatives (e.
 
 ## Install sniproxy
 
-If you're lucky, the package *sniproxy* might be present on your GNU/Linux distro; otherwise, you'll have to install it yourself. Follow the instructions at [the sniproxy homepage](https://github.com/dlundquist/sniproxy) for your operating system and install it.
+If you're lucky, the package `sniproxy` might be present on your GNU/Linux distro; otherwise, you'll have to install it yourself. Follow the instructions at [the sniproxy homepage](https://github.com/dlundquist/sniproxy) for your operating system and install it.
 
 In this example, on Ubuntu 10.04, the instructions were:
 
@@ -35,13 +35,13 @@ sudo dpkg -i ../sniproxy_*_*.deb
 
 ## Setting it up
 
-We'll be using *sniproxy* to listen on the standard HTTPS port (443) and allow it to decide where to send the request based on the hostname being requested. If it's a Sandstorm domain (ends in ```.sandcats.io```) it will forward the request to Sandstorm on port 6443. In any other case it'll forward the request to the web server you already had, which we will switch from listening on port 443 to port 7443.
+We'll be using sniproxy to listen on the standard HTTPS port (443) and allow it to decide where to send the request based on the hostname being requested. If it's a Sandstorm domain (ends in `.sandcats.io`) it will forward the request to Sandstorm on port 6443. In any other case it'll forward the request to the web server you already had, which we will switch from listening on port 443 to port 7443.
 
 The ports for Sandstorm and the web server are arbitrary; you can choose ones that work for you in case you have a collision with another service you're running. It should work as long as you're consistent in replacing the ports in the web server, Sandstorm and sniproxy configuration files.
 
 ## Setting up sniproxy
 
-We'll set *sniproxy* to forward Sandstorm domains to the Sandstorm instance and to send any other request to the web server. We'll disable the HTTP proxy feature in *sniproxy* as there is no need for the HTTP requests to go through it.
+We'll set sniproxy to forward Sandstorm domains to the Sandstorm instance and to send any other request to the web server. We'll disable the HTTP proxy feature in sniproxy as there is no need for the HTTP requests to go through it.
 
 ### Configuration
 
@@ -52,6 +52,7 @@ sudo nano /etc/sniproxy.conf
 ```
 
 /etc/sniproxy.conf contents:
+
 ```
 # sniproxy.conf
 # Setup for sharing port 443 with Sandstorm
@@ -79,9 +80,10 @@ table https_hosts {
     .*\.sandcats\.io 127.0.0.1:6443
 }
 ```
+
 ### Startup
 
-We'll have to ensure sniproxy starts when the system is rebooted. For that we'll need to ensure it is enabled in ```/etc/default/sniproxy``` (```ENABLED=1```). I had to also run this command to make sure sniproxy would automatically start on boot up:
+We'll have to ensure sniproxy starts when the system is rebooted. For that we'll need to ensure it is enabled in ```/etc/default/sniproxy``` (```ENABLED=1```). You may also need to run this command to make sure sniproxy will automatically start on boot up:
 
 ```bash
 sudo update-rc.d sniproxy enable
@@ -98,6 +100,7 @@ sudo nano /opt/sandstorm/sandstorm.conf
 ```
 
 Relevant contents of ```/opt/sandstorm/sandstorm.conf```:
+
 ```
 # Bind localhost to avoid anyone connecting directly to Sandstorm
 BIND_IP=127.0.0.1
@@ -117,6 +120,7 @@ If you are using nginx, you can change all the configuration files using ```sed`
 ```bash
 sudo sed -ri 's/443/7443/g' /etc/nginx/sites-available/*
 ```
+
 Keep in mind this might not work for you if you're using '443' anywhere in the configuration files that is not to refer the port.
 
 ## Final steps: put it to work
@@ -141,6 +145,6 @@ sudo sandstorm admin-token
 
 Now you can test by trying to get to your Sandstorm instance. In a web browser, visit https://example.sandcats.io (replace "example" with your sandcats domain) to make sure Sandstorm works. Next, test any other HTTPS service you had before (something like https://service.yourdomain.com).
 
-If you are having problems finishing this tutorial correctly, visit https://serverfault.com/ and ask your question there. Thanks for reading this tutorial!
+If you have any issues, feel free to [open an issue on GitHub](https://github.com/sandstorm-io/sandstorm/issues/new) or post on the [mailing list](https://groups.google.com/forum/#!forum/sandstorm-dev).
 
 

--- a/docs/administering/sniproxy.md
+++ b/docs/administering/sniproxy.md
@@ -1,0 +1,145 @@
+# sniproxy for sharing an TLS port 443 with Sandstorm
+
+**The purpose of this tutorial is to set up sniproxy so it’s possible to use regular https:// URLs for your main web server, like nginx or Apache, as well as Sandstorm, which has its own HTTPS handling. To make that work, they will need to share port 443.**
+
+## Introduction
+
+The purpose of this tutorial is to set up *sniproxy* so it's possible to use *Sandstorm* verified TLS encryption while coexisting with another web server that also uses TLS and make share a port for it (443).
+
+The main reason is to allow other users to connect with your *Sandstorm* instance in the standard HTTPS port (443) and keep using that port also for any other web apps.
+
+This action is going to change the BASE_URL of Sandstorm, presumably, so you'll trigger the erasing of OAuth configuration. To fix that, people will need to follow the "How do I log in, if there's a problem with logging in via the web?" section of https://docs.sandstorm.io/en/latest/administering/faq/
+
+I assume the server is running Debian or one of its derivatives (e.g. Ubuntu). Note that there will be some downtime in this process so you might want to do it when your server is not very busy.
+
+## Install sniproxy
+
+If you're lucky the package *sniproxy* might be present on your GNU/Linux distro; otherwise, you'll have to install it yourself. In my case (Ubuntu 10.04 I had to do it manually). Follow the instructions on https://github.com/dlundquist/sniproxy for your operating system and install it.
+
+In my case, on Ubuntu 10.04, I had to do it manually:
+```bash
+# Install required packages
+sudo apt-get install autotools-dev cdbs debhelper dh-autoreconf dpkg-dev gettext libev-dev libpcre3-dev libudns-dev pkg-config fakeroot git
+
+# Clone sniproxy repo from Github
+git clone https://github.com/dlundquist/sniproxy.git
+
+# Compile and create the package
+cd sniproxy
+./autogen.sh && dpkg-buildpackage
+
+# Install the package
+sudo dpkg -i ../sniproxy_*_*.deb
+```
+
+## Setting it up
+
+We'll be using *sniproxy* to listen on the standard HTTPS port (443) and make him decide where to send the request based on the hostname being requested. If it's a *Sandstorm* domain (ends in ```.sandcats.io```) it will forward the request to *Sandstorm* on port 6443. In any other case it'll forward the request to the web server you already had which switched from listening on port 443 to port 7443.
+
+The ports for *Sandstorm* and the web server are arbitrary; you can choose ones that work for you in case you have a collision with another service you're running. It should work as long as you're being consistent in replacing my choices in the web server, *Sandstorm* and sniproxy configurations.
+
+![alt text](http://www.r4t.es/sniproxy-graph.png "sniproxy incoming request graph")
+
+
+
+## Setting up sniproxy
+
+We'll set *sniproxy* to forward *Sandstorm* domains to the *Sandstorm* instance and to send any other request to the web server. We'll disable HTTP proxy on *sniproxy* as there is no need for the HTTP requests to go through it.
+
+### Configuration
+
+```bash
+sudo nano /etc/sniproxy.conf
+```
+
+/etc/sniproxy.conf contents:
+```
+# sniproxy.conf
+# Setup for sharing port 443 with Sandstorm
+
+user daemon
+pidfile /var/run/sniproxy.pid
+
+error_log {
+    syslog daemon
+    priority notice
+}
+
+listen 443 {
+    proto tls
+    table https_hosts
+    fallback 127.0.0.1:7443
+
+    access_log {
+        filename /var/log/sniproxy/https_access.log
+        priority notice
+    }
+}
+
+table https_hosts {
+    .*\.sandcats\.io 127.0.0.1:6443
+}
+```
+### Startup
+
+We'll have to ensure sniproxy starts when rebooted. For that we'll need to ensure is enabled in ```/etc/default/sniproxy``` (```ENABLED=1```). I had to also run this command to make sure sniproxy would automatically start on boot up::
+
+```bash
+sudo update-rc.d sniproxy enable
+```
+
+## Setting up Sandstorm
+
+Enabling TLS support on *Sandstorm* is out of the scope of this tutorial. If you don’t have it set up yet, head to the official documentation (https://docs.sandstorm.io/en/latest/administering/TLS/).
+
+TWe need to change Sandstorm's configuration so that it listens on port that sniproxy is forwarding the requests to (9687 in these examples). We make sure BASE_URL and WILDCARD_HOST use URLs on port 443. Since that is the standard, we don't need :443 at the end. We also adjust the BIND_IP. We'll assume you have a ```example.sandcats.io``` as your *Sandstorm* address in the configuration example.
+
+```bash
+sudo nano /opt/sandstorm/sandstorm.conf
+```
+
+Relevant contents of ```/opt/sandstorm/sandstorm.conf```:
+```
+# Bind localhost to avoid anyone connecting directly to Sandstorm
+BIND_IP=127.0.0.1
+# No ports here, standard HTTPS (port 443)
+BASE_URL=https://example.sandcats.io
+WILDCARD_HOST=*.example.sandcats.io
+# This is the port sniproxy will connect to
+HTTPS_PORT=6443
+```
+
+## Setting up your current web server
+
+This will depend on the server you have, typically Apache or nginx. Remember the accessible URLs will still use the standard HTTPS port; this change is only made to allow the sniproxy to sit in the middle.
+
+I'm using nginx and I could change all the configuration files using ```sed``` to replace 443 for 7443. What I did is:
+
+```bash
+sudo sed -ri 's/443/7443/g' /etc/nginx/sites-available/*
+```
+Keep in mind this might not work for you if you're using '443' anywhere in the configuration files that is not to refer the port.
+
+## Final steps: put it to work
+
+Now is the time to see if it worked. Shutdown your web server and Sandstorm and start them again. Start sniproxy as well.
+
+Supposing you use nginx this could be:
+```bash
+sudo service nginx stop
+sudo service sandstorm stop
+sudo service sniproxy start
+sudo service sandstorm start
+sudo service nginx start
+```
+
+Also you most probably have to fix the *Sandstorm* administrator OAuth token. Run the following and follow screen instructions:
+```bash
+sudo sandstorm admin-token
+```
+
+Now you can test by trying to get to your Sandstorm instance. In a web browser, visit https://example.sandcats.io (replace "example" with your sandcats domain) to make sure Sandstorm works. Next, test any other HTTPS service you had before (something like https://service.yourdomain.com).
+
+If you are having problems finishing this tutorial correctly, visit https://serverfault.com/ and ask your question there. Thanks for reading this tutorial!
+
+

--- a/docs/administering/sniproxy.md
+++ b/docs/administering/sniproxy.md
@@ -8,7 +8,7 @@ The purpose of this tutorial is to set up sniproxy so it's possible to use Sands
 
 The main reason is to allow users to connect with your Sandstorm instance in the standard HTTPS port (443) and keep using that port also for any other web apps.
 
-This action is going to change the BASE_URL of Sandstorm, presumably, so you'll trigger the erasing of OAuth configuration. To fix that, you will need to follow the "How do I log in, if there's a problem with logging in via the web?" section of [the FAQ](faq.md).
+This action is going to change the BASE_URL of Sandstorm, presumably, so you'll end up erasing the OAuth configuration. To fix that, you will need to follow the "How do I log in, if there's a problem with logging in via the web?" section of [the FAQ](faq.md).
 
 This document assumes the server is running Debian or one of its derivatives (e.g. Ubuntu). If your server is not, you might need to adjust some steps. Note that there will be some downtime in this process so you might want to do it when your server is not very busy.
 
@@ -33,15 +33,11 @@ cd sniproxy
 sudo dpkg -i ../sniproxy_*_*.deb
 ```
 
-## Setting it up
+## Setting up sniproxy
 
 We'll be using sniproxy to listen on the standard HTTPS port (443) and allow it to decide where to send the request based on the hostname being requested. If it's a Sandstorm domain (ends in `.sandcats.io`) it will forward the request to Sandstorm on port 6443. In any other case it'll forward the request to the web server you already had, which we will switch from listening on port 443 to port 7443.
 
-The ports for Sandstorm and the web server are arbitrary; you can choose ones that work for you in case you have a collision with another service you're running. It should work as long as you're consistent in replacing the ports in the web server, Sandstorm and sniproxy configuration files.
-
-## Setting up sniproxy
-
-We'll set sniproxy to forward Sandstorm domains to the Sandstorm instance and to send any other request to the web server. We'll disable the HTTP proxy feature in sniproxy as there is no need for the HTTP requests to go through it.
+The ports for Sandstorm and the web server are arbitrary; you can choose ones that work for you in case you have a collision with another service you're running. It should work as long as you're consistent in replacing the ports in the web server, Sandstorm and sniproxy configuration files. We'll also disable the HTTP proxy feature in sniproxy as there is no need for the HTTP requests to go through it.
 
 ### Configuration
 
@@ -51,7 +47,7 @@ You will need to edit the sniproxy configuration file by running something like:
 sudo nano /etc/sniproxy.conf
 ```
 
-/etc/sniproxy.conf contents:
+Here is the example configuration for `/etc/sniproxy.conf`:
 
 ```
 # sniproxy.conf
@@ -93,13 +89,13 @@ sudo update-rc.d sniproxy enable
 
 Enabling TLS support on Sandstorm is out of the scope of this tutorial. If you don’t have it set up yet, head to [the HTTPS guide](ssl.md).
 
-We need to change Sandstorm's configuration so that it listens on the port that sniproxy is forwarding the requests to (9687 in these examples). We make sure BASE_URL and WILDCARD_HOST use URLs on port 443. Since that is the standard port for HTTPS, we don't need :443 at the end. We also adjust the BIND_IP. We'll assume you have ```example.sandcats.io``` as your Sandstorm address in the configuration example; you can change the example to use a different domain if you need to.
+We need to change Sandstorm's configuration so that it listens on the port that sniproxy is forwarding the requests to (6443, in this example). We make sure BASE_URL and WILDCARD_HOST use URLs on port 443. Since that is the standard port for HTTPS, we don't need :443 at the end. We also adjust the BIND_IP. We'll assume you have `example.sandcats.io` as your Sandstorm address in the configuration example; you will replace this with your own Sandcats hostname.
 
 ```bash
 sudo nano /opt/sandstorm/sandstorm.conf
 ```
 
-Relevant contents of ```/opt/sandstorm/sandstorm.conf```:
+Relevant contents of `/opt/sandstorm/sandstorm.conf`:
 
 ```
 # Bind localhost to avoid anyone connecting directly to Sandstorm

--- a/docs/administering/ssl.md
+++ b/docs/administering/ssl.md
@@ -25,7 +25,7 @@ To share port 443 with other services on the same machine:
   Sandstorm can manage (and autorenew) its own certificates. This allows you to combine an **existing
   web server on port 443** with free sandcats.io HTTPS.
   
-- You [can follow this guide](https://juanjoalvarez.net/es/detail/2017/jan/12/how-set-sandstorm-behind-reverse-proxy-keeping-you/)
+- You [can follow this guide](https://web.archive.org/web/20190922195059/https://juanjoalvarez.net/es/detail/2017/jan/12/how-set-sandstorm-behind-reverse-proxy-keeping-you/)
   that explains how to use a [cron script](https://github.com/juanjux/sandstorm-sandcats-cert-installer) 
   to extract the certificates from your (sandcats.io enabled) Sandstorm installation to a location and 
   format where your reverse proxy can use them so it can serve Sandstorm by HTTPS, keeping your 

--- a/docs/administering/ssl.md
+++ b/docs/administering/ssl.md
@@ -21,10 +21,9 @@ You have a few options.
 
 To share port 443 with other services on the same machine:
 
-- You [can install `sniproxy` to share port
-  443](sniproxy.md) between your
-  existing server and Sandstorm so that Sandstorm can manage (and autorenew) its own certificates.
-  This allows you to combine an **existing web server on port 443** with free sandcats.io HTTPS.
+- You [can install `sniproxy` to share port 443](sniproxy.md) between your existing server and Sandstorm so that
+  Sandstorm can manage (and autorenew) its own certificates. This allows you to combine an **existing
+  web server on port 443** with free sandcats.io HTTPS.
   
 - You [can follow this guide](https://juanjoalvarez.net/es/detail/2017/jan/12/how-set-sandstorm-behind-reverse-proxy-keeping-you/)
   that explains how to use a [cron script](https://github.com/juanjux/sandstorm-sandcats-cert-installer) 

--- a/docs/administering/ssl.md
+++ b/docs/administering/ssl.md
@@ -22,7 +22,7 @@ You have a few options.
 To share port 443 with other services on the same machine:
 
 - You [can install `sniproxy` to share port
-  443](https://xamar.sandcats.io/shared/Bqa9dftNbc1Ni06D-SgBdkFuM_iky8VHAlTw0Rk1lzN) between your
+  443](sniproxy.md) between your
   existing server and Sandstorm so that Sandstorm can manage (and autorenew) its own certificates.
   This allows you to combine an **existing web server on port 443** with free sandcats.io HTTPS.
   

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
         - "Free sandcats.io HTTPS": "administering/sandcats-https.md"
         - "Self-signed SSL": "administering/self-signed.md"
         - "Reverse Proxy": "administering/reverse-proxy.md"
+        - "Sharing the HTTPS Port": "administering/sniproxy.md"
         - "Email": "administering/email.md"
         - "Running Sandstorm offline": "administering/offline.md"
     - "Reference docs for sandstorm.conf": "administering/config-file.md"


### PR DESCRIPTION
Okay, so, I rebased #1588 (and cleaned up the merge conflict with ssl.md) and then applied Asheesh's review notes. I have not adjusted the formatting of `sniproxy` where appropriate yet, nor added this doc to the sidebar, both of which I will do before merging this. I also may do a bit more review of my own, I haven't given it a clean read-through yet. I also removed the diagram because the link is dead.

@pjamar if there is any chance you still have that diagram somewhere, I would love to see it! <3