### PR TITLE
Add explicit imports for iron:core.

### DIFF
--- a/shell/imports/client/admin/login-providers.js
+++ b/shell/imports/client/admin/login-providers.js
@@ -3,6 +3,7 @@ import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { TAPi18n } from "meteor/tap:i18n";
+import { Iron } from "meteor/iron:core";
 
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/client/setup-wizard/wizard.js
+++ b/shell/imports/client/setup-wizard/wizard.js
@@ -5,6 +5,7 @@ import { Tracker } from "meteor/tracker";
 import { ReactiveVar } from "meteor/reactive-var";
 import { _ } from "meteor/underscore";
 import { Router } from "meteor/iron:router";
+import { Iron } from "meteor/iron:core";
 
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
 import AccountsUi from "/imports/client/accounts/accounts-ui.js";


### PR DESCRIPTION
The previous attempt erroneously tried to import this from `iron:router`, which is the wrong package. Tested this manually and it works. Would be nice to automate some of this (though once we actually get the linter going we should get errors about non-existent imports in the future...)