### PR TITLE
Fix broken use of Settings.

### DIFF
--- a/shell/imports/db-deprecated.js
+++ b/shell/imports/db-deprecated.js
@@ -63,7 +63,6 @@ ApiTokens = globalDb.collections.apiTokens;
 Notifications = globalDb.collections.notifications;
 StatsTokens = globalDb.collections.statsTokens;
 Misc = globalDb.collections.misc;
-Settings = globalDb.collections.settings;
 
 currentUserGrains = globalDb.currentUserGrains.bind(globalDb);
 isDemoUser = globalDb.isDemoUser.bind(globalDb);

--- a/shell/imports/sandstorm-db/profile.js
+++ b/shell/imports/sandstorm-db/profile.js
@@ -21,6 +21,7 @@ import { _ } from "meteor/underscore";
 
 import Identicon from "/imports/sandstorm-identicons/identicon.js";
 import { SandstormDb } from "./db.js";
+import { globalDb } from "/imports/db-deprecated.js";
 
 let makeIdenticon;
 let httpProtocol;

--- a/shell/imports/sandstorm-db/profile.js
+++ b/shell/imports/sandstorm-db/profile.js
@@ -21,7 +21,6 @@ import { _ } from "meteor/underscore";
 
 import Identicon from "/imports/sandstorm-identicons/identicon.js";
 import { SandstormDb } from "./db.js";
-import { Settings } from "/imports/db-deprecated.js";
 
 let makeIdenticon;
 let httpProtocol;
@@ -230,7 +229,7 @@ SandstormDb.fillInProfileDefaults = function (credential, profile) {
     profile.name = profile.name || "Demo User";
     profile.handle = profile.handle || "demo";
   } else if (services.ldap) {
-    const setting = Settings.findOne({ _id: "ldapNameField" });
+    const setting = globalDb.collections.settings.findOne({ _id: "ldapNameField" });
     const key = setting ? setting.value : "";
     profile.handle = profile.handle || services.ldap.username;
     profile.name = profile.name || services.ldap.rawAttrs[key] || profile.handle;


### PR DESCRIPTION
This should fix #3322, but I don't have an actual LDAP setup to test with.
Help testing would be appreciated.

This was caused by the recent refactoring -- we added an explicit import
for `Settings`, but no explicit *export*.

This is actually the only remaining use of the variable, so instead of
simply revert the broken refactor, I just switched it over to using
`globalDb.collection.settings` (which is used all over the place), and
removed the `Settings` alias entirely.