### PR TITLE
Remove "Home" label from login page

### DIFF
--- a/shell/i18n/en.i18n.json
+++ b/shell/i18n/en.i18n.json
@@ -40,9 +40,6 @@
       "title": "Not Found",
       "text": "404 Not Found :("
     },
-    "root": {
-      "title": ""
-    },
     "grainLogContents": {
       "prefix": "..."
     },

--- a/shell/i18n/en.i18n.json
+++ b/shell/i18n/en.i18n.json
@@ -41,7 +41,7 @@
       "text": "404 Not Found :("
     },
     "root": {
-      "title": "Home"
+      "title": ""
     },
     "grainLogContents": {
       "prefix": "..."

--- a/shell/i18n/fi.i18n.json
+++ b/shell/i18n/fi.i18n.json
@@ -41,7 +41,7 @@
       "text": "404 Ei löytynyt :("
     },
     "root": {
-      "title": "Koti"
+      "title": ""
     },
     "grainLogContents": {
       "prefix": "..."

--- a/shell/i18n/fi.i18n.json
+++ b/shell/i18n/fi.i18n.json
@@ -40,9 +40,6 @@
       "title": "Ei löytynyt",
       "text": "404 Ei löytynyt :("
     },
-    "root": {
-      "title": ""
-    },
     "grainLogContents": {
       "prefix": "..."
     },

--- a/shell/i18n/fr.i18n.json
+++ b/shell/i18n/fr.i18n.json
@@ -40,9 +40,6 @@
       "title": "Non trouvé",
       "text": "Erreur 404 - Non trouvé :("
     },
-    "root": {
-      "title": ""
-    },
     "grainLogContents": {
       "prefix": "…"
     },

--- a/shell/i18n/fr.i18n.json
+++ b/shell/i18n/fr.i18n.json
@@ -41,7 +41,7 @@
       "text": "Erreur 404 - Non trouvé :("
     },
     "root": {
-      "title": "Accueil"
+      "title": ""
     },
     "grainLogContents": {
       "prefix": "…"

--- a/shell/i18n/nl.i18n.json
+++ b/shell/i18n/nl.i18n.json
@@ -40,9 +40,6 @@
       "title": "Niet gevonden",
       "text": "404 Niet gevonden :("
     },
-    "root": {
-      "title": ""
-    },
     "grainLogContents": {
       "prefix": "..."
     },

--- a/shell/i18n/nl.i18n.json
+++ b/shell/i18n/nl.i18n.json
@@ -41,7 +41,7 @@
       "text": "404 Niet gevonden :("
     },
     "root": {
-      "title": "Home"
+      "title": ""
     },
     "grainLogContents": {
       "prefix": "..."

--- a/shell/i18n/zh-CN.i18n.json
+++ b/shell/i18n/zh-CN.i18n.json
@@ -40,9 +40,6 @@
             "title": "查无此沙",
             "text": "无法找到该沙粒 :("
         },
-        "root": {
-            "title": ""
-        },
         "grainLogContents": {
             "prefix": "……"
         },

--- a/shell/i18n/zh-CN.i18n.json
+++ b/shell/i18n/zh-CN.i18n.json
@@ -41,7 +41,7 @@
             "text": "无法找到该沙粒 :("
         },
         "root": {
-            "title": "首页"
+            "title": ""
         },
         "grainLogContents": {
             "prefix": "……"

--- a/shell/i18n/zh-TW.i18n.json
+++ b/shell/i18n/zh-TW.i18n.json
@@ -41,7 +41,7 @@
       "text": "404 查無此沙 :("
     },
     "root": {
-      "title": "首頁"
+      "title": ""
     },
     "grainLogContents": {
       "prefix": "……"

--- a/shell/i18n/zh-TW.i18n.json
+++ b/shell/i18n/zh-TW.i18n.json
@@ -40,9 +40,6 @@
       "title": "查無此沙",
       "text": "404 查無此沙 :("
     },
-    "root": {
-      "title": ""
-    },
     "grainLogContents": {
       "prefix": "……"
     },

--- a/shell/imports/client/shell.html
+++ b/shell/imports/client/shell.html
@@ -210,8 +210,6 @@ limitations under the License.
 </template>
 
 <template name="root">
-  {{>title (_ "shell.root.title")}}
-
   <div id="intro" class="{{#if splashUrl}}has-splash{{/if}}">
     {{> loginButtonsDialog accountsUi=globalAccountsUi}}
     {{#if splashUrl}}


### PR DESCRIPTION
Fixes #2051 

Absolutely no testing has been done. But it's a language file only change. Basically, the label "Home" is solely displayed on the log in screen, where it does nothing and serves no informative purpose. I don't really see a good reason to invent a more complicated solution here.

Current:
![image](https://user-images.githubusercontent.com/4399499/81232203-18252d00-8fba-11ea-9c2b-5af840b798c7.png)
Expected result (via Firefox dev console hacking):
![image](https://user-images.githubusercontent.com/4399499/81232327-4f93d980-8fba-11ea-8f29-09ace41b0a3a.png)

I'm a little surprised the little divider also seems to go away (CSS is a mysterious beast), but I think it looks pretty clean that way.