### PR TITLE
Be a bit stricter with eslint, fix a number of unused variable warnings.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,14 @@ jobs:
       #    name: sandstorm-0-fast.tar.xz
       #    path: sandstorm-0-fast.tar.xz
       - name: lint
-        run: make lint
+        run: |
+          # In addition to making sure the linting step doesn't flag any errors,
+          # we also want to make sure the number of warnings doesn't increase.
+          # We check for equality; if the number decreases, great! But then update
+          # the constant below.
+          make lint | tee lint.log
+          num_problems=$(cat lint.log | grep ' problems (0 errors, ' | awk '{print $2}')
+          [ "$num_problems" = 857 ]
       - name: test
         run: |
           set -o pipefail

--- a/shell/.eslintrc.yml
+++ b/shell/.eslintrc.yml
@@ -22,6 +22,6 @@ rules:
   # These are implied by eslint:recommended, but we haven't gotten around to
   # fixing them yet:
   no-undef: ["warn"]
-  no-unused-vars: ["off"]
-  no-empty: ["off"]
-  no-inner-declarations: ["off"]
+  no-unused-vars: ["warn"]
+  no-empty: ["warn"]
+  no-inner-declarations: ["warn"]

--- a/shell/imports/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/imports/sandstorm-ui-powerbox/powerbox-server.js
@@ -14,9 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Crypto from "crypto";
-import Future from "fibers/future";
-
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { _ } from "meteor/underscore";

--- a/shell/imports/server/accounts/accounts-server.js
+++ b/shell/imports/server/accounts/accounts-server.js
@@ -24,7 +24,6 @@ import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 
 import Crypto from "crypto";
-import Future from "fibers/future";
 
 const ValidHandle = Match.Where(function (handle) {
   check(handle, String);

--- a/shell/imports/server/accounts/saml-utils.js
+++ b/shell/imports/server/accounts/saml-utils.js
@@ -9,8 +9,6 @@ import zlib from "zlib";
 
 import { Meteor } from "meteor/meteor";
 
-const HOSTNAME = Url.parse(process.env.ROOT_URL).hostname;
-
 const SAML = function (options) {
   this.options = this.initialize(options);
 };

--- a/shell/imports/server/acme.js
+++ b/shell/imports/server/acme.js
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
-import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
+import { waitPromise } from "/imports/server/async-helpers.js";
 import ACME from "@root/acme";
 import CSR from "@root/csr";
 import PEM from "@root/pem";

--- a/shell/imports/server/backend.js
+++ b/shell/imports/server/backend.js
@@ -14,14 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Crypto from "crypto";
 import { Meteor } from "meteor/meteor";
-import { SANDSTORM_ALTHOME } from "/imports/server/constants.js";
-import { inMeteor, promiseToFuture, waitPromise } from "/imports/server/async-helpers.js";
+import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import Capnp from "/imports/server/capnp.js";
 import { globalDb } from "/imports/db-deprecated.js";
-
-const Backend = Capnp.importSystem("sandstorm/backend.capnp").Backend;
 
 let storageUsageUnimplemented = false;
 

--- a/shell/imports/server/backup.js
+++ b/shell/imports/server/backup.js
@@ -22,13 +22,9 @@ import { Router } from "meteor/iron:router";
 
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 
-import ChildProcess from "child_process";
-import Future from "fibers/future";
 import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
-
-const GrainInfo = Capnp.importSystem("sandstorm/grain.capnp").GrainInfo;
 
 const TOKEN_CLEANUP_MINUTES = 120;  // Give enough time for large uploads on slow connections.
 const TOKEN_CLEANUP_TIMER = TOKEN_CLEANUP_MINUTES * 60 * 1000;

--- a/shell/imports/server/demo-server.js
+++ b/shell/imports/server/demo-server.js
@@ -18,7 +18,6 @@ import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { Accounts } from "meteor/accounts-base";
 
-import { waitPromise } from "/imports/server/async-helpers.js";
 import { allowDemo } from "/imports/demo.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/server/dev-accounts-server.js
+++ b/shell/imports/server/dev-accounts-server.js
@@ -14,7 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Crypto from "crypto";
 import { Meteor } from "meteor/meteor";
 import { Match, check }  from "meteor/check";
 import { Accounts } from "meteor/accounts-base";

--- a/shell/imports/server/drivers/external-ui-view.js
+++ b/shell/imports/server/drivers/external-ui-view.js
@@ -26,7 +26,6 @@ import { REQUEST_HEADER_WHITELIST, RESPONSE_HEADER_WHITELIST }
     from "/imports/server/header-whitelist.js";
 import { globalDb } from "/imports/db-deprecated.js";
 
-import Future from "fibers/future";
 import Url from "url";
 import Http from "http";
 import Https from "https";

--- a/shell/imports/server/drivers/ip.js
+++ b/shell/imports/server/drivers/ip.js
@@ -19,7 +19,6 @@ import { Match, check } from "meteor/check";
 
 import Bignum from "bignum";
 import { PersistentImpl } from "/imports/server/persistent.js";
-import Future from "fibers/future";
 import Net from "net";
 import Tls from "tls";
 import Dgram from "dgram";

--- a/shell/imports/server/drivers/mail.js
+++ b/shell/imports/server/drivers/mail.js
@@ -32,23 +32,18 @@ import { inMeteor } from "/imports/server/async-helpers.js";
 import { makeHackSessionContext } from "/imports/server/hack-session.js";
 
 import Crypto from "crypto";
-import Future from "fibers/future";
 import Net from "net";
 import Url from "url";
 import Capnp from "/imports/server/capnp.js";
 
 const EmailRpc = Capnp.importSystem("sandstorm/email.capnp");
 const EmailImpl = Capnp.importSystem("sandstorm/email-impl.capnp");
-const HackSessionContext = Capnp.importSystem("sandstorm/hack-session.capnp").HackSessionContext;
-const Supervisor = Capnp.importSystem("sandstorm/supervisor.capnp").Supervisor;
 const EmailSendPort = EmailRpc.EmailSendPort;
 
 const ROOT_URL = Url.parse(process.env.ROOT_URL);
 const HOSTNAME = ROOT_URL.hostname;
 
 const RECIPIENT_LIMIT = 20;
-
-const CLIENT_TIMEOUT = 15000; // 15s
 
 // Every day, reset all per-user sent counts to zero.
 // TODO(cleanup): Consider a more granular approach. For example, each user could have a timer

--- a/shell/imports/server/grain-server.js
+++ b/shell/imports/server/grain-server.js
@@ -22,7 +22,7 @@ import { _ } from "meteor/underscore";
 import { Random } from "meteor/random";
 
 import { send as sendEmail } from "/imports/server/email.js";
-import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
+import { waitPromise } from "/imports/server/async-helpers.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions.js";

--- a/shell/imports/server/hack-session.js
+++ b/shell/imports/server/hack-session.js
@@ -14,11 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Crypto from "crypto";
 import Http from "http";
 import Https from "https";
-import Net from "net";
-import Dgram from "dgram";
 import Url from "url";
 
 import { Meteor } from "meteor/meteor";
@@ -33,12 +30,8 @@ import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 
-const EmailRpc = Capnp.importSystem("sandstorm/email.capnp");
 const HackSessionContext = Capnp.importSystem("sandstorm/hack-session.capnp").HackSessionContext;
-const Supervisor = Capnp.importSystem("sandstorm/supervisor.capnp").Supervisor;
 const SystemPersistent = Capnp.importSystem("sandstorm/supervisor.capnp").SystemPersistent;
-const IpRpc = Capnp.importSystem("sandstorm/ip.capnp");
-const EmailSendPort = EmailRpc.EmailSendPort;
 const Grain = Capnp.importSystem("sandstorm/grain.capnp");
 const Powerbox = Capnp.importSystem("sandstorm/powerbox.capnp");
 

--- a/shell/imports/server/installer.js
+++ b/shell/imports/server/installer.js
@@ -14,11 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Fs from "fs";
-import Path from "path";
 import Crypto from "crypto";
-import ChildProcess from "child_process";
-import Url from "url";
 
 import { Meteor } from "meteor/meteor";
 import { _ } from "meteor/underscore";
@@ -27,11 +23,8 @@ import { Random } from "meteor/random";
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
 import { ssrfSafeLookupOrProxy } from "/imports/server/networking.js";
 import { globalDb } from "/imports/db-deprecated.js";
-import Capnp from "/imports/server/capnp.js";
 
 const Request = HTTPInternals.NpmModules.request.module;
-
-const Manifest = Capnp.importSystem("sandstorm/package.capnp").Manifest;
 
 let installers;  // set to {} on main replica
 // To protect against race conditions, we require that each row in the Packages

--- a/shell/imports/server/notifications-server.js
+++ b/shell/imports/server/notifications-server.js
@@ -21,12 +21,8 @@ import { Random } from "meteor/random";
 
 import { waitPromise } from "/imports/server/async-helpers.js";
 import { createAppActivityDesktopNotification } from "/imports/server/desktop-notifications.js";
-import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
-
-const SupervisorCapnp = Capnp.importSystem("sandstorm/supervisor.capnp");
-const SystemPersistent = SupervisorCapnp.SystemPersistent;
 
 logActivity = function (grainId, accountIdOrAnonymous, event) {
   // accountIdOrAnonymous is the string "anonymous" for an anonymous user, or is null for a

--- a/shell/imports/server/pre-meteor.js
+++ b/shell/imports/server/pre-meteor.js
@@ -24,12 +24,7 @@ import { inMeteor } from "/imports/server/async-helpers.js";
 import { globalDb } from "/imports/db-deprecated.js";
 import ServerIdenticon from "/imports/sandstorm-identicons/identicon-server.js";
 import Url from "url";
-import Fs from "fs";
-import Dns from "dns";
 import Future from "fibers/future";
-import Http from "http";
-import Capnp from "/imports/server/capnp.js";
-const ByteStream = Capnp.importSystem("sandstorm/util.capnp").ByteStream;
 
 const HOSTNAME = Url.parse(process.env.ROOT_URL).hostname;
 const DDP_HOSTNAME = process.env.DDP_DEFAULT_CONNECTION_URL &&
@@ -74,7 +69,7 @@ function checkMagic(buf, magic) {
   return true;
 }
 
-function serveStaticAsset(req, res, hostId) {
+function serveStaticAsset(req, res) {
   inMeteor(() => {
     if (req.method === "GET") {
       const assetCspHeader = "default-src 'none'; style-src 'unsafe-inline'; sandbox";

--- a/shell/imports/server/scheduled-job.js
+++ b/shell/imports/server/scheduled-job.js
@@ -16,8 +16,8 @@
 
 import { Meteor } from "meteor/meteor";
 
-import { inMeteor, waitPromise } from "/imports/server/async-helpers.js";
-import { PersistentImpl, fetchApiToken } from "/imports/server/persistent.js";
+import { waitPromise } from "/imports/server/async-helpers.js";
+import { fetchApiToken } from "/imports/server/persistent.js";
 import Capnp from "/imports/server/capnp.js";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";

--- a/shell/imports/server/static-asset.js
+++ b/shell/imports/server/static-asset.js
@@ -16,10 +16,7 @@
 
 import Url from "url";
 import { Match, check } from "meteor/check";
-import Capnp from "/imports/server/capnp.js";
 import { globalDb } from "/imports/db-deprecated.js";
-
-const StaticAsset = Capnp.importSystem("sandstorm/grain.capnp").StaticAsset;
 
 const PROTOCOL = Url.parse(process.env.ROOT_URL).protocol;
 

--- a/shell/imports/server/stats-server.js
+++ b/shell/imports/server/stats-server.js
@@ -21,7 +21,6 @@ import { Random } from "meteor/random";
 import { Router } from "meteor/iron:router";
 import { HTTP } from "meteor/http";
 
-import { allowDemo } from "/imports/demo.js";
 import { globalDb } from "/imports/db-deprecated.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;

--- a/shell/imports/shared/grain-shared.js
+++ b/shell/imports/shared/grain-shared.js
@@ -32,7 +32,7 @@ Meteor.methods({
                                        { $set: { "ownerSeenAllActivity": true } });
   },
 
-  markActivityRead: function (grainId, obsolete) {
+  markActivityRead: function (grainId) {
     check(grainId, String);
 
     if (!this.userId) {
@@ -135,7 +135,7 @@ Meteor.methods({
     }
   },
 
-  forgetGrain: function (grainId, obsolete) {
+  forgetGrain: function (grainId) {
     check(grainId, String);
 
     if (!this.userId) {

--- a/shell/public/pwa-service-worker.js
+++ b/shell/public/pwa-service-worker.js
@@ -1,5 +1,5 @@
 
-self.addEventListener('install', function(event) {
+self.addEventListener('install', function() {
   // Dummy service worker that does nothing. This is required to get
   // mobile browsers' "add to home screen" functionality to work, even
   // if we don't use it.


### PR DESCRIPTION
This fixes a bunch of `no-unused-var` warnings, and also sets CI up to fail if the number of warnings goes *up*, which lets us actually make use of this while there are still hundreds of warnings to churn through.