### PR TITLE
Port some of the identicon stuff over to typescript.

### DIFF
--- a/shell/imports/sandstorm-db/profile.js
+++ b/shell/imports/sandstorm-db/profile.js
@@ -19,7 +19,7 @@ import { check } from "meteor/check";
 import { Accounts } from "meteor/accounts-base";
 import { _ } from "meteor/underscore";
 
-import Identicon from "/imports/sandstorm-identicons/identicon.js";
+import Identicon from "/imports/sandstorm-identicons/identicon.ts";
 import { SandstormDb } from "./db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 

--- a/shell/imports/sandstorm-identicons/helpers.js
+++ b/shell/imports/sandstorm-identicons/helpers.js
@@ -1,4 +1,4 @@
-import Identicon from "./identicon.js";
+import Identicon from "./identicon.ts";
 
 const VALID_USAGES = ["appGrid", "grain", "notification"];
 function checkUsage(usage) {

--- a/shell/imports/sandstorm-identicons/identicon-server.js
+++ b/shell/imports/sandstorm-identicons/identicon-server.js
@@ -1,6 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import Zlib from "zlib";
-import Identicon from "./identicon.js";
+import Identicon from "./identicon.ts";
 
 const gzipSync = Meteor.wrapAsync(Zlib.gzip, Zlib);
 

--- a/shell/imports/sandstorm-identicons/identicon.ts
+++ b/shell/imports/sandstorm-identicons/identicon.ts
@@ -9,10 +9,15 @@
  */
 
 // Trivially modified for Meteor context by Kenton Varda.
-// Later modified to produce an SVG rather than a PNG.
+// Later modified to produce an SVG rather than a PNG, and
+// to convert it to type script.
 
 class Identicon {
-  constructor(hash, size, margin) {
+  private hash: string;
+  private size: number;
+  private margin: number;
+
+  constructor(hash: string, size?: number, margin?: number) {
     this.hash   = hash;
     this.size   = size   || 64;
     this.margin = margin || .08;
@@ -24,7 +29,7 @@ class Identicon {
     const margin  = size * this.margin;
     const cell    = (size - (margin * 2)) / 5;
 
-    const rects = [];
+    const rects: string[] = [];
 
     // foreground is last 7 chars as hue at 50% saturation, 70% brightness
     const rgb     = this.hsl2rgb(parseInt(hash.substr(-7), 16) / 0xfffffff, .5, .7);
@@ -54,14 +59,14 @@ class Identicon {
             ${rects.join("\n")}</g> </svg>`;
   }
 
-  rectangle(x, y, w, h, rectangles) {
+  rectangle(x: number, y: number, w: number, h: number, rectangles: string[]) {
     rectangles.push(`<rect x="${x}" y="${y}" width="${w}" height="${h}"/>`);
   }
 
   // adapted from: https://gist.github.com/aemkei/1325937
-  hsl2rgb(h, s, b) {
+  hsl2rgb(h: number, s: number, b: number) {
     h *= 6;
-    s = [
+    const sat = [
       b += s *= b < .5 ? b : 1 - b,
       b - h % 1 * s * 2,
       b -= s *= 2,
@@ -71,9 +76,9 @@ class Identicon {
     ];
 
     return [
-      Math.floor(s[~~h    % 6] * 256),  // red
-      Math.floor(s[(h | 16) % 6] * 256),  // green
-      Math.floor(s[(h | 8)  % 6] * 256),  // blue
+      Math.floor(sat[~~h    % 6] * 256),  // red
+      Math.floor(sat[(h | 16) % 6] * 256),  // green
+      Math.floor(sat[(h | 8)  % 6] * 256),  // blue
     ];
   }
 


### PR DESCRIPTION
Just identicon.js for now, the rest will come in future commits.

This was mostly just a matter of adding annotations in the right places,
but I also had to rename a local variable s (to `sat`), because it was
being re-assigned to a value of a different type (number to number[]).
There should be no functional impact.

The identicon module is interesting mostly because it is the only
dependency of sandstorm-db/db.js. The db stuff will require more
refactoring to get to a place where typescript will be happy with it,
but it will also have much bigger payoffs.