### PR TITLE
Actually run the removeFeatureKeys migration.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           # the constant below.
           make lint | tee lint.log
           num_problems=$(cat lint.log | grep ' problems (0 errors, ' | awk '{print $2}')
-          [ "$num_problems" = 857 ]
+          [ "$num_problems" = 856 ]
       - name: test
         run: |
           set -o pipefail

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -1217,6 +1217,7 @@ const MIGRATIONS = [
   onePersonaPerAccountPostCleanup,
   cleanupBadExpiresIfUnused,
   deleteReferralNotifications,
+  removeFeatureKeys,
 ];
 
 const NEW_SERVER_STARTUP = [

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -777,8 +777,8 @@ function backgroundFillInGrainSizes(db, backend) {
 function removeFeatureKeys(db, backend) {
   // Remove obsolete data related to the Sandstorm for Work paywall, which was eliminated.
 
-  db.notifications.remove({ "admin.type": "cantRenewFeatureKey" });
-  db.notifications.remove({ "admin.type": "trialFeatureKeyExpired" });
+  db.collections.notifications.remove({ "admin.type": "cantRenewFeatureKey" });
+  db.collections.notifications.remove({ "admin.type": "trialFeatureKeyExpired" });
 }
 
 function setIpBlacklist(db, backend) {


### PR DESCRIPTION
Eslint caught this (with an unused-variable warning); apparently this
has been defined for a long time but never actually set to *run*.