### PR TITLE
Make uploadMeteorTestApp.js navigate to a canonical URL

### DIFF
--- a/tests/commands/uploadMeteorTestApp.js
+++ b/tests/commands/uploadMeteorTestApp.js
@@ -20,7 +20,7 @@ const testappPath = require('path').resolve(__dirname + "/../assets/meteor-testa
 
 exports.command = function() {
   return this
-    .url('/apps')
+    .url(this.launch_url + '/apps')
     .waitForElementVisible('.upload-button', short_wait)
     .perform(function (client, done) {
       client.setValue("input[type=file]", testappPath, () => {


### PR DESCRIPTION
This appears to fix `tests/account-settings`.

Looks like `appHooks` passing in https://github.com/sandstorm-io/sandstorm/runs/715515605 was a transient success, and it's back to failing.