### PR TITLE
Fix bug re: mass transfers resulting in tokens not being deleted.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           # the constant below.
           make lint | tee lint.log
           num_problems=$(cat lint.log | grep ' problems (0 errors, ' | awk '{print $2}')
-          [ "$num_problems" = 805 ]
+          [ "$num_problems" = 804 ]
       - name: test
         run: |
           set -o pipefail

--- a/shell/imports/server/transfers-server.js
+++ b/shell/imports/server/transfers-server.js
@@ -344,7 +344,7 @@ function startOneTransfer(db, userId) {
 
 function revokeTransferTokens(db, userId) {
   let revokeMap = {};
-  db.collections.incomingTransfers.find({userId: this.userId}).forEach(transfer => {
+  db.collections.incomingTransfers.find({userId}).forEach(transfer => {
     revokeMap[transfer.token] = transfer.source;
   });
 


### PR DESCRIPTION
As-written the function is called with nothing bound to `this`, so this
would probably just throw an exception. But clearly the intent was to
use the parameter.

Caught this via an unused variable warning.