### PR TITLE
Makefile: make sure the meteor bundle is present before running ekam.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ tmp/ekam-bin: tmp/.deps
 	    (cd deps/ekam && $(MAKE) bin/ekam-bootstrap && \
 	     cd ../.. && ln -s ../deps/ekam/bin/ekam-bootstrap tmp/ekam-bin)
 
-tmp/.ekam-run: tmp/ekam-bin src/sandstorm/* tmp/.deps deps/boringssl/build/ssl/libssl.a deps/libsodium/build/src/libsodium/.libs/libsodium.a | deps/llvm-build
+tmp/.ekam-run: $(NODEJS) tmp/ekam-bin src/sandstorm/* tmp/.deps deps/boringssl/build/ssl/libssl.a deps/libsodium/build/src/libsodium/.libs/libsodium.a | deps/llvm-build
 	@$(call color,building sandstorm with ekam)
 	@CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS2)" CXXFLAGS="$(CXXFLAGS2)" \
 	    LIBS="$(LIBS2)" NODEJS=$(NODEJS) tmp/ekam-bin -j$(PARALLEL)


### PR DESCRIPTION
Otherwise building node-capnp fails if the user has never run `meteor`,
due to not being able to find the development headers. This doesn't
trigger if the build is run as the same user that ran meteor's
`curl ... | sh` installer, which is why we haven't previously noticed
it.

Note that if the bundle is not present ./find-meteor-dev-bundle.sh will
pull it in, but although we define a variable in terms of this at the
top of the Makefile, its value is computed lazily, so it will not be run
until it is actually needed.

It might work to just use := instead of = when assigning the variable,
but conceptually having the build process depend on node seems like the
right thing (and it should also ensure a rebuild if the version of
node/the bundle is updated).

Fixes #3360