### PR TITLE
First pass at modernizing ssl.md

### DIFF
--- a/docs/administering/ssl.md
+++ b/docs/administering/ssl.md
@@ -1,9 +1,8 @@
 ## Sandstorm and HTTPS
 
-Sandstorm can now terminate TLS connections for most conventional configurations you may wish to employ.
-This includes automatic certificate renewal of certificates, if you utilize a supported DNS provider, as well
-as the ability to manually upload your own certificates, either self-signed or from a well-trusted certificate
-vendor.
+Sandstorm can terminate TLS connections for most conventional configurations you may wish to employ. This
+includes automatic certificate renewal of certificates if you use a supported DNS provider, as well as the
+ability to manually upload your own certificates, either self-signed or from a well-trusted certificate vendor.
 
 ### How to get HTTPS on your Sandstorm install
 
@@ -11,10 +10,22 @@ If you are using a hostname like `example.sandcats.io`, then you likely already 
 hostname. [This page](sandcats-https.md) provides help and advice for enabling and troubleshooting HTTPS for
 Sandcats-based installs.
 
-If you utilize a supported DNS provider (Sandcats.io, Cloudflare, Digital Ocean, DNSimple, Duck DNS, GoDaddy,
-Gandi, Namecheap, Name.com, AWS Route 53, or Vultr), you can create an ACME account from "SSL/TLS Certificates"
-admin panel to enable automatic certificate renewal. By default, this uses Let's Encrypt, however, you can use
-any ACME service here.
+If you use a supported DNS provider, you can create an ACME account from "SSL/TLS Certificates" admin panel
+to enable automatic certificate renewal. By default, this uses Let's Encrypt, however, you can use any ACME
+service here.
+
+Sandstorm supports automatic renewal with the following DNS providers:
+- Sandcats.io
+- Cloudflare
+- Digital Ocean
+- DNSimple
+- Duck DNS
+- GoDaddy
+- Gandi
+- Namecheap
+- Name.com
+- Route 53 (AWS)
+- Vultr
 
 If your certificate provider does not support ACME, and/or your DNS provider is not supported currently by
 Sandstorm, you can manually upload your certificate.

--- a/docs/administering/ssl.md
+++ b/docs/administering/ssl.md
@@ -1,29 +1,38 @@
 ## Sandstorm and HTTPS
 
-If you are using a hostname like `example.sandcats.io`, then you likely already have working HTTPS
-(SSL) for your hostname. This page provides details on a variety of options for setting up HTTPS,
-including the `sandcats.io` free certificates.
+Sandstorm can now terminate TLS connections for most conventional configurations you may wish to employ.
+This includes automatic certificate renewal of certificates, if you utilize a supported DNS provider, as well
+as the ability to manually upload your own certificates, either self-signed or from a well-trusted certificate
+vendor.
 
 ### How to get HTTPS on your Sandstorm install
 
-You have a few options.
+If you are using a hostname like `example.sandcats.io`, then you likely already have working HTTPS for your
+hostname. [This page](sandcats-https.md) provides help and advice for enabling and troubleshooting HTTPS for
+Sandcats-based installs.
 
-- Use [sandcats.io free HTTPS](sandcats-https.md), a free service of the Sandstorm.io company. Read
-  details, including how to enable/disable, on that page. Sandstorm automatically renews these
-  certificates, and they are valid in virtually all browsers.
+If you utilize a supported DNS provider (Sandcats.io, Cloudflare, Digital Ocean, DNSimple, Duck DNS, GoDaddy,
+Gandi, Namecheap, Name.com, AWS Route 53, or Vultr), you can create an ACME account from "SSL/TLS Certificates"
+admin panel to enable automatic certificate renewal. By default, this uses Let's Encrypt, however, you can use
+any ACME service here.
+
+If your certificate provider does not support ACME, and/or your DNS provider is not supported currently by
+Sandstorm, you can manually upload your certificate.
+
+### Additional options
 
 - Run a [reverse proxy](reverse-proxy.md) such as nginx using a wildcard certificate that you
-  acquire from a certificate vendor like GlobalSign. This is typically valid in all browsers and
-  [costs some money](https://www.google.com/search?q=cheap+wildcard+ssl).
+  acquire from a certificate vendor.
 
 - Set up a [custom certificate authority](self-signed.md) for you and your server, also known as
-  self-signed SSL. This will only be valid for browsers that you configure accordingly.
+  self-signed SSL. This will only be valid for browsers that you configure accordingly. This tutorial assumes
+  you are utilizing a reverse proxy.
 
 To share port 443 with other services on the same machine:
 
 - You [can install `sniproxy` to share port 443](sniproxy.md) between your existing server and Sandstorm so that
   Sandstorm can manage (and autorenew) its own certificates. This allows you to combine an **existing
-  web server on port 443** with free sandcats.io HTTPS.
+  web server on port 443** with Sandstorm.
   
 - You [can follow this guide](https://web.archive.org/web/20190922195059/https://juanjoalvarez.net/es/detail/2017/jan/12/how-set-sandstorm-behind-reverse-proxy-keeping-you/)
   that explains how to use a [cron script](https://github.com/juanjux/sandstorm-sandcats-cert-installer) 


### PR DESCRIPTION
So here's my first attempt at this. I basically give people a shunt over to sandcats-https.md right away if they are using Sandcats, then explain the other ways Sandstorm can configure HTTPS directly. I shoved reverse-proxy and self-signed tutorials out to an "Additional options" header, since that's now less ideal. I also tweaked the sniproxy bullet to let people know it's not just for Sandcats.io users here.

Paging @zenhack for opinions.