### PR TITLE
Larger changelog box on about

### DIFF
--- a/shell/client/styles/_about.scss
+++ b/shell/client/styles/_about.scss
@@ -64,7 +64,7 @@
     background-color: white;
     border: 16px solid white;
     overflow: auto;
-    height: 200px;
+    height: 400px;
     >* { margin-top: 0; }
   }
 


### PR DESCRIPTION
This is totally not tested, but this seems like the right place to do what I did in CSS.

Before, you can only see one *very short* changelog entry. In this case, you don't even see all of the updates on that given day! Even a slightly longer changelog might require scrolling.
![old](https://user-images.githubusercontent.com/4399499/84078320-59847000-a99e-11ea-861c-b7762df19119.png)

After, you see a healthy portion of the recent changelog, and at least on my 1080p screen with Firefox, you still can see there is another section below with the core developers and all. Usually you'll get three or so changelog entries in view at a time.
![new](https://user-images.githubusercontent.com/4399499/84078436-8a64a500-a99e-11ea-8505-814d552fb44a.png)

This was suggested in #2722 as one possible improvement to the page.
