### PR TITLE
Quiet some unused parameter warnings.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           # the constant below.
           make lint | tee lint.log
           num_problems=$(cat lint.log | grep ' problems (0 errors, ' | awk '{print $2}')
-          [ "$num_problems" = 800 ]
+          [ "$num_problems" = 799 ]
       - name: test
         run: |
           set -o pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           # the constant below.
           make lint | tee lint.log
           num_problems=$(cat lint.log | grep ' problems (0 errors, ' | awk '{print $2}')
-          [ "$num_problems" = 804 ]
+          [ "$num_problems" = 800 ]
       - name: test
         run: |
           set -o pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           # the constant below.
           make lint | tee lint.log
           num_problems=$(cat lint.log | grep ' problems (0 errors, ' | awk '{print $2}')
-          [ "$num_problems" = 799 ]
+          [ "$num_problems" = 798 ]
       - name: test
         run: |
           set -o pipefail

--- a/shell/imports/server/hack-session.js
+++ b/shell/imports/server/hack-session.js
@@ -493,7 +493,7 @@ class HackSessionContextImpl extends SessionContextImpl {
     }).bind(this));
   }
 
-  obsoleteGenerateApiToken(petname, userInfo, expires) {
+  obsoleteGenerateApiToken(_petname, _userInfo, _expires) {
     throw new Error("generateApiToken() has been removed. Use offer templates instead.");
   }
 
@@ -501,7 +501,7 @@ class HackSessionContextImpl extends SessionContextImpl {
     throw new Error("listApiTokens() has been removed. Use offer templates instead.");
   }
 
-  obsoleteRevokeApiToken(tokenId) {
+  obsoleteRevokeApiToken(_tokenId) {
     throw new Error("revokeApiToken() has been removed. Use offer templates instead.");
   }
 

--- a/shell/imports/server/notifications-server.js
+++ b/shell/imports/server/notifications-server.js
@@ -117,7 +117,7 @@ logActivity = function (grainId, accountIdOrAnonymous, event) {
         }));
       }
     });
-    waitPromise(Promise.all(promises).then(junk => undefined));
+    waitPromise(Promise.all(promises));
   }
 
   // Make a list of everyone to notify.

--- a/shell/imports/server/transfers-server.js
+++ b/shell/imports/server/transfers-server.js
@@ -351,7 +351,7 @@ function revokeTransferTokens(db, userId) {
   for (let token in revokeMap) {
     HTTP.del(revokeMap[token] + "/transfers/cancel", {
       headers: {"Authorization": "Bearer " + token}
-    }, (err, response) => {
+    }, (err, _response) => {
       if (err) {
         // Don't really care...
         console.error("Error revoking transfer token:", err);


### PR DESCRIPTION
Gets rid of a few more warnings. Most of these are just prefixing a `_` in some places where the behavior is fine, but the last commit also strips out an ineffectual .then(...).