### PR TITLE
Improve the "unknown host" error page.

### DIFF
--- a/src/sandstorm/gateway.c++
+++ b/src/sandstorm/gateway.c++
@@ -874,27 +874,42 @@ kj::Promise<void> GatewayService::handleForeignHostname(kj::StringPtr host,
 
 kj::String GatewayService::unknownForeignHostnameError(kj::StringPtr host) {
   return kj::str(
-      "<style type=\"text/css\">h2, h3, p { max-width: 600px; }</style>"
-      "<h2>Sandstorm static publishing needs further configuration (or wrong URL)</h2>\n"
-      "<p>If you were trying to configure static publishing for a blog or website, powered "
-      "by a Sandstorm app hosted at this server, you either have not added DNS TXT records "
-      "correctly, or the DNS cache has not updated yet (may take a while, like 5 minutes to one "
-      "hour).</p>\n"
+      "<style type=\"text/css\">h1, h2, h3, p { max-width: 600px; }</style>"
+
+      "<h1>Sandstorm doesn't recognize this host name</h1>"
+
+      "<h2>If you we're trying to visit Sandstorm's main interface</h2>"
+
       "<p>To visit this Sandstorm server's main interface, go to: <a href='", baseUrl, "'>",
       baseUrl, "</a></p>\n"
-      "<h3>DNS details</h3>\n"
-      "<p>No TXT records were found for the host: <code>sandstorm-www.", host, "</code></p>\n"
-      "<p>If you have the <tt>dig</tt> tool, you can run this command to learn more:</p>\n"
-      "<p><code>dig -t TXT sandstorm-www.", host, "</code></p>\n"
-      "<h3>Changing the server URL, or troubleshooting OAuth login</h3>\n"
-      "<p>If you are the server admin and want to use this address as the main interface, "
-      "edit /opt/sandstorm/sandstorm.conf, modify the BASE_URL setting, and restart "
-      "Sandstorm.</p>\n"
+
+      "<h2>If you got here after trying to log in via OAuth (e.g. through GitHub or Google)</h2>"
+
       "<p>If you got here after trying to log in via OAuth (e.g. through GitHub or Google), "
       "the problem is probably that the OAuth callback URL was set wrong. You need to "
       "update it through the respective login provider's management console. The "
       "easiest way to do that is to run <code>sudo sandstorm admin-token</code>, then "
-      "reconfigure the OAuth provider.</p>\n");
+      "reconfigure the OAuth provider.</p>\n"
+
+      "<h2>If you were trying to configure static publishing</h2>"
+
+      "<p>If you were trying to configure static publishing for a blog or website, powered "
+      "by a Sandstorm app hosted at this server, you either have not added DNS TXT records "
+      "correctly, or the DNS cache has not updated yet (may take a while, like 5 minutes to one "
+      "hour).</p>\n"
+
+      "<h3>DNS details</h3>\n"
+
+      "<p>No TXT records were found for the host: <code>sandstorm-www.", host, "</code></p>\n"
+      "<p>If you have the <tt>dig</tt> tool, you can run this command to learn more:</p>\n"
+      "<p><code>dig -t TXT sandstorm-www.", host, "</code></p>\n"
+
+      "<h2>Changing the server URL, or troubleshooting OAuth login</h2>\n"
+
+      "<p>If you are the server admin and want to use this address as the main interface, "
+      "edit /opt/sandstorm/sandstorm.conf, modify the BASE_URL setting, and restart "
+      "Sandstorm.</p>\n"
+      );
 }
 
 void GatewayService::taskFailed(kj::Exception&& exception) {

--- a/src/sandstorm/gateway.c++
+++ b/src/sandstorm/gateway.c++
@@ -883,6 +883,10 @@ kj::String GatewayService::unknownForeignHostnameError(kj::StringPtr host) {
       "<p>To visit this Sandstorm server's main interface, go to: <a href='", baseUrl, "'>",
       baseUrl, "</a></p>\n"
 
+      "<p>If you are the server admin and want to use this address as the main interface, "
+      "edit /opt/sandstorm/sandstorm.conf, modify the BASE_URL setting, and restart "
+      "Sandstorm.</p>\n"
+
       "<h2>If you got here after trying to log in via OAuth (e.g. through GitHub or Google)</h2>"
 
       "<p>If you got here after trying to log in via OAuth (e.g. through GitHub or Google), "
@@ -903,12 +907,6 @@ kj::String GatewayService::unknownForeignHostnameError(kj::StringPtr host) {
       "<p>No TXT records were found for the host: <code>sandstorm-www.", host, "</code></p>\n"
       "<p>If you have the <tt>dig</tt> tool, you can run this command to learn more:</p>\n"
       "<p><code>dig -t TXT sandstorm-www.", host, "</code></p>\n"
-
-      "<h2>Changing the server URL, or troubleshooting OAuth login</h2>\n"
-
-      "<p>If you are the server admin and want to use this address as the main interface, "
-      "edit /opt/sandstorm/sandstorm.conf, modify the BASE_URL setting, and restart "
-      "Sandstorm.</p>\n"
       );
 }
 


### PR DESCRIPTION
The main thing this does is re-order some of the information. From the
questions we get it seems like 99% of the time when a user sees this
page it's because they visited the wrong domain when trying to go to
Sandstorm's main interface, but the old error message de-emphasizes this
possibility, and we've seen a lot of confusion from users.

This patch puts the most likely possibility front-and-center, so users
who don't read the full wall of text still see it. Static publishing
is a less common cause of this error, so move that further down.

This also structures the page a bit more clearly, with each possible
source of errors being under a large heading indicating "If you were
tring to do X," to make finding information generally easier.