### PR TITLE
Put grains in cgroups.

### DIFF
--- a/src/sandstorm/backend.h
+++ b/src/sandstorm/backend.h
@@ -35,7 +35,7 @@ class BackendImpl final: public Backend::Server, private kj::TaskSet::ErrorHandl
 public:
   BackendImpl(kj::LowLevelAsyncIoProvider& ioProvider, kj::Network& network,
               SandstormCoreFactory::Client&& sandstormCoreFactory,
-	      Cgroup&& cgroup,
+	      kj::Maybe<Cgroup>&& cgroup,
               kj::Maybe<uid_t> sandboxUid);
 
 protected:
@@ -61,7 +61,7 @@ private:
   SandstormCoreFactory::Client coreFactory;
   kj::Maybe<uid_t> sandboxUid;   // if not using user namespaces
   kj::TaskSet tasks;
-  Cgroup cgroup;
+  kj::Maybe<Cgroup> cgroup;
 
   class RunningGrain {
   public:

--- a/src/sandstorm/backend.h
+++ b/src/sandstorm/backend.h
@@ -23,6 +23,7 @@
 #include <capnp/rpc-twoparty.h>
 #include <kj/one-of.h>
 #include <kj/vector.h>
+#include <sandstorm/cgroup2.h>
 
 namespace kj {
   class InputStream;
@@ -34,6 +35,7 @@ class BackendImpl final: public Backend::Server, private kj::TaskSet::ErrorHandl
 public:
   BackendImpl(kj::LowLevelAsyncIoProvider& ioProvider, kj::Network& network,
               SandstormCoreFactory::Client&& sandstormCoreFactory,
+	      Cgroup&& cgroup,
               kj::Maybe<uid_t> sandboxUid);
 
 protected:
@@ -59,6 +61,7 @@ private:
   SandstormCoreFactory::Client coreFactory;
   kj::Maybe<uid_t> sandboxUid;   // if not using user namespaces
   kj::TaskSet tasks;
+  Cgroup cgroup;
 
   class RunningGrain {
   public:

--- a/src/sandstorm/cgroup2.c++
+++ b/src/sandstorm/cgroup2.c++
@@ -4,36 +4,36 @@
 #include <kj/debug.h>
 
 namespace sandstorm {
-  Cgroup::Cgroup(kj::StringPtr path)
-    : dirfd(raiiOpen(path, O_DIRECTORY|O_CLOEXEC))
-  {}
+Cgroup::Cgroup(kj::StringPtr path)
+  : dirfd(raiiOpen(path, O_DIRECTORY|O_CLOEXEC))
+{}
 
-  Cgroup::Cgroup(kj::AutoCloseFd&& dirfd)
-    : dirfd(kj::mv(dirfd))
-  {}
+Cgroup::Cgroup(kj::AutoCloseFd&& dirfd)
+  : dirfd(kj::mv(dirfd))
+{}
 
-  Cgroup Cgroup::getOrMakeChild(kj::StringPtr path) {
-    int status;
-    do {
-      errno = 0;
-      status = mkdirat(dirfd.get(), path.cStr(), 0700);
-    } while(status != 0 && errno == EINTR);
+Cgroup Cgroup::getOrMakeChild(kj::StringPtr path) {
+  int status;
+  do {
+    errno = 0;
+    status = mkdirat(dirfd.get(), path.cStr(), 0700);
+  } while(status != 0 && errno == EINTR);
 
-    if(status < 0) {
-      KJ_REQUIRE(errno == EEXIST);
-    }
-
-    return Cgroup(raiiOpenAt(dirfd.get(), path, O_DIRECTORY|O_CLOEXEC));
+  if(status < 0) {
+    KJ_REQUIRE(errno == EEXIST);
   }
 
-  void Cgroup::removeChild(kj::StringPtr path) {
-    KJ_SYSCALL(unlinkat(dirfd.get(), path.cStr(), AT_REMOVEDIR));
-  }
+  return Cgroup(raiiOpenAt(dirfd.get(), path, O_DIRECTORY|O_CLOEXEC));
+}
 
-  void Cgroup::addPid(pid_t pid) {
-    auto procsfd = raiiOpenAt(dirfd.get(), "cgroup.procs", O_WRONLY);
-    auto pidStr = kj::str(pid);
-    auto cStr = pidStr.cStr();
-    KJ_SYSCALL(write(procsfd.get(), cStr, strlen(cStr)));
-  }
+void Cgroup::removeChild(kj::StringPtr path) {
+  KJ_SYSCALL(unlinkat(dirfd.get(), path.cStr(), AT_REMOVEDIR));
+}
+
+void Cgroup::addPid(pid_t pid) {
+  auto procsfd = raiiOpenAt(dirfd.get(), "cgroup.procs", O_WRONLY);
+  auto pidStr = kj::str(pid);
+  auto cStr = pidStr.cStr();
+  KJ_SYSCALL(write(procsfd.get(), cStr, strlen(cStr)));
+}
 };

--- a/src/sandstorm/cgroup2.c++
+++ b/src/sandstorm/cgroup2.c++
@@ -1,0 +1,35 @@
+#include <sandstorm/cgroup2.h>
+#include <sandstorm/util.h>
+
+#include <kj/debug.h>
+
+namespace sandstorm {
+  Cgroup::Cgroup(kj::StringPtr path)
+    : dirfd(raiiOpen(path, O_DIRECTORY|O_CLOEXEC))
+  {}
+
+  Cgroup::Cgroup(kj::AutoCloseFd&& dirfd)
+    : dirfd(kj::mv(dirfd))
+  {}
+
+  Cgroup Cgroup::getOrMakeChild(kj::StringPtr path) {
+    int status;
+    do {
+      errno = 0;
+      status = mkdirat(dirfd.get(), path.cStr(), 0700);
+    } while(status != 0 && errno == EINTR);
+
+    if(status < 0) {
+      KJ_REQUIRE(errno == EEXIST);
+    }
+
+    return Cgroup(raiiOpenAt(dirfd.get(), path, O_DIRECTORY|O_CLOEXEC));
+  }
+
+  void Cgroup::addPid(pid_t pid) {
+    auto procsfd = raiiOpenAt(dirfd.get(), "cgroup.procs", O_WRONLY);
+    auto pidStr = kj::str(pid);
+    auto cStr = pidStr.cStr();
+    KJ_SYSCALL(write(procsfd.get(), cStr, strlen(cStr)));
+  }
+};

--- a/src/sandstorm/cgroup2.c++
+++ b/src/sandstorm/cgroup2.c++
@@ -26,6 +26,10 @@ namespace sandstorm {
     return Cgroup(raiiOpenAt(dirfd.get(), path, O_DIRECTORY|O_CLOEXEC));
   }
 
+  void Cgroup::removeChild(kj::StringPtr path) {
+    KJ_SYSCALL(unlinkat(dirfd.get(), path.cStr(), AT_REMOVEDIR));
+  }
+
   void Cgroup::addPid(pid_t pid) {
     auto procsfd = raiiOpenAt(dirfd.get(), "cgroup.procs", O_WRONLY);
     auto pidStr = kj::str(pid);

--- a/src/sandstorm/cgroup2.h
+++ b/src/sandstorm/cgroup2.h
@@ -1,0 +1,31 @@
+#ifndef SANDSTORM_CGROUP2_H_
+#define SANDSTORM_CGROUP2_H_
+
+#include <sys/types.h>  // For pid_t
+#include <kj/io.h>
+
+namespace sandstorm {
+  class Cgroup {
+    // A Linux control group (version 2).
+
+    public:
+      Cgroup() = delete;
+      KJ_DISALLOW_COPY(Cgroup);
+      Cgroup(Cgroup&&) noexcept = default;
+
+      Cgroup(kj::StringPtr path);
+      // Open the cgroup corresponding to the directory `path`.
+
+      Cgroup getOrMakeChild(kj::StringPtr path);
+      // Open a cgroup that is a child of this one, creating it if it does not
+      // exist.
+
+      void addPid(pid_t pid);
+      // Add the given process to the cgroup.
+    private:
+      Cgroup(kj::AutoCloseFd&& dirfd);
+      kj::AutoCloseFd dirfd;
+  };
+};
+
+#endif

--- a/src/sandstorm/cgroup2.h
+++ b/src/sandstorm/cgroup2.h
@@ -20,6 +20,10 @@ namespace sandstorm {
       // Open a cgroup that is a child of this one, creating it if it does not
       // exist.
 
+      void removeChild(kj::StringPtr path);
+      // Delete a child of this cgroup. The child must not contain any
+      // processes.
+
       void addPid(pid_t pid);
       // Add the given process to the cgroup.
     private:

--- a/src/sandstorm/cgroup2.h
+++ b/src/sandstorm/cgroup2.h
@@ -5,31 +5,31 @@
 #include <kj/io.h>
 
 namespace sandstorm {
-  class Cgroup {
-    // A Linux control group (version 2).
+class Cgroup {
+  // A Linux control group (version 2).
 
-    public:
-      Cgroup() = delete;
-      KJ_DISALLOW_COPY(Cgroup);
-      Cgroup(Cgroup&&) noexcept = default;
+  public:
+    Cgroup() = delete;
+    KJ_DISALLOW_COPY(Cgroup);
+    Cgroup(Cgroup&&) noexcept = default;
 
-      Cgroup(kj::StringPtr path);
-      // Open the cgroup corresponding to the directory `path`.
+    Cgroup(kj::StringPtr path);
+    // Open the cgroup corresponding to the directory `path`.
 
-      Cgroup getOrMakeChild(kj::StringPtr path);
-      // Open a cgroup that is a child of this one, creating it if it does not
-      // exist.
+    Cgroup getOrMakeChild(kj::StringPtr path);
+    // Open a cgroup that is a child of this one, creating it if it does not
+    // exist.
 
-      void removeChild(kj::StringPtr path);
-      // Delete a child of this cgroup. The child must not contain any
-      // processes.
+    void removeChild(kj::StringPtr path);
+    // Delete a child of this cgroup. The child must not contain any
+    // processes.
 
-      void addPid(pid_t pid);
-      // Add the given process to the cgroup.
-    private:
-      Cgroup(kj::AutoCloseFd&& dirfd);
-      kj::AutoCloseFd dirfd;
-  };
+    void addPid(pid_t pid);
+    // Add the given process to the cgroup.
+  private:
+    Cgroup(kj::AutoCloseFd&& dirfd);
+    kj::AutoCloseFd dirfd;
+};
 };
 
 #endif

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -2179,7 +2179,9 @@ private:
       auto paf = kj::newPromiseAndFulfiller<Backend::Client>();
       TwoPartyServerWithClientBootstrap server(kj::mv(paf.promise));
       paf.fulfiller->fulfill(kj::heap<BackendImpl>(*io.lowLevelProvider, network,
-        server.getBootstrap().castAs<SandstormCoreFactory>(), sandboxUid));
+        server.getBootstrap().castAs<SandstormCoreFactory>(),
+        Cgroup("/run/cgroup2"),
+        sandboxUid));
 
       auto gatewayServer = kj::heap<capnp::TwoPartyServer>(kj::refcounted<CapRedirector>([&]() {
         return server.getBootstrap().castAs<SandstormCoreFactory>()

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -2180,7 +2180,10 @@ private:
       TwoPartyServerWithClientBootstrap server(kj::mv(paf.promise));
       paf.fulfiller->fulfill(kj::heap<BackendImpl>(*io.lowLevelProvider, network,
         server.getBootstrap().castAs<SandstormCoreFactory>(),
-        Cgroup("/run/cgroup2"),
+        // Collect all of the grains' cgroups into a single
+        // container, so they can't collectively starve sandstorm
+        // itself.
+        Cgroup("/run/cgroup2").getOrMakeChild("grains"),
         sandboxUid));
 
       auto gatewayServer = kj::heap<capnp::TwoPartyServer>(kj::refcounted<CapRedirector>([&]() {

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1296,8 +1296,6 @@ private:
       unshareUidNamespaceOnce();
     }
 
-    KJ_SYSCALL(unshare(CLONE_NEWCGROUP));
-
     // Unshare the mount namespace, so we can create some private bind mounts.
     KJ_SYSCALL(unshare(CLONE_NEWNS));
 
@@ -1373,27 +1371,35 @@ private:
     backupResolvConf();
 
     // Mount the cgroup2 filesystem at run/cgroup2:
-    KJ_SYSCALL(mkdir("run/cgroup2", 0700));
-    KJ_SYSCALL(mount("none", "run/cgroup2", "cgroup2", MS_NOSUID | MS_NOEXEC, ""));
-    KJ_IF_MAYBE(uids, chownCgroupsTo) {
-      KJ_LOG(ERROR, uids->uid, uids->gid);
-      // Give our unprivileged selves access to manage the cgroup.
-      // See the 'Delegation' section of 'Documentation/admin-guide/cgroup-v2.txt'
-      // in the Linux kernel source tree.
-      //
-      // We only do this if we were given uids to work with; we don't need to do
-      // this if the sandbox is already set up, so commands that expect
-      // an already running sandstorm will pass us nullptr to indicate that
-      // we don't need to do this.
-      //
-      // Additionally, we *can't* do this if we weren't started as root, so in
-      // that case we just skip it. Other parts of the system are built to
-      // handle the case where this isn't available gracefully.
-      if(runningAsRoot) {
-        KJ_SYSCALL(chown("run/cgroup2", uids->uid, uids->gid));
-        KJ_SYSCALL(chown("run/cgroup2/cgroup.procs", uids->uid, uids->gid));
-        KJ_SYSCALL(chown("run/cgroup2/cgroup.threads", uids->uid, uids->gid));
-        KJ_SYSCALL(chown("run/cgroup2/cgroup.subtree_control", uids->uid, uids->gid));
+    KJ_SYSCALL_HANDLE_ERRORS(unshare(CLONE_NEWCGROUP)) {
+      case EINVAL:
+        // Might happen on very old kernels before CLONE_NEWCGROUP was defined.
+        break;
+      default:
+        KJ_FAIL_SYSCALL("unshare(CLONE_NEWCGROUP)", error);
+    } else {
+      KJ_SYSCALL(mkdir("run/cgroup2", 0700));
+      KJ_SYSCALL(mount("none", "run/cgroup2", "cgroup2", MS_NOSUID | MS_NOEXEC, ""));
+      KJ_IF_MAYBE(uids, chownCgroupsTo) {
+        KJ_LOG(ERROR, uids->uid, uids->gid);
+        // Give our unprivileged selves access to manage the cgroup.
+        // See the 'Delegation' section of 'Documentation/admin-guide/cgroup-v2.txt'
+        // in the Linux kernel source tree.
+        //
+        // We only do this if we were given uids to work with; we don't need to do
+        // this if the sandbox is already set up, so commands that expect
+        // an already running sandstorm will pass us nullptr to indicate that
+        // we don't need to do this.
+        //
+        // Additionally, we *can't* do this if we weren't started as root, so in
+        // that case we just skip it. Other parts of the system are built to
+        // handle the case where this isn't available gracefully.
+        if(runningAsRoot) {
+          KJ_SYSCALL(chown("run/cgroup2", uids->uid, uids->gid));
+          KJ_SYSCALL(chown("run/cgroup2/cgroup.procs", uids->uid, uids->gid));
+          KJ_SYSCALL(chown("run/cgroup2/cgroup.threads", uids->uid, uids->gid));
+          KJ_SYSCALL(chown("run/cgroup2/cgroup.subtree_control", uids->uid, uids->gid));
+        }
       }
     }
 

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -57,7 +57,6 @@
 #include <linux/rtnetlink.h>
 #include <sys/eventfd.h>
 #include <sys/resource.h>
-#include <sandstorm/cgroup2.h>
 
 // We need to define these constants before libseccomp has a chance to inject bogus
 // values for them. See https://github.com/seccomp/libseccomp/issues/27
@@ -752,15 +751,6 @@ kj::String SupervisorMain::realPath(kj::StringPtr path) {
 // =====================================================================================
 
 void SupervisorMain::setupSupervisor() {
-  {
-    // Put ourselves in a cgroup:
-    auto pid = getpid();
-    auto cgroupName = kj::str("grain-", grainId);
-    Cgroup("/run/cgroup2")
-      .getOrMakeChild(cgroupName)
-      .addPid(pid);
-  }
-
   // Enable no_new_privs so that once we drop privileges we can never regain them through e.g.
   // execing a suid-root binary.  Sandboxed apps should not need that.
   KJ_SYSCALL(prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0));


### PR DESCRIPTION
This patch adds rudimentary support for cgroups (v2). Currently, we create a cgroup `grains` under the main sandstorm cgroup, and then put each grain in a cgroup within that.

Right now this doesn't really achieve anything useful, as we're not setting any policy on the cgroups, but this will enable future changes including:

- Making sandstorm robust to DoS attacks by grains; right now it's entirely possible to bog down a sandstorm box using e.g. a fork bomb inside a grain, but using cgroups we can place appropriate limits to prevent this kind of thing.
- Atomically pausing grains when taking backups, which would solve #3186.

Since in some cases (notably if we're not running as root) we may not be able to gain the ability to manage cgroups, this gracefully degrades to the status quo if we are unable to do so. Note that this is going to be the case when running the test suite (since it doesn't start as root).

Also worth noting is that on most modern systems, systemd starts up and assigns most of the cgroup controllers to the legacy cgroup v1 hierarchies, so on such a system we won't be able to actually impose limits (though sorting into cgroups still works). Users can address this by supplying a kernel command line parameter, but we probably can't make it automatically work very easily. Hopefully distros will gradually migrate away from this setup and eventually it will "just work" on most systems.

I tested this both on my local dev setup and thelibrary.sandcats.io, where it appears to work. I would appreciate others testing on their setups (possibly running different distros from me and such).

