### PR TITLE
Add `-> stream` to a couple capnp methods.

### DIFF
--- a/shell/imports/server/drivers/ip.js
+++ b/shell/imports/server/drivers/ip.js
@@ -36,6 +36,10 @@ class ByteStreamConnection {
   }
 
   write(data) {
+    // TODO: try to apply some backpressure? Node docs say that write()
+    // always succeeds and just buffers the data if needed, so we could
+    // end up burning a bunch of memory if the sender is sending too
+    // fast.
     this.connection.write(data);
   }
 

--- a/src/sandstorm/app-index/app-index.c++
+++ b/src/sandstorm/app-index/app-index.c++
@@ -88,7 +88,7 @@ public:
         auto promises = kj::heapArrayBuilder<kj::Promise<void>>(3);
         auto req1 = stream.writeRequest();
         req1.setData(content.getContent());
-        promises.add(req1.send().then([](auto&&) {}));
+        promises.add(req1.send());
         promises.add(stream.doneRequest().send().then([](auto&&) {}));
         promises.add(stream.getResultRequest().send().then([](auto&&) {}));
 

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -503,7 +503,7 @@ private:
   bool aborted = false;
 
   kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> writeReady;
-  capnp::Request<ByteStream::WriteParams, ByteStream::WriteResults> nextWrite = nullptr;
+  capnp::StreamingRequest<ByteStream::WriteParams> nextWrite = nullptr;
   capnp::Orphan<capnp::Data> nextWriteData;
   size_t nextWriteSize = 0;  // how many bytes are already in `nextWriteData`
 
@@ -516,7 +516,7 @@ private:
       nextWriteData.truncate(nextWriteSize);
       nextWrite.adoptData(kj::mv(nextWriteData));
 
-      auto result = nextWrite.send().then([this](auto&&) {
+      auto result = nextWrite.send().then([this]() {
         return pumpWrites();
       });
 
@@ -923,7 +923,7 @@ public:
     auto request = clientStream.sendBytesRequest(
         capnp::MessageSize { data.size() / sizeof(capnp::word) + 8, 0 });
     request.setMessage(data);
-    tasks.add(request.send().ignoreResult());
+    tasks.add(request.send());
   }
 
 protected:

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -2287,6 +2287,31 @@ private:
       KJ_LOG(ERROR, exception);
     }
 
+    // Read all unread data from logFile and send it to the stream.
+    kj::Promise<void> copyLog() {
+      auto req = stream.writeRequest();
+      auto orphanage =
+          capnp::Orphanage::getForMessageContaining<ByteStream::WriteParams::Builder>(req);
+      auto orphan = orphanage.newOrphan<capnp::Data>(4096);
+      auto data = orphan.get();
+
+      size_t n = kj::FdInputStream(logFile.get())
+          .tryRead(data.begin(), data.size(), data.size());
+      bool done = n < data.size();
+      if (done) {
+        orphan.truncate(n);
+      }
+      req.adoptData(kj::mv(orphan));
+
+      if(done) {
+        return req.send();
+      } else {
+        return req.send().then([this]() {
+          return copyLog();
+        });
+      }
+    }
+
     kj::Promise<void> watchLoop() {
       // Exhaust all events from the inotify queue, because edge triggering.
       // Luckily we don't actually have to interpret the events because we're only waiting on
@@ -2308,33 +2333,13 @@ private:
         KJ_SYSCALL(lseek(logFile, 0, SEEK_SET));
       }
 
-      // Read all unread data from logFile and send it to the stream.
-      // TODO(perf): Flow control? Currently we avoid asking for very much data at once.
-      for (;;) {
-        auto req = stream.writeRequest();
-        auto orphanage =
-            capnp::Orphanage::getForMessageContaining<ByteStream::WriteParams::Builder>(req);
-        auto orphan = orphanage.newOrphan<capnp::Data>(4096);
-        auto data = orphan.get();
+      return copyLog().then([this]() {
+        KJ_SYSCALL(lastOffset = lseek(logFile, 0, SEEK_CUR));
 
-        size_t n = kj::FdInputStream(logFile.get())
-            .tryRead(data.begin(), data.size(), data.size());
-        bool done = n < data.size();
-        if (done) {
-          orphan.truncate(n);
-        }
-        req.adoptData(kj::mv(orphan));
-
-        tasks.add(req.send());
-
-        if (done) break;
-      }
-
-      KJ_SYSCALL(lastOffset = lseek(logFile, 0, SEEK_CUR));
-
-      // OK, now wait for more.
-      return inotifyObserver.whenBecomesReadable().then([this]() {
-        return watchLoop();
+        // OK, now wait for more.
+        return inotifyObserver.whenBecomesReadable().then([this]() {
+          return watchLoop();
+        });
       });
     }
 

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -2134,7 +2134,7 @@ public:
         auto req = params.getStream().writeRequest();
         auto data = req.initData(backlog1);
         in.read(data.begin(), backlog1);
-        firstWrite = req.send().ignoreResult();
+        firstWrite = req.send();
       }
     }
 
@@ -2325,7 +2325,7 @@ private:
         }
         req.adoptData(kj::mv(orphan));
 
-        tasks.add(req.send().ignoreResult());
+        tasks.add(req.send());
 
         if (done) break;
       }

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -161,7 +161,7 @@ kj::Promise<void> pump(kj::AsyncInputStream& input, ByteStream::Client stream) {
     req.adoptData(kj::mv(orphan));
 
     // TODO(perf): Parallelize writes.
-    return req.send().then([&input,KJ_MVCAP(stream)](auto&&) mutable {
+    return req.send().then([&input,KJ_MVCAP(stream)]() mutable {
       return pump(input, kj::mv(stream));
     });
   });
@@ -183,7 +183,7 @@ kj::Promise<void> pump(kj::InputStream& input, ByteStream::Client stream) {
   req.adoptData(kj::mv(orphan));
 
   // TODO(perf): Parallelize writes.
-  return req.send().then([&input,KJ_MVCAP(stream)](auto&&) mutable {
+  return req.send().then([&input,KJ_MVCAP(stream)]() mutable {
     return pump(input, kj::mv(stream));
   });
 }

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -160,7 +160,6 @@ kj::Promise<void> pump(kj::AsyncInputStream& input, ByteStream::Client stream) {
     orphan.truncate(n);
     req.adoptData(kj::mv(orphan));
 
-    // TODO(perf): Parallelize writes.
     return req.send().then([&input,KJ_MVCAP(stream)]() mutable {
       return pump(input, kj::mv(stream));
     });
@@ -182,7 +181,6 @@ kj::Promise<void> pump(kj::InputStream& input, ByteStream::Client stream) {
   orphan.truncate(n);
   req.adoptData(kj::mv(orphan));
 
-  // TODO(perf): Parallelize writes.
   return req.send().then([&input,KJ_MVCAP(stream)]() mutable {
     return pump(input, kj::mv(stream));
   });

--- a/src/sandstorm/util.capnp
+++ b/src/sandstorm/util.capnp
@@ -94,7 +94,7 @@ interface ByteStream {
   #   Moreover, the interface would be awkward to use and implement. E.g. what happens if you call
   #   read() twice on the same capability?
 
-  write @0 (data :Data);
+  write @0 (data :Data) -> stream;
   # Add bytes.
   #
   # It's safe to make overlapping calls to `write()`, since Cap'n Proto enforces E-Order and so

--- a/src/sandstorm/web-session-bridge.c++
+++ b/src/sandstorm/web-session-bridge.c++
@@ -558,14 +558,13 @@ public:
   }
 
 private:
-  kj::Promise<void> writeImpl(size_t size, capnp::Request<
-      WebSession::WebSocketStream::SendBytesParams,
-      WebSession::WebSocketStream::SendBytesResults>&& req) {
+  kj::Promise<void> writeImpl(size_t size,
+      capnp::StreamingRequest<WebSession::WebSocketStream::SendBytesParams>&& req) {
     KJ_IF_MAYBE(e, writeError) {
       return kj::cp(*e);
     }
 
-    writeTasks.add(req.send().then([this,size](auto&& response) {
+    writeTasks.add(req.send().then([this,size]() {
       bytesInFlight -= size;
       if (bytesInFlight < MAX_IN_FLIGHT) {
         KJ_IF_MAYBE(f, writeReadyFulfiller) {

--- a/src/sandstorm/web-session-bridge.c++
+++ b/src/sandstorm/web-session-bridge.c++
@@ -499,8 +499,7 @@ kj::Promise<kj::Maybe<kj::String>> WebSessionBridge::davXmlContent(
 
 namespace {
 
-class WebSocketPipe final : public kj::AsyncIoStream, public kj::Refcounted,
-                            private kj::TaskSet::ErrorHandler {
+class WebSocketPipe final : public kj::AsyncIoStream, public kj::Refcounted {
   // Class which adapts a pair of WebSession::WebSocketStreams into an AsyncIoStream which in turn
   // can be wrapped by a kj::WebSocket using kj::newWebSocket().
   //
@@ -514,8 +513,7 @@ class WebSocketPipe final : public kj::AsyncIoStream, public kj::Refcounted,
 
 public:
   WebSocketPipe(WebSession::WebSocketStream::Client outgoing)
-      : outgoing(kj::mv(outgoing)),
-        writeTasks(*this) {}
+      : outgoing(kj::mv(outgoing)) {}
 
   WebSession::WebSocketStream::Client getIncomingStreamCapability() {
     return kj::heap<WebSocketStreamImpl>(kj::addRef(*this));
@@ -531,7 +529,7 @@ public:
   kj::Promise<void> write(const void* buffer, size_t size) override {
     auto req = KJ_REQUIRE_NONNULL(outgoing, "already called shutdownWrite()").sendBytesRequest();
     req.setMessage(kj::arrayPtr(reinterpret_cast<const byte*>(buffer), size));
-    return writeImpl(size, kj::mv(req));
+    return req.send();
   }
 
   kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) override {
@@ -550,45 +548,11 @@ public:
     }
     KJ_ASSERT(pos == builder.end());
 
-    return writeImpl(size, kj::mv(req));
+    return req.send();
   }
 
   kj::Promise<void> whenWriteDisconnected() override {
     return kj::NEVER_DONE;
-  }
-
-private:
-  kj::Promise<void> writeImpl(size_t size,
-      capnp::StreamingRequest<WebSession::WebSocketStream::SendBytesParams>&& req) {
-    KJ_IF_MAYBE(e, writeError) {
-      return kj::cp(*e);
-    }
-
-    writeTasks.add(req.send().then([this,size]() {
-      bytesInFlight -= size;
-      if (bytesInFlight < MAX_IN_FLIGHT) {
-        KJ_IF_MAYBE(f, writeReadyFulfiller) {
-          f->get()->fulfill();
-        }
-      }
-    }));
-    bytesInFlight += size;
-
-    if (bytesInFlight < MAX_IN_FLIGHT) {
-      return kj::READY_NOW;
-    } else {
-      auto paf = kj::newPromiseAndFulfiller<void>();
-      writeReadyFulfiller = kj::mv(paf.fulfiller);
-      return kj::mv(paf.promise);
-    }
-  }
-
-  void taskFailed(kj::Exception&& exception) override {
-    KJ_IF_MAYBE(f, writeReadyFulfiller) {
-      f->get()->reject(kj::mv(exception));
-      writeReadyFulfiller = nullptr;
-    }
-    writeError = kj::mv(exception);
   }
 
 public:
@@ -706,12 +670,7 @@ public:
 
 private:
   // Outgoing direction.
-  static constexpr size_t MAX_IN_FLIGHT = 65536;
-  size_t bytesInFlight = 0;
-  kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> writeReadyFulfiller;
-  kj::Maybe<kj::Exception> writeError;
   kj::Maybe<WebSession::WebSocketStream::Client> outgoing;
-  kj::TaskSet writeTasks;
 
   // Incoming direction.
   struct CurrentWrite {

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -463,7 +463,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   }
 
   interface WebSocketStream {
-    sendBytes @0 (message :Data);
+    sendBytes @0 (message :Data) -> stream;
     # Send some bytes.  WARNING:  At present, we just send the raw bytes of the WebSocket protocol.
     # In the future, this will be replaced with a `sendMessage()` method that sends one WebSocket
     # datagram at a time.


### PR DESCRIPTION
...to take advantage of the new flow-control stuff in capnp 0.8

This also requires some mechanical changes to the C++ uses of these,
but it's mostly just a matter of dropping some calls to ignoreResult()
and the like.

Closes #3373