### PR TITLE
Updated cron script for extracting certificates

### DIFF
--- a/docs/administering/ssl.md
+++ b/docs/administering/ssl.md
@@ -44,10 +44,11 @@ To share port 443 with other services on the same machine:
 - You [can install `sniproxy` to share port 443](sniproxy.md) between your existing server and Sandstorm so that
   Sandstorm can manage (and autorenew) its own certificates. This allows you to combine an **existing
   web server on port 443** with Sandstorm.
-  
+
 - You [can follow this guide](https://web.archive.org/web/20190922195059/https://juanjoalvarez.net/es/detail/2017/jan/12/how-set-sandstorm-behind-reverse-proxy-keeping-you/)
-  that explains how to use a [cron script](https://github.com/Michael-S/sandstorm_certs_extract_cron)
-  to extract the certificates from your Sandstorm-managed TLS Sandstorm installation. Please note that the
-  guide itself references an older cron script that does not work with Sandstorm versions newer than
-  June 2020. The extracted certificates will be a format where your reverse proxy can use them so it can
-  serve Sandstorm by HTTPS along with any other services on your server.
+  that explains how to use a cron script to extract the certificates from your installation with
+  Sandstorm-managed TLS. Please note that the guide itself references an older cron script that
+  does not work with Sandstorm versions newer than June 2020, but there is an updated script
+  [here](https://github.com/Michael-S/sandstorm_certs_extract_cron). The extracted certificates
+  will be formatted so your reverse proxy can use them to serve Sandstorm by HTTPS
+  along with any other services on your server.

--- a/docs/administering/ssl.md
+++ b/docs/administering/ssl.md
@@ -47,8 +47,7 @@ To share port 443 with other services on the same machine:
   
 - You [can follow this guide](https://web.archive.org/web/20190922195059/https://juanjoalvarez.net/es/detail/2017/jan/12/how-set-sandstorm-behind-reverse-proxy-keeping-you/)
   that explains how to use a [cron script](https://github.com/Michael-S/sandstorm_certs_extract_cron)
-  to extract the certificates from your (sandcats.io enabled) Sandstorm installation. Please note that the
+  to extract the certificates from your Sandstorm-managed TLS Sandstorm installation. Please note that the
   guide itself references an older cron script that does not work with Sandstorm versions newer than
   June 2020. The extracted certificates will be a format where your reverse proxy can use them so it can
-  serve Sandstorm by HTTPS, keeping your sandcats.io domain and free auto-renewable certificates, along
-  with any other services on your server.
+  serve Sandstorm by HTTPS along with any other services on your server.

--- a/docs/administering/ssl.md
+++ b/docs/administering/ssl.md
@@ -46,7 +46,9 @@ To share port 443 with other services on the same machine:
   web server on port 443** with Sandstorm.
   
 - You [can follow this guide](https://web.archive.org/web/20190922195059/https://juanjoalvarez.net/es/detail/2017/jan/12/how-set-sandstorm-behind-reverse-proxy-keeping-you/)
-  that explains how to use a [cron script](https://github.com/juanjux/sandstorm-sandcats-cert-installer) 
-  to extract the certificates from your (sandcats.io enabled) Sandstorm installation to a location and 
-  format where your reverse proxy can use them so it can serve Sandstorm by HTTPS, keeping your 
-  sandcats.io domain and free auto-renewable certificates, along with any other services on your server.
+  that explains how to use a [cron script](https://github.com/Michael-S/sandstorm_certs_extract_cron)
+  to extract the certificates from your (sandcats.io enabled) Sandstorm installation. Please note that the
+  guide itself references an older cron script that does not work with Sandstorm versions newer than
+  June 2020. The extracted certificates will be a format where your reverse proxy can use them so it can
+  serve Sandstorm by HTTPS, keeping your sandcats.io domain and free auto-renewable certificates, along
+  with any other services on your server.


### PR DESCRIPTION
The original script to extract Sandcats certificates no longer works,
per Sandstorm issue #3370.  This is an attempt at a new script that
appears to work properly.

The new script could also be copied to a repository owned by the
Sandstorm project or one of the committers, and it's trivial shell
commands so I'm happy to relicense it upon request.