### PR TITLE
Clarify installer downloads over HTTPS

### DIFF
--- a/docs/administering/install-script.md
+++ b/docs/administering/install-script.md
@@ -42,7 +42,7 @@ If you run `install.sh -h`, you will see a message like:
 usage: ./install.sh [-d] [-e] [-u] [<bundle>]
 If <bundle> is provided, it must be the name of a Sandstorm bundle file,
 like 'sandstorm-123.tar.xz', which will be installed. Otherwise, the script
-downloads a bundle from the internet via HTTP.
+downloads a bundle from the internet via HTTPS.
 
 If -d is specified, the auto-installs with defaults suitable for app development.
 If -e is specified, default to listening on an external interface, not merely loopback.

--- a/install.sh
+++ b/install.sh
@@ -311,7 +311,7 @@ usage() {
   echo "usage: $SCRIPT_NAME [-d] [-e] [-p PORT_NUMBER] [-u] [<bundle>]" >&2
   echo "If <bundle> is provided, it must be the name of a Sandstorm bundle file," >&2
   echo "like 'sandstorm-123.tar.xz', which will be installed. Otherwise, the script" >&2
-  echo "downloads a bundle from the internet via HTTP." >&2
+  echo "downloads a bundle from the internet via HTTPS." >&2
   echo '' >&2
   echo 'If -d is specified, the auto-installs with defaults suitable for app development.' >&2
   echo 'If -e is specified, default to listening on an external interface, not merely loopback.' >&2


### PR DESCRIPTION
I read this in the Docs, and I was briefly like "I sure hope we don't download the bundle using HTTP". Which, of course, we don't. It was a quote from text in the installer script, so I fixed it in both places.