### PR TITLE
Fix a typo in the install script and docs

### DIFF
--- a/docs/administering/install-script.md
+++ b/docs/administering/install-script.md
@@ -47,7 +47,7 @@ downloads a bundle from the internet via HTTP.
 If -d is specified, the auto-installs with defaults suitable for app development.
 If -e is specified, default to listening on an external interface, not merely loopback.
 If -i is specified, default to (i)nsecure mode where we do not request a HTTPS certificate.
-If -u is specified, default to avoiding root priviliges. Note that the dev tools only work if the server as root privileges.
+If -u is specified, default to avoiding root priviliges. Note that the dev tools only work if the server has root privileges.
 ```
 
 The `-d` option will use **development defaults** for all options, creating a fully non-interactive

--- a/install.sh
+++ b/install.sh
@@ -317,7 +317,7 @@ usage() {
   echo 'If -e is specified, default to listening on an external interface, not merely loopback.' >&2
   echo 'If -i is specified, default to (i)nsecure mode where we do not request a HTTPS certificate.' >&2
   echo 'If -p is specified, use its argument (PORT_NUMBER) as the default port for HTTP. Otherwise, use 6080. Note that if the install script enables HTTPS via sandcats.io, it will use 443 instead!'
-  echo 'If -u is specified, default to avoiding root priviliges. Note that the dev tools only work if the server as root privileges.' >&2
+  echo 'If -u is specified, default to avoiding root priviliges. Note that the dev tools only work if the server has root privileges.' >&2
   exit 1
 }
 


### PR DESCRIPTION
Noticed this while reading the discussion in #3379.