### PR TITLE
Remove stray HTTPS = sandcats.io in installer text

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -316,7 +316,7 @@ usage() {
   echo 'If -d is specified, the auto-installs with defaults suitable for app development.' >&2
   echo 'If -e is specified, default to listening on an external interface, not merely loopback.' >&2
   echo 'If -i is specified, default to (i)nsecure mode where we do not request a HTTPS certificate.' >&2
-  echo 'If -p is specified, use its argument (PORT_NUMBER) as the default port for HTTP. Otherwise, use 6080. Note that if the install script enables HTTPS via sandcats.io, it will use 443 instead!'
+  echo 'If -p is specified, use its argument (PORT_NUMBER) as the default port for HTTP. Otherwise, use 6080. Note that if the install script enables HTTPS, it will use 443 instead!'
   echo 'If -u is specified, default to avoiding root priviliges. Note that the dev tools only work if the server has root privileges.' >&2
   exit 1
 }


### PR DESCRIPTION
No longer true just for Sandcats.io.