### PR TITLE
ExternalWebSession: avoid extra slashes when the path is ""

### DIFF
--- a/shell/imports/server/drivers/external-ui-view.js
+++ b/shell/imports/server/drivers/external-ui-view.js
@@ -417,6 +417,8 @@ class ExternalWebSession extends PersistentImpl {
         //
         // TODO(soon): Once apps have updated, prepend "/" unconditionally.
         options.path = path.startsWith("/") ? path : "/" + path;
+      } else if(path === "") {
+        options.path = this.path;
       } else {
         options.path = this.path + "/" + path;
       }


### PR DESCRIPTION
Currently, if the caller makes a request to an ExternalWebSession with
path = "", An extra trailing slash is appended to the URL. This makes
capabilities for non-"directory" URLs useless; e.g. if the
ExternalWebSession points to the URL:

    http://example.com/rss.xml

Then when trying to fetch that exact URL (rather than something under
it), the requested URL will most likely be:

    http://example.com/rss.xml/

...which will probably result in 404.

This patch fixes the behavior, such that no additional slash is added if
path = "".