### PR TITLE
Disable HTTP access through hack-session.

### DIFF
--- a/shell/imports/sandstorm-db/db.js
+++ b/shell/imports/sandstorm-db/db.js
@@ -1131,6 +1131,23 @@ class SandstormDb {
     };
   }
 
+  allowLegacyHackSessionHttp() {
+    // Returns true iff the legacy hack-session http-related methods have been
+    // enabled. It is only possible to set this by directly manipulating the
+    // mongo database:
+    //
+    // $ sandstorm mongo
+    // ssrs:PRIMARY> db.settings.upsert({_id: "allowLegacyHackSessionHttp", value: true})
+    //
+    // Soon, these interfaces will be removed entirely and this setting will no longer
+    // be recognized. This is intentionally undocumented; if anyone actually needs this
+    // during the transition, we want them to come talk to us about it. If the setting
+    // is disabled, the relevant error messages direct developers to use the new API,
+    // and ask the mailing list if they need help.
+    const row = this.collections.settings.findOne({_id: "allowLegacyHackSessionHttp"})
+    return (row !== null) && row.value
+  }
+
   isAdmin() {
     // Returns true if the user is the administrator.
 

--- a/src/sandstorm/hack-session.capnp
+++ b/src/sandstorm/hack-session.capnp
@@ -49,17 +49,9 @@ interface HackSessionContext @0xe14c1f5321159b8f
   #   special. Do not create these directories unless you intend for them to serve their respective
   #   purposes.
 
-  httpGet @1 (url: Text) -> (mimeType :Text, content :Data);
-  # Perform a simple HTTP GET request, returning the content. Note that this hack is especially
-  # temporary because it allows apps to trivially leak data. Longer-term, we want the user to
-  # explicitly approve communications with external servers. However, since we don't have the
-  # infrastrucutre for that yet, and we really want an RSS reader on Sandstorm, we're temporarily
-  # adding this. As of this writing, it's possible to issue arbitrary HTTP requests from the client
-  # side anyway.
-  #
-  # This interface is very limited currently -- e.g. it does not support arbitrary headers, POSTs,
-  # etc. If you need any of these things, talk to the Sandstorm developers and we'll consider
-  # adding some more hacks, but, again, this will all go away once the Powerbox is implemented.
+  obsoleteHttpGet @1 (url: Text) -> (mimeType :Text, content :Data);
+  obsoleteGetUiViewForEndpoint @8 (url :Text) -> (view :Grain.UiView);
+  # OBSOLETE. Apps that need to make HTTP connections should use the powerbox.
 
   getUserAddress @2 () -> Email.EmailAddress;
   # Returns the address of the owner of the grain.
@@ -69,18 +61,6 @@ interface HackSessionContext @0xe14c1f5321159b8f
   obsoleteListApiTokens @4 () -> (tokens :List(TokenInfo));
   obsoleteRevokeApiToken @5 (tokenId :Text);
   # OBSOLETE. Apps that need to present API tokens to users should use offer templates.
-
-  getUiViewForEndpoint @8 (url :Text) -> (view :Grain.UiView);
-  # There are 3 cases here that are seamlessly handled by the platform
-  # 1. If the URL is a local webkey, return a wrapped version of the UiView that respects user
-  # permissions
-  # 2. If the URL is a remote webkey (i.e. a different Sandstorm server), set up an ApiSession
-  # that sends the Authorization header correctly. We wrap it in a UiVew so that this is seamless.
-  # Some day, we'll connect via Cap'n Proto instead, and actually return the remote UiView
-  # verbatim.
-  # 3. If the URL is not a webkey at all, wrap it the same as #2, but don't send an Authorization
-  # header.
-  # If the url is a webkey, then your url must not contain a path.
 
   struct TokenInfo {
     tokenId @0 :Text;


### PR DESCRIPTION
Per the comments in db.js, it is still possible to re-enable this for
now, through an un-documented database setting that users will have to
ask us about to learn of. In the comments for #3192 we'd planned on
making this an option in sandstorm.conf, but this is a bit easier to
implement and given that we're intentionally avoiding documenting this,
requiring people who need it to pop open `sandstorm mongo` seems fine.

When we finally remove this, we'll want to add a database migration that
deletes the setting.

---

It's up for discussion *when* we merge this; we could have it land in the next release if folks thing that's reasonable (that gives folks a few weeks to get the ttrss update). I could be talked into putting it off for another release if others think that's too soon.

We should also decide how long we're going to wait between this landing and actually outright removing the functionality.