### PR TITLE
Fix incorrect formatting of qValue in accept header.

### DIFF
--- a/shell/imports/server/drivers/external-ui-view.js
+++ b/shell/imports/server/drivers/external-ui-view.js
@@ -429,7 +429,7 @@ class ExternalWebSession extends PersistentImpl {
       // set accept header
       if ("accept" in context) {
         options.headers.accept = context.accept.map((acceptedType) => {
-          return acceptedType.mimeType + "; " + acceptedType.qValue;
+          return acceptedType.mimeType + "; q=" + acceptedType.qValue;
         }).join(", ");
       } else if (!("accept" in options.headers)) {
         options.headers.accept = "*/*";


### PR DESCRIPTION
This was the source of https://github.com/zenhack/ttrss-sandstorm/issues/14;
Sandstorm was sending an accept header with the value `*/*; 1`, but the
correct syntax is `*/*; q=1`, and Discourse is apparently stricter than
most web servers on this point.