### PR TITLE
Content security policy for grains.

### DIFF
--- a/src/sandstorm/config.c++
+++ b/src/sandstorm/config.c++
@@ -264,6 +264,13 @@ Config readConfig(const char *path, bool parseUids) {
       config.stripeKey = kj::mv(value);
     } else if (key == "STRIPE_PUBLIC_KEY") {
       config.stripePublicKey = kj::mv(value);
+    } else if (key == "ALLOW_LEGACY_RELAXED_CSP") {
+      KJ_LOG(WARNING,
+          "The option ALLOW_LEGACY_RELAXED_CSP will be removed "
+          "soon. Apps that rely on loading thrid party resources "
+          "should be modified to embed those resources in the app "
+          "package instead.");
+      config.allowLegacyRelaxedCSP = value == "true" || value == "yes";
     } else {
       KJ_LOG(WARNING, "Ignoring unrecognized config option", key);
     }

--- a/src/sandstorm/config.h
+++ b/src/sandstorm/config.h
@@ -32,6 +32,8 @@ struct Config {
   kj::Maybe<kj::String> termsPublicId = nullptr;
   kj::Maybe<kj::String> stripeKey = nullptr;
   kj::Maybe<kj::String> stripePublicKey = nullptr;
+
+  bool allowLegacyRelaxedCSP = false;
 };
 
 // Read and return the config file from `path`.

--- a/src/sandstorm/gateway.c++
+++ b/src/sandstorm/gateway.c++
@@ -442,8 +442,8 @@ kj::Maybe<kj::Own<kj::HttpService>> GatewayService::getUiBridge(kj::HttpHeaders&
     capnp::MallocMessageBuilder requestMessage(128);
     auto params = requestMessage.getRoot<WebSession::Params>();
 
-    auto basePath = kj::str(baseUrl.scheme, "://",
-        KJ_ASSERT_NONNULL(headers.get(kj::HttpHeaderId::HOST)));
+    kj::StringPtr host = KJ_ASSERT_NONNULL(headers.get(kj::HttpHeaderId::HOST));
+    auto basePath = kj::str(baseUrl.scheme, "://", host);
     params.setBasePath(basePath);
     params.setUserAgent(headers.get(tables.hUserAgent).orDefault("UnknownAgent/0.0"));
 
@@ -503,7 +503,8 @@ kj::Maybe<kj::Own<kj::HttpService>> GatewayService::getUiBridge(kj::HttpHeaders&
       timer.now(),
       kj::refcounted<WebSessionBridge>(timer, sessionRedirector.castAs<WebSession>(),
                                        Handle::Client(kj::mv(loadingPaf.promise)),
-                                       tables.bridgeTables, options)
+                                       tables.bridgeTables, options,
+                                       kj::str(host), kj::str(baseUrl.host))
     };
     auto insertResult = uiHosts.insert(std::make_pair(key, kj::mv(entry)));
     KJ_ASSERT(insertResult.second);

--- a/src/sandstorm/gateway.h
+++ b/src/sandstorm/gateway.h
@@ -78,7 +78,7 @@ public:
 
   GatewayService(kj::Timer& timer, kj::HttpClient& shellHttp, GatewayRouter::Client router,
                  Tables& tables, kj::StringPtr baseUrl, kj::StringPtr wildcardHost,
-                 kj::Maybe<kj::StringPtr> termsPublicId);
+                 kj::Maybe<kj::StringPtr> termsPublicId, bool allowLegacyRelaxedCSP);
 
   kj::Promise<void> cleanupLoop();
   // Must run this to purge expired capabilities.
@@ -147,6 +147,8 @@ private:
   bool isPurging = false;
 
   kj::TaskSet tasks;
+
+  bool allowLegacyRelaxedCSP;
 
   kj::Promise<void> send401Unauthorized(Response& response);
   kj::Promise<void> sendError(

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -2476,7 +2476,8 @@ private:
       GatewayService service(io.provider->getTimer(), *shellHttp, kj::cp(router),
                              gatewayTables, config.rootUrl, config.wildcardHost,
                              config.termsPublicId.map(
-                                 [](const kj::String& str) -> kj::StringPtr { return str; }));
+                                 [](const kj::String& str) -> kj::StringPtr { return str; }),
+                             config.allowLegacyRelaxedCSP);
 
       kj::HttpHeaderId hXRealIp = headerTableBuilder.add("X-Real-Ip");
 

--- a/src/sandstorm/web-session-bridge.c++
+++ b/src/sandstorm/web-session-bridge.c++
@@ -1287,20 +1287,20 @@ kj::Promise<void> WebSessionBridge::handleResponse(
           tables.hContentSecurityPolicy,
           kj::str(
             "default-src 'none'; "
-#define UNSAFE "'unsafe-inline' 'unsafe-eval' data:; "
+#define UNSAFE "'unsafe-inline' 'unsafe-eval' data: blob:; "
             "img-src * " UNSAFE
             "media-src * " UNSAFE
             "script-src 'self' " UNSAFE
             "style-src 'self' " UNSAFE
             "child-src 'self' " UNSAFE
             "worker-src 'self' " UNSAFE
+            "font-src 'self' " UNSAFE
 
             // frame-src needs to allow references to BASE_URL, because
             // we allow apps to pull the content of offer-iframes from
             // there:
             "frame-src 'self' ", baseHttpHost, " ", UNSAFE
 #undef UNSAFE
-            "font-src 'self'; "
 
             // 'self' alone does not allow websocket connections; see:
             // https://github.com/w3c/webappsec-csp/issues/7

--- a/src/sandstorm/web-session-bridge.h
+++ b/src/sandstorm/web-session-bridge.h
@@ -84,7 +84,9 @@ public:
 
   WebSessionBridge(kj::Timer& timer, WebSession::Client session,
                    kj::Maybe<Handle::Client> loadingIndicator,
-                   const Tables& tables, Options options);
+                   const Tables& tables, Options options,
+                   kj::Maybe<kj::String>&& host = nullptr,
+                   kj::Maybe<kj::String>&& baseHost = nullptr);
 
   void restrictParentFrame(kj::StringPtr parent, kj::StringPtr self);
   // Return headers that prevents any origin except the designated one from framing us.
@@ -117,6 +119,7 @@ private:
   kj::Maybe<Handle::Client> loadingIndicator;
   const Tables& tables;
   Options options;
+  kj::Maybe<kj::String> host, baseHost;
 
   struct FrameRestriction {
     kj::String parent;

--- a/src/sandstorm/web-session-bridge.h
+++ b/src/sandstorm/web-session-bridge.h
@@ -86,7 +86,8 @@ public:
                    kj::Maybe<Handle::Client> loadingIndicator,
                    const Tables& tables, Options options,
                    kj::Maybe<kj::String>&& host = nullptr,
-                   kj::Maybe<kj::String>&& baseHost = nullptr);
+                   kj::Maybe<kj::String>&& baseHost = nullptr,
+                   bool allowLegacyRelaxedCSP = false);
 
   void restrictParentFrame(kj::StringPtr parent, kj::StringPtr self);
   // Return headers that prevents any origin except the designated one from framing us.
@@ -120,6 +121,7 @@ private:
   const Tables& tables;
   Options options;
   kj::Maybe<kj::String> host, baseHost;
+  bool allowLegacyRelaxedCSP;
 
   struct FrameRestriction {
     kj::String parent;


### PR DESCRIPTION
This blocks grains from loading external resources, with the exception
of images and media (per the comment, there are legitimate uses for
these that we want to allow; eventually we'll want the user to
specifically approve these).

---

While the pr itself is complete, before this lands we need to go through and find apps that this breaks, and maybe fix/update them. So far I've lightly tested:

- Davros
- uWiki
- Etherpad
- Ethercalc
- Draw.io
- Rocket.Chat
- Contact Otter
- ttrss

Of these, the following problems arose:

- [ ] Draw.io seems to be trying to pull in MathJax from a cdn, so I assume rendering some formulae will break
- [ ] As @orblivion pointed out on the mailing list, uWiki pulls in some third party resources, @ocdtrekkie is already working on it.
- [ ] Contact otter tries to pull in styles and scripts from elsewhere. At least the styles should be pulled in to the package. Google analytics should of course remain broken, as that's the whole point of all this.

The others shook out some bugs in the policy but trigger no violations with the current iteration. We should go through other apps to see what else breaks.