### PR TITLE
Flip the default for ALLOW_LEGACY_RELAXED_CSP to true.

### DIFF
--- a/src/sandstorm/config.h
+++ b/src/sandstorm/config.h
@@ -33,7 +33,7 @@ struct Config {
   kj::Maybe<kj::String> stripeKey = nullptr;
   kj::Maybe<kj::String> stripePublicKey = nullptr;
 
-  bool allowLegacyRelaxedCSP = false;
+  bool allowLegacyRelaxedCSP = true;
 };
 
 // Read and return the config file from `path`.


### PR DESCRIPTION
We'll roll this out a bit more cautiously: ship it off by default, ask
people to test, once we stop getting bug reports then we can flip it
back on.