### PR TITLE
Update docs: Remove mention of Sandcats HTTPS certificate service

### DIFF
--- a/docs/administering/sandcats-https.md
+++ b/docs/administering/sandcats-https.md
@@ -99,8 +99,8 @@ GitHub websites.
 
 ### Technical details
 
-**Automatic renewal.** Sandstorm's built-in HTTPS uses the
-[Sandcats.io service](sandcats.md) to renew certificates without
+**Automatic renewal.** Sandstorm's built-in HTTPS uses
+[Let's Encrypt](https://letsencrypt.org/) to renew certificates without
 needing any manual intervention.
 
 <!--

--- a/docs/administering/sandcats.md
+++ b/docs/administering/sandcats.md
@@ -1,6 +1,6 @@
 # About Sandcats.io
 
-Sandcats.io is a free-of-cost dynamic DNS service and HTTPS certificate service run by the Sandstorm
+Sandcats.io is a free-of-cost dynamic DNS service run by the Sandstorm
 development team. In a nutshell:
 
 * Sandstorm users can have a free domain name of the form `example.sandcats.io`.
@@ -36,37 +36,6 @@ The Sandcats DNS service provides **60-second** latency for IP address updates v
 protocol to detect address changes. To achieve this low latency, when Sandcats integration is
 enabled, your Sandstorm server sends a UDP ping message to the central Sandcats service every 60
 seconds.
-
-The Sandcats certificate service (for providing users with valid HTTPS) provides seven-day
-certificates and an API for automatic renewal.
-
-Sandcats uses **HTTPS client certificates** for authentication, which Sandstorm and the install
-script manage for users. You can find these certificates under `/opt/sandstorm/var/sandcats` by
-default. Please save these somewhere safe so you can hold onto your domain.
-
-# How the HTTPS service works
-
-The Sandstorm install script, when it runs on your server, generates a private key and certificate
-signing request that it sends to the Sandcats.io service (via the `/getcertificate` JSON-RPC
-endpoint).
-
-Sandcats verifies that the request is coming from the owner of this particular `example.sandcats.io`
-domain name, and if so, passes the request along to GlobalSign for signing. The install script
-receives the signed certificate and places it in
-`/opt/sandstorm/var/sandcats/https/example.sandcats.io/`.
-
-When Sandstorm starts, it looks in the above directory for keys & certificates and uses the first
-certificate that is valid.
-
-These certificates expire weekly, so Sandstorm also checks every (approximately) 2 hours if the
-certificate it is using is on the last 3 days of its lifetime. If so, Sandstorm takes the same
-action as the install script: generate new key, generate certificate signing request, send that to
-Sandcats.io, store the response. (As an implementation detail, these certs technically last 9 days,
-but we renew them every 7 days.)
-
-Sandstorm automatically starts using new certificates without needing intervention from the server
-operator. You can read the code that powers that in `meteor-bundle-main.js` in the `sandstorm` git
-repository.
 
 # Administering your sandcats.io subdomain
 
@@ -179,12 +148,6 @@ running the `install.sh` script. We call that **file-based recovery.** Here are 
   <myname>.sandcats.io` from another machine. This will help eliminate DNS as an issue when trying
   to access your server.
 
-Note that if you are using sandcats.io free HTTPS certificates, we suggest also backing up and
-restoring the contents of `/opt/sandstorm/var/sandcats/https`. This is a suggestion rather than a
-hard requirement; Sandstorm will request new certificates at startup. However, if your server makes
-lots of requests, you will run afoul of the sandcats.io anti-abuse protections. See the [Diagnosing
-"Not Authorized" problems](#diagnosing-not-authorized-problems) section for details.
-
 ## Diagnosing "Not Authorized" problems
 
 If you see `Not Authorized` in your log files, the sandcats.io service is returning HTTP code 403
@@ -197,13 +160,7 @@ registered with `sandcats.io`, you can move them to whichever server you want us
 recovery.
 
 Another reason you might see `Not Authorized` in the log files is if your server has run afoul of
-sandcats.io's defense in depth against Sandstorm bugs. The HTTPS certificate service within
-`sandcats.io` will reject new certificate requests if your server has more than approximately 5
-active certificates per week; this code exists to prevent a Sandstorm bug from requesting many
-thousands of certificates. If you are constantly requesting new certificates, you can request only
-about 5 before being automatically blocked in this way.  Typically, your server will keep retrying
-and the sandcats.io service will permit it to get certificates again when one of your certificates
-expire.
+sandcats.io's defense in depth against Sandstorm bugs.
 
 In either case, if you need further help, please email support@sandstorm.io!
 


### PR DESCRIPTION
Use of the Sandcats certificate service was [removed in Sandstorm v0.269](https://github.com/sandstorm-io/sandstorm/commit/93d80ac4bf2ca721f239fb58395a32970f92e953).