### PR TITLE
Remove obsolete messges re: oasis.

### DIFF
--- a/shell/imports/client/apps/applist.html
+++ b/shell/imports/client/apps/applist.html
@@ -3,21 +3,6 @@
   {{#sandstormTopbarItem name="title" priority=5 topbar=globalTopbar }}{{_ "apps.title"}}{{/sandstormTopbarItem}}
   {{#if isSignedUpOrDemo}}
   <div class="app-list">
-    {{#if freePlanGoingAway}}
-      <div class="free-plan-going-away">
-        <button class="upgrade-plan-now button-primary">Upgrade now</button>
-        Starting October 14, 2018, the Free plan will no longer allow creating grains, only accessing grains shared by others. Pre-existing data will remain available for download. <a href="https://sandstorm.io/news/2018-08-27-discontinuing-free-plan" target="_blank">Learn more »</a>
-      </div>
-    {{/if}}
-
-    {{#if oasisShuttingDown}}
-      <div class="oasis-shutting-down">
-        Sandstorm Oasis will shut down on December 31, 2019. Consider <a href="/transfers">transfering</a>
-        your data to a self-hosted server.
-        <a href="https://sandstorm.io/news/2019-09-15-shutting-down-oasis" target="_blank">Learn more »</a>
-      </div>
-    {{/if}}
-
     <h1>{{_ "apps.title"}}
       <form class="standard-form">
         <div class="button-row">

--- a/shell/imports/client/grain/grainlist.html
+++ b/shell/imports/client/grain/grainlist.html
@@ -2,21 +2,6 @@
   {{setDocumentTitle}}
   {{#sandstormTopbarItem name="title" priority=5 topbar=globalTopbar }}{{_ "grains.title"}}{{/sandstormTopbarItem}}
   <div class="grain-list">
-    {{#if freePlanGoingAway}}
-      <div class="free-plan-going-away">
-        <button class="upgrade-plan-now button-primary">Upgrade now</button>
-        Starting October 14, 2018, the Free plan will no longer allow creating grains, only accessing grains shared by others. Pre-existing data will remain available for download. <a href="https://sandstorm.io/news/2018-08-27-discontinuing-free-plan" target="_blank">Learn more »</a>
-      </div>
-    {{/if}}
-
-    {{#if oasisShuttingDown}}
-      <div class="oasis-shutting-down">
-        Sandstorm Oasis will shut down on December 31, 2019. Consider <a href="/transfers">transfering</a>
-        your data to a self-hosted server.
-        <a href="https://sandstorm.io/news/2019-09-15-shutting-down-oasis" target="_blank">Learn more »</a>
-      </div>
-    {{/if}}
-
     <h1>
       <div>
         {{_ "grains.title"}} <button title="{{_ "grains.grainlist.sandstormGrainListPage.introButton.hint"}}" class="question-mark"></button>

--- a/shell/imports/client/shell-client.js
+++ b/shell/imports/client/shell-client.js
@@ -703,17 +703,6 @@ Template.registerHelper("con", function () {
   return Array.prototype.slice.call(arguments, 0, -1).join('.')
 });
 
-Template.registerHelper("freePlanGoingAway", function () {
-  return Meteor.settings.public.stripePublicKey &&
-      (Meteor.user().plan || "free") === "free" &&
-      globalDb.getMyPlan().grains > 0 &&
-      !globalDb.isDemoUser();
-});
-
-Template.registerHelper("oasisShuttingDown", function () {
-  return globalDb.getServerTitle() == "Sandstorm Oasis";
-});
-
 Template.root.helpers({
   storageUsage: function () {
     return Meteor.userId() ? prettySize(Meteor.user().storageUsage || 0) : undefined;


### PR DESCRIPTION
Both of these events have come to pass; we don't need the notification
code for them any more.