### PR TITLE
Remove an obsolete reference to oasis.

### DIFF
--- a/shell/imports/client/grain.html
+++ b/shell/imports/client/grain.html
@@ -25,10 +25,6 @@
       {{else if quotaExhausted}}
         <p class="grain-quota-exhausted grain-interstitial">
           {{_ "grains.grainView.quotaExhausted"}}
-          {{#if paymentsEnabled}}
-            <br>
-            <a target="_blank" href="https://sandstorm.io/news/2018-10-18-how-to-download-oasis-data">If the owner was on the free plan, this could be because Oasis's free plan was discontinued on October 17, 2018. Please click here for more details.</a>
-          {{/if}}
         </p>
       {{else if missingPackage}}
         <p class="grain-interstitial">


### PR DESCRIPTION
Oasis doesn't exist anymore, so if this message ever triggers it will just be confusing.