### PR TITLE
Add comment CSRF headers to whitelist.

### DIFF
--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -164,6 +164,10 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       "x-hgarg-*",             # Mercurial client
       "x-phabricator-*",       # Phabricator
       "x-requested-with",      # JQuery header used by Rails and other frameworks
+
+      # Headers used for csrf protection by various frameworks:
+      "x-csrftoken",
+      "x-csrf-token",
     ];
   }
 


### PR DESCRIPTION
This adds headers mentioned in the discussion on #457 to the
additionalHeaders whitelist. We could add more if people want to audit
additional frameworks, but this is a start.