### PR TITLE
Fix a path traversal vulnerability involving static publishing.

### DIFF
--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -2211,7 +2211,7 @@ public:
 
     auto sandboxDir = raiiOpen("sandbox", O_RDONLY);
     KJ_IF_MAYBE(wwwDir, raiiOpenAtIfExists(sandboxDir.get(), "www", O_RDONLY|O_NOFOLLOW)) {
-      KJ_IF_MAYBE(fd, raiiOpenAtIfExistsContained(wwwDir->get(), path, O_RDONLY)) {
+      KJ_IF_MAYBE(fd, raiiOpenAtIfExistsContained(wwwDir->get(), kj::Path(path), O_RDONLY)) {
         struct stat stats;
         KJ_SYSCALL(fstat(*fd, &stats));
 

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -2209,31 +2209,32 @@ public:
       }
     }
 
-    auto fullPath = kj::str("sandbox/www/", path);
-    KJ_IF_MAYBE(fd, raiiOpenIfExists(fullPath, O_RDONLY)) {
-      struct stat stats;
-      KJ_SYSCALL(fstat(*fd, &stats));
+    auto sandboxDir = raiiOpen("sandbox", O_RDONLY);
+    KJ_IF_MAYBE(wwwDir, raiiOpenAtIfExists(sandboxDir.get(), "www", O_RDONLY|O_NOFOLLOW)) {
+      KJ_IF_MAYBE(fd, raiiOpenAtIfExistsContained(wwwDir->get(), path, O_RDONLY)) {
+        struct stat stats;
+        KJ_SYSCALL(fstat(*fd, &stats));
 
-      if (S_ISREG(stats.st_mode)) {
-        auto stream = params.getStream();
-        context.releaseParams();
-        auto req = stream.expectSizeRequest();
-        req.setSize(stats.st_size);
-        auto expectSizeTask = req.send();
-        auto inStream = kj::heap<kj::FdInputStream>(kj::mv(*fd));
-        return pump(*inStream, kj::mv(stream)).attach(kj::mv(inStream), kj::mv(expectSizeTask));
-      } else if (S_ISDIR(stats.st_mode)) {
-        context.getResults(capnp::MessageSize {4, 0})
-            .setStatus(Supervisor::WwwFileStatus::DIRECTORY);
-        return kj::READY_NOW;
-      } else {
-        KJ_FAIL_ASSERT("not a regular file");
+        if (S_ISREG(stats.st_mode)) {
+          auto stream = params.getStream();
+          context.releaseParams();
+          auto req = stream.expectSizeRequest();
+          req.setSize(stats.st_size);
+          auto expectSizeTask = req.send();
+          auto inStream = kj::heap<kj::FdInputStream>(kj::mv(*fd));
+          return pump(*inStream, kj::mv(stream)).attach(kj::mv(inStream), kj::mv(expectSizeTask));
+        } else if (S_ISDIR(stats.st_mode)) {
+          context.getResults(capnp::MessageSize {4, 0})
+              .setStatus(Supervisor::WwwFileStatus::DIRECTORY);
+          return kj::READY_NOW;
+        } else {
+          KJ_FAIL_ASSERT("not a regular file");
+        }
       }
-    } else {
-      context.getResults(capnp::MessageSize {4, 0})
-          .setStatus(Supervisor::WwwFileStatus::NOT_FOUND);
-      return kj::READY_NOW;
     }
+    context.getResults(capnp::MessageSize {4, 0})
+        .setStatus(Supervisor::WwwFileStatus::NOT_FOUND);
+    return kj::READY_NOW;
   }
 
 private:

--- a/src/sandstorm/util-test.c++
+++ b/src/sandstorm/util-test.c++
@@ -304,7 +304,7 @@ KJ_TEST("raiiOpenAtIfExistsContained") {
     KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/a/b/link-to-a", 0)));
 
     auto expectSucceed = [&](kj::StringPtr path) -> kj::AutoCloseFd {
-      KJ_IF_MAYBE(fd, raiiOpenAtIfExistsContained(dir.get(), path, O_RDONLY)) {
+      KJ_IF_MAYBE(fd, raiiOpenAtIfExistsContained(dir.get(), kj::Path::parse(path), O_RDONLY)) {
         return kj::mv(*fd);
       } else {
         KJ_FAIL_ASSERT("Opening ", path, " should have succeeded.");
@@ -313,7 +313,7 @@ KJ_TEST("raiiOpenAtIfExistsContained") {
 
     auto expectFail = [&](kj::StringPtr path) {
       auto maybeExn = kj::runCatchingExceptions([&]() {
-        raiiOpenAtIfExistsContained(dir.get(), path, O_RDONLY);
+        raiiOpenAtIfExistsContained(dir.get(), kj::Path::parse(path), O_RDONLY);
       });
       KJ_IF_MAYBE(exn, maybeExn) {
       } else {
@@ -350,14 +350,6 @@ KJ_TEST("raiiOpenAtIfExistsContained") {
     expectContents("subdir/a/link-to-b/c", "subdir/a/b/c");
     expectContents("subdir/a/link-to-b/link-to-c", "subdir/a/b/c");
     expectContents("subdir/a/b/link-to-a/b/c", "subdir/a/b/c");
-
-    // This makes sure we correctly treat ".." as referring to the
-    // parent directory of the _target_ rather than resolving the
-    // ".." in path space, which would result in us opening
-    // "subdir/a/b/file"
-    //
-    // TODO(now): this is currently failing
-    expectContents("subdir/a/b/link-to-a/../file", "subdir/file");
   }
 }
 

--- a/src/sandstorm/util-test.c++
+++ b/src/sandstorm/util-test.c++
@@ -247,7 +247,12 @@ KJ_TEST("raiiOpenAtIfExistsContained") {
 
     auto dir = raiiOpen(tempdir, O_DIRECTORY);
 
-    raiiOpenAt(dir.get(), "file", O_CREAT | O_RDWR);
+    auto writeFileAt = [&](int fd, kj::StringPtr path, kj::StringPtr data) {
+      auto file = raiiOpenAt(fd, path, O_CREAT | O_RDWR);
+      KJ_SYSCALL(write(file.get(), data.cStr(), data.size()));
+    };
+
+    writeFileAt(dir.get(), "file", "file");
     KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "file", 0)));
 
     KJ_SYSCALL(symlinkat("file", dir.get(), "link-to-file"));
@@ -265,12 +270,38 @@ KJ_TEST("raiiOpenAtIfExistsContained") {
     KJ_SYSCALL(symlinkat("..", dir.get(), "subdir/link-to-parent"));
     KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/link-to-parent", 0)));
 
+    KJ_SYSCALL(symlinkat("../file", dir.get(), "subdir/link-to-parent-file"));
+    KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/link-to-parent-file", 0)));
+
+    writeFileAt(dir.get(), "subdir/file", "subdir/file");
+    KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/file", 0)));
+
+    KJ_SYSCALL(symlinkat("file", dir.get(), "subdir/link-to-subdir-file"));
+    KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/link-to-subdir-file", 0)));
+
     KJ_SYSCALL(symlinkat("../..", dir.get(), "subdir/link-to-grandparent"));
     KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/link-to-grandparent", 0)));
 
     KJ_SYSCALL(symlinkat("/", dir.get(), "subdir/link-to-root"));
     KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/link-to-root", 0)));
 
+    KJ_SYSCALL(mkdirat(dir.get(), "subdir/a", 0700));
+    KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/a", AT_REMOVEDIR)));
+
+    KJ_SYSCALL(mkdirat(dir.get(), "subdir/a/b", 0700));
+    KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/a/b", AT_REMOVEDIR)));
+
+    writeFileAt(dir.get(), "subdir/a/b/c", "subdir/a/b/c");
+    KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/a/b/c", 0)));
+
+    KJ_SYSCALL(symlinkat("c", dir.get(), "subdir/a/b/link-to-c"));
+    KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/a/b/link-to-c", 0)));
+
+    KJ_SYSCALL(symlinkat("b", dir.get(), "subdir/a/link-to-b"));
+    KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/a/link-to-b", 0)));
+
+    KJ_SYSCALL(symlinkat("..", dir.get(), "subdir/a/b/link-to-a"));
+    KJ_DEFER(KJ_SYSCALL(unlinkat(dir.get(), "subdir/a/b/link-to-a", 0)));
 
     auto expectSucceed = [&](kj::StringPtr path) -> kj::AutoCloseFd {
       KJ_IF_MAYBE(fd, raiiOpenAtIfExistsContained(dir.get(), path, O_RDONLY)) {
@@ -296,12 +327,37 @@ KJ_TEST("raiiOpenAtIfExistsContained") {
       KJ_ASSERT(result < 0, "shouldn't have gotten access to /");
     };
 
-    expectSucceed("link-to-file");
+    auto readFile = [&](kj::StringPtr path) -> kj::String {
+      return kj::FdInputStream(expectSucceed(path)).readAllText();
+    };
+
+    auto expectContents = [&](kj::StringPtr path, kj::StringPtr expected) {
+      auto actual = readFile(path);
+      if(actual != expected) {
+        KJ_FAIL_ASSERT("unexpected contents", expected, actual);
+      }
+    };
+
+    expectContents("link-to-file", "file");
     expectFail("link-to-parent");
     expectRootTruncated("link-to-root");
     expectSucceed("subdir/link-to-parent");
+    expectContents("subdir/link-to-parent-file", "file");
+    expectContents("subdir/link-to-subdir-file", "subdir/file");
     expectFail("subdir/link-to-grandparent");
     expectRootTruncated("subdir/link-to-root");
+    expectContents("subdir/a/b/link-to-c", "subdir/a/b/c");
+    expectContents("subdir/a/link-to-b/c", "subdir/a/b/c");
+    expectContents("subdir/a/link-to-b/link-to-c", "subdir/a/b/c");
+    expectContents("subdir/a/b/link-to-a/b/c", "subdir/a/b/c");
+
+    // This makes sure we correctly treat ".." as referring to the
+    // parent directory of the _target_ rather than resolving the
+    // ".." in path space, which would result in us opening
+    // "subdir/a/b/file"
+    //
+    // TODO(now): this is currently failing
+    expectContents("subdir/a/b/link-to-a/../file", "subdir/file");
   }
 }
 

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -117,8 +117,15 @@ kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::StringPtr 
           }
           symlink_limit--;
 
-          memset(&path_buf, 0, sizeof path_buf);
-          KJ_SYSCALL(readlinkat(file.get(), part, path_buf, PATH_MAX));
+          ssize_t target_len;
+          KJ_SYSCALL(target_len = readlinkat(file.get(), part, path_buf, PATH_MAX+1));
+          if(target_len >= PATH_MAX) {
+            // It might be nice to handle larger paths here by dynamically
+            // resizing the buffer. TODO: consider using the kj filesystem
+            // API instead, which does this itself.
+            KJ_FAIL_REQUIRE("readlinkat: name too long");
+          }
+          path_buf[target_len] = '\0';
           kj::Path nextPath = path.slice(0, i).eval(path_buf);
           path = kj::mv(nextPath).append(path.slice(i+1, path.size()));
           i = 0;

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -96,8 +96,15 @@ kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExists(
   }
 }
 
-kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::StringPtr name, int flags, mode_t mode) {
-  auto path = kj::Path::parse(name);
+kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::StringPtr path, int flags, mode_t mode) {
+  return raiiOpenAtIfExistsContained(dirfd, kj::Path::parse(path), flags, mode);
+}
+
+kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::PathPtr path, int flags, mode_t mode) {
+  return raiiOpenAtIfExistsContained(dirfd, kj::Path{}.append(path), flags, mode);
+}
+
+kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::Path&& path, int flags, mode_t mode) {
   int fd;
   KJ_SYSCALL(fd = dup(dirfd));
   kj::AutoCloseFd file(fd);

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <kj/function.h>
 #include <kj/async.h>
+#include <kj/filesystem.h>
 #include <capnp/rpc-twoparty.h>
 #include <sandstorm/util.capnp.h>
 #include <set>
@@ -67,9 +68,14 @@ kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExists(
     int dirfd, kj::StringPtr name, int flags, mode_t mode = 0666);
 
 
-kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::StringPtr name, int flags, mode_t mode = 0666);
-// Similar to raiiOpenAtIfExists, but makes sure not to follow symlinks that point outside
-// of `dirfd`.
+kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::PathPtr path, int flags, mode_t mode = 0666);
+kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::Path&& path, int flags, mode_t mode = 0666);
+// Similar to raiiOpenAtIfExists, but:
+//
+// - Makes sure not to follow symlinks that point outside of `dirfd`.
+// - Takes a kj::Path&& or PathPtr, instead of a StringPtr.
+//
+// The kj::Path&& version is slightly more efficient.
 
 size_t getFileSize(int fd, kj::StringPtr filename);
 

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -59,11 +59,17 @@ struct Pipe {
 
 kj::AutoCloseFd raiiOpen(kj::StringPtr name, int flags, mode_t mode = 0666);
 kj::AutoCloseFd raiiOpenAt(int dirfd, kj::StringPtr name, int flags, mode_t mode = 0666);
+// wrappers around the open() and openat() syscalls, respectively.
 
 kj::Maybe<kj::AutoCloseFd> raiiOpenIfExists(
     kj::StringPtr name, int flags, mode_t mode = 0666);
 kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExists(
     int dirfd, kj::StringPtr name, int flags, mode_t mode = 0666);
+
+
+kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::StringPtr name, int flags, mode_t mode = 0666);
+// Similar to raiiOpenAtIfExists, but makes sure not to follow symlinks that point outside
+// of `dirfd`.
 
 size_t getFileSize(int fd, kj::StringPtr filename);
 


### PR DESCRIPTION
N.B. I originally sent this to security@sandstorm.io out of an abundance of caution, but as @kentonv points out it's very unlikely any real apps are affected in a way that matters, and there are some deisgn questions regarding the solution, so per his request I'm opening a normal PR so we can discuss publicly.

---

Previously, getWwwFileHack() would unconditionally follow symbolic
links.  An attacker able to place symlinks in a grains /var/www could
abuse this to perform a path traversal attack, allowing regular files
visible to the supervisor but outside of the static publishing directory
to be accessed via static publishing.

This is limited to the grain's mutable storage, since the supervisor
self-sandboxes, but notably it does include the parent directory of the
sandbox, which is not normally accessible to the grain. This directory
contains the grain log.

The damage is mostly confined to the grain itself, as the supervisor has
access to little else besides the grain's storage, but this could still
be used to extract confidential information from a grain that allows
less-privileged users of the grain to upload files for static
publishing, if the upload mechanism allows symlinks.

With this patch, we avoid following symlinks automatically and instead
resolve them manually, refusing to follow any link that points outside
of www.

---

The design issue @kentonv raised via email:

> As for the ability for symlinks to refer to other app-visible files, I think it's debatable whether it should be the app's responsibility vs. Sandstorm's to validate symlinks. I can see an argument that Sandstorm should do it to defend the app, but I can also see an argument that it's useful for the app to be able to create symlinks that point outside of www, and maybe it should be the app's responsibility to make sure they don't point anywhere bad?

As written, the patch takes the more conservative approach of only following symlinks that stay inside the static publishing directory. My inclination is to keep it this way; so far I don't believe we've seen any use cases that would greatly benefit from the more relaxed approach, and it seems worthwhile avoid app authors needing to write fiddly validation code if we can.