### PR TITLE
cgroups: don't fail to back up if cgroup.freeze doesn't exist.

### DIFF
--- a/src/sandstorm/cgroup2.h
+++ b/src/sandstorm/cgroup2.h
@@ -48,9 +48,13 @@ class Cgroup {
     void addPid(pid_t pid);
     // Add the given process to the cgroup.
 
-    FreezeHandle freeze();
+    kj::Maybe<FreezeHandle> freeze();
     // Freeze the cgroup, suspending all processes within it. The cgroup will
     // be unfrozen when the returned handle is dropped.
+    //
+    // This may return nullptr if the 'cgroup.freeze' file does not exist,
+    // which can happen if the feature is not compiled into the running
+    // kernel.
   private:
     Cgroup(kj::AutoCloseFd&& dirfd);
     kj::AutoCloseFd dirfd;


### PR DESCRIPTION
Apparently this functionality is configurable independently from
the rest of cgroups2, so we can't rely on it necessarily being
there.

Fixes #3457

---

@ocdtrekkie, @orblivion, can you guys test this on your own systems to make sure it fixes the problem? Once CI completes there should be a build you can download, or you can build from source.