### PR TITLE
Fix a build error affecting some systems.

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -1284,7 +1284,7 @@ private:
   kj::AutoCloseFd trashDir;
 
   struct SessionRecord {
-    SessionRecord(const SessionRecord& other) = delete;
+    SessionRecord(const SessionRecord& other) = default;
     SessionRecord(SessionRecord&& other) = default;
 
     SessionContext::Client& sessionCtx;


### PR DESCRIPTION
In the vm created by vagrant-spk, sandstorm-http-bridge currently fails
to build, apparently because the implementation of insertSession() ends
up selecting the (deleted) copy constructor for SessionRecord. This
doesn't seem to be the case on my usual dev system, where this was
building just fine.

Perhaps the difference lies in the version of the C++ stdlib (the
compilers should be the same), but why these are different is stretching
the limits of my C++ knowledge.

...but using the copy constructor here is actually fine, since
SessionRecord doesn't own any of its data anyway. So I guess we can just
allow this.

The build failure was reported on the mailing list by @troyjfarrell,
here:

https://groups.google.com/forum/#!topic/sandstorm-dev/ARrmLkmWJcw