### PR TITLE
Install docs: add strace to the dependency list.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -141,6 +141,7 @@ Please install the following:
 * `zlib1g-dev`
 * `golang-go`
 * `cmake`
+* `strace`
 * discount (markdown parser)
 * [Meteor](http://meteor.com) version 1.8.2
 
@@ -148,7 +149,7 @@ On Debian or Ubuntu, you should be able to get all these with:
 
     sudo apt-get install build-essential libcap-dev xz-utils zip \
         unzip strace curl discount git python zlib1g-dev \
-        golang-go cmake
+        golang-go cmake strace
     curl https://install.meteor.com/?release=1.8.2 | sh
 
 On Fedora 27 you should be able to get them with (as root):
@@ -156,7 +157,7 @@ On Fedora 27 you should be able to get them with (as root):
     dnf install make libcap-devel libstdc++-devel libstdc++-static \
        glibc-headers glibc-static glibc-locale-source xz zip \
        unzip strace curl discount git python2 zlib-devel \
-       golang cmake
+       golang cmake strace
     curl https://install.meteor.com/?release=1.8.2 | sh
 
 If you have trouble getting the build to work on your distro, we recommend trying in a virtual


### PR DESCRIPTION
@troyjfarrell pointed out on the mailing list that this is used by
`make-bundle.sh`, but not mentioned in the docs.

`gcc` is also missing as a dependency, but probably we should solve that
one by changing the script to use the same C compiler as the rest of the
build.