### PR TITLE
make-bundle.sh: use the same compiler as the rest of the build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,7 +380,7 @@ shell-build: shell/imports/* shell/imports/*/* shell/imports/*/*/* shell/imports
 
 bundle: tmp/.ekam-run shell-build make-bundle.sh localedata-C meteor-bundle-main.js
 	@$(call color,bundle)
-	@./make-bundle.sh
+	@CC=$(CC) ./make-bundle.sh
 
 sandstorm-$(BUILD).tar.xz: bundle
 	@$(call color,compress release bundle)

--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -176,7 +176,7 @@ int main() {
 }
 __EOF__
 
-gcc tmp/dnstest.c -o tmp/dnstest
+$CC tmp/dnstest.c -o tmp/dnstest
 strace tmp/dnstest 2>&1 | grep -o '"/[^"]*"' | tr -d '"' | copyDeps
 
 # Add some whitelisted entries to host.list that we always want to include,


### PR DESCRIPTION
@troyjfarrell pointed out that the build currently relies on gcc,
even though we build with clang, because of this statement in
make-bundle.sh. This patch changes it to use whatever compiler
is used for the rest of the build, avoiding the dependency on a
system gcc.