### PR TITLE
Add pathname and hash support for shared URLs

### DIFF
--- a/docs/developing/path.md
+++ b/docs/developing/path.md
@@ -121,7 +121,17 @@ window.parent.postMessage({'startSharing': {}}, '*');
 ```
 
 This shares at the app's default permission level. In the future, we may extend
-this API to permit the app to choose a permission level.
+this API to permit the app to choose a permission level.  Additionally, the app
+may add a pathname or hash to the shared URL by including those as arguments:
+
+```js
+window.parent.postMessage({
+  startSharing: {
+    pathname: 'download/123',
+    hash: 'linux',
+  }
+}, '*');
+```
 
 If your app wants Sandstorm to display a list of users who have access to the grain, you can
 ask Sandstorm to show who has access with this Javascript code:

--- a/shell/imports/client/grain-client.js
+++ b/shell/imports/client/grain-client.js
@@ -524,8 +524,8 @@ Template.shareableLinkTab.events({
       if (error) {
         console.error(error.stack);
       } else {
-        var url = new URL(getOrigin()),
-        path = "shared/" + result.token;
+        const url = new URL(getOrigin());
+        let path = "shared/" + result.token;
         if ("pathname" in shareData) {
           if (!shareData.pathname.startsWith("/")) path += "/";
           path += shareData.pathname;

--- a/shell/imports/client/grain-client.js
+++ b/shell/imports/client/grain-client.js
@@ -1528,6 +1528,14 @@ Meteor.startup(function () {
       // TODO(security): defend against malicious apps spamming this call, blocking all other UI.
       const currentGrain = globalGrains.getActive();
       if (senderGrain === currentGrain && !globalTopbar.isPopupOpen()) {
+        try {
+          check(event.data.startSharing, {hash: Match.Maybe(String), pathname: Match.Maybe(String)});
+        } catch (err) {
+          console.error(err);
+          console.log("startSharing data is not the expected shape.");
+          console.log("See https://docs.sandstorm.io/en/latest/developing/path/#helping-the-user-share-access");
+          return;
+        }
         senderGrain.setShareData(event.data.startSharing);
         globalTopbar.openPopup("share", true);
       }

--- a/shell/imports/client/grain-client.js
+++ b/shell/imports/client/grain-client.js
@@ -1532,8 +1532,8 @@ Meteor.startup(function () {
           check(event.data.startSharing, {hash: Match.Maybe(String), pathname: Match.Maybe(String)});
         } catch (err) {
           console.error(err);
-          console.log("startSharing data is not the expected shape.");
-          console.log("See https://docs.sandstorm.io/en/latest/developing/path/#helping-the-user-share-access");
+          console.error("startSharing data is not the expected shape.");
+          console.error("See https://docs.sandstorm.io/en/latest/developing/path/#helping-the-user-share-access");
           return;
         }
         senderGrain.setShareData(event.data.startSharing);

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -781,23 +781,7 @@ class GrainView {
   }
 
   setShareData(shareData) {
-    var result = {};
-    if ("hash" in shareData) {
-      if (Match.test(shareData.hash, String)) {
-        result["hash"] = shareData.hash;
-      } else {
-        console.warn('shareData["hash"] is not a string--skipping it');
-      }
-    }
-    if ("pathname" in shareData) {
-      if (Match.test(shareData.pathname, String)) {
-        result["pathname"] = shareData.pathname;
-      } else {
-        console.warn('shareData["pathname"] is not a string--skipping it');
-      }
-    }
-    check(result, {"hash": Match.Maybe(String), "pathname": Match.Maybe(String)});
-    this._shareData = result;
+    this._shareData = shareData;
   }
 
   shareData() {

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -83,6 +83,7 @@ class GrainView {
     this._options = options;
 
     this._powerboxRequest = new ReactiveVar(undefined);
+    this._shareData = {};
 
     this._userIdentityRevealed = new ReactiveVar(undefined);
     // `false` means incognito; `undefined` means we still need to decide whether to reveal
@@ -777,6 +778,30 @@ class GrainView {
   setGeneratedApiToken(newApiToken) {
     this._generatedApiToken = newApiToken;
     this._dep.changed();
+  }
+
+  setShareData(shareData) {
+    var result = {};
+    if ("hash" in shareData) {
+      if (Match.test(shareData.hash, String)) {
+        result["hash"] = shareData.hash;
+      } else {
+        console.warn('shareData["hash"] is not a string--skipping it');
+      }
+    }
+    if ("pathname" in shareData) {
+      if (Match.test(shareData.pathname, String)) {
+        result["pathname"] = shareData.pathname;
+      } else {
+        console.warn('shareData["pathname"] is not a string--skipping it');
+      }
+    }
+    check(result, {"hash": Match.Maybe(String), "pathname": Match.Maybe(String)});
+    this._shareData = result;
+  }
+
+  shareData() {
+    return this._shareData;
   }
 
   setPowerboxRequest(powerboxRequest) {

--- a/tests/tests/postmessage-api.js
+++ b/tests/tests/postmessage-api.js
@@ -128,22 +128,14 @@ module.exports['Test startSharing with pathname and hash'] = function (browser) 
     // Get link from a#share-token-text.  Check for hash and pathname.
     .waitForElementVisible('#share-token-text', short_wait)
     .assert.containsText('#share-token-text', '/pathname/123#hash123')
-    // Remove the link
+    // Find the link and remove it.
     .click('button.who-has-access')
     .waitForElementVisible('table.shared-links', short_wait)
-    // Find the link and remove it.
-    .execute(function () {
-      document.querySelectorAll("table.shared-links span.token-petname").forEach(function(link) {
-        let linkText = link.textContent.trimLeft();
-        if (linkText.startsWith(linkLabel)) {
-          let revokeButton = link.parentElement.parentElement.querySelector("button.revoke-token");
-          if (revokeButton) revokeButton.click();
-        }
-      });
-    })
+    .assert.containsText('table.shared-links tr:last-child span.token-petname', linkLabel)
+    .click('table.shared-links tr:last-child button.revoke-token')
+    // Close the sharing popup.
     .click('button.close-popup')
-    .waitForElementNotPresent('.popup.share', short_wait)
-
+    .waitForElementNotPresent('.popup.share', short_wait);
 };
 
 module.exports['Test showConnectionGraph'] = function (browser) {

--- a/tests/tests/postmessage-api.js
+++ b/tests/tests/postmessage-api.js
@@ -109,6 +109,43 @@ module.exports['Test startSharing'] = function (browser) {
     .waitForElementNotPresent('.popup.share', short_wait)
 };
 
+module.exports['Test startSharing with pathname and hash'] = function (browser) {
+  const linkLabel = 'Test startSharing with pathname and hash';
+  browser
+    .grainFrame()
+    // Post a startSharing message to open the sharing popup.
+    .execute(function () {
+      window.parent.postMessage({startSharing: {hash: 'hash123', pathname: 'pathname/123'}}, '*');
+    })
+    .frameParent()
+    // Get the link without sending e-mail.
+    .waitForElementVisible('#shareable-link-tab-header', short_wait)
+    .click('#shareable-link-tab-header')
+    // Lable this link
+    .waitForElementVisible('input.label', short_wait)
+    .setValue('input.label', linkLabel)
+    .submitForm('.new-share-token')
+    // Get link from a#share-token-text.  Check for hash and pathname.
+    .waitForElementVisible('#share-token-text', short_wait)
+    .assert.containsText('#share-token-text', '/pathname/123#hash123')
+    // Remove the link
+    .click('button.who-has-access')
+    .waitForElementVisible('table.shared-links', short_wait)
+    // Find the link and remove it.
+    .execute(function () {
+      document.querySelectorAll("table.shared-links span.token-petname").forEach(function(link) {
+        let linkText = link.textContent.trimLeft();
+        if (linkText.startsWith(linkLabel)) {
+          let revokeButton = link.parentElement.parentElement.querySelector("button.revoke-token");
+          if (revokeButton) revokeButton.click();
+        }
+      });
+    })
+    .click('button.close-popup')
+    .waitForElementNotPresent('.popup.share', short_wait)
+
+};
+
 module.exports['Test showConnectionGraph'] = function (browser) {
   browser
     .grainFrame()


### PR DESCRIPTION
This commit allows apps to provide a path and hash when using the postMessage
startSharing API.

This commit uses the ``URL`` [browser API](https://caniuse.com/url), so we'll need a polyfill if we're supporting browsers that don't support this.

Implements #3428.