### PR TITLE
Finish removing legacy HTTP access via HackSession

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           # the constant below.
           make lint | tee lint.log
           num_problems=$(cat lint.log | grep ' problems (0 errors, ' | awk '{print $2}')
-          [ "$num_problems" = 796 ]
+          [ "$num_problems" = 795 ]
       - name: test
         run: |
           set -o pipefail

--- a/shell/imports/sandstorm-db/db.js
+++ b/shell/imports/sandstorm-db/db.js
@@ -1131,23 +1131,6 @@ class SandstormDb {
     };
   }
 
-  allowLegacyHackSessionHttp() {
-    // Returns true iff the legacy hack-session http-related methods have been
-    // enabled. It is only possible to set this by directly manipulating the
-    // mongo database:
-    //
-    // $ sandstorm mongo
-    // ssrs:PRIMARY> db.settings.upsert({_id: "allowLegacyHackSessionHttp", value: true})
-    //
-    // Soon, these interfaces will be removed entirely and this setting will no longer
-    // be recognized. This is intentionally undocumented; if anyone actually needs this
-    // during the transition, we want them to come talk to us about it. If the setting
-    // is disabled, the relevant error messages direct developers to use the new API,
-    // and ask the mailing list if they need help.
-    const row = this.collections.settings.findOne({_id: "allowLegacyHackSessionHttp"})
-    return (row !== null) && row.value
-  }
-
   isAdmin() {
     // Returns true if the user is the administrator.
 

--- a/shell/imports/server/hack-session.js
+++ b/shell/imports/server/hack-session.js
@@ -410,95 +410,14 @@ class HackSessionContextImpl extends SessionContextImpl {
     }).bind(this));
   }
 
-  obsoleteHttpGet(url) {
-    const _this = this;
-    const session = _this;
-
-    return inMeteor(() => {
-      if(!globalDb.allowLegacyHackSessionHttp()) {
-        throw new Error(
-          "HackSession.httpGet() is disabled and will be permanently removed soon. " +
-          "You should port your app to to use the powerbox instead. If you need " +
-          "help figuring out how to transition, please contact us via the " +
-          "sandstorm-dev@googlegroups.com mailing list."
-        )
-      }
-      return ssrfSafeLookup(globalDb, url);
-    }).then(safe => {
-      return new Promise((resolve, reject) => {
-        let requestMethod = Http.request;
-        if (safe.url.indexOf("https://") === 0) {
-          requestMethod = Https.request;
-        } else if (safe.url.indexOf("http://") !== 0) {
-          const err = new Error("Protocol not recognized.");
-          err.nature = "precondition";
-          reject(err);
-        }
-
-        const options = Url.parse(safe.url);
-        options.headers = { host: safe.host };
-        options.servername = safe.host.split(":")[0];
-
-        const req = requestMethod(options, (resp) => {
-          const buffers = [];
-          let err;
-
-          switch (Math.floor(resp.statusCode / 100)) {
-            case 2: // 2xx response -- OK.
-              resp.on("data", (buf) => {
-                buffers.push(buf);
-              });
-
-              resp.on("end", () => {
-                resolve({
-                  content: Buffer.concat(buffers),
-                  mimeType: resp.headers["content-type"] || null,
-                });
-              });
-              break;
-            case 3: // 3xx response -- redirect.
-              resolve(session.obsoleteHttpGet(resp.headers.location));
-              break;
-            case 4: // 4xx response -- client error.
-              err = new Error("Status code " + resp.statusCode + " received in response.");
-              err.nature = "precondition";
-              reject(err);
-              break;
-            case 5: // 5xx response -- internal server error.
-              err = new Error("Status code " + resp.statusCode + " received in response.");
-              err.nature = "localBug";
-              reject(err);
-              break;
-            default: // ???
-              err = new Error("Invalid status code " + resp.statusCode + " received in response.");
-              err.nature = "localBug";
-              reject(err);
-              break;
-          }
-        });
-
-        req.on("error", (e) => {
-          e.nature = "networkFailure";
-          reject(e);
-        });
-
-        req.setTimeout(15000, () => {
-          req.abort();
-          const err = new Error("Request timed out.");
-          err.nature = "localBug";
-          err.durability = "overloaded";
-          reject(err);
-        });
-
-        req.end();
-      });
-    });
-  }
-
   getUserAddress() {
     return inMeteor((function () {
       return this._getUserAddress();
     }).bind(this));
+  }
+
+  obsoleteHttpGet(_url) {
+    throw new Error("httpGet() has been removed. Use the powerbox instead.");
   }
 
   obsoleteGenerateApiToken(_petname, _userInfo, _expires) {
@@ -513,33 +432,8 @@ class HackSessionContextImpl extends SessionContextImpl {
     throw new Error("revokeApiToken() has been removed. Use offer templates instead.");
   }
 
-  obsoleteGetUiViewForEndpoint(url) {
-    return inMeteor(() => {
-      if(!globalDb.allowLegacyHackSessionHttp()) {
-        throw new Error(
-          "HackSession.getUiViewForEndpoint() is disabled and will be permanently removed soon. " +
-          "You should port your app to to use the powerbox instead. If you need " +
-          "help figuring out how to transition, please contact us via the " +
-          "sandstorm-dev@googlegroups.com mailing list."
-        )
-      }
-
-      const parsedUrl = Url.parse(url);
-
-      if (parsedUrl.hash) { // Assume that anything with a fragment is a webkey
-        if (parsedUrl.pathname && parsedUrl.pathname !== "/") {
-          throw new Error("Webkey urls cannot contain a path.");
-        }
-
-        const token = parsedUrl.hash.slice(1); // Get rid of # which is always the first character
-        const hostId = matchWildcardHost(parsedUrl.host);
-        // Connecting to a remote server with a bearer token.
-        // TODO(someday): Negotiate server-to-server Cap'n Proto connection.
-        return { view: new ExternalUiView(url, token) };
-      } else {
-        return { view: new ExternalUiView(url) };
-      }
-    })
+  obsoleteGetUiViewForEndpoint(_url) {
+    throw new Error("getUiViewForEndpoint() has been removed. Use the powerbox instead.");
   }
 }
 

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -1174,6 +1174,15 @@ function deleteReferralNotifications(db, _backend) {
   db.collections.notifications.remove({mailingListBonus: {$exists: true}});
 }
 
+function deleteHackSessionHttpSetting(db, _backend) {
+  // When started the process of removing support for HTTP access through
+  // HackSession, we introduced this setting to allow users to temporarily
+  // re-enable it as a stopgap while apps were being ported. Now that the
+  // functionality has ben removed entirely, we should remove this setting
+  // as well:
+  db.collections.settings.remove({_id: "allowLegacyHackSessionHttp"});
+}
+
 // This must come after all the functions named within are defined.
 // Only append to this list!  Do not modify or remove list entries;
 // doing so is likely change the meaning and semantics of user databases.
@@ -1218,6 +1227,7 @@ const MIGRATIONS = [
   cleanupBadExpiresIfUnused,
   deleteReferralNotifications,
   removeFeatureKeys,
+  deleteHackSessionHttpSetting,
 ];
 
 const NEW_SERVER_STARTUP = [


### PR DESCRIPTION
This has been disabled for a few months and nobody's complained, so I think we can safely remove this.

This patch removes:

- The implementations of the obsolete methods on `HackSession` itself (they now just throw exceptions)
- Support code used to check whether to enable the functionality
  - Also includes a database migration to remove the setting.
- Some code paths that were only used via `HackSession`, and are not relevant when the powerbox is used to obtain HTTP access.