### PR TITLE
Fix some regressions re: the recent static publishng symlink fix.

### DIFF
--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -2210,8 +2210,8 @@ public:
     }
 
     auto sandboxDir = raiiOpen("sandbox", O_RDONLY);
-    KJ_IF_MAYBE(wwwDir, raiiOpenAtIfExists(sandboxDir.get(), "www", O_RDONLY|O_NOFOLLOW)) {
-      KJ_IF_MAYBE(fd, raiiOpenAtIfExistsContained(wwwDir->get(), kj::Path(path), O_RDONLY)) {
+    KJ_IF_MAYBE(wwwDir, raiiOpenAtIfExistsContained(sandboxDir.get(), kj::Path{"www"}, O_RDONLY)) {
+      KJ_IF_MAYBE(fd, raiiOpenAtIfExistsContained(wwwDir->get(), kj::Path::parse(path), O_RDONLY)) {
         struct stat stats;
         KJ_SYSCALL(fstat(*fd, &stats));
 

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <kj/vector.h>
 #include <kj/async-unix.h>
+#include <kj/filesystem.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -93,6 +94,50 @@ kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExists(
   } else {
     return kj::AutoCloseFd(fd);
   }
+}
+
+kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::StringPtr path, int flags, mode_t mode) {
+  return raiiOpenAtIfExistsContained(dirfd, kj::Path::parse(path), flags, mode);
+}
+
+kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::PathPtr path, int flags, mode_t mode) {
+  return raiiOpenAtIfExistsContained(dirfd, kj::Path{}.append(path), flags, mode);
+}
+
+kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::Path&& path, int flags, mode_t mode) {
+  int fd;
+  KJ_SYSCALL(fd = dup(dirfd));
+  kj::AutoCloseFd file(fd);
+  int symlink_limit = 16; // arbitrary limit
+
+  int i = 0;
+  while(i < path.size()) {
+    const char *part = path[i].cStr();
+    KJ_SYSCALL_HANDLE_ERRORS(fd = openat(file.get(), part, flags | O_NOFOLLOW, mode)) {
+      case ENOENT:
+        return nullptr;
+      case ELOOP:
+        {
+          if(symlink_limit == 0) {
+            KJ_FAIL_SYSCALL("openat()", error);
+          }
+          symlink_limit--;
+
+          auto target = kj::newDiskReadableDirectory(kj::mv(file))->readlink(kj::Path(part));
+          kj::Path nextPath = path.slice(0, i).eval(target);
+          path = kj::mv(nextPath).append(path.slice(i+1, path.size()));
+          i = 0;
+          KJ_SYSCALL(fd = dup(dirfd));
+          break;
+        }
+      default:
+        KJ_FAIL_SYSCALL("openat()", error);
+    } else {
+      i++;
+    }
+    file = kj::AutoCloseFd(fd);
+  }
+  return kj::mv(file);
 }
 
 size_t getFileSize(int fd, kj::StringPtr filename) {

--- a/src/sandstorm/util.h
+++ b/src/sandstorm/util.h
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <kj/function.h>
 #include <kj/async.h>
+#include <kj/filesystem.h>
 #include <capnp/rpc-twoparty.h>
 #include <sandstorm/util.capnp.h>
 #include <set>
@@ -59,11 +60,22 @@ struct Pipe {
 
 kj::AutoCloseFd raiiOpen(kj::StringPtr name, int flags, mode_t mode = 0666);
 kj::AutoCloseFd raiiOpenAt(int dirfd, kj::StringPtr name, int flags, mode_t mode = 0666);
+// wrappers around the open() and openat() syscalls, respectively.
 
 kj::Maybe<kj::AutoCloseFd> raiiOpenIfExists(
     kj::StringPtr name, int flags, mode_t mode = 0666);
 kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExists(
     int dirfd, kj::StringPtr name, int flags, mode_t mode = 0666);
+
+
+kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::PathPtr path, int flags, mode_t mode = 0666);
+kj::Maybe<kj::AutoCloseFd> raiiOpenAtIfExistsContained(int dirfd, kj::Path&& path, int flags, mode_t mode = 0666);
+// Similar to raiiOpenAtIfExists, but:
+//
+// - Makes sure not to follow symlinks that point outside of `dirfd`.
+// - Takes a kj::Path&& or PathPtr, instead of a StringPtr.
+//
+// The kj::Path&& version is slightly more efficient.
 
 size_t getFileSize(int fd, kj::StringPtr filename);
 


### PR DESCRIPTION
There are two problems:

1. Davros apparently makes /var/www itself a symlink to another
   directory
2. We need to call Path::parse() on the path. Apparently I didn't test
   this thoroughly enough after changing raiiOpenAtIfExistsContained
   to take a kj::Path rather than a string.

We fix (1) by allowing /var/www itself to be a symlink, and then only
enforcing that symlinks within that directory do not point outside of
it.

Fixes #3472

---

@ocdtrekkie sent me a backup of his davros grain, and I've confirmed that this fixes that case. I have not tested the issue affecting docs.sandstorm.io, but from the error message I'm fairly confident that this is the issue.

I will probably send a follow pr making sure we have test coverage for all this, but this should at least fix the issue.