### PR TITLE
Generate JavaScript source maps.

### DIFF
--- a/shell/.meteor/packages
+++ b/shell/.meteor/packages
@@ -32,7 +32,6 @@ reactive-dict@1.3.0
 fourseven:scss@4.12.0
 sha@1.0.9
 standard-minifier-css@1.6.1
-standard-minifier-js@2.6.0
 shell-server@0.5.0
 fongandrew:find-and-modify@0.2.2
 
@@ -44,3 +43,4 @@ dynamic-import@0.5.2
 tap:i18n
 typescript@3.7.6
 meteortesting:mocha
+zodern:standard-minifier-js

--- a/shell/.meteor/versions
+++ b/shell/.meteor/versions
@@ -68,7 +68,6 @@ meteortesting:browser-tests@1.3.4
 meteortesting:mocha@2.0.1
 meteortesting:mocha-core@8.0.1
 minifier-css@1.5.3
-minifier-js@2.6.0
 minimongo@1.6.0
 modern-browsers@0.1.5
 modules@0.15.0
@@ -99,7 +98,6 @@ socket-stream-client@0.3.1
 spacebars@1.0.15
 spacebars-compiler@1.1.3
 standard-minifier-css@1.6.1
-standard-minifier-js@2.6.0
 tap:i18n@1.8.2
 templating@1.3.2
 templating-compiler@1.3.3
@@ -112,3 +110,6 @@ underscore@1.0.10
 url@1.3.1
 webapp@1.9.1
 webapp-hashing@1.0.9
+zodern:caching-minifier@0.4.0
+zodern:minifier-js@4.0.0
+zodern:standard-minifier-js@4.0.0


### PR DESCRIPTION
This will give us accurate stack traces in the browser, and generally
make debugging client-side code easier.

Note that there is a pr to merge this functionality into meteor core:

https://github.com/meteor/meteor/pull/10341

...but which is stalled on some things Sandstorm doesn't actually care
about (notably, many developers don't actually want to expose the source
to end-users, they want the source maps uploaded to a CI or something,
but Sandstorm is FOSS so we absolutely _do_ want users to have the
source).

The PR has been open for a couple years though. If/when that lands we
can switch over to using meteor core's support.