### PR TITLE
sandstorm-http-bridge: Fix some build errors against capnp master.

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -416,7 +416,7 @@ public:
     // TODO(soon):  If the app returned a normal response without upgrading, we should forward that
     //   through, as it's perfectly valid HTTP.  The WebSession interface currently does not
     //   support this.
-    KJ_ASSERT(status_code == 101, "Sandboxed app does not support WebSocket.",
+    KJ_ASSERT((int)status_code == 101, "Sandboxed app does not support WebSocket.",
               (int)upgrade, (int)status_code, statusString);
 
     KJ_IF_MAYBE(protocol, findHeader("sec-websocket-protocol")) {
@@ -764,7 +764,7 @@ private:
     statusString = kj::heapString(rawStatusString);
 
     headersComplete = true;
-    KJ_ASSERT(status_code >= 100, (int)status_code);
+    KJ_ASSERT((int)status_code >= 100, (int)status_code);
     return ignoreBody;
   }
 
@@ -2687,7 +2687,7 @@ private:
       struct in_addr ipv4;
       ipv4.s_addr = ntohl(uint32_t(lower64));
       const char* ok = inet_ntop(AF_INET, &ipv4, buf, INET_ADDRSTRLEN);
-      KJ_REQUIRE(ok != NULL, "inet_ntop() failed");
+      KJ_REQUIRE(ok != nullptr, "inet_ntop() failed");
       kj::String s = kj::heapString(buf);
       return kj::mv(s);
     } else {
@@ -2712,7 +2712,7 @@ private:
       ipv6.s6_addr[14] = ((lower64 >>  8) & 0xff);
       ipv6.s6_addr[15] = ((lower64      ) & 0xff);
       const char* ok = inet_ntop(AF_INET6, &ipv6, buf, INET6_ADDRSTRLEN);
-      KJ_REQUIRE(ok != NULL, "inet_ntop() failed");
+      KJ_REQUIRE(ok != nullptr, "inet_ntop() failed");
       kj::String s = kj::heapString(buf);
       return kj::mv(s);
     }


### PR DESCRIPTION
I tried updating the capnproto submodule and found that
sandstorm-http-bridge doesn't build against master; this patch fixes the
build errors.

The particular errors we were seeing were:

```
/ekam-provider/canonical/sandstorm/sandstorm-http-bridge.c++:767:15:
  error: non-const reference cannot
  bind to bit-field 'status_code'
    KJ_ASSERT(status_code >= 100, (int)status_code);
              ^~~~~~~~~~~
```

And:

```
In file included from /ekam-provider/canonical/sandstorm/sandstorm-http-bridge.c++:24:
/ekam-provider/c++header/kj/debug.h:655:19: error: comparison between pointer and integer ('const char
  *' and 'long')
  DEFINE_OPERATOR(!=);
  ~~~~~~~~~~~~~~~~^~~
/ekam-provider/c++header/kj/debug.h:651:25: note: expanded from macro 'DEFINE_OPERATOR'
    bool result = value OP other; \
                  ~~~~~ ^  ~~~~~
/ekam-provider/canonical/sandstorm/sandstorm-http-bridge.c++:2715:21: note: in instantiation of
  function template specialization 'kj::_::DebugExpression<const char *&>::operator!=<long>' requested
  here
      KJ_REQUIRE(ok != NULL, "inet_ntop() failed");
```

...in two places each.

The errors seem to have been introduced by the new "magic assert
stringification" feature; git bisect blames commit
a77d7e16ac0a9e1f6e7f7b62e90a6cfe13e38400. From that commit message:

```
> How does it work? We use template magic and operator precedence.  The
> assertion actually evaluates something like this:
>
>         if (auto _kjCondition = kj::_::MAGIC_ASSERT << foo == bar)
>
>     `<<` has operator precedence slightly above `==`, so `kj::_::MAGIC_ASSERT << foo` gets evaluated first
> . This wraps `foo` in a little wrapper that captures the comparison operators and keeps enough information
>  around to be able to stringify the left and right sides of the
> comparison independently.
```

I assume this is failing in the status_code case because there's no
operator<< with the right type (status_code is a 16-bit bitfield), so
the cast fixes the problem there.

From the second error message it sounds like the compiler was trying to
treat NULL as an integer type for some reason, which can't happen with
nullptr, so this seems to fix the problem there.