### PR TITLE
Fix #3484

### DIFF
--- a/shell/imports/client/setup-wizard/wizard.js
+++ b/shell/imports/client/setup-wizard/wizard.js
@@ -491,6 +491,9 @@ Template.setupWizardOrganization.events({
           enabled: instance.gappsChecked.get(),
           domain: instance.gappsDomain.get().trim(),
         },
+        oidc: {
+          enabled: instance.oidcChecked.get(),
+        },
         ldap: {
           enabled: instance.ldapChecked.get(),
         },


### PR DESCRIPTION
When oidc support was added, we never updated the setup wizard to supply
this now-mandatory parameter.

I tested this manually and confirmed that it fixes the problem, but
soonish I want to write some tests for the setup wizard in particular,
as this isn't the first time we've introduced bugs that only affect
setup.