### PR TITLE
Fix tests/grain.js tests using Chromium 80 and Debian 10

### DIFF
--- a/tests/nightwatch.json
+++ b/tests/nightwatch.json
@@ -28,7 +28,10 @@
       "desiredCapabilities": {
         "browserName": "chrome",
         "javascriptEnabled" : true,
-        "acceptSslCerts" : true
+        "acceptSslCerts" : true,
+        "chromeOptions": {
+          "w3c": false
+        }
       },
       "exclude" : "./unittests/*"
     },


### PR DESCRIPTION
Use the old wire protocol with ChromeDriver (set w3c to false).  This fixes some Chrome (mis)behaviors, including failing to switch browser windows.  Tested with Chromium 80 on Debian 10.