### PR TITLE
Update upload-artifact to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       #    path: ccache-debug.tar.gz
       - name: upload sandstorm tarball
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: sandstorm-0-fast.tar.xz
           path: sandstorm-0-fast.tar.xz
@@ -81,13 +81,13 @@ jobs:
           (make test |& tee testlog.txt; echo "Result: $?") || true
       - name: upload test log
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: testlog.txt
           path: testlog.txt
       - name: upload screenshots
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: screenshots
           path: tests/screenshots


### PR DESCRIPTION
So, currently our tests failed because Selenium flipped out, didn't actually run tests... and then why they failed was that there were no screenshots to upload. Interestingly, this means with our current test script... tests should fail when we have no test failures (and hence no screenshots).

If we upgrade to upload-artifact@v2, it generates a warning when there are no screenshots, rather than an error. I believe this is the correct way to go, though we should do better ensuring when Selenium fails, tests also fail at that step.