### PR TITLE
Fix a typo in a variable name.

### DIFF
--- a/shell/imports/server/scheduled-job.js
+++ b/shell/imports/server/scheduled-job.js
@@ -64,7 +64,7 @@ export const runDueJobs = (nowMillis) => {
   jobs.forEach((job) => {
     if (job.lastKeepAlive) {
       if (job.retries && job.retries >= MAX_DISCONNECTED_RETRIES) {
-        db.recordScheduleJobRan(job, {
+        db.recordScheduledJobRan(job, {
           finished: job.lastKeepAlive,
           type: "disconnected",
           message: "MAX_DISCONNECTED_RETRIES exceeded",


### PR DESCRIPTION
I spotted this when it threw an exception while I was doing other
development. So, this fixes a bug where the intended logic was to stop
re-trying after some number of consecutive disconnects, but because of
the typo, tasks would stay in the "retry queue" forever, unless they
were eventually successful.

Not a super serious bug, since retries don't happen rapidly anyway,
but...