### PR TITLE
Add a SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,4 +6,4 @@ Sandstorm operates on an evergreen release model. Only the latest release is con
 
 ## Reporting a Vulnerability
 
-Please report security vulnerabilities to security@sandstorm.io for responsible disclosure. We ask that you hold disclosure for at least 90 days from disclosure or 48 hours from patch release, whichever is shorter.
+Please report security vulnerabilities to security@sandstorm.io for responsible disclosure. We ask that you withhold public disclosure for at least 90 days after reporting the vulnerability or 48 hours after the release of fixed code which corrects the issue, whichever is shorter.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+Sandstorm operates on an evergreen release model. Only the latest release is considered supported.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities to security@sandstorm.io for responsible disclosure. We ask that you hold disclosure for at least 90 days from disclosure or 48 hours from patch release, whichever is shorter.


### PR DESCRIPTION
Someone asked us how to submit security issues with Sandstorm on IRC. I tried to look on my own to verify that the disclosure address was/is still security@sandstorm.io and could not quickly find it. Common GitHub practice is a SECURITY.md file, in this format, generated from the GitHub Security tab for this repo.

90 day disclosure is pretty standard, and as a community project, I think we should ask for at least that, but given Sandstorm's automatic update model, I feel it's safe to disclose a couple days after we release a fix. So hopefully I got the policy about where it should be there.

We probably should also add a https://securitytxt.org/ to the website.