### PR TITLE
Artifacts from failing tests get valid filenames

### DIFF
--- a/tests/utils.js
+++ b/tests/utils.js
@@ -45,7 +45,7 @@ module.exports = {
       if (count === 0) {
         test = wrapLoginDev(test);
       }
-      newTests['Dev Account: ' + name] = test;
+      newTests['Dev Account- ' + name] = test;
       ++count;
     }
 


### PR DESCRIPTION
Fixes #3550, I think. (Well, it won't fix that tests are failing left and right, but it might give us screenshots again.)