### PR TITLE
Add more owncloud/nextcloud client headers

### DIFF
--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -161,6 +161,9 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
       "x-oc-mtime",            # Owncloud client
       "oc-fileid",             # Owncloud client
       "oc-chunked",            # Owncloud client
+      "oc-checksum",           # Owncloud client
+      "oc-chunk-offset",       # Owncloud client
+      "oc-lazyops",            # Owncloud client
       "x-hgarg-*",             # Mercurial client
       "x-phabricator-*",       # Phabricator
       "x-requested-with",      # JQuery header used by Rails and other frameworks


### PR DESCRIPTION
Adds some additional ownCloud/NextCloud client headers relating to https://github.com/mnutt/davros/issues/114.

The new headers:
* `oc-checksum` - a hash (typically `SHA1`) of the entire file. After all chunks have been uploaded, davros should be checking this to ensure that it uploaded correctly, otherwise we may end up saving a corrupted file. [this header has been around for a while, I should have been doing this all along]
* `oc-chunk-offset` - part of a new chunking scheme. Right now the legacy chunking scheme relies on all chunks being the same size in order to calculate the offset (number * chunkSize); this header would allow the client to vary the chunk size based on timing/bandwidth.
* `oc-lazyops` - I'm unlikely to implement this soon, but it would be a way for the client to signal "I don't want to wait for a response". The server would then hypothetically respond with a location where the client could poll for progress updates.