### PR TITLE
Vagrantfile: `apt-get update` before install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cd /vagrant
     echo localhost > /etc/hostname
     hostname localhost
+    sudo apt-get update
     sudo apt-get install -y curl
     sudo OVERRIDE_DEFAULT_SERVER_USER=vagrant ./install.sh -d -e > /dev/null
     sudo sed --in-place='' --expression='s/^BIND_IP=.*/BIND_IP=0.0.0.0/' /opt/sandstorm/sandstorm.conf


### PR DESCRIPTION
Prior to this change, I got 404 errors for both curl and libcurl3.

```
    default: Err:1 http://deb.debian.org/debian stretch/main amd64 libcurl3 amd64 7.52.1-5+deb9u9
    default:   404  Not Found [IP: 151.101.250.132 80]
    default: Ign:2 http://deb.debian.org/debian stretch/main amd64 curl amd64 7.52.1-5+deb9u9
    default: Err:1 http://security.debian.org/debian-security stretch/updates/main amd64 libcurl3 amd64 7.52.1-5+deb9u9
    default:   404  Not Found [IP: 151.101.250.132 80]
    default: Err:2 http://security.debian.org/debian-security stretch/updates/main amd64 curl amd64 7.52.1-5+deb9u9
    default:   404  Not Found [IP: 151.101.250.132 80]
    default: E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/c/curl/libcurl3_7.52.1-5+deb9u9_amd64.deb  404  Not Found [IP: 151.101.250.132 80]
    default: E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/c/curl/curl_7.52.1-5+deb9u9_amd64.deb  404  Not Found [IP: 151.101.250.132 80]
    default: E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```