### PR TITLE
Remove remaining references to phantomjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,6 @@ bundle/
 .docker
 .shell-env
 .vagrant/
-phantomjsdriver.log
 selenium-debug.log
 tests/downloads
 tests/assets/*

--- a/tests/nightwatch.json
+++ b/tests/nightwatch.json
@@ -41,15 +41,6 @@
       },
       "filter" : "./unittests/*",
       "exclude" : ""
-    },
-
-    "phantomjs" : {
-      "desiredCapabilities": {
-        "browserName": "phantomjs",
-        "javascriptEnabled" : true,
-        "acceptSslCerts" : true,
-        "phantomjs.binary.path" : "node_modules/phantomjs/bin/phantomjs"
-      }
     }
   }
 }


### PR DESCRIPTION
We haven't atually used phantomjs in a long time, but apparently we
never actually removed these bits.

---

I noticed this while otherwise fussing around with our test suite.