### PR TITLE
make ci-clean: delete test-app.spk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ clean: ci-clean
 ci-clean:
 	@# Clean only the stuff that we want to clean between CI builds.
 	rm -rf bin tmp node_modules bundle shell-build sandstorm-*.tar.xz
+	rm -rf test-app.spk
 	rm -rf tests/assets/meteor-testapp.spk meteor-testapp/.meteor-spk
 
 install: sandstorm-$(BUILD)-fast.tar.xz install.sh


### PR DESCRIPTION
Caught this while debugging the new test failures. We delete
meteor-testapp.spk, so we should delete this one too.