### PR TITLE
Update documentation on installing from source

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -135,6 +135,8 @@ Please install the following:
 * `xz`
 * `zip`
 * `unzip`
+* `flex`
+* `bison`
 * `strace`
 * `curl`
 * `python`
@@ -149,7 +151,7 @@ On Debian or Ubuntu, you should be able to get all these with:
 
     sudo apt-get install build-essential libcap-dev xz-utils zip \
         unzip strace curl discount git python zlib1g-dev \
-        golang-go cmake strace
+        golang-go cmake strace flex bison locales
     curl https://install.meteor.com/?release=1.8.2 | sh
 
 On Fedora 27 you should be able to get them with (as root):
@@ -157,13 +159,13 @@ On Fedora 27 you should be able to get them with (as root):
     dnf install make libcap-devel libstdc++-devel libstdc++-static \
        glibc-headers glibc-static glibc-locale-source xz zip \
        unzip strace curl discount git python2 zlib-devel \
-       golang cmake strace
+       golang cmake strace flex bison
     curl https://install.meteor.com/?release=1.8.2 | sh
 
 If you have trouble getting the build to work on your distro, we recommend trying in a virtual
 machine running the latest stable Debian release. This is easy to set up using Vagrant, like:
 
-    vagrant init debian/contrib-stretch64
+    vagrant init debian/bullseye64
     vagrant up
     vagrant ssh
 


### PR DESCRIPTION
- `flex` and `bison` are required for the build.
- `locales` is required under Debian/Ubuntu; otherwise the build fails because `/usr/share/i18n/charmaps` is missing.
- bullseye is now the latest Debian stable release.  The source build fails on stretch because `SECCOMP_FILTER_FLAG_LOG` is undeclared, unless (presumably) the kernel headers were to be upgraded.  (See also 2021-09-06 discussion on IRC.)  The `contrib-` is no longer necessary because the `vboxsf` kernel module is in `debian/bullseye64`.