### PR TITLE
Update build instructions for Fedora (closes #3565)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -131,10 +131,13 @@ Please install the following:
 * Linux x86_64, with kernel version 3.13 or later
 * C and C++ standard libraries and headers
 * GNU Make
+* GNU diffutils
+* `g++`
 * `libcap` with headers
 * `xz`
 * `zip`
 * `unzip`
+* `which`
 * `flex`
 * `bison`
 * `strace`
@@ -154,12 +157,12 @@ On Debian or Ubuntu, you should be able to get all these with:
         golang-go cmake strace flex bison locales
     curl https://install.meteor.com/?release=1.8.2 | sh
 
-On Fedora 27 you should be able to get them with (as root):
+On Fedora 34 you should be able to get them with:
 
-    dnf install make libcap-devel libstdc++-devel libstdc++-static \
-       glibc-headers glibc-static glibc-locale-source xz zip \
-       unzip strace curl discount git python2 zlib-devel \
-       golang cmake strace flex bison
+    sudo dnf install make libcap-devel libstdc++-devel libstdc++-static \
+       glibc-headers glibc-static glibc-locale-source gcc-c++ xz zip \
+       unzip strace curl discount git python zlib-devel zlib-static \
+       golang cmake strace flex bison which diffutils
     curl https://install.meteor.com/?release=1.8.2 | sh
 
 If you have trouble getting the build to work on your distro, we recommend trying in a virtual


### PR DESCRIPTION
`zlib-static` worked, and I verified once again that everything I added to the install list is actually required for the build.