### PR TITLE
Set Referrer-Policy: same-origin

### DIFF
--- a/src/sandstorm/web-session-bridge.h
+++ b/src/sandstorm/web-session-bridge.h
@@ -54,6 +54,7 @@ public:
     kj::HttpHeaderId hETag;
     kj::HttpHeaderId hIfMatch;
     kj::HttpHeaderId hIfNoneMatch;
+    kj::HttpHeaderId hReferrerPolicy;
     kj::HttpHeaderId hSecWebSocketProtocol;
     kj::HttpHeaderId hVary;
     kj::HttpHeaderId hXFrameOptions;

--- a/src/sandstorm/web-session.capnp
+++ b/src/sandstorm/web-session.capnp
@@ -611,6 +611,7 @@ interface WebSession @0xa50711a14d35a8ce extends(Grain.UiSession) {
   #   * Access-Control-*
   # * Sandstorm uses these for sandboxing:
   #   * Content-Security-Policy
+  #   * Referrer-Policy
   #   * X-Frame-Options
   # * Redundant or irrelevant to Cap'n Proto RPC:
   #   * Connection


### PR DESCRIPTION
This sets `Referrer-Policy: same-origin` according to the discussion at https://github.com/sandstorm-io/sandstorm/issues/824#issuecomment-870142865, and would thus close #824 if merged.  Currently, I've chosen to set this header for all requests, including API requests (it may not be strictly necessary there, but should not hurt anything either) and regardless of whether `allowLegacyRelaxedCSP` is true (the legacy escape hatch should not be necessary for this header).  In the end, I chose to set the header to `same-origin` rather than `no-referrer` after reading this comment in `gateway.c++`:

https://github.com/sandstorm-io/sandstorm/blob/a0fd3f8884d72fc96bd9ade43e8283886f93490e/src/sandstorm/gateway.c%2B%2B#L341-L353

I did not actually test whether `Referrer-Policy: no-referrer` causes the same issue with `Origin: null`, but I would assume it does, since the meta tag is just [another way of setting the same policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#integration_with_html).  I've so far been unable to find consistent information about whether the header or the meta tag takes precedence if both are specified and conflict with one another.  If it were to turn out that the header takes precedence, then that would allow us to remove the `Origin: null` workaround I quoted above without having to change any apps.

I've tested this a bit on my local machine, including loading some feeds with images in tinytinyRSS and otherwise verifying that the response header is being set.