### PR TITLE
Vagrantfile improvements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ EOF
 
   # Use NFS for the /vagrant shared directory, for performance and
   # compatibility.
-  config.vm.synced_folder ".", "/vagrant", type: "nfs"
+  config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_udp: false
 
   # Calculate the number of CPUs and the amount of RAM the system has,
   # in a platform-dependent way; further logic below.


### PR DESCRIPTION
This patch series contains a number of improvements to the `Vagrantfile`.  Each commit contains a detailed description of the change.  Something I forgot to mention: One of the side effects of changing to a non-`contrib` image (1d50c1ec59a3f67e1d5b12abad5a99461c0217ec) is that `libvirt` is now available as a second virtualization provider.  My desire to get `libvirt` actually working is what led to 7b265d6426fc446ac066de4df2b05c6760fbf091.