### PR TITLE
Fix graphviz diagrams on "How It Works" page.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ sudo apt-get install -y graphviz virtualenv
 cd ~/projects/sandstorm
 virtualenv tmp/docs-virtualenv
 tmp/docs-virtualenv/bin/pip install mkdocs==1.0.4
-tmp/docs-virtualenv/bin/pip install markdown-inline-graphviz-extension==1.1
+tmp/docs-virtualenv/bin/pip install mkdocs-markdown-graphviz==1.3
 tmp/docs-virtualenv/bin/mkdocs serve
 ```
 

--- a/docs/generate.sh
+++ b/docs/generate.sh
@@ -50,7 +50,7 @@ assert_dependencies() {
     if [ ! -x "tmp/docs-virtualenv/bin/mkdocs" ] ; then
       mkdir -p tmp
       virtualenv tmp/docs-virtualenv
-      tmp/docs-virtualenv/bin/pip install mkdocs==1.0.4 markdown-inline-graphviz-extension==1.1
+      tmp/docs-virtualenv/bin/pip install mkdocs==1.0.4 mkdocs-markdown-graphviz==1.3
     fi
     export PATH=$PWD/tmp/docs-virtualenv/bin:$PATH
   fi

--- a/docs/using/how-it-works.md
+++ b/docs/using/how-it-works.md
@@ -22,7 +22,7 @@ and the grain occur over the Cap'n Proto WebSession format.  With existing
 applications, the Sandstorm HTTP bridge is used to translate between Cap'n
 Proto and HTTP.
 
-{% dot communication_overview_http_app.svg
+```graphviz dot communication_overview_http_app.svg
     graph communication_overview_http_app {
       rankdir=LR;
       compound=true;
@@ -47,12 +47,12 @@ Proto and HTTP.
       websession -- bridge;
       bridge -- app;
     }
-%}
+```
 
 When an application can speak Cap'n Proto directly to Sandstorm, the HTTP
 bridge is not needed.
 
-{% dot communication_overview_native_app.svg
+```graphviz dot communication_overview_native_app.svg
     graph communication_overview_native_app {
       rankdir=LR;
       compound=true;
@@ -75,4 +75,4 @@ bridge is not needed.
       proxy -- websession;
       websession -- app;
     }
-%}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ theme:
 repo_url: https://github.com/sandstorm-io/sandstorm
 edit_uri: edit/master/docs/
 markdown_extensions:
-    - markdown_inline_graphviz
+    - mkdocs_markdown_graphviz
     - admonition
 extra_css:
     - "extra.css"


### PR DESCRIPTION
This fixes the diagrams on the "How It Works" page by migrating to mkdocs-markdown-graphviz, following https://github.com/sandstorm-io/sandstorm/pull/3548#issuecomment-898581699.

I've tested this in a container locally, so _hopefully_ it does indeed fix things.

The problem before was that, somewhere, a bunch of `<p>` tags were being added to the SVG output of `dot`.  This newer fork of the previous extension entirely circumvents that problem by base64 encoding the SVG output instead of having it inline.

The page in question is at https://docs.sandstorm.io/en/latest/using/how-it-works/