### PR TITLE
Add a workflow for previewing doc changes

### DIFF
--- a/.github/workflows/doc-ci.yml
+++ b/.github/workflows/doc-ci.yml
@@ -1,0 +1,35 @@
+name: doc-ci
+
+on:
+  push:
+    paths:
+      - 'mkdocs.yml'
+      - 'docs/**'
+  pull_request:
+    paths:
+      - 'mkdocs.yml'
+      - 'docs/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y git virtualenv graphviz
+        virtualenv tmp/docs-virtualenv
+        tmp/docs-virtualenv/bin/pip install -r docs/requirements.txt
+    - name: build docs
+      run: |
+        export PATH=$PWD/tmp/docs-virtualenv/bin:$PATH
+        mkdir docbuild
+        bash -x docs/generate.sh -d docbuild
+        tar cvf docbuild.tar docbuild
+    - name: upload docbuild.tar
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: docbuild.tar
+        path: docbuild.tar

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,7 @@ Run the following.
 sudo apt-get install -y graphviz virtualenv
 cd ~/projects/sandstorm
 virtualenv tmp/docs-virtualenv
-tmp/docs-virtualenv/bin/pip install mkdocs==1.0.4
-tmp/docs-virtualenv/bin/pip install mkdocs-markdown-graphviz==1.3
+tmp/docs-virtualenv/bin/pip install -r docs/requirements.txt
 tmp/docs-virtualenv/bin/mkdocs serve
 ```
 

--- a/docs/generate.sh
+++ b/docs/generate.sh
@@ -50,7 +50,7 @@ assert_dependencies() {
     if [ ! -x "tmp/docs-virtualenv/bin/mkdocs" ] ; then
       mkdir -p tmp
       virtualenv tmp/docs-virtualenv
-      tmp/docs-virtualenv/bin/pip install mkdocs==1.0.4 mkdocs-markdown-graphviz==1.3
+      tmp/docs-virtualenv/bin/pip install -r docs/requirements.txt
     fi
     export PATH=$PWD/tmp/docs-virtualenv/bin:$PATH
   fi

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs==1.0.4
+mkdocs-markdown-graphviz==1.3


### PR DESCRIPTION
This at least outputs an artifact we can download, which gets us one step closer to Ian's wish at https://github.com/sandstorm-io/sandstorm/pull/3573#issuecomment-938296567.

I've tested this with [act](https://github.com/nektos/act) using the command

```
act -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest -W .github/workflows/doc-ci.yml
```

(I had to remove any broken symlinks in the source directory before it would work, but that's an act problem, not a sandstorm one.)

The act environment doesn't perfectly match the GitHub Actions environment, so there's no guaranteeing this will work, but it should be pretty close...