### PR TITLE
Fix the icon font generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,17 +289,11 @@ tmp/.shell-env: tmp/.ekam-run $(IMAGES) shell/imports/client/changelog.html shel
 	@cd shell/ && PATH=$(METEOR_DEV_BUNDLE)/bin:$$PATH $(METEOR_DEV_BUNDLE)/bin/npm install
 	@touch tmp/.shell-env
 
-# grunt-webfont 0.4.8 does not work on Node 12. The latest version of grunt-webfont, OTOH, produces
-# a broken font file (all icons invisible and zero-width). For now we stick with the old version
-# and run it using Meteor 1.8.2's node which is old enough to run it. This means you have to
-# install Meteor 1.8.2 in addition to the latest version in order to build Sandstorm. :(
-METEOR_DEV_BUNDLE_ICONS=$(shell ./find-meteor-dev-bundle.sh METEOR@1.8.2)
-
 icons/node_modules: icons/package.json
-	cd icons && PATH=$(METEOR_DEV_BUNDLE_ICONS)/bin:$$PATH $(METEOR_DEV_BUNDLE_ICONS)/bin/npm install
+	cd icons && PATH=$(METEOR_DEV_BUNDLE)/bin:$$PATH $(METEOR_DEV_BUNDLE)/bin/npm install
 
 shell/client/styles/_icons.scss: icons/node_modules icons/*svg icons/Gruntfile.js
-	cd icons && PATH=$(METEOR_DEV_BUNDLE_ICONS)/bin:$$PATH ./node_modules/.bin/grunt
+	cd icons && PATH=$(METEOR_DEV_BUNDLE)/bin:$$PATH ./node_modules/.bin/grunt
 
 shell/imports/client/changelog.html: CHANGELOG.md
 	@mkdir -p tmp

--- a/icons/Gruntfile.js
+++ b/icons/Gruntfile.js
@@ -1,5 +1,5 @@
 module.exports = function(grunt) {
-  grunt.loadNpmTasks("grunt-webfont");
+  grunt.loadNpmTasks("grunt-webfonts");
 
 
   grunt.initConfig({
@@ -13,6 +13,9 @@ module.exports = function(grunt) {
           engine: "node",
           autoHint: false,
           htmlDemo: false,
+          normalize: true,
+          fontHeight: 1001,
+          fontFilename: 'icons-{hash}',
           relativeFontPath: "/icons/",
           stylesheet: "scss",
           templateOptions: {

--- a/icons/package.json
+++ b/icons/package.json
@@ -5,6 +5,6 @@
   "devDependencies": {
     "grunt": "^1.0.4",
     "grunt-cli": "^1.3.2",
-    "grunt-webfont": "0.4.8"
+    "grunt-webfonts": "4.0.1"
   }
 }


### PR DESCRIPTION
This switches to the maintained `grunt-webfonts` and sets options to fix the font generation by normalizing the icon sizes.

The font is not exactly the same as can be seen here:
<img width="402" alt="image" src="https://user-images.githubusercontent.com/4368/136674589-a9006451-f0f6-44d6-88ae-65bc1c66ff25.png">

Compared to the original font:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/4368/136674555-6a952b70-f5a2-4f14-920b-d23077c27e60.png">

The problem is that the SVGs are not the same size and while the old version of `grunt-webfont` would normalize the sizes automatically. In the last versions of the package you had to specify explicitly that you wanted the icons normalized and the algorithm for doing that seems to have changed slightly.

If we want to preserve the font as it was we need to normalize the SVGs manually in an editor.