### PR TITLE
install.md: remove duplicate mention of strace

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -146,7 +146,6 @@ Please install the following:
 * `zlib1g-dev`
 * `golang-go`
 * `cmake`
-* `strace`
 * discount (markdown parser)
 * [Meteor](http://meteor.com) version 1.8.2
 


### PR DESCRIPTION
`git-blame` points to 6b0ad2716 (first mention) and e055782e1 (second mention).  I guess, as of the second commit, it was missing from the `dnf` and `apt-get` commands but not the overall list.  Easy enough to fix.