### PR TITLE
Factor out some common sandbox setup code

### DIFF
--- a/src/sandstorm/sandbox.c++
+++ b/src/sandstorm/sandbox.c++
@@ -1,0 +1,39 @@
+#include <fcntl.h>
+#include <kj/io.h>
+#include "util.h"
+#include "sandbox.h"
+
+namespace sandstorm::sandbox {
+
+static void writeSetgroupsIfPresent(const char *contents) {
+  KJ_IF_MAYBE(fd, raiiOpenIfExists("/proc/self/setgroups", O_WRONLY | O_CLOEXEC)) {
+    kj::FdOutputStream(kj::mv(*fd)).write(contents, strlen(contents));
+  }
+}
+
+static void writeUserNSMap(const char *type, kj::StringPtr contents) {
+  kj::FdOutputStream(raiiOpen(kj::str("/proc/self/", type, "_map").cStr(), O_WRONLY | O_CLOEXEC))
+      .write(contents.begin(), contents.size());
+}
+
+void hideUserGroupIds(uid_t realUid, gid_t realGid, bool randomize) {
+    uid_t fakeUid = 1000;
+    gid_t fakeGid = 1000;
+
+    if (randomize) {
+      // "Randomize" the UID and GID in dev mode. This catches app bugs where the app expects the
+      // UID or GID to be always 1000, which is not true of servers that use the privileged sandbox
+      // rather than the userns sandbox. (The "randomization" algorithm here is only meant to
+      // appear random to a human. The funny-looking numbers are just arbitrary primes chosen
+      // without much thought.)
+      time_t now = time(nullptr);
+      fakeUid = now * 4721 % 2000 + 1;
+      fakeGid = now * 2791 % 2000 + 1;
+    }
+
+    writeSetgroupsIfPresent("deny\n");
+    writeUserNSMap("uid", kj::str(fakeUid, " ", realUid, " 1\n"));
+    writeUserNSMap("gid", kj::str(fakeGid, " ", realGid, " 1\n"));
+}
+
+};

--- a/src/sandstorm/sandbox.h
+++ b/src/sandstorm/sandbox.h
@@ -1,0 +1,17 @@
+#pragma once
+// Utility functions for setting up a sandbox.
+//
+// TODO: right now some of the sandbox code from the supervisor is duplicated
+// in the code for taking backups. We should factor all of that out and move
+// it here; right now only a few pieces have been moved.
+
+#include <unistd.h>
+
+namespace sandstorm::sandbox {
+
+void hideUserGroupIds(uid_t realUid, gid_t realGid, bool randomize);
+// Use user namespaces to mask the real user- and group- ids as seen
+// by a grain. If randomize is true, the the uids are chosen at random
+// (weakly; do not rely on this being particularly good randomness).
+// otherwise, we choose 1000:1000.
+};


### PR DESCRIPTION
...between the supervisor and the backup code. We should ideally pull
most of what's common out into a shared module, but I was looking at
this while debugging #3584, and it seemed like a good start.