### PR TITLE
Stop installing a very old version of meteor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,8 @@ jobs:
 
             sudo apt-get install -y build-essential libcap-dev xz-utils zip unzip strace curl discount git python zlib1g-dev cmake ccache
       - name: install meteor
-        # Install Meteor 1.8.2 because the icons build (which doesn't actually use meteor) needs
-        # the Node binary from this version. Other required versions of meteor will be installed
-        # automatically as needed by the meteor tool.
         run: |
-            curl https://install.meteor.com/?release=1.8.2 | sh
+            curl https://install.meteor.com/ | sh
       - name: cache ccache files
         uses: actions/cache@v1.1.0
         with:

--- a/docs/install.md
+++ b/docs/install.md
@@ -147,14 +147,14 @@ Please install the following:
 * `golang-go`
 * `cmake`
 * discount (markdown parser)
-* [Meteor](http://meteor.com) version 1.8.2
+* [Meteor](http://meteor.com)
 
 On Debian or Ubuntu, you should be able to get all these with:
 
     sudo apt-get install build-essential libcap-dev xz-utils zip \
         unzip strace curl discount git python zlib1g-dev \
         golang-go cmake strace flex bison locales
-    curl https://install.meteor.com/?release=1.8.2 | sh
+    curl https://install.meteor.com/ | sh
 
 On Fedora 34 you should be able to get them with:
 
@@ -162,7 +162,7 @@ On Fedora 34 you should be able to get them with:
        glibc-headers glibc-static glibc-locale-source gcc-c++ xz zip \
        unzip strace curl discount git python zlib-devel zlib-static \
        golang cmake strace flex bison which diffutils
-    curl https://install.meteor.com/?release=1.8.2 | sh
+    curl https://install.meteor.com/ | sh
 
 If you have trouble getting the build to work on your distro, we recommend trying in a virtual
 machine running the latest stable Debian release. This is easy to set up using Vagrant, like:


### PR DESCRIPTION
This should be unnecessary now that #3576 has been merged.

This should also fix the build error we've been seeing in CI.