### PR TITLE
Update doc: Installing from source now requires python3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
             echo "The github runner seems to have some version of golang already; installing golang-go breaks."
             which go || sudo apt-get install golang-go
 
-            sudo apt-get install -y build-essential libcap-dev xz-utils zip unzip strace curl discount git python zlib1g-dev cmake ccache
+            sudo apt-get install -y build-essential libcap-dev xz-utils zip unzip strace curl discount git python3 zlib1g-dev cmake ccache
       - name: install meteor
         run: |
             curl https://install.meteor.com/ | sh

--- a/docs/install.md
+++ b/docs/install.md
@@ -142,7 +142,7 @@ Please install the following:
 * `bison`
 * `strace`
 * `curl`
-* `python`
+* `python3`
 * `zlib1g-dev`
 * `golang-go`
 * `cmake`
@@ -152,7 +152,7 @@ Please install the following:
 On Debian or Ubuntu, you should be able to get all these with:
 
     sudo apt-get install build-essential libcap-dev xz-utils zip \
-        unzip strace curl discount git python zlib1g-dev \
+        unzip strace curl discount git python3 zlib1g-dev \
         golang-go cmake strace flex bison locales
     curl https://install.meteor.com/ | sh
 


### PR DESCRIPTION
Recently, the clang update script [was changed](https://chromium.googlesource.com/chromium/src/tools/clang.git/+/5c0e867150ea239d3f0f0316370e71672c77b91a) to require python3, specifically.

I discovered this change when attempting to build Sandstorm using a [Dockerfile](https://gist.github.com/garrison/f025090ce914641f0d1e492612dcbd4e#file-dockerfile-debian) that worked previously.  I have verified that this change alone fixes the build under Debian; it seems that python2 is not also required (nor is `/usr/bin/python`, for that matter).

In Fedora, "python" already refers to python3, so no change was needed to that install line.