### PR TITLE
Make the grain close button bigger on mobile.

### DIFF
--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -766,6 +766,10 @@ body>.topbar {
           right: 0px;
           width: 24px;
           height: 24px;
+          @media #{$mobile} {
+            height: 44px;
+            width: 44px;
+          }
           margin: 2px;
           display: block;
           background-image: url("/close.svg");

--- a/shell/client/styles/_topbar.scss
+++ b/shell/client/styles/_topbar.scss
@@ -741,6 +741,11 @@ body>.topbar {
           left: (($navbar-width-desktop-shrunk - 24px) / 2);
           width: 24px;
           height: 24px;
+          @media #{$mobile} {
+            left: (($navbar-width-desktop-shrunk - 40px) / 2);
+            width: 40px;
+            height: 40px;
+          }
         }
         .notification-count {
           position: absolute;
@@ -767,8 +772,8 @@ body>.topbar {
           width: 24px;
           height: 24px;
           @media #{$mobile} {
-            height: 44px;
-            width: 44px;
+            height: 40px;
+            width: 40px;
           }
           margin: 2px;
           display: block;


### PR DESCRIPTION
...Filling the entire vertical space alotted for it.

I have found this difficult to press at its current size on mobile; this
essentially doubles the size, so it should be better.

Aesthetically it would be nice to also enlarge the grain icon for
symmetry, but just applying the same rule ends up with it overflowing
the bounds significantly.

I am trying to resist the temptation to redo this whole section with
flexbox & grid right now, but I might find time to actually do that later,
as I think it would make all this easier to reason about.

---

# Screenshots

## Before

![Screen Shot 2021-12-01 at 17 37 58](https://user-images.githubusercontent.com/883774/144326285-4dd23f4e-f127-4ee4-91bf-a1fbfdc78332.png)

## After

![Screen Shot 2021-12-01 at 17 36 54](https://user-images.githubusercontent.com/883774/144326336-6d363a73-4342-457f-9c5a-9bbf86e3283a.png)

---

It looks the same on desktop as it did before.