### PR TITLE
Use Custom App Market URL as shown in href

### DIFF
--- a/shell/imports/client/apps/applist-client.js
+++ b/shell/imports/client/apps/applist-client.js
@@ -199,19 +199,6 @@ Template.sandstormAppListPage.helpers({
 });
 
 Template.sandstormAppListPage.events({
-  "click .install-button": function (event) {
-    event.preventDefault();
-    event.stopPropagation();
-    const ref = Template.instance().data;
-    const appMarket = ref._db.collections.settings.findOne({ _id: "appMarketUrl" });
-    let url = "https://apps.sandstorm.io/?host=";
-    if (appMarket) {
-      url = appMarket.value + '?host=';
-    }
-    window.open(url +
-        document.location.protocol + "//" + document.location.host, "_blank");
-  },
-
   "click .upload-button": function (event, instance) {
     const input = instance.find(".upload-button input");
     if (input == event.target) {

--- a/shell/imports/client/apps/applist-client.js
+++ b/shell/imports/client/apps/applist-client.js
@@ -213,6 +213,14 @@ Template.sandstormAppListPage.events({
     });
   },
 
+  "click .install-button": function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const url = event.currentTarget.getAttribute("href");
+    window.open(url +
+          document.location.protocol + "//" + document.location.host, "_blank");
+  },
+
   "click .uninstall-action": function (event) {
     const db = Template.instance().data._db;
     const appId = this.appId;

--- a/shell/imports/client/apps/applist.html
+++ b/shell/imports/client/apps/applist.html
@@ -43,7 +43,7 @@
     <h2 class="all-apps">{{_ "apps.appList.allApps"}}</h2>
     {{/if}}
 
-    <a class="app-button install-button {{#if searching}}hide{{/if}}" href="{{appMarketUrl}}">
+    <a class="app-button install-button {{#if searching}}hide{{/if}}" href="{{appMarketUrl}}" target="_blank">
       <div class="app-icon pseudoapp install-icon"></div>
       <span class="action-title">{{_ "apps.appList.install"}}</span>
       <span class="action-text">{{_ "apps.appList.fromMarket"}}</span>


### PR DESCRIPTION
As of the prior patch, when using a custom app-market URL, the URL in the href of this <a> tag is correct, so we should just use it under the DRY principle. This requires setting
the target attribute to "_blank" to preserve current behavior of opening the
link in a new tab.

This addresses #3029 