### PR TITLE
Fix a bug in the update tool's key generation.

### DIFF
--- a/src/sandstorm/update-tool.c++
+++ b/src/sandstorm/update-tool.c++
@@ -167,10 +167,15 @@ public:
     kj::FdOutputStream(raiiOpen(arg, O_WRONLY | O_APPEND | O_CREAT, 0600))
         .write(random, sizeof(random));
 
+    // Generate the key
+    byte publicKey[crypto_sign_ed25519_PUBLICKEYBYTES];
+    byte secretKey[crypto_sign_ed25519_SECRETKEYBYTES];
+    KJ_ASSERT(crypto_sign_ed25519_seed_keypair(publicKey, secretKey, random) == 0);
+
     // Write key.
     capnp::MallocMessageBuilder message;
     auto key = message.getRoot<PublicSigningKey>();
-    memcpy(getUnderlyingBytes(kj::cp(key), sizeof(random)), random, sizeof(random));
+    memcpy(getUnderlyingBytes(kj::cp(key), sizeof(publicKey)), publicKey, sizeof(publicKey));
     printKey(key);
     context.exitInfo("*** Don't forget to back up the keyring! ***");
   }


### PR DESCRIPTION
I encountered this while testing #3603; as written, the `update-tool add`
subcommand does not print out the correct public key for the keypair
that it generates; instead, it prints out the seed used to generate the
keypair. This patch changes the code to actually generate the keypair
from the seed, and then print out the public key that should be added
to update-tool.capnp

I assume this code was not used to generate the current contents of that
file, since if it was loading the keyring would fail (which is the
problem I encountered).