### PR TITLE
Fix web-publishing test

### DIFF
--- a/src/sandstorm/test-app/shutdown.html
+++ b/src/sandstorm/test-app/shutdown.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+  <body>
+    <span id="result">Shutdown success</span>
+  </body>
+</html>

--- a/src/sandstorm/test-app/static-index.html
+++ b/src/sandstorm/test-app/static-index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+  <body>
+    <span id="result">Success</span>
+  </body>
+</html>

--- a/src/sandstorm/test-app/test-app.c++
+++ b/src/sandstorm/test-app/test-app.c++
@@ -137,10 +137,12 @@ public:
                  sandstorm::SessionContext::Client context,
                  sandstorm::WebSession::Params::Reader params,
                  kj::Promise<sandstorm::SandstormApi<>::Client>& api,
+                 capnp::TwoPartyVatNetwork::Connection& conn,
                  bool isPowerboxRequest = false)
       : isPowerboxRequest(isPowerboxRequest),
         sessionContext(kj::mv(context)),
-        api(api) {}
+        api(api),
+        conn(conn) {}
 
   kj::Promise<void> get(GetContext context) override {
     // HTTP GET request.
@@ -156,8 +158,26 @@ public:
       auto staticFd = raiiOpen("/var/www/index.html", O_RDWR|O_CREAT);
       auto data = TEST_SHUTDOWN_HTML.get();
       KJ_SYSCALL(write(staticFd.get(), data.begin(), data.size()));
-      // TODO: defer this until after the response is sent:
-      exit(0);
+      auto response = context.getResults();
+      auto content = response.initContent();
+      content.setStatusCode(sandstorm::WebSession::Response::SuccessCode::OK);
+      content.setMimeType("text/plain");
+
+      // After sending the return message, shut down the connection and then
+      // exit.
+      //
+      // We need to wait for the return message to actually be sent,
+      // otherwise the supervisor will try to re-connect in order to retry
+      // the method call, which will start us back up again.
+      kj::evalLast([this]() {
+        return conn.shutdown().then([]() {
+          exit(0);
+        });
+      }).detach([](kj::Exception&& e) {
+        KJ_FAIL_ASSERT(e);
+      });
+
+      return kj::READY_NOW;
     } else if (path == "publicId" || path == "publicId/") {
       return sessionContext.castAs<sandstorm::HackSessionContext>()
         .getPublicIdRequest()
@@ -253,6 +273,7 @@ private:
   bool isPowerboxRequest;
   sandstorm::SessionContext::Client sessionContext;
   kj::Promise<sandstorm::SandstormApi<>::Client>& api;
+  capnp::TwoPartyVatNetwork::Connection& conn;
 };
 
 // =======================================================================================
@@ -260,8 +281,10 @@ private:
 class UiViewImpl final: public sandstorm::MainView<ObjectId>::Server {
 public:
 
-  UiViewImpl(kj::Promise<sandstorm::SandstormApi<>::Client> api)
-  : api(kj::mv(api)) {}
+  UiViewImpl(kj::Promise<sandstorm::SandstormApi<>::Client> api,
+             capnp::TwoPartyVatNetwork::Connection& conn)
+  : api(kj::mv(api)),
+    conn(conn) {}
 
   kj::Promise<void> getViewInfo(GetViewInfoContext context) override {
     auto viewInfo = context.initResults();
@@ -283,7 +306,7 @@ public:
     context.getResults().setSession(
         kj::heap<WebSessionImpl>(params.getUserInfo(), params.getContext(),
                                  params.getSessionParams().getAs<sandstorm::WebSession::Params>(),
-                                 api));
+                                 api, conn));
 
     return kj::READY_NOW;
   }
@@ -297,7 +320,7 @@ public:
     context.getResults().setSession(
         kj::heap<WebSessionImpl>(params.getUserInfo(), params.getContext(),
                                  params.getSessionParams().getAs<sandstorm::WebSession::Params>(),
-                                 api,
+                                 api, conn,
                                  true));
 
     return kj::READY_NOW;
@@ -328,6 +351,7 @@ public:
   }
 private:
   kj::Promise<sandstorm::SandstormApi<>::Client> api;
+  capnp::TwoPartyVatNetwork::Connection& conn;
 };
 
 // =======================================================================================
@@ -359,20 +383,23 @@ public:
     // Set up RPC on file descriptor 3.
     auto stream = ioContext.lowLevelProvider->wrapSocketFd(3);
     capnp::TwoPartyVatNetwork network(*stream, capnp::rpc::twoparty::Side::CLIENT);
-
+    capnp::MallocMessageBuilder message;
+    auto vatId = message.getRoot<capnp::rpc::twoparty::VatId>();
+    vatId.setSide(capnp::rpc::twoparty::Side::SERVER);
+    auto conn = network.connect(vatId);
     auto pf = kj::newPromiseAndFulfiller<sandstorm::SandstormApi<>::Client>();
-    auto rpcSystem = capnp::makeRpcServer(network, kj::heap<UiViewImpl>(kj::mv(pf.promise)));
 
-    {
-      capnp::MallocMessageBuilder message;
-      auto vatId = message.getRoot<capnp::rpc::twoparty::VatId>();
-      vatId.setSide(capnp::rpc::twoparty::Side::SERVER);
-      sandstorm::SandstormApi<>::Client api =
-          rpcSystem.bootstrap(vatId).castAs<sandstorm::SandstormApi<>>();
-      pf.fulfiller->fulfill(kj::mv(api));
+    KJ_IF_MAYBE(c, conn) {
+      auto rpcSystem = capnp::makeRpcServer(network, kj::heap<UiViewImpl>(kj::mv(pf.promise), **c));
+      {
+        sandstorm::SandstormApi<>::Client api =
+            rpcSystem.bootstrap(vatId).castAs<sandstorm::SandstormApi<>>();
+        pf.fulfiller->fulfill(kj::mv(api));
+      }
+      kj::NEVER_DONE.wait(ioContext.waitScope);
+    } else {
+      KJ_FAIL_ASSERT("Returned connection was null");
     }
-
-    kj::NEVER_DONE.wait(ioContext.waitScope);
   }
 
 private:

--- a/src/sandstorm/test-app/test-app.capnp
+++ b/src/sandstorm/test-app/test-app.capnp
@@ -8,6 +8,8 @@ using Spk = import "/sandstorm/package.capnp";
 
 const testAppHtml :Data = embed "test-app.html";
 const testPowerboxHtml :Data = embed "test-powerbox.html";
+const testShutdownHtml :Data = embed "shutdown.html";
+const testStaticHtml :Data = embed "static-index.html";
 
 struct ObjectId {
   union {

--- a/src/sandstorm/test-app/test-app.html
+++ b/src/sandstorm/test-app/test-app.html
@@ -165,5 +165,21 @@ function doPowerboxRequest(desc) {
       Schedule a one-shot job.</button></p>
 
     <p><button onclick="doPost('/test-system-api', '')" id="do-test-system-api">Test the system api.</button></p>
+
+    <p><button id="shutdown">Shut down server</button></p>
+
+    <div id="publicId"></div>
+
+    <script>
+      document.getElementById("shutdown").addEventListener("click", function() {
+        window.location = "/shutdown";
+      });
+      doGet("/publicId").then(function(xhr) {
+        const elt = document.createElement("p");
+        elt.setAttribute("id", "public-address");
+        elt.innerHTML = xhr.responseText;
+        document.getElementById("publicId").appendChild(elt);
+      });
+    </script>
   </body>
 </html>

--- a/tests/apps/web-publishing.js
+++ b/tests/apps/web-publishing.js
@@ -34,9 +34,8 @@ module.exports["Basic web publishing"] = function (browser) {
   browser
     .init()
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/jparyani/web-publishing-1.spk",
-      "ea3ef5ac80af4fb8041c635185b2a10f", "qkag0k1ta3guun74g4rxx4xfqun8a3d7vsagh3843cvvxhh6n8s0")
-    .assert.containsText("#grainTitle", "Untitled WebPublishingTest grain")
+    .uploadTestApp()
+    .assert.containsText("#grainTitle", "Untitled Sandstorm Test App instance")
     .waitForElementVisible(".grain-frame", short_wait)
     .grainFrame()
     .waitForElementVisible("#public-address", short_wait)
@@ -54,9 +53,8 @@ module.exports["Web publishing with grain shutdown"] = function (browser) {
   browser
     .init()
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/jparyani/web-publishing-1.spk",
-      "ea3ef5ac80af4fb8041c635185b2a10f", "qkag0k1ta3guun74g4rxx4xfqun8a3d7vsagh3843cvvxhh6n8s0")
-    .assert.containsText("#grainTitle", "Untitled WebPublishingTest grain")
+    .uploadTestApp()
+    .assert.containsText("#grainTitle", "Untitled Sandstorm Test App instance")
     .waitForElementVisible(".grain-frame", short_wait)
     .grainFrame()
     .waitForElementVisible("#public-address", short_wait)


### PR DESCRIPTION
N.B. this includes the commits from #3603, which should be reviewed & merged first.

This fixes the `apps/web-publishing.js` test that has been failing since forever.

It folds the functionality from the https://github.com/jparyani/sandstorm-test-app/tree/web-publishing into the test app we maintain in-tree, and then implements the solution I suggested [here](https://github.com/sandstorm-io/sandstorm/issues/3240#issuecomment-1024863154), i.e. defer the exit() until the return message has been sent.