### PR TITLE
Don't map ourselves to root in the user namespace.

### DIFF
--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1952,17 +1952,17 @@ private:
     // Start the server monitor.
     pid_t sandstormPid;
     {
-      int cloneFlags = CLONE_PARENT_SETTID | SIGCHLD;
-      if(!runningAsRoot) {
-        cloneFlags |= CLONE_NEWUSER|CLONE_NEWPID;
+      int cloneFlags = SIGCHLD;
+      if (!runningAsRoot) {
+        cloneFlags |= CLONE_NEWUSER | CLONE_NEWPID;
         unsharedUidNamespace = true;
       }
 
       uid_t uid = getuid();
       gid_t gid = getgid();
 
-      KJ_SYSCALL(syscall(SYS_clone, cloneFlags, nullptr, &sandstormPid, 0));
-      if(sandstormPid == 0) {
+      KJ_SYSCALL(sandstormPid = syscall(SYS_clone, cloneFlags, nullptr, nullptr, 0));
+      if (sandstormPid == 0) {
         runServerMonitor(config, fdBundle, uid, gid);
         KJ_UNREACHABLE;
       }


### PR DESCRIPTION
Take 2 for fixing #3584; this follows @kentonv's suggestion (2). As it turns out, we were already creating a userns in the right spot, but it doesn't take effect until after a fork(), so we have to do some footwork to make sure the rest of the logic happens in a child process.

Caveat: a few tests still fail on my machine, but for reasons that don't seem to be related: things like: 

```
 ✖ tests/system-api

   - Test system api (18.338s)
   Timed out while waiting for element <.grainlog-contents > pre> to be present for 5000 milliseconds.  - expected "visible" but got: "not found"
       at Object.module.exports.Test system api (/home/isd/src/foreign/sandstorm/tests/tests/system-api.js:38:6)
       at processTicksAndRejections (internal/process/task_queues.js:77:11)
```

Despite the fact that, when I run this with `SHOW_BROWSER=true`, the thing it's querying for is there. I'm also seeing these failures on my other branch, which I wasn't before. Before I fuss with this more I want to see if it passes in CI; marking this as a draft for now, but if I don't see those failures in CI I'll mark it as ready for review again.

Also, we do not appear to have tests that actually check that updates work correctly (we should add those), but I did check this manually. With only the first hunk (not mapping to uid 0), updates are indeed broken, but with the full patch they work again, as does launching apps afterwards.