### PR TITLE
WIP: make upgrading demo accounts available via a config option.

### DIFF
--- a/src/sandstorm/config.c++
+++ b/src/sandstorm/config.c++
@@ -241,6 +241,8 @@ Config readConfig(const char *path, bool parseUids) {
       config.allowDemoAccounts = value == "true" || value == "yes";
     } else if (key == "ALLOW_DEV_ACCOUNTS") {
       config.allowDevAccounts = value == "true" || value == "yes";
+    } else if (key == "ALLOW_UNINVITED") {
+      config.allowUninvited = value == "true" || value == "yes";
     } else if (key == "IS_TESTING") {
       config.isTesting = value == "true" || value == "yes";
     } else if (key == "HIDE_TROUBLESHOOTING") {

--- a/src/sandstorm/config.h
+++ b/src/sandstorm/config.h
@@ -25,6 +25,7 @@ struct Config {
   kj::String sandcatsHostname = nullptr;
   bool allowDemoAccounts = false;
   bool isTesting = false;
+  bool allowUninvited = false;
   bool allowDevAccounts = false;
   bool hideTroubleshooting = false;
   uint smtpListenPort = 30025;

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -2659,6 +2659,7 @@ private:
           "{ \"build\":", buildstamp,
           ", \"allowDemoAccounts\":", config.allowDemoAccounts ? "true" : "false",
           ", \"allowDevAccounts\":", config.allowDevAccounts ? "true" : "false",
+          ", \"allowUninvited\":", config.allowUninvited ? "true" : "false",
           ", \"isTesting\":", config.isTesting ? "true" : "false",
           ", \"hideTroubleshooting\":", config.hideTroubleshooting ? "true" : "false",
           ", \"wildcardHost\":\"", config.wildcardHost, "\"",

--- a/tests/run-local.sh
+++ b/tests/run-local.sh
@@ -138,6 +138,7 @@ rm -rf "$SANDSTORM_DIR"
 
 echo "IS_TESTING=true
 ALLOW_DEMO_ACCOUNTS=true
+ALLOW_UNINVITED=true
 BASE_URL=http://local.sandstorm.io:$PORT
 WILDCARD_HOST=*.local.sandstorm.io:$PORT
 PORT=$PORT


### PR DESCRIPTION
This fixes #3239 by providing a config option to re-enable the ability
to upgrade demo accounts to full accounts, which was removed in order to
allow alpha to act as the demo server when oasis was shut down.

Unfortunately, this seems to break *other* tests. The handful I examined
resulted in permission errors trying to upload the test app; presumably
when this is enabled our test accounts are somehow getting marked as
not allowed to upload their own apps.

---

Accordingly, I'm marking this as a draft until that can be debugged.