### PR TITLE
Docs: Update graphviz extension

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs==1.0.4
-mkdocs-markdown-graphviz==1.3
+mkdocs-graphviz==1.4.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+jinja2==3.0.3
 mkdocs==1.0.4
-mkdocs-graphviz==1.4.4
+mkdocs-graphviz==1.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ theme:
 repo_url: https://github.com/sandstorm-io/sandstorm
 edit_uri: edit/master/docs/
 markdown_extensions:
-    - mkdocs_markdown_graphviz
+    - mkdocs_graphviz
     - admonition
 extra_css:
     - "extra.css"


### PR DESCRIPTION
The author of this mkdocs extension renamed it and relicensed it as GPLv3 from MIT.

https://github.com/rodrigoschwencke/mkdocs-markdown-graphviz to
https://gitlab.com/rodrigo.schwencke/mkdocs-graphviz

And he took down the original, which is why the Docs CI check on Ian's PR failed.