### PR TITLE
Update file locations in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -41,16 +41,16 @@ shell/public/fonts/WOFF/OTF/SourceSansPro-BoldIt.otf.woff
     License: SIL Open Font License, Version 1.1
     License URL: https://github.com/adobe-fonts/source-sans-pro/blob/master/LICENSE.txt
 
-shell/client/accounts/login-buttons.html
-shell/client/accounts/login-buttons.js
-shell/client/accounts/login-buttons-session.js
+shell/imports/client/accounts/login-buttons.html
+shell/imports/client/accounts/login-buttons.js
+shell/imports/client/accounts/login-buttons-session.js
     What: forked from accounts-ui/accounts-ui-unstyled
     Source URL: https://github.com/meteor/meteor
     Copyright: Meteor Development Group
     License: MIT
     License URL: https://github.com/meteor/meteor/blob/devel/LICENSE.txt
 
-shell/client/vendor/ansi-up.js
+shell/imports/client/vendor/ansi-up.js
     What: ansi_up library (converts ANSI escape codes to HTML)
     Source URL: http://github.com/drudru/ansi_up
     Copyright: Dru Nelson
@@ -58,22 +58,15 @@ shell/client/vendor/ansi-up.js
     License URL: https://github.com/drudru/ansi_up/blob/master/Readme.md
                  (at bottom)
 
-shell/packages/sandstorm-identicons/identicon.js
+shell/imports/sandstorm-identicons/identicon.ts
     What: identicon.js
     Source URL: https://github.com/stewartlord/identicon.js
     Copyright: Stewart Lord
     License: BSD 2-clause
     License URL: http://opensource.org/licenses/bsd-license.php
 
-shell/packages/sandstorm-identicons/pnglib.js
-    What: PNGlib
-    Source URL: https://github.com/stewartlord/pnglib.js
-    Copyright: Robert Eisele
-    License: BSD 2-clause
-    License URL: http://opensource.org/licenses/bsd-license.php
-
 shell/imports/client/accounts/ldap/ldap-client.js
-shell/server/accounts/ldap/ldap-server.js
+shell/imports/server/accounts/ldap/ldap-server.js
     What: forked from Meteor accounts-ldap package
     Source URL: https://github.com/typ90/meteor-accounts-ldap
     Copyright: Eric Typaldos
@@ -82,7 +75,7 @@ shell/server/accounts/ldap/ldap-server.js
 
 shell/imports/client/accounts/saml/saml-client.js
 shell/imports/server/accounts/saml-utils.js
-shell/server/accounts/saml/saml-server.js
+shell/imports/server/accounts/saml/saml-server.js
     What: forked from Meteor accounts-saml package
     Source URL: https://github.com/nate-strauser/meteor-accounts-saml
     Copyright: Nathan Strauser

--- a/shell/imports/client/shell.html
+++ b/shell/imports/client/shell.html
@@ -526,7 +526,6 @@ limitations under the License.
         <li><a href="https://github.com/rs22/acme-dns-01-desec">ACME.js deSEC plugin by Robert Schmid</a> (MIT {{_ "shell.about.dependencies.license"}})</li>
         <li><a href="https://github.com/latacora/acme-dns-01-gcp">ACME.js GCP plugin by Latacora</a> (MPL)</li>
         <li><a href="https://git.y.gy/firstdorsal/acme-dns-01-powerdns">ACME.js PowerDNS plugin by Paul Colin Hennig</a> (MIT {{_ "shell.about.dependencies.license"}})</li>
-        <li><a href="http://www.xarg.org/2010/03/generate-client-side-png-files-using-javascript/">PNGlib by Robert Eisele</a> (BSD {{_ "shell.about.dependencies.license"}})</li>
         <li><a href="http://libb64.sourceforge.net/">libb64 by Chris Venter</a> (Public Domain)</li>
         <li><a href="http://tukaani.org/xz/">XZ Utils</a> (Public Domain / GPL)</li>
         <li><a href="http://www.info-zip.org/">Info-ZIP</a> (Info-ZIP {{_ "shell.about.dependencies.license"}})</li>


### PR DESCRIPTION
From some of the refactoring, the files referred to in the license have moved. One additional note, pnglib.js no longer exists in our project as far as I can tell: It was removed in #2268 back in 2016.