### PR TITLE
Split `lint` target into separate `lint` and `typecheck-ts` targets.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,8 @@ jobs:
         with:
           name: sandstorm-0-fast.tar.xz
           path: sandstorm-0-fast.tar.xz
+      - name: typecheck-ts
+        run: make typecheck-ts
       - name: lint
         run: |
           # In addition to making sure the linting step doesn't flag any errors,

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,8 @@ test: sandstorm-$(BUILD)-fast.tar.xz test-app.spk tests/assets/meteor-testapp.sp
 	tests/run-local.sh sandstorm-$(BUILD)-fast.tar.xz test-app.spk
 lint: shell-env
 	cd shell && meteor npm run lint
+typecheck-ts:
+	cd shell && meteor npm run typecheck
 
 installer-test:
 	(cd installer-tests && bash prepare-for-tests.sh && PYTHONUNBUFFERED=yes TERM=xterm SLOW_TEXT_TIMEOUT=120 ~/.local/bin/stodgy-tester --plugin stodgy_tester.plugins.sandstorm_installer_tests --on-vm-start=uninstall_sandstorm --rsync)

--- a/shell/imports/client/backups.ts
+++ b/shell/imports/client/backups.ts
@@ -1,5 +1,5 @@
 import downloadFile from '/imports/client/download-file.js';
-import { meteorCallPromise } from '/imports/client/meteor-call-promise.ts';
+import { meteorCallPromise } from '/imports/client/meteor-call-promise.js';
 
 // TODO: can we move this somewhere more centralized/does meteor provide
 // type declarations for this somewhere?

--- a/shell/package.json
+++ b/shell/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "eslint . --ext .ts --ext .js && tsc"
+    "lint": "eslint . --ext .ts --ext .js",
+    "typecheck": "tsc"
   },
   "author": "",
   "repository": {


### PR DESCRIPTION
I find myself wanting to just do the typechecking bit often, and especially with how much output eslint currently generates, this makes things nicer to work with.

This also fixes an import path that tsc was complaining about.