### PR TITLE
Capitalize settings

### DIFF
--- a/shell/i18n/en.i18n.json
+++ b/shell/i18n/en.i18n.json
@@ -234,7 +234,7 @@
     },
     "grainSettingsButton": {
       "hint": "Grain Settings",
-      "text": "settings"
+      "text": "Settings"
     },
     "grainApiTokenButton": {
       "hint": "Get webkey",


### PR DESCRIPTION
So this is the most minor nitpick I've ever done: On desktop, the Grain Settings button does not show text, and shows the hint when you hover it. However, on mobile, where I've never before tried to view Grain Settings, it uses the "text" value on the sidebar menu, where it's the only not-capitalized option.