### PR TITLE
Installer: Update help URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1670,7 +1670,7 @@ sandcats_provide_help() {
   echo "You can:"
   echo ""
   echo "* Read more about it at:"
-  echo "  https://github.com/sandstorm-io/sandstorm/wiki/Sandcats-dynamic-DNS"
+  echo "  https://docs.sandstorm.io/en/latest/administering/sandcats/"
   echo ""
   echo "* Recover access to a domain you once registered with sandcats"
   echo ""


### PR DESCRIPTION
This is another quick one: We refer people to an old wiki page which then tells people to go to the docs. Just updating this URL to be direct.