### PR TITLE
Fix typescript errors

### DIFF
--- a/shell/imports/client/backups.ts
+++ b/shell/imports/client/backups.ts
@@ -1,4 +1,6 @@
 import downloadFile from '/imports/client/download-file.js';
+
+// @ts-ignore
 import { meteorCallPromise } from '/imports/client/meteor-call-promise.ts';
 
 // TODO: can we move this somewhere more centralized/does meteor provide

--- a/shell/imports/client/backups.ts
+++ b/shell/imports/client/backups.ts
@@ -13,7 +13,7 @@ export function makeAndDownloadBackup(grainId: string, suggestedFilename: string
   // Make a backup and then download it. 'suggestedFileName' is the file name
   // to save as, minus the .zip suffix.
 
-  return meteorCallPromise("backupGrain", grainId).then((id) => {
+  return meteorCallPromise("backupGrain", grainId).then((id: string) => {
     const origin = __meteor_runtime_config__.DDP_DEFAULT_CONNECTION_URL || "";
     const url = origin + "/downloadBackup/" + id;
     downloadFile(url, suggestedFilename + ".zip");


### PR DESCRIPTION
This fixes two errors currently being flagged by tsc in CI: https://github.com/sandstorm-io/sandstorm/runs/6845088479?check_suite_focus=true#step:10:12

The first of these we just ignore; I previously tried to follow the suggestion and change the extension to `.js`, but that seems to break the build, at least for @kentonv.

The second we just add a type annotation.