### PR TITLE
Drop .js/.ts suffixes in imports.

### DIFF
--- a/shell/client/main.ts
+++ b/shell/client/main.ts
@@ -39,28 +39,28 @@
 // Load packages that the sandstorm shell depends on before sandstorm itself.
 
 // sandstorm-db.
-import "../imports/sandstorm-db/db.js";
-import "../imports/sandstorm-db/profile.js";
+import "../imports/sandstorm-db/db";
+import "../imports/sandstorm-db/profile";
 
 // sandstorm-accounts-packages
-import "../imports/sandstorm-accounts-packages/accounts.js";
+import "../imports/sandstorm-accounts-packages/accounts";
 
 // sandstorm-ui-topbar.  Depends on sandstorm-identicons.
 import "../imports/sandstorm-ui-topbar/topbar.html";
-import "../imports/sandstorm-ui-topbar/topbar.js";
+import "../imports/sandstorm-ui-topbar/topbar";
 
 // sandstorm-ui-powerbox.  Depends on sandstorm-db and sandstorm-ui-topbar
 import "../imports/sandstorm-ui-powerbox/powerbox.html";
 
 // blackrock-payments
-import "../imports/blackrock-payments/constants.js";
+import "../imports/blackrock-payments/constants";
 import "../imports/blackrock-payments/client/billingSettings.html";
 import "../imports/blackrock-payments/client/billingPrompt.html";
 import "../imports/blackrock-payments/client/payments-api.html";
-import "../imports/blackrock-payments/client/billingSettings.js";
-import "../imports/blackrock-payments/client/billingPrompt.js";
-import "../imports/blackrock-payments/client/payments-client.js";
-import "../imports/blackrock-payments/client/payments-api-client.js";
+import "../imports/blackrock-payments/client/billingSettings";
+import "../imports/blackrock-payments/client/billingPrompt";
+import "../imports/blackrock-payments/client/payments-client";
+import "../imports/blackrock-payments/client/payments-api-client";
 
 // Load sandstorm shell.
 // Templates come first.
@@ -104,60 +104,60 @@ import "../imports/client/styleguide.html";
 import "../imports/client/transfers.html";
 
 // Things that came from client/lib.
-import "../imports/client/globals.js";
+import "../imports/client/globals";
 
 // Everything else that came from client/
-import "../imports/client/accounts/credentials/credentials-client.js";
-import "../imports/client/accounts/email-token/token-client.js";
-import "../imports/client/accounts/saml/saml-client-pt2.js";
-import "../imports/client/accounts/account-settings.js";
-import "../imports/client/accounts/accounts-testing.js";
-import "../imports/client/accounts/login-buttons-session.js";
-import "../imports/client/accounts/login-buttons.js";
-import "../imports/client/admin/admin-new-client.js";
-import "../imports/client/admin/app-sources-client.js";
-import "../imports/client/admin/certificates-client.js";
-import "../imports/client/admin/email-config-client.js";
-import "../imports/client/admin/hosting-management-client.js";
-import "../imports/client/admin/login-providers.js";
-import "../imports/client/admin/maintenance-message-client.js";
-import "../imports/client/admin/network-capabilities-client.js";
-import "../imports/client/admin/networking-client.js";
-import "../imports/client/admin/organization-client.js";
-import "../imports/client/admin/personalization-client.js";
-import "../imports/client/admin/preinstalled-apps-client.js";
-import "../imports/client/admin/stats-client.js";
-import "../imports/client/admin/system-status-client.js";
-import "../imports/client/admin/user-accounts-client.js";
-import "../imports/client/admin/user-details-client.js";
-import "../imports/client/admin/user-invite-client.js";
-import "../imports/client/apps/app-details-client.js";
-import "../imports/client/apps/applist-client.js";
-import "../imports/client/apps/install-client.js";
-import "../imports/client/billing/billingPromptLocal-client.js";
-import "../imports/client/grain/contact-autocomplete.js";
-import "../imports/client/grain/grainlist-client.js";
-import "../imports/client/grain/settings-client.ts";
-import "../imports/client/setup-wizard/wizard.js";
-import "../imports/client/vendor/ansi-up.js";
-import "../imports/client/widgets/widgets-client.js";
-import "../imports/db-deprecated.js";
-import "../imports/client/00-startup.js";
-import "../imports/client/admin-client.js";
-import "../imports/client/demo-client.js";
-import "../imports/client/desktop-notifications-client.js";
-import "../imports/client/dev-accounts-client.js";
-import "../imports/client/grain-client.js";
-import "../imports/client/install-client.js";
-import "../imports/client/notifications-client.js";
-import "../imports/client/powerbox-builtins.js";
-import "../imports/client/shell-client.js";
-import "../imports/client/signup-client.js";
-import "../imports/client/styleguide.js";
-import "../imports/client/transfers-client.js";
+import "../imports/client/accounts/credentials/credentials-client";
+import "../imports/client/accounts/email-token/token-client";
+import "../imports/client/accounts/saml/saml-client-pt2";
+import "../imports/client/accounts/account-settings";
+import "../imports/client/accounts/accounts-testing";
+import "../imports/client/accounts/login-buttons-session";
+import "../imports/client/accounts/login-buttons";
+import "../imports/client/admin/admin-new-client";
+import "../imports/client/admin/app-sources-client";
+import "../imports/client/admin/certificates-client";
+import "../imports/client/admin/email-config-client";
+import "../imports/client/admin/hosting-management-client";
+import "../imports/client/admin/login-providers";
+import "../imports/client/admin/maintenance-message-client";
+import "../imports/client/admin/network-capabilities-client";
+import "../imports/client/admin/networking-client";
+import "../imports/client/admin/organization-client";
+import "../imports/client/admin/personalization-client";
+import "../imports/client/admin/preinstalled-apps-client";
+import "../imports/client/admin/stats-client";
+import "../imports/client/admin/system-status-client";
+import "../imports/client/admin/user-accounts-client";
+import "../imports/client/admin/user-details-client";
+import "../imports/client/admin/user-invite-client";
+import "../imports/client/apps/app-details-client";
+import "../imports/client/apps/applist-client";
+import "../imports/client/apps/install-client";
+import "../imports/client/billing/billingPromptLocal-client";
+import "../imports/client/grain/contact-autocomplete";
+import "../imports/client/grain/grainlist-client";
+import "../imports/client/grain/settings-client";
+import "../imports/client/setup-wizard/wizard";
+import "../imports/client/vendor/ansi-up";
+import "../imports/client/widgets/widgets-client";
+import "../imports/db-deprecated";
+import "../imports/client/00-startup";
+import "../imports/client/admin-client";
+import "../imports/client/demo-client";
+import "../imports/client/desktop-notifications-client";
+import "../imports/client/dev-accounts-client";
+import "../imports/client/grain-client";
+import "../imports/client/install-client";
+import "../imports/client/notifications-client";
+import "../imports/client/powerbox-builtins";
+import "../imports/client/shell-client";
+import "../imports/client/signup-client";
+import "../imports/client/styleguide";
+import "../imports/client/transfers-client";
 
-import "../imports/shared/admin.js";
-import "../imports/shared/dev-accounts.js";
-import "../imports/shared/grain-shared.js";
+import "../imports/shared/admin";
+import "../imports/shared/dev-accounts";
+import "../imports/shared/grain-shared";
 
-import "../imports/client/testing.js";
+import "../imports/client/testing";

--- a/shell/imports/blackrock-payments/client/billingPrompt.js
+++ b/shell/imports/blackrock-payments/client/billingPrompt.js
@@ -19,10 +19,10 @@ import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { _ } from "meteor/underscore";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { MAILING_LIST_BONUS } from "/imports/blackrock-payments/constants.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { MAILING_LIST_BONUS } from "/imports/blackrock-payments/constants";
 import { StripeCards, StripeCustomerData, updateStripeData }
-  from "/imports/blackrock-payments/client/payments-client.js";
+  from "/imports/blackrock-payments/client/payments-client";
 
 var idCounter = 0;
 

--- a/shell/imports/blackrock-payments/client/billingSettings.js
+++ b/shell/imports/blackrock-payments/client/billingSettings.js
@@ -19,10 +19,10 @@ import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { _ } from "meteor/underscore";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 import { StripeCards, StripeCustomerData, updateStripeData }
-  from "/imports/blackrock-payments/client/payments-client.js";
+  from "/imports/blackrock-payments/client/payments-client";
 
 var messageListener = function (showPrompt, template, event) {
   if (event.origin !== window.location.protocol + "//" + makeWildcardHost("payments")) {

--- a/shell/imports/blackrock-payments/client/payments-api-client.js
+++ b/shell/imports/blackrock-payments/client/payments-api-client.js
@@ -19,9 +19,9 @@ import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { _ } from "meteor/underscore";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 import { updateStripeData }
-  from "/imports/blackrock-payments/client/payments-client.js";
+  from "/imports/blackrock-payments/client/payments-client";
 
 Template.stripePaymentAcceptorPowerboxConfiguration.events({
   "submit form"(event) {

--- a/shell/imports/blackrock-payments/server/payments-api-server.js
+++ b/shell/imports/blackrock-payments/server/payments-api-server.js
@@ -18,9 +18,9 @@ import Crypto from "crypto";
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 
-import { stripe } from "/imports/blackrock-payments/server/payments-server.js";
+import { stripe } from "/imports/blackrock-payments/server/payments-server";
 
-import Capnp from "/imports/server/capnp.js";
+import Capnp from "/imports/server/capnp";
 const PaymentsRpc = Capnp.importSystem("sandstorm/payments.capnp");
 
 function wrapAsyncAsPromise(obj, func) {

--- a/shell/imports/blackrock-payments/server/payments-server.js
+++ b/shell/imports/blackrock-payments/server/payments-server.js
@@ -33,9 +33,9 @@ import { Random } from "meteor/random";
 import { HTTP } from "meteor/http";
 import { _ } from "meteor/underscore";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { MAILING_LIST_BONUS } from "/imports/blackrock-payments/constants.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
+import { MAILING_LIST_BONUS } from "/imports/blackrock-payments/constants";
 
 const ROOT_URL = process.env.ROOT_URL;
 const HOSTNAME = Url.parse(ROOT_URL).hostname;

--- a/shell/imports/client/00-startup.js
+++ b/shell/imports/client/00-startup.js
@@ -18,8 +18,8 @@ import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { Session } from "meteor/session";
 
-import { globalDb } from "/imports/db-deprecated.js";
-import { SandstormTopbar } from "/imports/sandstorm-ui-topbar/topbar.js";
+import { globalDb } from "/imports/db-deprecated";
+import { SandstormTopbar } from "/imports/sandstorm-ui-topbar/topbar";
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', function() {
@@ -27,8 +27,8 @@ if ('serviceWorker' in navigator) {
   })
 }
 
-import AccountsUi from "/imports/client/accounts/accounts-ui.js";
-import { GrainViewList } from "/imports/client/grain/grainview-list.js";
+import AccountsUi from "/imports/client/accounts/accounts-ui";
+import { GrainViewList } from "/imports/client/grain/grainview-list";
 
 Session.setDefault("shrink-navbar", false);
 // window.globalGrains is used by test code and must remain exported.

--- a/shell/imports/client/accounts/account-settings.js
+++ b/shell/imports/client/accounts/account-settings.js
@@ -22,10 +22,10 @@ import { Session } from "meteor/session";
 import { HTTP } from "meteor/http";
 import { _ } from "meteor/underscore";
 
-import { formatFutureTime } from "/imports/dates.js";
-import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants.js";
-import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { formatFutureTime } from "/imports/dates";
+import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants";
+import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 Template.sandstormAccountSettings.onCreated(function () {
   this.autorun(() => {

--- a/shell/imports/client/accounts/credentials/credentials-client.js
+++ b/shell/imports/client/accounts/credentials/credentials-client.js
@@ -24,7 +24,7 @@ import { Router } from "meteor/iron:router";
 import { Accounts } from "meteor/accounts-base"
 import { _ } from "meteor/underscore";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 const LoginCredentialsOfLinkedAccounts = new Mongo.Collection("loginCredentialsOfLinkedAccounts");
 // Pseudocollection populated by the `accountsOfCredential(sourceCredentialId)` subscription. Contains

--- a/shell/imports/client/accounts/email-token/token-client.js
+++ b/shell/imports/client/accounts/email-token/token-client.js
@@ -22,8 +22,8 @@ import { Router } from "meteor/iron:router";
 import {
   loginWithEmailToken,
   createAndEmailTokenForUser,
-} from "/imports/client/accounts/email-token/token-login-helpers.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+} from "/imports/client/accounts/email-token/token-login-helpers";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 // Email token login routes.
 Router.route("/_emailLogin/:_email/:_token", function () {

--- a/shell/imports/client/accounts/login-buttons.js
+++ b/shell/imports/client/accounts/login-buttons.js
@@ -30,14 +30,14 @@ import { Router } from "meteor/iron:router";
 import {
   loginWithEmailToken,
   createAndEmailTokenForUser,
-} from "/imports/client/accounts/email-token/token-login-helpers.js";
-import { GrainViewList } from '/imports/client/grain/grainview-list.js';
-import { loginWithLDAP } from "/imports/client/accounts/ldap/ldap-client.js";
-import { loginWithSaml } from "/imports/client/accounts/saml/saml-client.js";
-import { loginWithOidc } from "/imports/oidc/oidc-client.js";
-import AccountsUi from "/imports/client/accounts/accounts-ui.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+} from "/imports/client/accounts/email-token/token-login-helpers";
+import { GrainViewList } from "/imports/client/grain/grainview-list";
+import { loginWithLDAP } from "/imports/client/accounts/ldap/ldap-client";
+import { loginWithSaml } from "/imports/client/accounts/saml/saml-client";
+import { loginWithOidc } from "/imports/oidc/oidc-client";
+import AccountsUi from "/imports/client/accounts/accounts-ui";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 // for convenience
 const loginButtonsSession = Accounts._loginButtonsSession;

--- a/shell/imports/client/accounts/saml/saml-client-pt2.js
+++ b/shell/imports/client/accounts/saml/saml-client-pt2.js
@@ -1,7 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { Router } from "meteor/iron:router";
 
-import { loginWithSaml } from "/imports/client/accounts/saml/saml-client.js";
+import { loginWithSaml } from "/imports/client/accounts/saml/saml-client";
 
 // Reexported for use in shared/admin.js.  We should probably break that up into
 // client/ and server/ pieces so we can actually import functions in the appropriate

--- a/shell/imports/client/admin/app-sources-client.js
+++ b/shell/imports/client/admin/app-sources-client.js
@@ -2,7 +2,7 @@ import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 const DEFAULT_APP_MARKET_URL = "https://apps.sandstorm.io";
 const DEFAULT_APP_UPDATES_ENABLED = true;

--- a/shell/imports/client/admin/certificates-client.js
+++ b/shell/imports/client/admin/certificates-client.js
@@ -17,7 +17,7 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 Template.newAdminCertificates.onCreated(function () {
   this.formState = new ReactiveVar({

--- a/shell/imports/client/admin/email-config-client.js
+++ b/shell/imports/client/admin/email-config-client.js
@@ -2,7 +2,7 @@ import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 
-import { globalDb } from '/imports/db-deprecated.js';
+import { globalDb } from "/imports/db-deprecated";
 
 Template.newAdminEmailConfig.onCreated(function () {
   const c = globalDb.getSmtpConfig();

--- a/shell/imports/client/admin/hosting-management-client.js
+++ b/shell/imports/client/admin/hosting-management-client.js
@@ -2,7 +2,7 @@ import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 const DEFAULT_QUOTA_ENABLED = false;
 const DEFAULT_QUOTA_LDAP_ATTRIBUTE = "quota";

--- a/shell/imports/client/admin/login-providers.js
+++ b/shell/imports/client/admin/login-providers.js
@@ -6,7 +6,7 @@ import { TAPi18n } from "meteor/tap:i18n";
 import { Iron } from "meteor/iron:core";
 import { ServiceConfiguration } from "meteor/service-configuration";
 
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 const idpData = function (configureCallback) {
   const emailTokenEnabled = globalDb.getSettingWithFallback("emailToken", false);

--- a/shell/imports/client/admin/maintenance-message-client.js
+++ b/shell/imports/client/admin/maintenance-message-client.js
@@ -2,7 +2,7 @@ import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 Template.newAdminMaintenance.onCreated(function () {
   const messageText = globalDb.getSettingWithFallback("adminAlert", "");

--- a/shell/imports/client/admin/network-capabilities-client.js
+++ b/shell/imports/client/admin/network-capabilities-client.js
@@ -3,8 +3,8 @@ import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { _ } from "meteor/underscore";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 function deriveIntroducer(cap) {
   // For a given ApiToken, determine the account ID of the user who should be attributed for

--- a/shell/imports/client/admin/networking-client.js
+++ b/shell/imports/client/admin/networking-client.js
@@ -18,8 +18,8 @@ import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 
-import { PRIVATE_IPV4_ADDRESSES, PRIVATE_IPV6_ADDRESSES } from "/imports/constants.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { PRIVATE_IPV4_ADDRESSES, PRIVATE_IPV6_ADDRESSES } from "/imports/constants";
+import { globalDb } from "/imports/db-deprecated";
 
 const DEFAULT_IP_BLACKLIST = PRIVATE_IPV4_ADDRESSES.concat(PRIVATE_IPV6_ADDRESSES).join("\n");
 

--- a/shell/imports/client/admin/organization-client.js
+++ b/shell/imports/client/admin/organization-client.js
@@ -3,7 +3,7 @@ import { Template } from "meteor/templating";
 import { Tracker } from "meteor/tracker";
 import { ReactiveVar } from "meteor/reactive-var";
 
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 Template.newAdminOrganization.onCreated(function () {
   const emailChecked = globalDb.getOrganizationEmailEnabled() || false;

--- a/shell/imports/client/admin/personalization-client.js
+++ b/shell/imports/client/admin/personalization-client.js
@@ -3,8 +3,8 @@ import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { HTTP } from "meteor/http";
 
-import { DEFAULT_SIGNUP_DIALOG } from "/imports/client/personalization.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { DEFAULT_SIGNUP_DIALOG } from "/imports/client/personalization";
+import { globalDb } from "/imports/db-deprecated";
 
 Template.newAdminPersonalization.onCreated(function () {
   this.serverTitle = new ReactiveVar(globalDb.getSettingWithFallback("serverTitle", ""));

--- a/shell/imports/client/admin/preinstalled-apps-client.js
+++ b/shell/imports/client/admin/preinstalled-apps-client.js
@@ -4,7 +4,7 @@ import { Tracker } from "meteor/tracker";
 import { ReactiveVar } from "meteor/reactive-var";
 import { _ } from "meteor/underscore";
 
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 const APP_LIMIT = 10;
 

--- a/shell/imports/client/admin/stats-client.js
+++ b/shell/imports/client/admin/stats-client.js
@@ -4,8 +4,8 @@ import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { _ } from "meteor/underscore";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 // Pseudo-collection defined via publish.
 const RealTimeStats = new Mongo.Collection("realTimeStats");

--- a/shell/imports/client/admin/system-status-client.js
+++ b/shell/imports/client/admin/system-status-client.js
@@ -1,9 +1,9 @@
 import { Meteor } from "meteor/meteor";
 import { Mongo } from "meteor/mongo";
 import { Template } from "meteor/templating";
-import downloadFile from "/imports/client/download-file.js";
-import getBuildInfo from "/imports/client/build-info.js";
-import { allowDemo } from "/imports/demo.js";
+import downloadFile from "/imports/client/download-file";
+import getBuildInfo from "/imports/client/build-info";
+import { allowDemo } from "/imports/demo";
 
 // Pseudocollection holding number of grains with open sessions and accounts with open sessions.
 const systemStatus = new Mongo.Collection("systemStatus");

--- a/shell/imports/client/admin/user-accounts-client.js
+++ b/shell/imports/client/admin/user-accounts-client.js
@@ -4,8 +4,8 @@ import { ReactiveVar } from "meteor/reactive-var";
 import { Router } from "meteor/iron:router";
 import { _ } from "meteor/underscore";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js"
-import { globalDb } from "/imports/db-deprecated.js";
+import { SandstormDb } from "/imports/sandstorm-db/db"
+import { globalDb } from "/imports/db-deprecated";
 
 const matchesUser = function (searchKey, user) {
   // We match a user if we can find the searchKey in one of the following fields:

--- a/shell/imports/client/admin/user-details-client.js
+++ b/shell/imports/client/admin/user-details-client.js
@@ -3,10 +3,10 @@ import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { Router } from "meteor/iron:router";
 
-import { formatFutureTime } from "/imports/dates.js";
-import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { formatFutureTime } from "/imports/dates";
+import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 Template.newAdminUserDetailsCredentialTableRow.helpers({
   isOrganizationMember(credential) {

--- a/shell/imports/client/admin/user-invite-client.js
+++ b/shell/imports/client/admin/user-invite-client.js
@@ -3,7 +3,7 @@ import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { Router } from "meteor/iron:router";
 
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 Template.newAdminUserInviteLink.onCreated(function () {
   this.formState = new ReactiveVar("default");

--- a/shell/imports/client/apps/app-details-client.js
+++ b/shell/imports/client/apps/app-details-client.js
@@ -4,8 +4,8 @@ import { ReactiveVar } from "meteor/reactive-var";
 import { Router } from "meteor/iron:router";
 import { _ } from "meteor/underscore";
 
-import { iconSrcForPackage } from "/imports/sandstorm-identicons/helpers.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { iconSrcForPackage } from "/imports/sandstorm-identicons/helpers";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 const latestPackageForAppId = function (db, appId) {
   // Dev apps mask current package version.

--- a/shell/imports/client/apps/applist-client.js
+++ b/shell/imports/client/apps/applist-client.js
@@ -7,7 +7,7 @@ import { _ } from "meteor/underscore";
 import { TAPi18n } from "meteor/tap:i18n";
 
 import { introJs } from "intro.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 SandstormAppList = function (db, quotaEnforcer) {
   this._filter = new ReactiveVar("");

--- a/shell/imports/client/apps/install-client.js
+++ b/shell/imports/client/apps/install-client.js
@@ -3,7 +3,7 @@ import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { Router } from "meteor/iron:router";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 const INSTALL_STEPS = ["download", "verify", "unpack", "analyze", "ready", "failed", "delete"];
 const checkStep = function (step) {

--- a/shell/imports/client/backups.ts
+++ b/shell/imports/client/backups.ts
@@ -1,5 +1,5 @@
-import downloadFile from '/imports/client/download-file.js';
-import { meteorCallPromise } from '/imports/client/meteor-call-promise.ts';
+import downloadFile from "/imports/client/download-file";
+import { meteorCallPromise } from "/imports/client/meteor-call-promise";
 
 // TODO: can we move this somewhere more centralized/does meteor provide
 // type declarations for this somewhere?

--- a/shell/imports/client/billing/billingPromptLocal-client.js
+++ b/shell/imports/client/billing/billingPromptLocal-client.js
@@ -1,5 +1,5 @@
 import { Template } from "meteor/templating";
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 Template.billingPromptLocal.helpers({
   onDismiss: function () {

--- a/shell/imports/client/contacts.js
+++ b/shell/imports/client/contacts.js
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import { Mongo } from "meteor/mongo";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 const transform = function (contact) {
   SandstormDb.fillInPictureUrl(contact);

--- a/shell/imports/client/demo-client.js
+++ b/shell/imports/client/demo-client.js
@@ -20,9 +20,9 @@ import { Tracker } from "meteor/tracker";
 import { Router } from "meteor/iron:router";
 import { Accounts } from "meteor/accounts-base";
 
-import { allowDemo } from "/imports/demo.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { allowDemo } from "/imports/demo";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 Meteor.loginWithDemo = function (options, callback) {
   Router.go("demo");

--- a/shell/imports/client/desktop-notifications-client.js
+++ b/shell/imports/client/desktop-notifications-client.js
@@ -19,9 +19,9 @@ import { Template } from "meteor/templating";
 import { Random } from "meteor/random";
 import { Router } from "meteor/iron:router";
 
-import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
-import { iconSrcForPackage, identiconForApp } from "/imports/sandstorm-identicons/helpers.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers";
+import { iconSrcForPackage, identiconForApp } from "/imports/sandstorm-identicons/helpers";
+import { globalDb } from "/imports/db-deprecated";
 
 // Test if localStorage is usable.
 // We can't use Meteor._localStorage for this because we need to be able to enumerate the elements

--- a/shell/imports/client/grain-client.js
+++ b/shell/imports/client/grain-client.js
@@ -32,14 +32,14 @@ import { $ } from "meteor/jquery";
 
 import { introJs } from "intro.js";
 
-import downloadFile from "/imports/client/download-file.js";
-import { makeAndDownloadBackup } from "/imports/client/backups.ts";
-import { ContactProfiles } from "/imports/client/contacts.js";
-import { isStandalone } from "/imports/client/standalone.js";
-import { GrainView } from "/imports/client/grain/grainview.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { SandstormPowerboxRequest } from "/imports/sandstorm-ui-powerbox/powerbox-client.js";
+import downloadFile from "/imports/client/download-file";
+import { makeAndDownloadBackup } from "/imports/client/backups";
+import { ContactProfiles } from "/imports/client/contacts";
+import { isStandalone } from "/imports/client/standalone";
+import { GrainView } from "/imports/client/grain/grainview";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
+import { SandstormPowerboxRequest } from "/imports/sandstorm-ui-powerbox/powerbox-client";
 
 // Pseudo-collections.
 TokenInfo = new Mongo.Collection("tokenInfo");

--- a/shell/imports/client/grain/contact-autocomplete.js
+++ b/shell/imports/client/grain/contact-autocomplete.js
@@ -4,7 +4,7 @@ import { ReactiveVar } from "meteor/reactive-var";
 import { Random } from "meteor/random";
 import { _ } from "meteor/underscore";
 
-import { ContactProfiles } from "/imports/client/contacts.js";
+import { ContactProfiles } from "/imports/client/contacts";
 
 const generateAutoCompleteContacts = function (template) {
   let currentText = template.currentText.get();

--- a/shell/imports/client/grain/grainlist-client.js
+++ b/shell/imports/client/grain/grainlist-client.js
@@ -9,9 +9,9 @@ import { _ } from "meteor/underscore";
 import { TAPi18n } from "meteor/tap:i18n";
 
 import { introJs } from "intro.js";
-import { identiconForApp } from "/imports/sandstorm-identicons/helpers.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { makeAndDownloadBackup } from "/imports/client/backups.ts";
+import { identiconForApp } from "/imports/sandstorm-identicons/helpers";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { makeAndDownloadBackup } from "/imports/client/backups";
 
 SandstormGrainListPage = {};
 

--- a/shell/imports/client/grain/grainview-list.js
+++ b/shell/imports/client/grain/grainview-list.js
@@ -22,9 +22,9 @@ import { Router } from "meteor/iron:router";
 import { Accounts } from "meteor/accounts-base";
 import { SHA256 } from "meteor/sha";
 
-import { GrainView, onceConditionIsTrue } from "./grainview.js";
-import { isStandalone } from "/imports/client/standalone.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { GrainView, onceConditionIsTrue } from "./grainview";
+import { isStandalone } from "/imports/client/standalone";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 class GrainViewList {
   constructor(db) {

--- a/shell/imports/client/grain/grainview.js
+++ b/shell/imports/client/grain/grainview.js
@@ -24,12 +24,12 @@ import { Random } from "meteor/random";
 import { Router } from "meteor/iron:router";
 import { _ } from "meteor/underscore";
 
-import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
-import { isStandalone } from "/imports/client/standalone.js";
-import { GrainViewList } from "/imports/client/grain/grainview-list.js";
-import { identiconForApp, iconSrcForPackage } from "/imports/sandstorm-identicons/helpers.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers";
+import { isStandalone } from "/imports/client/standalone";
+import { GrainViewList } from "/imports/client/grain/grainview-list";
+import { identiconForApp, iconSrcForPackage } from "/imports/sandstorm-identicons/helpers";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 let counter = 0;
 

--- a/shell/imports/client/grain/settings-client.ts
+++ b/shell/imports/client/grain/settings-client.ts
@@ -1,9 +1,9 @@
 
-import { TAPi18n } from "/imports/tapi18n.js";
+import { TAPi18n } from "/imports/tapi18n";
 import { Template } from "meteor/templating";
 import { Match, check } from "meteor/check";
-import { globalDb } from "/imports/db-deprecated.js";
-import { GrainView } from "/imports/client/grain/grainview.js";
+import { globalDb } from "/imports/db-deprecated";
+import { GrainView } from "/imports/client/grain/grainview";
 
 Template.sandstormGrainSettingsPage.onCreated(function() {
   const instance = Template.instance();

--- a/shell/imports/client/install-client.js
+++ b/shell/imports/client/install-client.js
@@ -17,9 +17,9 @@
 import { Meteor } from "meteor/meteor";
 import { Router } from "meteor/iron:router";
 
-import { allowDemo } from "/imports/demo.js";
-import { isSafeDemoAppUrl } from "/imports/install.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { allowDemo } from "/imports/demo";
+import { isSafeDemoAppUrl } from "/imports/install";
+import { globalDb } from "/imports/db-deprecated";
 
 Router.map(function () {
   this.route("install", {

--- a/shell/imports/client/notifications-client.js
+++ b/shell/imports/client/notifications-client.js
@@ -19,11 +19,11 @@ import { Template } from "meteor/templating";
 import { Tracker } from "meteor/tracker";
 import { _ } from "meteor/underscore";
 
-import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers.js";
-import { iconSrcForPackage, iconSrcForDenormalizedGrainMetadata } from "/imports/sandstorm-identicons/helpers.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { MAILING_LIST_BONUS } from "/imports/blackrock-payments/constants.js";
+import { computeTitleFromTokenOwnerUser } from "/imports/client/model-helpers";
+import { iconSrcForPackage, iconSrcForDenormalizedGrainMetadata } from "/imports/sandstorm-identicons/helpers";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
+import { MAILING_LIST_BONUS } from "/imports/blackrock-payments/constants";
 
 testNotifications = () => {
   // Run on console to create some dummy notifications for the purpose of seeing what they look

--- a/shell/imports/client/setup-wizard/wizard.js
+++ b/shell/imports/client/setup-wizard/wizard.js
@@ -7,10 +7,10 @@ import { _ } from "meteor/underscore";
 import { Router } from "meteor/iron:router";
 import { Iron } from "meteor/iron:core";
 
-import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
-import AccountsUi from "/imports/client/accounts/accounts-ui.js";
-import downloadFile from "/imports/client/download-file.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui";
+import AccountsUi from "/imports/client/accounts/accounts-ui";
+import downloadFile from "/imports/client/download-file";
+import { globalDb } from "/imports/db-deprecated";
 
 // Pseudocollection telling the client if there's an admin user yet.
 HasAdmin = new Mongo.Collection("hasAdmin");

--- a/shell/imports/client/shell-client.js
+++ b/shell/imports/client/shell-client.js
@@ -27,11 +27,11 @@ import { Session } from "meteor/session";
 import { Router } from "meteor/iron:router";
 import { TAPi18n } from "meteor/tap:i18n";
 
-import getBuildInfo from "/imports/client/build-info.js";
-import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui.js";
-import { isStandalone } from "/imports/client/standalone.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import getBuildInfo from "/imports/client/build-info";
+import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui";
+import { isStandalone } from "/imports/client/standalone";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 // Subscribe to basic grain information first and foremost, since
 // without it we might e.g. redirect to the wrong place on login.

--- a/shell/imports/client/signup-client.js
+++ b/shell/imports/client/signup-client.js
@@ -19,8 +19,8 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { Router } from "meteor/iron:router";
-import { DEFAULT_SIGNUP_DIALOG } from "/imports/client/personalization.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { DEFAULT_SIGNUP_DIALOG } from "/imports/client/personalization";
+import { globalDb } from "/imports/db-deprecated";
 
 Template.signup.helpers({
   signupDialog: function () {

--- a/shell/imports/client/testing.js
+++ b/shell/imports/client/testing.js
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
-import { isTesting } from "/imports/shared/testing.js";
+import { isTesting } from "/imports/shared/testing";
 
 function mockLoginGithub() {
   Meteor.call("createMockGithubUser", function (err) {

--- a/shell/imports/client/transfers-client.js
+++ b/shell/imports/client/transfers-client.js
@@ -19,8 +19,8 @@ import { Template } from "meteor/templating";
 import { Router } from "meteor/iron:router";
 import { TAPi18n } from "meteor/tap:i18n";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 function isValidServerUrl(str) {
   let url;

--- a/shell/imports/db-deprecated.js
+++ b/shell/imports/db-deprecated.js
@@ -24,11 +24,11 @@
 //   passed in, thus allowing mocking the database for unit tests.
 
 import { Meteor } from "meteor/meteor";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 let quotaManager;
 if (Meteor.isServer) {
-  import { LDAP } from "/imports/server/accounts/ldap.js";
+  import { LDAP } from "/imports/server/accounts/ldap";
   // Imports are usually not allowed to occur in a block. However, it is the only way to do
   // this under Meteor. Using // jscs:disable doesn't work for what it considers syntax violations,
   // and so we've added this file to .jscsrc's excludedFiles explicitly.

--- a/shell/imports/sandstorm-accounts-packages/accounts.js
+++ b/shell/imports/sandstorm-accounts-packages/accounts.js
@@ -1,7 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { Accounts } from "meteor/accounts-base";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 if (Meteor.isClient) {
   Meteor.loginWithGoogle = function (options, callback) {

--- a/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
+++ b/shell/imports/sandstorm-autoupdate-apps/autoupdate-apps-tests.js
@@ -23,8 +23,8 @@ import { Meteor } from "meteor/meteor";
 import { Accounts } from "meteor/accounts-base";
 import { HTTP } from "meteor/http";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { SandstormAutoupdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { SandstormAutoupdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps";
 
 const globalDb = new SandstormDb();
 // TODO(cleanup): Use a lightweight fake (minimongo-based?) database here and construct a clean

--- a/shell/imports/sandstorm-db/db.js
+++ b/shell/imports/sandstorm-db/db.js
@@ -23,7 +23,7 @@ import { _ } from "meteor/underscore";
 import { Random } from "meteor/random";
 import { SHA256 } from "meteor/sha";
 import { HTTP } from "meteor/http";
-import { iconSrcForPackage } from "/imports/sandstorm-identicons/helpers.js";
+import { iconSrcForPackage } from "/imports/sandstorm-identicons/helpers";
 
 // Useful for debugging: Set the env variable LOG_MONGO_QUERIES to have the server write every
 // query it makes, so you can see if it's doing queries too often, etc.
@@ -2421,7 +2421,7 @@ _.extend(SandstormDb, {
 });
 
 if (Meteor.isServer) {
-  import { waitPromise } from "/imports/server/async-helpers.ts";
+  import { waitPromise } from "/imports/server/async-helpers";
 
   const Crypto = Npm.require("crypto");
   const ContentType = Npm.require("content-type");

--- a/shell/imports/sandstorm-db/profile.js
+++ b/shell/imports/sandstorm-db/profile.js
@@ -19,9 +19,9 @@ import { check } from "meteor/check";
 import { Accounts } from "meteor/accounts-base";
 import { _ } from "meteor/underscore";
 
-import Identicon from "/imports/sandstorm-identicons/identicon.ts";
-import { SandstormDb } from "./db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import Identicon from "/imports/sandstorm-identicons/identicon";
+import { SandstormDb } from "./db";
+import { globalDb } from "/imports/db-deprecated";
 
 let makeIdenticon;
 let httpProtocol;

--- a/shell/imports/sandstorm-db/scheduled-jobs-db.js
+++ b/shell/imports/sandstorm-db/scheduled-jobs-db.js
@@ -16,8 +16,8 @@
 
 import Crypto from "crypto";
 import { Match, check } from "meteor/check";
-import Capnp from "/imports/server/capnp.js";
-import { SandstormDb } from "./db.js";
+import Capnp from "/imports/server/capnp";
+import { SandstormDb } from "./db";
 
 const MINIMUM_SCHEDULING_SLACK_NANO = Capnp.importSystem("sandstorm/grain.capnp").minimumSchedulingSlack;
 

--- a/shell/imports/sandstorm-identicons/helpers.js
+++ b/shell/imports/sandstorm-identicons/helpers.js
@@ -1,4 +1,4 @@
-import Identicon from "./identicon.ts";
+import Identicon from "./identicon";
 
 const VALID_USAGES = ["appGrid", "grain", "notification"];
 function checkUsage(usage) {

--- a/shell/imports/sandstorm-identicons/identicon-server.js
+++ b/shell/imports/sandstorm-identicons/identicon-server.js
@@ -1,6 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import Zlib from "zlib";
-import Identicon from "./identicon.ts";
+import Identicon from "./identicon";
 
 const gzipSync = Meteor.wrapAsync(Zlib.gzip, Zlib);
 

--- a/shell/imports/sandstorm-permissions/permissions.js
+++ b/shell/imports/sandstorm-permissions/permissions.js
@@ -20,7 +20,7 @@ import { Match, check } from "meteor/check";
 import { Random } from "meteor/random";
 import { _ } from "meteor/underscore";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 export const SandstormPermissions = {};
 

--- a/shell/imports/sandstorm-permissions/permissions.tests.js
+++ b/shell/imports/sandstorm-permissions/permissions.tests.js
@@ -22,11 +22,11 @@ import { Match, check } from "meteor/check";
 import { Accounts } from "meteor/accounts-base";
 import chai from "chai";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 // We import profile.js for the side-effect of defining more methods on SandstormDb.
 // TODO(cleanup): Avoid adding methods to an object from another module like this; ew.
-import {} from "/imports/sandstorm-db/profile.js";
-import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions.js";
+import {} from "/imports/sandstorm-db/profile";
+import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions";
 
 const globalDb = new SandstormDb();
 // TODO(cleanup): Use a lightweight fake (minimongo-based?) database here and construct a clean

--- a/shell/imports/sandstorm-ui-powerbox/powerbox-client.js
+++ b/shell/imports/sandstorm-ui-powerbox/powerbox-client.js
@@ -22,8 +22,8 @@ import { Template } from "meteor/templating";
 import { ReactiveVar } from "meteor/reactive-var";
 import { _ } from "meteor/underscore";
 
-import { identiconForApp } from "/imports/sandstorm-identicons/helpers.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { identiconForApp } from "/imports/sandstorm-identicons/helpers";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 const PowerboxOptions = new Mongo.Collection("powerboxOptions");
 

--- a/shell/imports/sandstorm-ui-powerbox/powerbox-server.js
+++ b/shell/imports/sandstorm-ui-powerbox/powerbox-server.js
@@ -18,10 +18,10 @@ import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { _ } from "meteor/underscore";
 
-import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions.js";
-import Capnp from "/imports/server/capnp.js";
+import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions";
+import Capnp from "/imports/server/capnp";
 
-import { waitPromise } from '../server/async-helpers.ts';
+import { waitPromise } from '../server/async-helpers';
 
 const Powerbox = Capnp.importSystem("sandstorm/powerbox.capnp");
 const Grain = Capnp.importSystem("sandstorm/grain.capnp");

--- a/shell/imports/server/00-startup.js
+++ b/shell/imports/server/00-startup.js
@@ -17,16 +17,16 @@
 import { Meteor } from "meteor/meteor";
 import { HTTP } from "meteor/http";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions.js";
-import { FrontendRefRegistry } from "/imports/server/frontend-ref.js";
-import { PersistentImpl } from "/imports/server/persistent.js";
-import { migrateToLatest } from "/imports/server/migrations.js";
-import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants.js";
-import { onInMeteor } from "/imports/server/async-helpers.ts";
-import { monkeyPatchHttp } from "/imports/server/networking.js";
-import { SandstormAutoupdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
+import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions";
+import { FrontendRefRegistry } from "/imports/server/frontend-ref";
+import { PersistentImpl } from "/imports/server/persistent";
+import { migrateToLatest } from "/imports/server/migrations";
+import { ACCOUNT_DELETION_SUSPENSION_TIME } from "/imports/constants";
+import { onInMeteor } from "/imports/server/async-helpers";
+import { monkeyPatchHttp } from "/imports/server/networking";
+import { SandstormAutoupdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps";
 let url = require("url");
 
 process.on('unhandledRejection', (reason, p) => {

--- a/shell/imports/server/account-suspension.js
+++ b/shell/imports/server/account-suspension.js
@@ -18,8 +18,8 @@ import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { _ } from "meteor/underscore";
 
-import { send } from "/imports/server/email.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { send } from "/imports/server/email";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 function sendDeletionEmails(db, deletedUserId, byAdminUserId, feedback) {
   const deletedUser = db.getUser(deletedUserId);

--- a/shell/imports/server/accounts/accounts-server.js
+++ b/shell/imports/server/accounts/accounts-server.js
@@ -19,9 +19,9 @@ import { Match, check } from "meteor/check";
 import { Accounts } from "meteor/accounts-base";
 import { _ } from "meteor/underscore";
 
-import { fetchPicture, userPictureUrl } from "/imports/server/accounts/picture.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { fetchPicture, userPictureUrl } from "/imports/server/accounts/picture";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 import Crypto from "crypto";
 

--- a/shell/imports/server/accounts/accounts-ui-methods.js
+++ b/shell/imports/server/accounts/accounts-ui-methods.js
@@ -21,7 +21,7 @@ import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { _ } from "meteor/underscore";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 const ValidHandle = Match.Where(function (handle) {
   check(handle, String);

--- a/shell/imports/server/accounts/credentials/credentials-server.js
+++ b/shell/imports/server/accounts/credentials/credentials-server.js
@@ -19,8 +19,8 @@ import { check } from "meteor/check";
 import { Accounts } from "meteor/accounts-base";
 import { _ } from "meteor/underscore";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { SandstormBackend } from "/imports/server/backend.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { SandstormBackend } from "/imports/server/backend";
 
 const linkCredentialToAccountInternal = function (db, backend, credentialId, accountId, allowLogin) {
   // Links the credential to the account. If `allowLogin` is true, grants the credential login access

--- a/shell/imports/server/accounts/email-token/token-server.js
+++ b/shell/imports/server/accounts/email-token/token-server.js
@@ -7,9 +7,9 @@ import { Random } from "meteor/random";
 import { Accounts } from "meteor/accounts-base";
 import { SHA256 } from "meteor/sha";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { send as sendEmail } from "/imports/server/email.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
+import { send as sendEmail } from "/imports/server/email";
 
 const V1_ROUNDS = 4096; // Selected to take ~5msec at creation time (2016) on a developer's laptop.
 const V1_KEYSIZE = 32; // 256 bits / 8 bits/byte = 32 bytes

--- a/shell/imports/server/accounts/ldap/ldap-server.js
+++ b/shell/imports/server/accounts/ldap/ldap-server.js
@@ -1,4 +1,4 @@
-import { LDAP } from "/imports/server/accounts/ldap.js";
+import { LDAP } from "/imports/server/accounts/ldap";
 
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";

--- a/shell/imports/server/accounts/saml/saml-server.js
+++ b/shell/imports/server/accounts/saml/saml-server.js
@@ -6,8 +6,8 @@ import { check } from "meteor/check";
 import { _ } from "meteor/underscore";
 import { Accounts } from "meteor/accounts-base";
 
-import { SAML } from "/imports/server/accounts/saml-utils.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { SAML } from "/imports/server/accounts/saml-utils";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 import Fiber from "fibers";
 import BodyParser from "body-parser";

--- a/shell/imports/server/acme.js
+++ b/shell/imports/server/acme.js
@@ -15,16 +15,16 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
-import { waitPromise } from "/imports/server/async-helpers.ts";
+import { waitPromise } from "/imports/server/async-helpers";
 import ACME from "@root/acme";
 import CSR from "@root/csr";
 import PEM from "@root/pem";
 import Keypairs from "@root/keypairs";
 import { pki, asn1 } from "node-forge";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 import URL from "url";
-import { getSandcatsAcmeOptions } from "/imports/server/sandcats.js";
+import { getSandcatsAcmeOptions } from "/imports/server/sandcats";
 import Crypto from "crypto";
 
 // Relevant settings in database `Settings` table:
@@ -74,7 +74,7 @@ function createAcmeClient(directory) {
 // order to send security notices. We have already registered security+acme@sandstorm.io as a
 // maintainer, so doing it again is redundant, and we don't want everyone's Sandstorm servers
 // pinging an unexpected third party. So, we monkey-patch the library to remove this call.
-import Maintainers from "@root/acme/maintainers.js";
+import Maintainers from "@root/acme/maintainers";
 if (!Maintainers.init) {
   throw new Error("code to monkey-patch ACME.js needs update");
 }

--- a/shell/imports/server/admin-server.js
+++ b/shell/imports/server/admin-server.js
@@ -24,15 +24,15 @@ import { ServiceConfiguration } from "meteor/service-configuration";
 import Fs from "fs";
 import Crypto from "crypto";
 import Heapdump from "heapdump";
-import { SANDSTORM_LOGDIR } from "/imports/server/constants.js";
-import { clearAdminToken, checkAuth, tokenIsValid, tokenIsSetupSession } from "/imports/server/auth.js";
-import { send as sendEmail } from "/imports/server/email.js";
-import { fillUndefinedForChangedDoc } from "/imports/server/observe-helpers.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { computeStats } from "/imports/server/stats-server.js";
+import { SANDSTORM_LOGDIR } from "/imports/server/constants";
+import { clearAdminToken, checkAuth, tokenIsValid, tokenIsSetupSession } from "/imports/server/auth";
+import { send as sendEmail } from "/imports/server/email";
+import { fillUndefinedForChangedDoc } from "/imports/server/observe-helpers";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
+import { computeStats } from "/imports/server/stats-server";
 import { HTTP } from "meteor/http";
-import { createAcmeAccount, renewCertificateNow } from "/imports/server/acme.js";
+import { createAcmeAccount, renewCertificateNow } from "/imports/server/acme";
 import { Issuer } from "openid-client";
 
 const publicAdminSettings = [

--- a/shell/imports/server/admin/admin-alert-server.js
+++ b/shell/imports/server/admin/admin-alert-server.js
@@ -1,6 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
-import { checkAuth } from "/imports/server/auth.js";
+import { checkAuth } from "/imports/server/auth";
 
 const maintenanceMessageShape = {
   text: String,

--- a/shell/imports/server/admin/network-capabilities-server.js
+++ b/shell/imports/server/admin/network-capabilities-server.js
@@ -1,6 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
-import { checkAuth } from "/imports/server/auth.js";
+import { checkAuth } from "/imports/server/auth";
 
 Meteor.publish("adminGrains", function (grainIds) {
   // If the caller is an admin, publishes the Grains referred to by the provided list of grain IDs.

--- a/shell/imports/server/admin/personalization-server.js
+++ b/shell/imports/server/admin/personalization-server.js
@@ -1,7 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
-import { checkAuth } from "/imports/server/auth.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { checkAuth } from "/imports/server/auth";
+import { globalDb } from "/imports/db-deprecated";
 
 const personalizationMessageShape = {
   serverTitle: String,

--- a/shell/imports/server/admin/system-status-server.js
+++ b/shell/imports/server/admin/system-status-server.js
@@ -5,9 +5,9 @@ import { _ } from "meteor/underscore";
 
 import Crypto from "crypto";
 import Fs from "fs";
-import { checkAuth } from "/imports/server/auth.js";
+import { checkAuth } from "/imports/server/auth";
 
-import { SANDSTORM_LOGDIR } from "/imports/server/constants.js";
+import { SANDSTORM_LOGDIR } from "/imports/server/constants";
 
 const hashSessionId = function (sessionId) {
   return Crypto.createHash("sha256").update(sessionId).digest("base64");

--- a/shell/imports/server/auth.js
+++ b/shell/imports/server/auth.js
@@ -2,8 +2,8 @@ import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import Crypto from "crypto";
 import Fs from "fs";
-import { SANDSTORM_VARDIR } from "/imports/server/constants.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { SANDSTORM_VARDIR } from "/imports/server/constants";
+import { globalDb } from "/imports/db-deprecated";
 
 const ADMIN_TOKEN_EXPIRATION_TIME = 60 * 60 * 1000;
 const SANDSTORM_ADMIN_TOKEN = SANDSTORM_VARDIR + "/adminToken";

--- a/shell/imports/server/backend.js
+++ b/shell/imports/server/backend.js
@@ -15,9 +15,9 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
-import { inMeteor, waitPromise } from "/imports/server/async-helpers.ts";
-import Capnp from "/imports/server/capnp.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { inMeteor, waitPromise } from "/imports/server/async-helpers";
+import Capnp from "/imports/server/capnp";
+import { globalDb } from "/imports/db-deprecated";
 
 let storageUsageUnimplemented = false;
 

--- a/shell/imports/server/backup.js
+++ b/shell/imports/server/backup.js
@@ -20,11 +20,11 @@ import { _ } from "meteor/underscore";
 import { Random } from "meteor/random";
 import { Router } from "meteor/iron:router";
 
-import { inMeteor, waitPromise } from "/imports/server/async-helpers.ts";
+import { inMeteor, waitPromise } from "/imports/server/async-helpers";
 
-import Capnp from "/imports/server/capnp.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import Capnp from "/imports/server/capnp";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 const TOKEN_CLEANUP_MINUTES = 120;  // Give enough time for large uploads on slow connections.
 const TOKEN_CLEANUP_TIMER = TOKEN_CLEANUP_MINUTES * 60 * 1000;

--- a/shell/imports/server/core.js
+++ b/shell/imports/server/core.js
@@ -19,17 +19,17 @@ import { Match, check } from "meteor/check";
 import { _ } from "meteor/underscore";
 
 import Crypto from "crypto";
-import { inMeteor, waitPromise } from "/imports/server/async-helpers.ts";
-import { StaticAssetImpl, IdenticonStaticAssetImpl } from "/imports/server/static-asset.js";
+import { inMeteor, waitPromise } from "/imports/server/async-helpers";
+import { StaticAssetImpl, IdenticonStaticAssetImpl } from "/imports/server/static-asset";
 import { PersistentImpl, hashSturdyRef, generateSturdyRef, checkRequirements,
-         fetchApiToken, insertApiToken } from "/imports/server/persistent.js";
-import { SandstormBackend } from "/imports/server/backend.js";
-import { hashAppIdForIdenticon } from "/imports/sandstorm-identicons/helpers.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { schedulePeriodic, scheduleOneShot } from "/imports/server/scheduled-job.js";
-import { makeGatewayRouter } from "/imports/server/gateway-router.js";
-import { makeShellCli } from "/imports/server/shell-cli.js";
-import Capnp from "/imports/server/capnp.js";
+         fetchApiToken, insertApiToken } from "/imports/server/persistent";
+import { SandstormBackend } from "/imports/server/backend";
+import { hashAppIdForIdenticon } from "/imports/sandstorm-identicons/helpers";
+import { globalDb } from "/imports/db-deprecated";
+import { schedulePeriodic, scheduleOneShot } from "/imports/server/scheduled-job";
+import { makeGatewayRouter } from "/imports/server/gateway-router";
+import { makeShellCli } from "/imports/server/shell-cli";
+import Capnp from "/imports/server/capnp";
 
 const PersistentHandle = Capnp.importSystem("sandstorm/supervisor.capnp").PersistentHandle;
 const SandstormCore = Capnp.importSystem("sandstorm/supervisor.capnp").SandstormCore;

--- a/shell/imports/server/demo-server.js
+++ b/shell/imports/server/demo-server.js
@@ -18,9 +18,9 @@ import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { Accounts } from "meteor/accounts-base";
 
-import { allowDemo } from "/imports/demo.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { allowDemo } from "/imports/demo";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 const DEMO_EXPIRATION_MS = 60 * 60 * 1000;
 const DEMO_GRACE_MS = 10 * 60 * 1000;  // time between expiration and deletion

--- a/shell/imports/server/desktop-notifications-server.js
+++ b/shell/imports/server/desktop-notifications-server.js
@@ -15,8 +15,8 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 SandstormDb.periodicCleanup(120000, () => {
   // Remove old desktop notfications regularly.

--- a/shell/imports/server/desktop-notifications.js
+++ b/shell/imports/server/desktop-notifications.js
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import { Match, check } from "meteor/check";
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 const createAppActivityDesktopNotification = (options) => {
   check(options, {

--- a/shell/imports/server/drivers/external-ui-view.js
+++ b/shell/imports/server/drivers/external-ui-view.js
@@ -19,19 +19,19 @@ import { Match, check } from "meteor/check";
 import { HTTP } from "meteor/http";
 import { _ } from "meteor/underscore";
 
-import { inMeteor } from "/imports/server/async-helpers.ts";
-import { PersistentImpl } from "/imports/server/persistent.js";
-import { ssrfSafeLookup } from "/imports/server/networking.js";
+import { inMeteor } from "/imports/server/async-helpers";
+import { PersistentImpl } from "/imports/server/persistent";
+import { ssrfSafeLookup } from "/imports/server/networking";
 import { REQUEST_HEADER_WHITELIST, RESPONSE_HEADER_WHITELIST }
-    from "/imports/server/header-whitelist.js";
-import { globalDb } from "/imports/db-deprecated.js";
+    from "/imports/server/header-whitelist";
+import { globalDb } from "/imports/db-deprecated";
 
-import { responseCodes } from "/imports/server/web-session.ts";
+import { responseCodes } from "/imports/server/web-session";
 
 import Url from "url";
 import Http from "http";
 import Https from "https";
-import Capnp from "/imports/server/capnp.js";
+import Capnp from "/imports/server/capnp";
 const ApiSession = Capnp.importSystem("sandstorm/api-session.capnp").ApiSession;
 const PersistentApiSession =
     Capnp.importSystem("sandstorm/api-session-impl.capnp").PersistentApiSession;

--- a/shell/imports/server/drivers/ip.js
+++ b/shell/imports/server/drivers/ip.js
@@ -18,11 +18,11 @@ import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 
 import Bignum from "bignum";
-import { PersistentImpl } from "/imports/server/persistent.js";
+import { PersistentImpl } from "/imports/server/persistent";
 import Net from "net";
 import Tls from "tls";
 import Dgram from "dgram";
-import Capnp from "/imports/server/capnp.js";
+import Capnp from "/imports/server/capnp";
 
 const IpRpc = Capnp.importSystem("sandstorm/ip.capnp");
 

--- a/shell/imports/server/drivers/mail.js
+++ b/shell/imports/server/drivers/mail.js
@@ -23,18 +23,18 @@ import { Accounts } from "meteor/accounts-base";
 import { SMTPServer } from "smtp-server";
 import { MailParser } from "mailparser";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { PersistentImpl } from "/imports/server/persistent.js";
-import { rawSend } from "/imports/server/email.js";
-import { shouldRestartGrain } from "/imports/server/backend.js";
-import { inMeteor } from "/imports/server/async-helpers.ts";
-import { makeHackSessionContext } from "/imports/server/hack-session.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
+import { PersistentImpl } from "/imports/server/persistent";
+import { rawSend } from "/imports/server/email";
+import { shouldRestartGrain } from "/imports/server/backend";
+import { inMeteor } from "/imports/server/async-helpers";
+import { makeHackSessionContext } from "/imports/server/hack-session";
 
 import Crypto from "crypto";
 import Net from "net";
 import Url from "url";
-import Capnp from "/imports/server/capnp.js";
+import Capnp from "/imports/server/capnp";
 
 const EmailRpc = Capnp.importSystem("sandstorm/email.capnp");
 const EmailImpl = Capnp.importSystem("sandstorm/email-impl.capnp");

--- a/shell/imports/server/email.js
+++ b/shell/imports/server/email.js
@@ -6,7 +6,7 @@ import nodemailer from "nodemailer";
 import smtpPool from "nodemailer-smtp-pool";
 import Future from "fibers/future";
 
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 const getSmtpConfig = function () {
   const config = globalDb.collections.settings.findOne({ _id: "smtpConfig" });

--- a/shell/imports/server/frontend-ref.js
+++ b/shell/imports/server/frontend-ref.js
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { checkRequirements } from "./persistent.js";
+import { checkRequirements } from "./persistent";
 
 class FrontendRefRegistry {
   constructor() {

--- a/shell/imports/server/gateway-router.js
+++ b/shell/imports/server/gateway-router.js
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { inMeteor, waitPromise } from "/imports/server/async-helpers.ts";
+import { inMeteor, waitPromise } from "/imports/server/async-helpers";
 import Crypto from "crypto";
 import Dns from "dns";
 
@@ -23,13 +23,13 @@ import { Match, check } from "meteor/check";
 import { _ } from "meteor/underscore";
 import { Random } from "meteor/random";
 
-import Capnp from "/imports/server/capnp.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions.js";
+import Capnp from "/imports/server/capnp";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
+import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions";
 
-import { responseCodes } from "/imports/server/web-session.ts";
-import { makeHackSessionContext } from "/imports/server/hack-session.js";
+import { responseCodes } from "/imports/server/web-session";
+import { makeHackSessionContext } from "/imports/server/hack-session";
 
 const GatewayRouter = Capnp.importSystem("sandstorm/backend.capnp").GatewayRouter;
 const ApiSession = Capnp.importSystem("sandstorm/api-session.capnp").ApiSession;

--- a/shell/imports/server/grain-server.js
+++ b/shell/imports/server/grain-server.js
@@ -21,11 +21,11 @@ import { Match, check } from "meteor/check";
 import { _ } from "meteor/underscore";
 import { Random } from "meteor/random";
 
-import { send as sendEmail } from "/imports/server/email.js";
-import { waitPromise } from "/imports/server/async-helpers.ts";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions.js";
+import { send as sendEmail } from "/imports/server/email";
+import { waitPromise } from "/imports/server/async-helpers";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
+import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions";
 
 const ROOT_URL = process.env.ROOT_URL;
 

--- a/shell/imports/server/hack-session.js
+++ b/shell/imports/server/hack-session.js
@@ -23,12 +23,12 @@ import { Match, check } from "meteor/check";
 import { _ } from "meteor/underscore";
 import { Random } from "meteor/random";
 
-import { hashSturdyRef, checkRequirements, fetchApiToken } from "/imports/server/persistent.js";
-import { inMeteor, waitPromise } from "/imports/server/async-helpers.ts";
-import { ssrfSafeLookup } from "/imports/server/networking.js";
-import Capnp from "/imports/server/capnp.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { hashSturdyRef, checkRequirements, fetchApiToken } from "/imports/server/persistent";
+import { inMeteor, waitPromise } from "/imports/server/async-helpers";
+import { ssrfSafeLookup } from "/imports/server/networking";
+import Capnp from "/imports/server/capnp";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 const HackSessionContext = Capnp.importSystem("sandstorm/hack-session.capnp").HackSessionContext;
 const SystemPersistent = Capnp.importSystem("sandstorm/supervisor.capnp").SystemPersistent;

--- a/shell/imports/server/header-whitelist.js
+++ b/shell/imports/server/header-whitelist.js
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Capnp from "/imports/server/capnp.js";
+import Capnp from "/imports/server/capnp";
 const WebSession = Capnp.importSystem("sandstorm/web-session.capnp").WebSession;
 
 class HeaderWhitelist {

--- a/shell/imports/server/identity.js
+++ b/shell/imports/server/identity.js
@@ -18,12 +18,12 @@ import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import { _ } from "meteor/underscore";
 
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { SandstormPermissions }  from "/imports/sandstorm-permissions/permissions.js";
-import { PersistentImpl } from "/imports/server/persistent.js";
-import { StaticAssetImpl, IdenticonStaticAssetImpl } from "/imports/server/static-asset.js";
-import Capnp from "/imports/server/capnp.js";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
+import { SandstormPermissions }  from "/imports/sandstorm-permissions/permissions";
+import { PersistentImpl } from "/imports/server/persistent";
+import { StaticAssetImpl, IdenticonStaticAssetImpl } from "/imports/server/static-asset";
+import Capnp from "/imports/server/capnp";
 
 const IdentityRpc = Capnp.importSystem("sandstorm/identity-impl.capnp");
 const Identity = Capnp.importSystem("sandstorm/identity.capnp").Identity;

--- a/shell/imports/server/install-server.js
+++ b/shell/imports/server/install-server.js
@@ -19,12 +19,12 @@ import { Match, check } from "meteor/check";
 import { Random } from "meteor/random";
 import { Router } from "meteor/iron:router";
 
-import { allowDemo } from "/imports/demo.js";
-import { isSafeDemoAppUrl } from "/imports/install.js"
-import { promiseToFuture, waitPromise } from "/imports/server/async-helpers.ts";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { cancelDownload } from "/imports/server/installer.js";
+import { allowDemo } from "/imports/demo";
+import { isSafeDemoAppUrl } from "/imports/install"
+import { promiseToFuture, waitPromise } from "/imports/server/async-helpers";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
+import { cancelDownload } from "/imports/server/installer";
 
 const TOKEN_CLEANUP_MINUTES = 120;  // Give enough time for large uploads on slow connections.
 const TOKEN_CLEANUP_TIMER = TOKEN_CLEANUP_MINUTES * 60 * 1000;

--- a/shell/imports/server/installer.js
+++ b/shell/imports/server/installer.js
@@ -20,9 +20,9 @@ import { Meteor } from "meteor/meteor";
 import { _ } from "meteor/underscore";
 import { Random } from "meteor/random";
 
-import { inMeteor, waitPromise } from "/imports/server/async-helpers.ts";
-import { ssrfSafeLookupOrProxy } from "/imports/server/networking.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { inMeteor, waitPromise } from "/imports/server/async-helpers";
+import { ssrfSafeLookupOrProxy } from "/imports/server/networking";
+import { globalDb } from "/imports/db-deprecated";
 
 const Request = HTTPInternals.NpmModules.request.module;
 

--- a/shell/imports/server/migrations.js
+++ b/shell/imports/server/migrations.js
@@ -8,10 +8,10 @@ import { Meteor } from "meteor/meteor";
 import { Mongo } from "meteor/mongo";
 import { _ } from "meteor/underscore";
 import { Match } from "meteor/check";
-import { userPictureUrl, fetchPicture } from "/imports/server/accounts/picture.js";
-import { waitPromise } from "/imports/server/async-helpers.ts";
-import { PRIVATE_IPV4_ADDRESSES, PRIVATE_IPV6_ADDRESSES } from "/imports/constants.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
+import { userPictureUrl, fetchPicture } from "/imports/server/accounts/picture";
+import { waitPromise } from "/imports/server/async-helpers";
+import { PRIVATE_IPV4_ADDRESSES, PRIVATE_IPV6_ADDRESSES } from "/imports/constants";
+import { SandstormDb } from "/imports/sandstorm-db/db";
 
 import Future from "fibers/future";
 import Url from "url";

--- a/shell/imports/server/networking.js
+++ b/shell/imports/server/networking.js
@@ -19,7 +19,7 @@ import Dns from "dns";
 import Ip from "ip";
 import Url from "url";
 
-import { SPECIAL_IPV4_ADDRESSES, SPECIAL_IPV6_ADDRESSES } from "/imports/constants.js";
+import { SPECIAL_IPV4_ADDRESSES, SPECIAL_IPV6_ADDRESSES } from "/imports/constants";
 
 const lookupInFiber = Meteor.wrapAsync(Dns.lookup, Dns);
 

--- a/shell/imports/server/notifications-server.js
+++ b/shell/imports/server/notifications-server.js
@@ -19,10 +19,10 @@ import { Match, check } from "meteor/check";
 import { _ } from "meteor/underscore";
 import { Random } from "meteor/random";
 
-import { waitPromise } from "/imports/server/async-helpers.ts";
-import { createAppActivityDesktopNotification } from "/imports/server/desktop-notifications.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { waitPromise } from "/imports/server/async-helpers";
+import { createAppActivityDesktopNotification } from "/imports/server/desktop-notifications";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
 logActivity = function (grainId, accountIdOrAnonymous, event) {
   // accountIdOrAnonymous is the string "anonymous" for an anonymous user, or is null for a

--- a/shell/imports/server/persistent.js
+++ b/shell/imports/server/persistent.js
@@ -20,9 +20,9 @@ import { _ } from "meteor/underscore";
 import { Random } from "meteor/random";
 
 import Crypto from "crypto";
-import { inMeteor } from "/imports/server/async-helpers.ts";
-import Capnp from "/imports/server/capnp.js";
-import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions.js";
+import { inMeteor } from "/imports/server/async-helpers";
+import Capnp from "/imports/server/capnp";
+import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions";
 
 const privateDb = Symbol("PersistentImpl.db");
 const privateTemplate = Symbol("PersistentImpl.template");

--- a/shell/imports/server/pre-meteor.js
+++ b/shell/imports/server/pre-meteor.js
@@ -20,9 +20,9 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 
-import { inMeteor } from "/imports/server/async-helpers.ts";
-import { globalDb } from "/imports/db-deprecated.js";
-import ServerIdenticon from "/imports/sandstorm-identicons/identicon-server.js";
+import { inMeteor } from "/imports/server/async-helpers";
+import { globalDb } from "/imports/db-deprecated";
+import ServerIdenticon from "/imports/sandstorm-identicons/identicon-server";
 import Url from "url";
 import Future from "fibers/future";
 

--- a/shell/imports/server/sandcats.js
+++ b/shell/imports/server/sandcats.js
@@ -23,7 +23,7 @@ import fs from "fs";
 import dgram from "dgram";
 import Url from "url";
 
-import { SANDSTORM_ALTHOME } from "/imports/server/constants.js";
+import { SANDSTORM_ALTHOME } from "/imports/server/constants";
 
 const SANDCATS_HOSTNAME = (Meteor.settings && Meteor.settings.public &&
                            Meteor.settings.public.sandcatsHostname);

--- a/shell/imports/server/scheduled-job.js
+++ b/shell/imports/server/scheduled-job.js
@@ -16,12 +16,12 @@
 
 import { Meteor } from "meteor/meteor";
 
-import { waitPromise } from "/imports/server/async-helpers.ts";
-import { fetchApiToken } from "/imports/server/persistent.js";
-import Capnp from "/imports/server/capnp.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
-import { filterCallbacks, subscriptionCallbacks } from "/imports/collection-utils.ts";
+import { waitPromise } from "/imports/server/async-helpers";
+import { fetchApiToken } from "/imports/server/persistent";
+import Capnp from "/imports/server/capnp";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
+import { filterCallbacks, subscriptionCallbacks } from "/imports/collection-utils";
 
 const ScheduledJob = Capnp.importSystem("sandstorm/grain.capnp").ScheduledJob;
 const SystemPersistent = Capnp.importSystem("sandstorm/supervisor.capnp").SystemPersistent;

--- a/shell/imports/server/shell-cli.js
+++ b/shell/imports/server/shell-cli.js
@@ -14,12 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { inMeteor, waitPromise } from "/imports/server/async-helpers.ts";
-import { createAcmeAccount, renewCertificateNow } from "/imports/server/acme.js";
-import { SandstormDb } from "/imports/sandstorm-db/db.js";
-import { globalDb } from "/imports/db-deprecated.js";
+import { inMeteor, waitPromise } from "/imports/server/async-helpers";
+import { createAcmeAccount, renewCertificateNow } from "/imports/server/acme";
+import { SandstormDb } from "/imports/sandstorm-db/db";
+import { globalDb } from "/imports/db-deprecated";
 
-import Capnp from "/imports/server/capnp.js";
+import Capnp from "/imports/server/capnp";
 const ShellCli = Capnp.importSystem("sandstorm/backend.capnp").ShellCli;
 
 class ShellCliImpl {

--- a/shell/imports/server/shell-server.js
+++ b/shell/imports/server/shell-server.js
@@ -36,8 +36,8 @@
 import { Meteor } from "meteor/meteor";
 import { BrowserPolicy } from "meteor/browser-policy";
 
-import { inMeteor } from "/imports/server/async-helpers.ts";
-import { globalDb } from "/imports/db-deprecated.js";
+import { inMeteor } from "/imports/server/async-helpers";
+import { globalDb } from "/imports/db-deprecated";
 
 BrowserPolicy.framing.disallow();  // Disallow framing of the UI.
 Meteor.startup(() => {
@@ -59,7 +59,7 @@ Meteor.startup(() => {
 });
 
 // Allow anything to be loaded from the static asset host.
-import { staticAssetHost } from "/imports/server/constants.js";
+import { staticAssetHost } from "/imports/server/constants";
 BrowserPolicy.content.allowImageOrigin(staticAssetHost);
 BrowserPolicy.content.allowScriptOrigin(staticAssetHost);
 BrowserPolicy.content.allowFontOrigin(staticAssetHost);

--- a/shell/imports/server/signup-server.js
+++ b/shell/imports/server/signup-server.js
@@ -19,7 +19,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 Meteor.publish("signupKey", function (key) {
   check(key, String);

--- a/shell/imports/server/standalone-server.js
+++ b/shell/imports/server/standalone-server.js
@@ -17,7 +17,7 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 Meteor.publish("standaloneDomain", function (domain) {
   check(domain, String);

--- a/shell/imports/server/startup.js
+++ b/shell/imports/server/startup.js
@@ -17,8 +17,8 @@
 // This file is for various startup code that doesn't fit neatly anywhere else
 
 import { Meteor } from "meteor/meteor";
-import { globalDb } from "/imports/db-deprecated.js";
-import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions.js";
+import { globalDb } from "/imports/db-deprecated";
+import { SandstormPermissions } from "/imports/sandstorm-permissions/permissions";
 
 const ROOT_URL = process.env.ROOT_URL;
 

--- a/shell/imports/server/static-asset.js
+++ b/shell/imports/server/static-asset.js
@@ -16,7 +16,7 @@
 
 import Url from "url";
 import { Match, check } from "meteor/check";
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 const PROTOCOL = Url.parse(process.env.ROOT_URL).protocol;
 

--- a/shell/imports/server/stats-server.js
+++ b/shell/imports/server/stats-server.js
@@ -21,7 +21,7 @@ import { Random } from "meteor/random";
 import { Router } from "meteor/iron:router";
 import { HTTP } from "meteor/http";
 
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 

--- a/shell/imports/server/testing.js
+++ b/shell/imports/server/testing.js
@@ -15,10 +15,10 @@
 // limitations under the License.
 
 import { Meteor } from "meteor/meteor";
-import { globalDb } from "/imports/db-deprecated.js";
-import { runDueJobs } from '/imports/server/scheduled-job.js';
-import { SandstormAutoupdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
-import { isTesting } from "/imports/shared/testing.js";
+import { globalDb } from "/imports/db-deprecated";
+import { runDueJobs } from "/imports/server/scheduled-job";
+import { SandstormAutoupdateApps } from "/imports/sandstorm-autoupdate-apps/autoupdate-apps";
+import { isTesting } from "/imports/shared/testing";
 
 function clearUser(id) {
   globalDb.collections.userActions.remove({ userId: id });

--- a/shell/imports/server/transfers-server.js
+++ b/shell/imports/server/transfers-server.js
@@ -24,10 +24,10 @@ import { Match, check } from "meteor/check";
 import { Router } from "meteor/iron:router";
 import { HTTP } from "meteor/http";
 
-import { inMeteor, waitPromise } from "/imports/server/async-helpers.ts";
-import { globalDb } from "/imports/db-deprecated.js";
+import { inMeteor, waitPromise } from "/imports/server/async-helpers";
+import { globalDb } from "/imports/db-deprecated";
 import { createGrainBackup, createBackupToken, restoreGrainBackup, storeGrainBackup }
-  from "/imports/server/backup.js";
+  from "/imports/server/backup";
 
 function isValidServerUrl(str) {
   let url;

--- a/shell/imports/shared/admin.js
+++ b/shell/imports/shared/admin.js
@@ -21,7 +21,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { Accounts } from "meteor/accounts-base";
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 function serviceEnabled(name) {
   const setting = globalDb.collections.settings.findOne({ _id: name });

--- a/shell/imports/shared/dev-accounts.js
+++ b/shell/imports/shared/dev-accounts.js
@@ -16,7 +16,7 @@
 
 import { Accounts } from "meteor/accounts-base";
 
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 Accounts.loginServices.dev = {
   isEnabled: function () {

--- a/shell/imports/shared/grain-shared.js
+++ b/shell/imports/shared/grain-shared.js
@@ -16,7 +16,7 @@
 
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
-import { globalDb } from "/imports/db-deprecated.js";
+import { globalDb } from "/imports/db-deprecated";
 
 Meteor.methods({
   // Methods defined in this file have meaningful latency compensation (client-side prediction)

--- a/shell/server/main.ts
+++ b/shell/server/main.ts
@@ -39,76 +39,76 @@
 // Import packages that sandstorm depends on.
 
 // sandstorm-db.
-import "../imports/sandstorm-db/db.js";
-import "../imports/sandstorm-db/profile.js";
-import "../imports/sandstorm-db/scheduled-jobs-db.js";
+import "../imports/sandstorm-db/db";
+import "../imports/sandstorm-db/profile";
+import "../imports/sandstorm-db/scheduled-jobs-db";
 
 // sandstorm-permissions.  Depends on sandstorm-db.
-import "../imports/sandstorm-permissions/permissions.js";
+import "../imports/sandstorm-permissions/permissions";
 
 // sandstorm-autoupdate-apps.  Depends on sandstorm-db.
-import "../imports/sandstorm-autoupdate-apps/autoupdate-apps.js";
+import "../imports/sandstorm-autoupdate-apps/autoupdate-apps";
 
 // sandstorm-accounts-packages
-import "../imports/sandstorm-accounts-packages/accounts.js";
+import "../imports/sandstorm-accounts-packages/accounts";
 
 // sandstorm-ui-powerbox.
-import "../imports/sandstorm-ui-powerbox/powerbox-server.js";
+import "../imports/sandstorm-ui-powerbox/powerbox-server";
 
 // blackrock-payments.  Depends on sandstorm-db
-import "../imports/blackrock-payments/constants.js";
-import "../imports/blackrock-payments/server/payments-server.js";
-import "../imports/blackrock-payments/server/payments-api-server.js";
+import "../imports/blackrock-payments/constants";
+import "../imports/blackrock-payments/server/payments-server";
+import "../imports/blackrock-payments/server/payments-api-server";
 
 // oidc
-import "../imports/oidc/oidc-server.js";
+import "../imports/oidc/oidc-server";
 
 // Import everything from server/ in the order that Meteor would have.
-import "../imports/server/accounts/credentials/credentials-server.js";
-import "../imports/server/accounts/email-token/token-server.js";
-import "../imports/server/accounts/ldap/ldap-server.js";
-import "../imports/server/accounts/saml/saml-server.js";
-import "../imports/server/accounts/accounts-server.js";
-import "../imports/server/accounts/accounts-ui-methods.js";
-import "../imports/server/accounts/accounts-ui-server.js";
-import "../imports/server/admin/admin-alert-server.js";
-import "../imports/server/admin/admin-user-invite.js";
-import "../imports/server/admin/network-capabilities-server.js";
-import "../imports/server/admin/personalization-server.js";
-import "../imports/server/admin/system-status-server.js";
-import "../imports/server/drivers/external-ui-view.js";
-import "../imports/server/drivers/ip.js";
-import "../imports/server/drivers/mail.js";
-import "../imports/db-deprecated.js";
-import "../imports/server/00-startup.js";
-import "../imports/server/account-suspension.js";
-import "../imports/server/acme.js";
-import "../imports/server/admin-server.js";
-import "../imports/server/backup.js";
-import "../imports/server/contacts-server.js";
-import "../imports/server/core.js";
-import "../imports/server/demo-server.js";
-import "../imports/server/desktop-notifications-server.js";
-import "../imports/server/dev-accounts-server.js";
-import "../imports/server/gateway-router.js";
-import "../imports/server/grain-server.js";
-import "../imports/server/hack-session.js";
-import "../imports/server/identity.js";
-import "../imports/server/installer.js";
-import "../imports/server/install-server.js";
-import "../imports/server/notifications-server.js";
-import "../imports/server/pre-meteor.js";
-import "../imports/server/sandcats.js";
-import "../imports/server/scheduled-job.js";
-import "../imports/server/shell-server.js";
-import "../imports/server/signup-server.js";
-import "../imports/server/standalone-server.js";
-import "../imports/server/startup.js";
-import "../imports/server/stats-server.js";
-import "../imports/server/transfers-server.js";
+import "../imports/server/accounts/credentials/credentials-server";
+import "../imports/server/accounts/email-token/token-server";
+import "../imports/server/accounts/ldap/ldap-server";
+import "../imports/server/accounts/saml/saml-server";
+import "../imports/server/accounts/accounts-server";
+import "../imports/server/accounts/accounts-ui-methods";
+import "../imports/server/accounts/accounts-ui-server";
+import "../imports/server/admin/admin-alert-server";
+import "../imports/server/admin/admin-user-invite";
+import "../imports/server/admin/network-capabilities-server";
+import "../imports/server/admin/personalization-server";
+import "../imports/server/admin/system-status-server";
+import "../imports/server/drivers/external-ui-view";
+import "../imports/server/drivers/ip";
+import "../imports/server/drivers/mail";
+import "../imports/db-deprecated";
+import "../imports/server/00-startup";
+import "../imports/server/account-suspension";
+import "../imports/server/acme";
+import "../imports/server/admin-server";
+import "../imports/server/backup";
+import "../imports/server/contacts-server";
+import "../imports/server/core";
+import "../imports/server/demo-server";
+import "../imports/server/desktop-notifications-server";
+import "../imports/server/dev-accounts-server";
+import "../imports/server/gateway-router";
+import "../imports/server/grain-server";
+import "../imports/server/hack-session";
+import "../imports/server/identity";
+import "../imports/server/installer";
+import "../imports/server/install-server";
+import "../imports/server/notifications-server";
+import "../imports/server/pre-meteor";
+import "../imports/server/sandcats";
+import "../imports/server/scheduled-job";
+import "../imports/server/shell-server";
+import "../imports/server/signup-server";
+import "../imports/server/standalone-server";
+import "../imports/server/startup";
+import "../imports/server/stats-server";
+import "../imports/server/transfers-server";
 
-import "../imports/shared/admin.js";
-import "../imports/shared/dev-accounts.js";
-import "../imports/shared/grain-shared.js";
+import "../imports/shared/admin";
+import "../imports/shared/dev-accounts";
+import "../imports/shared/grain-shared";
 
-import "../imports/server/testing.js";
+import "../imports/server/testing";


### PR DESCRIPTION
...with the singular exception of intro.js, where it's part of the
package name, not a file extension.

This is mostly to fix an issue where typescript doesn't want you to
import files with a .ts extension (it will accept .js, but that's super
weird if the file doesn't actually have that extension, and when I tried
it it broke the build for Kenton). Changing the import of .js files is
mainly for consistency.

This also changes some imports to use double quotes (") instead of
single quotes ('); I noticed these while searching for import sites to
replace.

---

This fixes two errors currently being flagged by tsc in CI: https://github.com/sandstorm-io/sandstorm/runs/6845088479?check_suite_focus=true#step:10:12 

Supersedes #3635.