### PR TITLE
Apply backpressure when installing packages.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           # the constant below.
           make lint | tee lint.log
           num_problems=$(cat lint.log | grep ' problems (0 errors, ' | awk '{print $2}')
-          [ "$num_problems" = 774 ]
+          [ "$num_problems" = 773 ]
       - name: test
         run: |
           set -o pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           # the constant below.
           make lint | tee lint.log
           num_problems=$(cat lint.log | grep ' problems (0 errors, ' | awk '{print $2}')
-          [ "$num_problems" = 776 ]
+          [ "$num_problems" = 774 ]
       - name: test
         run: |
           set -o pipefail

--- a/release-process.md
+++ b/release-process.md
@@ -1,0 +1,42 @@
+How to push a Sandstorm release
+===============================
+
+You will need:
+* The release signing key.
+* SSH access to the Sandstorm release server.
+
+Steps:
+
+1. Make sure relevant pull requests have been merged.
+
+2. `git pull` the master branch.
+
+3. Update dependencies. After each step, commit the changes using the command you ran as the commit message.
+    * Submodules: `make update-deps`
+    * Meteor: `cd shell && meteor update --all-packages`
+        * If Meteor can't be updated for some reason (e.g. a new release will break Sandstorm and
+          we can't fix it yet), use `meteor update --packages-only --all-packages`
+    * NPM modules: `cd shell && meteor npm update --depth 9999 --save`
+
+4. Test it:
+    * `make test` to run automated tests.
+    * `make update` to update your local install, then manually test anything that seems worth sanity-checking, such as things that changed since last release.
+
+5. Update `CHANGELOG.md` summarizing new changes.
+
+6. Release it:
+    * Run: `./release.sh`
+
+7. Check alpha.sandstorm.io (which the release script will have directly updated) to verify it's not broken.
+
+8. `git push`
+
+Emergency Rollback
+==================
+
+If you discover after `release.sh` completes that the release is fatally broken, do this:
+
+1. SSH into updates server and edit `/var/www/install.sandstorm.io/dev`. This file contains the current release number. Change it back to the previous release. This stops anyone else from updating.
+
+2. Fix or revert the breakage and do a new release as soon as possible, so that the people who did update to the broken release can update again to fix it. Sandstorm does not allow rolling back a release once it has been installed, so a new release is the only way forward.
+

--- a/shell/imports/server/install-server.js
+++ b/shell/imports/server/install-server.js
@@ -21,7 +21,7 @@ import { Router } from "meteor/iron:router";
 
 import { allowDemo } from "/imports/demo.js";
 import { isSafeDemoAppUrl } from "/imports/install.js"
-import { promiseToFuture, waitPromise } from "/imports/server/async-helpers.ts";
+import { waitPromise } from "/imports/server/async-helpers.ts";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
 import { cancelDownload, doClientUpload } from "/imports/server/installer.js";
@@ -152,7 +152,7 @@ Router.map(function () {
         this.response.end();
       } else if (this.request.method === "POST") {
         try {
-          const packageId = promiseToFuture(doClientUpload(this.request, globalBackend)).wait();
+          const packageId = waitPromise(doClientUpload(this.request, globalBackend));
           this.response.writeHead(200, {
             "Content-Length": packageId.length,
             "Content-Type": "text/plain",

--- a/shell/imports/server/install-server.js
+++ b/shell/imports/server/install-server.js
@@ -24,7 +24,7 @@ import { isSafeDemoAppUrl } from "/imports/install.js"
 import { promiseToFuture, waitPromise } from "/imports/server/async-helpers.ts";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
-import { cancelDownload } from "/imports/server/installer.js";
+import { cancelDownload, doClientUpload } from "/imports/server/installer.js";
 
 const TOKEN_CLEANUP_MINUTES = 120;  // Give enough time for large uploads on slow connections.
 const TOKEN_CLEANUP_TIMER = TOKEN_CLEANUP_MINUTES * 60 * 1000;

--- a/shell/imports/server/install-server.js
+++ b/shell/imports/server/install-server.js
@@ -24,7 +24,7 @@ import { isSafeDemoAppUrl } from "/imports/install.js"
 import { waitPromise } from "/imports/server/async-helpers.ts";
 import { SandstormDb } from "/imports/sandstorm-db/db.js";
 import { globalDb } from "/imports/db-deprecated.js";
-import { cancelDownload, doClientUpload } from "/imports/server/installer.js";
+import { cancelDownload, readPackageFromStream } from "/imports/server/installer.js";
 
 const TOKEN_CLEANUP_MINUTES = 120;  // Give enough time for large uploads on slow connections.
 const TOKEN_CLEANUP_TIMER = TOKEN_CLEANUP_MINUTES * 60 * 1000;
@@ -152,7 +152,7 @@ Router.map(function () {
         this.response.end();
       } else if (this.request.method === "POST") {
         try {
-          const packageId = waitPromise(doClientUpload(this.request, globalBackend));
+          const packageId = waitPromise(readPackageFromStream(this.request, globalBackend)).packageId;
           this.response.writeHead(200, {
             "Content-Length": packageId.length,
             "Content-Type": "text/plain",

--- a/shell/imports/server/install-server.js
+++ b/shell/imports/server/install-server.js
@@ -152,7 +152,7 @@ Router.map(function () {
         this.response.end();
       } else if (this.request.method === "POST") {
         try {
-          const packageId = promiseToFuture(doClientUpload(this.request)).wait();
+          const packageId = promiseToFuture(doClientUpload(this.request, globalBackend)).wait();
           this.response.writeHead(200, {
             "Content-Length": packageId.length,
             "Content-Type": "text/plain",

--- a/shell/imports/server/installer.js
+++ b/shell/imports/server/installer.js
@@ -19,7 +19,6 @@ import { pipeline, Writable } from "stream";
 
 import { Meteor } from "meteor/meteor";
 import { _ } from "meteor/underscore";
-import { Random } from "meteor/random";
 
 import { inMeteor, waitPromise } from "/imports/server/async-helpers.ts";
 import { ssrfSafeLookupOrProxy } from "/imports/server/networking.js";
@@ -294,17 +293,11 @@ class AppInstaller {
     console.log("Downloading app:", this.url);
     this.updateProgress("download");
 
-    this.uploadStream = globalBackend.cap().installPackage().stream;
-    return this.doDownloadTo(this.uploadStream);
-  }
-
-  doDownloadTo(out) {
     inMeteor(this.wrapCallback(function () {
       const safe = ssrfSafeLookupOrProxy(globalDb, this.url);
 
       let bytesExpected = undefined;
       let bytesReceived = 0;
-      const hasher = Crypto.createHash("sha256");
       let done = false;
       const updateDownloadProgress = _.throttle(this.wrapCallback(() => {
         if (!done) {

--- a/shell/imports/server/installer.js
+++ b/shell/imports/server/installer.js
@@ -132,8 +132,8 @@ if (!Meteor.settings.replicaNumber) {
   });
 }
 
-export function doClientUpload(stream) {
-  const backendStream = globalBackend.cap().installPackage().stream;
+export function doClientUpload(stream, backend) {
+  const backendStream = backend.cap().installPackage().stream;
   const hasher = Crypto.createHash("sha256");
 
   return new Promise((resolve, reject) => {

--- a/shell/imports/server/installer.js
+++ b/shell/imports/server/installer.js
@@ -153,7 +153,7 @@ export function readPackageFromStream(stream, backend, progress = function() {})
         backendStream.write(chunk).then(() => {
           callback();
           progress(chunk.length);
-        });
+        }, reject);
       },
     }), (err, _val) => {
       if(err) {

--- a/shell/imports/server/installer.js
+++ b/shell/imports/server/installer.js
@@ -94,7 +94,7 @@ const startInstallInternal = (pkg) => {
   installer.start();
 };
 
-function cancelDownload(packageId) {
+export function cancelDownload(packageId) {
   globalDb.collections.packages.remove({ _id: packageId, status: "download" });
 }
 
@@ -132,7 +132,7 @@ if (!Meteor.settings.replicaNumber) {
   });
 }
 
-doClientUpload = (stream) => {
+export function doClientUpload(stream) {
   const backendStream = globalBackend.cap().installPackage().stream;
   const hasher = Crypto.createHash("sha256");
 
@@ -155,7 +155,7 @@ doClientUpload = (stream) => {
         .then(() => resolve(packageId), reject)
     });
   }).finally(() => backendStream.close());
-};
+}
 
 class AppInstaller {
   constructor(packageId, url, appId, isAutoUpdated) {
@@ -510,5 +510,3 @@ function getAllManifestAssets(manifest) {
 
   return result;
 }
-
-export { cancelDownload };

--- a/shell/imports/server/installer.js
+++ b/shell/imports/server/installer.js
@@ -133,6 +133,8 @@ if (!Meteor.settings.replicaNumber) {
 }
 
 export function doClientUpload(stream, backend) {
+  // doClientUpload reads an spk pacakge from stream and uploads it into backend.
+  // Returns a promise which resolves to the package id when the upload completes.
   const backendStream = backend.cap().installPackage().stream;
   const hasher = Crypto.createHash("sha256");
 


### PR DESCRIPTION
This should fix #3429, and when installing apps I generally see stable memory usage now, though I haven't actually tried an install with all of the usual apps going at once.

This reworks the logic for uploading and downloading packages so that it applies some backpressure, instead of letting stuff build up in memory. It possibly applies *too much* backpressure, as it waits for each call to ByteStream.write(), but since it's generally reading from a network connection and writing to a local socket which is much faster I suspect this won't have much impact in practice. The "right" solution is probably to expose capnp-c++'s streaming support via node-capnp.

Along the way I did a few minor cleanups of nearby code, and fixed some warnings.