### PR TITLE
release.sh: automatically push to master

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -80,6 +80,9 @@ GIT_REVISION="$(<bundle/git-revision)"
 git tag -u $SIGNING_KEY_ID "$TAG_NAME" "$GIT_REVISION" -m "Release Sandstorm ${DISPLAY_VERSION}"
 git push origin "$TAG_NAME"
 
+# Remember to push it to master too...
+git push origin master
+
 echo "**** Pushing build $BUILD ****"
 
 rm -f $TARBALL.sig $TARBALL.update-sig install.sh.sig


### PR DESCRIPTION
Per discussion on IRC, the script currently pushes the tag, but does not
push to the master branch. This patch adds that logic to the script, so
hopefully Kenton won't have to remember to do this going forward.

Note that this is untested.