### PR TITLE
Google Apps for Work is Workspace

### DIFF
--- a/docs/administering/for-work.md
+++ b/docs/administering/for-work.md
@@ -29,9 +29,9 @@ Login providers have different settings that are used to define your organizatio
 considered a member of your organization if the settings for **at least one** login provider
 declare the user to be a member. You can enable/disable this on a per-login-provider basis.
 
-- **Google authentication.** All users who use a particular Google Apps domain of your choosing can
-  receive user status in Sandstorm. When you enable the use of Google Apps to define the boundary
-  of your organization, you must specify which Google Apps domain represents your organization.
+- **Google authentication.** All users who use a particular Google Workspace domain of your choosing can
+  receive user status in Sandstorm. When you enable the use of Google Workspace to define the boundary
+  of your organization, you must specify which Google Workspace domain represents your organization.
 
 - **SAML authentication, including Active Directory.** All users who log in via SAML can
   automatically receive user status in Sandstorm. When you use SAML to define the boundary of your

--- a/shell/i18n/en.i18n.json
+++ b/shell/i18n/en.i18n.json
@@ -756,12 +756,12 @@
             "subtext": "Users with an email address at this domain will be members of this server's organization."
           },
           "gappsToggle": {
-            "label": "Users authenticated via Google Apps for Work",
+            "label": "Users authenticated via Google Workspace",
             "subtext": "Note: disabled because Google login is not configured."
           },
           "gappsDomain": {
             "label": "Domain:",
-            "subtext": "Users with a Google Apps for Work account under this domain will be members of this server's organization."
+            "subtext": "Users with a Google Workspace account under this domain will be members of this server's organization."
           },
           "ldapToggle": {
             "label": "Users authenticated via LDAP",
@@ -1736,12 +1736,12 @@
           "subtext": "Users with an email address at this domain will be members of this server's organization."
         },
         "gappsToggle": {
-          "label": "Users authenticated via Google Apps for Work",
+          "label": "Users authenticated via Google Workspace",
           "subtext": "Note: disabled because Google login is not configured."
         },
         "gappsDomain": {
           "label": "Domain:",
-          "subtext": "Users with a Google Apps for Work account under this domain will be members of this server's organization."
+          "subtext": "Users with a Google Workspace account under this domain will be members of this server's organization."
         },
         "ldapToggle": {
           "label": "Users authenticated via LDAP",

--- a/shell/i18n/fi.i18n.json
+++ b/shell/i18n/fi.i18n.json
@@ -710,12 +710,12 @@
             "subtext": "Käyttäjät joiden sähköpostiosoitteena on tämä domain tulevat olemaan tämän palvelimen organisaation jäseniä."
           },
           "gappsToggle": {
-            "label": "Käyttäjät jotka tunnistautuvat G Suiten kautta",
+            "label": "Käyttäjät jotka tunnistautuvat Google Workspace kautta",
             "subtext": "Huom: poistettu käytöstä koska Google kirjautuminen ei ole määriteltynä."
           },
           "gappsDomain": {
             "label": "Domain:",
-            "subtext": "Käyttäjät joilla on G Suite tili tällä domainilla tulevat olemaan tämän palvelimen organisaation jäseniä."
+            "subtext": "Käyttäjät joilla on Google Workspace tili tällä domainilla tulevat olemaan tämän palvelimen organisaation jäseniä."
           },
           "ldapToggle": {
             "label": "Käyttäjät tunnistautuvat LDAPin kautta",
@@ -1685,12 +1685,12 @@
           "subtext": "Käyttäjät joilla on tämän domainin sähköpostiosoite tulevat olemaan tämän palvelimen organisaation jäseniä."
         },
         "gappsToggle": {
-          "label": "G Suiten kautta kirjautuneet käyttäjät",
+          "label": "Google Workspace kautta kirjautuneet käyttäjät",
           "subtext": "Huom: poistettu käytöstä koska Google kirjautumista ei ole määritelty."
         },
         "gappsDomain": {
           "label": "Domain:",
-          "subtext": "G Suiten kautta kirjautuneet tämän domainin käyttäjät tulevat olemaan tämän palvelimen organisaation jäseniä."
+          "subtext": "Google Workspace kautta kirjautuneet tämän domainin käyttäjät tulevat olemaan tämän palvelimen organisaation jäseniä."
         },
         "ldapToggle": {
           "label": "LDAPin kautta kirjautuneet käyttäjät",

--- a/shell/i18n/fi.i18n.json
+++ b/shell/i18n/fi.i18n.json
@@ -710,7 +710,7 @@
             "subtext": "Käyttäjät joiden sähköpostiosoitteena on tämä domain tulevat olemaan tämän palvelimen organisaation jäseniä."
           },
           "gappsToggle": {
-            "label": "Käyttäjät jotka tunnistautuvat Google Workspace kautta",
+            "label": "Google Workspacen kautta kirjautuneet käyttäjät",
             "subtext": "Huom: poistettu käytöstä koska Google kirjautuminen ei ole määriteltynä."
           },
           "gappsDomain": {
@@ -1685,12 +1685,12 @@
           "subtext": "Käyttäjät joilla on tämän domainin sähköpostiosoite tulevat olemaan tämän palvelimen organisaation jäseniä."
         },
         "gappsToggle": {
-          "label": "Google Workspace kautta kirjautuneet käyttäjät",
+          "label": "Google Workspacen kautta kirjautuneet käyttäjät",
           "subtext": "Huom: poistettu käytöstä koska Google kirjautumista ei ole määritelty."
         },
         "gappsDomain": {
           "label": "Domain:",
-          "subtext": "Google Workspace kautta kirjautuneet tämän domainin käyttäjät tulevat olemaan tämän palvelimen organisaation jäseniä."
+          "subtext": "Käyttäjät joilla on Google Workspace tili tällä domainilla tulevat olemaan tämän palvelimen organisaation jäseniä."
         },
         "ldapToggle": {
           "label": "LDAPin kautta kirjautuneet käyttäjät",

--- a/shell/i18n/fr.i18n.json
+++ b/shell/i18n/fr.i18n.json
@@ -665,12 +665,12 @@
             "subtext": "Les utilisateurs ayant une adresse électronique dans ce domaine seront membres de l'organisation de ce serveur."
           },
           "gappsToggle": {
-            "label": "Authentification d'utilisateurs via Google Apps for Work",
+            "label": "Authentification d'utilisateurs via Google Workspace",
             "subtext": "Note : désactivée car l'authentification via Google n'est pas configurée."
           },
           "gappsDomain": {
             "label": "Domaine :",
-            "subtext": "Les utilisateurs disposant d'un compte Google Apps for Work sous ce domaine seront membres de l'organisation de ce serveur."
+            "subtext": "Les utilisateurs disposant d'un compte Google Workspace sous ce domaine seront membres de l'organisation de ce serveur."
           },
           "ldapToggle": {
             "label": "Authentification d'utilisateurs via LDAP",
@@ -1634,12 +1634,12 @@
           "subtext": "Les utilisateurs ayant une adresse électronique dans ce domaine seront membres de l'organisation de ce serveur."
         },
         "gappsToggle": {
-          "label": "Utilisateurs authentifiés par Google Apps for Work",
+          "label": "Utilisateurs authentifiés par Google Workspace",
           "subtext": "Note : désactivé car l'authentification via Google n'est pas configurée."
         },
         "gappsDomain": {
           "label": "Domaine :",
-          "subtext": "Les utilisateurs disposant d'un compte Google Apps for Work sous ce domaine seront membres de l'organisation de ce serveur."
+          "subtext": "Les utilisateurs disposant d'un compte Google Workspace sous ce domaine seront membres de l'organisation de ce serveur."
         },
         "ldapToggle": {
           "label": "Utilisateurs identifiés via LDAP",

--- a/shell/i18n/nl.i18n.json
+++ b/shell/i18n/nl.i18n.json
@@ -710,12 +710,12 @@
             "subtext": "Gebruikers met een email adres op dit domein zullen lid zijn van deze servers organisatie."
           },
           "gappsToggle": {
-            "label": "Gebruikers geverifieerd via Google Apps voor Werk",
+            "label": "Gebruikers geverifieerd via Google Workspace",
             "subtext": "Opmerking: uitgeschakeld omdat Google login niet is geconfigureerd."
           },
           "gappsDomain": {
             "label": "Domein:",
-            "subtext": "Gebruikers met een Google Apps voor Werk account onder dit domein zullen lid zijn van deze servers organisatie."
+            "subtext": "Gebruikers met een Google Workspace account onder dit domein zullen lid zijn van deze servers organisatie."
           },
           "ldapToggle": {
             "label": "Gebruikers geverifieerd via LDAP",
@@ -1685,12 +1685,12 @@
           "subtext": "Gebruikers met een email adres op dit domein zullen lid zijn van deze servers organisatie."
         },
         "gappsToggle": {
-          "label": "Gebruikers geverifieerd via Google Apps for Work",
+          "label": "Gebruikers geverifieerd via Google Workspace",
           "subtext": "Opmerking: uitgeschakeld omdat Google login niet is geconfigureerd."
         },
         "gappsDomain": {
           "label": "Domein:",
-          "subtext": "Gebruikers met een Google Apps for Work account onder dit domein zullen lid zijn van deze servers organiasatie."
+          "subtext": "Gebruikers met een Google Workspace account onder dit domein zullen lid zijn van deze servers organiasatie."
         },
         "ldapToggle": {
           "label": "Gebruikers geverifieerd via LDAP",

--- a/shell/i18n/zh-CN.i18n.json
+++ b/shell/i18n/zh-CN.i18n.json
@@ -710,12 +710,12 @@
                         "subtext": "用户如果持有这些域名下的邮箱，那么他们会成为该服务器上组织里的用户。"
                     },
                     "gappsToggle": {
-                        "label": "用户可通过 Google Apps for Work 认证",
+                        "label": "用户可通过 Google Workspace 认证",
                         "subtext": "注：该功能被禁用，因为未配置 Google 登录。"
                     },
                     "gappsDomain": {
                         "label": "域名:",
-                        "subtext": "如果用户的 Google Apps for Work 帐户在该域名下，那么他们会成为该服务器上组织里的用户。"
+                        "subtext": "如果用户的 Google Workspace 帐户在该域名下，那么他们会成为该服务器上组织里的用户。"
                     },
                     "ldapToggle": {
                         "label": "用户可通过 LDAP 认证",
@@ -1686,12 +1686,12 @@
                     "subtext": "用户使用该域名的电子邮件地址注册时会成为该服务器的组织成员。"
                 },
                 "gappsToggle": {
-                    "label": "用户通过 Google Apps for Work 验证",
+                    "label": "用户通过 Google Workspace 验证",
                     "subtext": "注：已禁用，因为通过 Google 登录未被配置。"
                 },
                 "gappsDomain": {
                     "label": "域名:",
-                    "subtext": "拥有该域名 Google Apps for Work 的用户注册时会成为该服务器的组织成员。"
+                    "subtext": "拥有该域名 Google Workspace 的用户注册时会成为该服务器的组织成员。"
                 },
                 "ldapToggle": {
                     "label": "用户通过 LDAP 验证",

--- a/shell/i18n/zh-TW.i18n.json
+++ b/shell/i18n/zh-TW.i18n.json
@@ -664,12 +664,12 @@
             "subtext": "使用上記網域信箱的人會自動認證為組織成員。"
           },
           "gappsToggle": {
-            "label": "G Suite 使用者認證",
+            "label": "Google Workspace 使用者認證",
             "subtext": "注意：因為 Google 登入設定未完成，所以無法使用。"
           },
           "gappsDomain": {
             "label": "網域：",
-            "subtext": "使用上記網域 G Suite 的人會自動認證為組織成員。"
+            "subtext": "使用上記網域 Google Workspace 的人會自動認證為組織成員。"
           },
           "ldapToggle": {
             "label": "LDAP 使用者認證",
@@ -1632,12 +1632,12 @@
           "subtext": "使用此網域電郵註冊的使用者將自動提升權限為組織成員（使用者）。"
         },
         "gappsToggle": {
-          "label": "以 G Suite 認證的使用者",
+          "label": "以 Google Workspace 認證的使用者",
           "subtext": "因為 Google 登入尚未設定，故無法使用。"
         },
         "gappsDomain": {
           "label": "網域：",
-          "subtext": "使用此網域 G Suite 註冊的使用者將自動提升權限為組織成員（使用者）。"
+          "subtext": "使用此網域 Google Workspace 註冊的使用者將自動提升權限為組織成員（使用者）。"
         },
         "ldapToggle": {
           "label": "以 LDAP 認證的使用者",


### PR DESCRIPTION
Trying to keep up with Google's rebranding is probably a pointless endeavor, but our lang files didn't even all use the same Google branding, as two of them referred to G Suite, and the rest as Google Apps for Work. This PR updates our language in both the setup wizard and the admin panel that this is Google Workspace now.