### PR TITLE
Docs: Fix GPG export instructions

### DIFF
--- a/docs/developing/publishing-apps.md
+++ b/docs/developing/publishing-apps.md
@@ -111,7 +111,7 @@ If you do it correctly, `cat pgp-signature | gpg` should print out the statement
 
 To verify your signature, you also need to export your public key and include it in your app package. You can run the following command, where `<key-id>` is a PGP key ID or a username associated with the key:
 
-`gpg --export <key-id> --export-options export-minimal > pgp-keyring`
+`gpg --export-options export-minimal --export <key-id> > pgp-keyring`
 
 ## Add required metadata
 


### PR DESCRIPTION
I attempted to follow these instructions this evening, and gpg gave me an error claiming that "--export-options is not considered an option", and I had a fairly difficult time getting a search result to explain why. (I assumed it was removed/renamed/replaced.) As it turns out, an answer about the same error for a different option revealed... gpg is sort of picky about the order of arguments, and so I tried flipping the order here, and it worked without incident.