### PR TITLE
Docs: Delete B rating comment

### DIFF
--- a/docs/administering/sandcats-https.md
+++ b/docs/administering/sandcats-https.md
@@ -103,11 +103,6 @@ GitHub websites.
 [Let's Encrypt](https://letsencrypt.org/) to renew certificates without
 needing any manual intervention.
 
-<!--
-**B rating.** Sandstorm's HTTPS cipher suites are kind of OK but really
-could be better.
--->
-
 **No reverse proxy.** This configuration removes the need for a
 reverse proxy or HTTPS terminator like `nginx`. If you want to set up
 a reverse proxy, you would typically use `BIND_IP=127.0.0.1` and


### PR DESCRIPTION
Just a random Asheesh comment I noticed. It looks like it was committed with the original creation of the page... commented out.

- We now get an A rating from Qualys SSL Test.
- This is no longer Sandcats-specific anyways.
- I don't think we should list this specifically in this page because the criteria regularly changes.
- If this was left here as a note we should improve the rating, commented out in docs is a bad place for it.