### PR TITLE
Block webrtc

### DIFF
--- a/src/sandstorm/web-session-bridge.c++
+++ b/src/sandstorm/web-session-bridge.c++
@@ -1290,6 +1290,7 @@ kj::Promise<void> WebSessionBridge::handleResponse(
           tables.hContentSecurityPolicy,
           kj::str(
             "default-src 'none'; "
+            "webrtc 'block'; "
 #define UNSAFE "'unsafe-inline' 'unsafe-eval' data: blob:; "
             "img-src * " UNSAFE
             "media-src * " UNSAFE


### PR DESCRIPTION
...when using ALLOW_LEGACY_RELAXED_CSP=false

Note that this doesn't actually work yet, because the browsers don't
implement this feature, but I've at least gotten it into the standards.
I will probably have to do the implementation work myself too.

But we may as well go ahead and add this to Sandstorm without waiting
for the browsers.

See also: https://github.com/sandstormports/community-project/issues/12