### PR TITLE
Override shouldResolveBeforeRedirecting to true in capnp membranes.

### DIFF
--- a/src/sandstorm/app-index/app-index.c++
+++ b/src/sandstorm/app-index/app-index.c++
@@ -269,6 +269,10 @@ private:
     }
 
     kj::Own<MembranePolicy> addRef() override { return kj::addRef(*this); }
+
+    bool shouldResolveBeforeRedirecting() override {
+      return true;
+    }
   };
 };
 

--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -902,6 +902,10 @@ public:
   kj::Own<capnp::MembranePolicy> addRef() override {
     return kj::addRef(*this);
   }
+
+  bool shouldResolveBeforeRedirecting() override {
+    return true;
+  }
 private:
 };
 

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -1494,6 +1494,10 @@ public:
           kj::mv(parent)
         }) {}
 
+  bool shouldResolveBeforeRedirecting() override {
+    return true;
+  }
+
   kj::Maybe<capnp::Capability::Client> inboundCall(
       uint64_t interfaceId, uint16_t methodId, capnp::Capability::Client target) override {
     // Don't shut down as long as we're receiving inbound calls.
@@ -1650,6 +1654,10 @@ public:
       : policy(kj::mv(policy)),
         token(kj::heapArray<const byte>(token)),
         sandstormCore(kj::mv(sandstormCore)) {}
+
+  bool shouldResolveBeforeRedirecting() override {
+    return true;
+  }
 
   class SaveHandler final: public SystemPersistent::Server {
   public:


### PR DESCRIPTION
I assumed that all membranes should have this enabled, but maybe that's not the case. Happy to change if so.

The reason this is necessary is because the default for this is being changed: https://github.com/capnproto/capnproto/pull/1530