### PR TITLE
Partially document ShellCli.

### DIFF
--- a/src/sandstorm/backend.capnp
+++ b/src/sandstorm/backend.capnp
@@ -217,9 +217,18 @@ interface GatewayRouter {
 }
 
 interface ShellCli {
+  # ShellCli provides methods used by the CLI to communicate with a running sandstorm front-end.
+
+  const socketPath :Text = "var/sandstorm/socket/shell-cli";
+  # Path (relative to sandstorm's installation directory, normally /opt/sandstorm) to a socket
+  # where a ShellCli is the bootstrap interface.
+
   createAcmeAccount @0 (directory :Text, email :Text, agreeToTerms :Bool);
+
   setAcmeChallenge @1 (module :Text, options :Text);
+
   renewCertificateNow @2 ();
+  # Renew HTTPs certs immediately.
 }
 
 interface SandstormCoreFactory {

--- a/src/sandstorm/run-bundle.c++
+++ b/src/sandstorm/run-bundle.c++
@@ -1139,7 +1139,7 @@ public:
           bundleDir(main.getInstallDir()),
           sandstormHome(kj::str(bundleDir.slice(0, KJ_ASSERT_NONNULL(bundleDir.findLast('/'))))),
           cap(network.parseAddress(
-                kj::str("unix:", sandstormHome, "/var/sandstorm/socket/shell-cli"))
+                kj::str("unix:", sandstormHome, "/", ShellCli::SOCKET_PATH))
               .then([this](kj::Own<kj::NetworkAddress> addr) {
             auto promise = addr->connect();
             return promise.attach(kj::mv(addr))
@@ -2414,8 +2414,8 @@ private:
       // Listen for connections on the shell CLI socket and forward them to the shell. We do this
       // in the backend, rather than in the shell itself, mainly because node-capnp lacks support
       // for creating listen sockets.
-      unlink("/var/sandstorm/socket/shell-cli");
-      auto shellCliListener = network.parseAddress("unix:/var/sandstorm/socket/shell-cli")
+      unlink(kj::str("/", ShellCli::SOCKET_PATH).cStr());
+      auto shellCliListener = network.parseAddress(kj::str("unix:/", ShellCli::SOCKET_PATH))
           .wait(io.waitScope)->listen();
       auto shellCliServer = kj::heap<capnp::TwoPartyServer>(kj::refcounted<CapRedirector>([&]() {
         return server.getBootstrap().castAs<SandstormCoreFactory>()


### PR DESCRIPTION
This patch:

- Partially documents the ShellCli interface in backend.capnp
- Exposes the path to the socket as a constant in the capnp schema.

There are two methods left un-documented, since I don't fully understand
what they do, and was hoping Kenton could shed some light on them, since
he wrote the code. In particular:

- I don't know what the directory argument to createAcmeAccount does.
- I'm generally fuzzy about how setAcmeChallenge is used.

If I can get clarification on those, I'll rebase and finish the job.