### PR TITLE
Typecheck: Disable strictNullChecks

### DIFF
--- a/shell/tsconfig.json
+++ b/shell/tsconfig.json
@@ -12,7 +12,7 @@
     /* Strict Type-Checking Options */
     "strict": true,
     "noImplicitAny": true,
-    "strictNullChecks": true,
+    "strictNullChecks": false,
 
     /* Additional Checks */
     "noUnusedLocals": true,


### PR DESCRIPTION
This is a *potential* fix for the failure of typecheck-ts. (We could also locked TypeScript down to 4.7.x, or fix the issues in question, of course...

I believe the new errors were caused due to: https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#unconstrained-generics-no-longer-assignable-to and this is an example of another project fixing their compatibility with 4.8: https://github.com/prisma/prisma/pull/15072 which I feel may be useful reference if someone wants to tackle this "correctly".