### PR TITLE
Report install failures to Alpha

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,8 +88,8 @@ fail() {
     if USE_DEFAULTS=no prompt-yesno "Hmm, installation failed. Would it be OK to send an anonymous error report to the sandstorm.io team so we know something is wrong?
 It would only contain this error code: $error_code" "yes" ; then
       echo "Sending problem report..." >&2
-      local BEARER_TOKEN="ZiV1jbwHBPfpIjF3LNFv9-glp53F7KcsvVvljgKxQAL"
-      local API_ENDPOINT="https://api.oasis.sandstorm.io/api"
+      local BEARER_TOKEN="4-Og3Ty2SPmpkZGnVc_8hnBGXK0JBBXDeBn_55FWixJ"
+      local API_ENDPOINT="https://alpha-api-df09d5faefd551337b59659de8ae7207.sandstorm.io"
       local HTTP_STATUS=$(
         dotdotdot_curl \
           --silent \


### PR DESCRIPTION
Fixes #3625 

I don't totally want to shut this off, because this completely opt-in telemetry tells us A. if there's people installing Sandstorm at some vague rate (or at least trying and failing) and B. what issues they are running into. However, I could not rebuild the J(A)SON Datastore app, because it's a bitrotted meteor-spk app. https://github.com/sandstorm-io/sandstorm-error-collector is significantly simpler and more straightforward.

I've shared the grain I've pointed this at to both Kenton and Ian so everyone knows where it is.