### PR TITLE
Improvements to experimental seccomp filter

### DIFF
--- a/src/sandstorm/seccomp-bpf/filter.s
+++ b/src/sandstorm/seccomp-bpf/filter.s
@@ -99,6 +99,7 @@ start:
     jeq #SYS_inotify_rm_watch, allow_near
     jeq #SYS_kill, allow_near
     jeq #SYS_link, allow_near
+    jeq #SYS_linkat, allow_near
     jeq #SYS_listen, allow_near
     jeq #SYS_lseek, allow_near
     jeq #SYS_lstat, allow_near
@@ -125,6 +126,7 @@ start:
     jeq #SYS_readlink, allow_near
     jeq #SYS_readlinkat, allow_near
     jeq #SYS_rename, allow_near
+    jeq #SYS_renameat, allow_near
     jeq #SYS_rmdir, allow_near
     jeq #SYS_rt_sigaction, allow_near
     jeq #SYS_rt_sigpending, allow_near

--- a/src/sandstorm/seccomp-bpf/filter.s
+++ b/src/sandstorm/seccomp-bpf/filter.s
@@ -118,6 +118,7 @@ start:
     jeq #SYS_ppoll, allow_near
     jeq #SYS_pread64, allow_near
     jeq #SYS_prlimit64, allow_near
+    jeq #SYS_pselect6, allow_near
     jeq #SYS_pwrite64, allow_near
     jeq #SYS_read, allow_near
     jeq #SYS_readv, allow_near
@@ -163,6 +164,8 @@ start:
     jeq #SYS_unlink, allow_near
     jeq #SYS_unlinkat, allow_near
     jeq #SYS_utime, allow_near
+    jeq #SYS_utimensat, allow_near
+    jeq #SYS_utimes, allow_near
     jeq #SYS_vfork, allow_near
     jeq #SYS_wait4, allow_near
     jeq #SYS_write, allow_near

--- a/src/sandstorm/seccomp-bpf/filter.s
+++ b/src/sandstorm/seccomp-bpf/filter.s
@@ -103,6 +103,7 @@ start:
     jeq #SYS_lseek, allow_near
     jeq #SYS_lstat, allow_near
     jeq #SYS_mkdir, allow_near
+    jeq #SYS_mkdirat, allow_near
     jeq #SYS_mremap, allow_near
     jeq #SYS_msync, allow_near
     jeq #SYS_munmap, allow_near

--- a/src/sandstorm/seccomp-bpf/filter.s
+++ b/src/sandstorm/seccomp-bpf/filter.s
@@ -40,6 +40,7 @@ start:
     jeq #SYS_close, allow_near
     jeq #SYS_clock_getres, allow_near
     jeq #SYS_clock_gettime, allow_near
+    jeq #SYS_clock_nanosleep, allow_near
     jeq #SYS_connect, allow_near
     jeq #SYS_creat, allow_near
     jeq #SYS_dup, allow_near

--- a/src/sandstorm/seccomp-bpf/filter.s
+++ b/src/sandstorm/seccomp-bpf/filter.s
@@ -156,6 +156,9 @@ start:
     jeq #SYS_timer_getoverrun, allow_near
     jeq #SYS_timer_gettime, allow_near
     jeq #SYS_timer_settime, allow_near
+    jeq #SYS_timerfd_create, allow_near
+    jeq #SYS_timerfd_gettime, allow_near
+    jeq #SYS_timerfd_settime, allow_near
     jeq #SYS_times, allow_near
     jeq #SYS_tkill, allow_near
     jeq #SYS_truncate, allow_near


### PR DESCRIPTION
This patch updates the experimental (bpf_asm) seccomp filter so that it allows a few more syscalls, and no longer tries to filter specific arguments to setsockopt()/getsockopt(). This significantly improves compatibility; notably it makes mongo happy, and at this point *most* (but not all) apps in the market seem to work as expected.