### PR TITLE
Add sponsor button to repo

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: sandstormcommunity


### PR DESCRIPTION
I think we should make it easy for people checking out the repo to figure out where they can support the project. I'm not super-prepared to go plastering requests for donations across readmes and docs pages, but I think we should turn the built-in sponsor button on for those explicitly looking for it. There are a couple projects that I would love to find someone to do for us if we had the support.