### PR TITLE
Roll back capnproto update

### DIFF
--- a/src/sandstorm/sandstorm-http-bridge.c++
+++ b/src/sandstorm/sandstorm-http-bridge.c++
@@ -1223,7 +1223,7 @@ public:
 
       // We need to verify the capability is still connected. Send a dummy call to check. We'll
       // use a known-invalid type ID / method number and expect to get an UNIMPLEMENTED error.
-      auto ping = identity.typelessRequest(0, 65535, capnp::MessageSize { 4, 0 }, {});
+      auto ping = identity.typelessRequest(0, 65535, capnp::MessageSize { 4, 0 });
       ping.initAsAnyStruct(0, 0);
       return ping.send().then([identity](auto&&) mutable -> kj::Promise<Identity::Client> {
         // Weird, we shouldn't get here.

--- a/src/sandstorm/supervisor.c++
+++ b/src/sandstorm/supervisor.c++
@@ -2204,6 +2204,8 @@ public:
   }
 
   kj::Promise<void> getWwwFileHack(GetWwwFileHackContext context) override {
+    context.allowCancellation();
+
     auto params = context.getParams();
     auto path = params.getPath();
 

--- a/src/sandstorm/supervisor.capnp
+++ b/src/sandstorm/supervisor.capnp
@@ -18,8 +18,7 @@
 # This file contains interfaces defining communication between a Sandstorm grain supervisor and
 # other components of the system. These interfaces are NOT used by Sandstorm applications.
 
-using Cxx = import "/capnp/c++.capnp";
-$Cxx.namespace("sandstorm");
+$import "/capnp/c++.capnp".namespace("sandstorm");
 
 using Util = import "util.capnp";
 using Grain = import "grain.capnp";
@@ -82,8 +81,7 @@ interface Supervisor {
     notFound @2;
   }
 
-  getWwwFileHack @9 (path :Text, stream :Util.ByteStream) -> (status :WwwFileStatus)
-      $Cxx.allowCancellation;
+  getWwwFileHack @9 (path :Text, stream :Util.ByteStream) -> (status :WwwFileStatus);
   # Reads a file from under the grain's "/var/www" directory. If the path refers to a regular
   # file, the contents are written to `stream`, and `status` is returned as `file`. If the path
   # refers to a directory or is not found, then `stream` is NOT called at all and the method

--- a/src/sandstorm/util.c++
+++ b/src/sandstorm/util.c++
@@ -893,7 +893,7 @@ capnp::Capability::Server::DispatchCallResult CapRedirector::dispatchCall(
     uint64_t interfaceId, uint16_t methodId,
     capnp::CallContext<capnp::AnyPointer, capnp::AnyPointer> context) {
   capnp::AnyPointer::Reader params = context.getParams();
-  auto req = target.typelessRequest(interfaceId, methodId, params.targetSize(), {});
+  auto req = target.typelessRequest(interfaceId, methodId, params.targetSize());
   req.set(params);
 
   auto oldIteration = iteration;
@@ -915,7 +915,7 @@ capnp::Capability::Server::DispatchCallResult CapRedirector::dispatchCall(
     // OK, this disconnect is new to us. We need to determine if this disconnected capability
     // is our direct target or something else that was accessed as part of the call. So, send
     // a dummy call to check.
-    auto ping = target.typelessRequest(0, 65535, capnp::MessageSize { 4, 0 }, {});
+    auto ping = target.typelessRequest(0, 65535, capnp::MessageSize { 4, 0 });
     ping.initAsAnyStruct(0, 0);
     return ping.send().then([](auto&&) -> void {
       KJ_LOG(ERROR, "dummy ping request should have failed with UNIMPLEMENTED");


### PR DESCRIPTION
Per #3676, the latest update seems to have broken etherpad; this patch rolls capnp back to the latest stable release while we suss out what exactly went wrong. It also reverts a commit related to API changes.