### PR TITLE
Replace WordPress app key

### DIFF
--- a/src/sandstorm/appid-replacements.capnp
+++ b/src/sandstorm/appid-replacements.capnp
@@ -110,7 +110,16 @@ const appIdReplacementList :List(AppIdReplacement) = [
   # See also [this discussion](https://github.com/wekan/wekan/issues/640) about the future
   # governance of Wekan.
 
-# ---- end Wekan entry ----
+  # ---- end Wekan entry ----
+  
+  # ---- WordPress entry ----
+
+  (original = "aax9j672p6z8n7nyupzvj2nmumeqd4upa0f7mgu8gprwmy53x04h",
+   replacement = "zp00qqrha6gp8515ju84ys91syyq8ezv77g9s1r0t3urz92uzmqh"),
+  # The original key was held by Jan Jambor and David Renshaw. The app was left unmaintained from
+  # 2018 to 2023, so Jacob Weisz replaced the key rather than trying to track down the original.
+
+  # ---- end WordPress entry ----
 
   # Add your entry here!
 ];


### PR DESCRIPTION
It's been a half decade since WordPress on Sandstorm was updated, I am not inclined to chase people down for keys who may or may not have retained them that long. @JamborJan was the last keyholder, but a Sandstorm-the-company team member or two may have also held it.

The pending update I have does *not* bump the WordPress version forward at this time, but does clean up some package bitrot, updates the base box slightly, and most importantly, adds Ian's powerbox-http-proxy so that WordPress can grab media when importing a backup. (It's likely this will make many other plugins usable inside the sandbox, and very likely, allow updates for non-read-only plugins.)

I flubbed line 123 here, I will force-push the branch in a couple minutes.