### PR TITLE
Allow sending emails to current user instead of grain owner

### DIFF
--- a/shell/imports/server/hack-session.js
+++ b/shell/imports/server/hack-session.js
@@ -372,20 +372,21 @@ class HackSessionContextImpl extends SessionContextImpl {
     // Get the user's e-mail address.
     //
     // Must be called in a Meteor context.
-
-    const grain = globalDb.collections.grains.findOne(this.grainId, { fields: { userId: 1 } });
-
-    const user = Meteor.users.findOne({_id: grain.userId});
-
-    const email = _.findWhere(SandstormDb.getUserEmails(user), { primary: true });
-
     const result = {};
-    if (email) {
-      result.address = email.email;
-    }
 
-    if (user.profile.name) {
-      result.name = user.profile.name;
+    // Account id may be null in an incognito session
+    if (this.accountId) {
+        const user = Meteor.users.findOne({_id: this.accountId});
+
+        const email = _.findWhere(SandstormDb.getUserEmails(user), { primary: true });
+
+        if (email) {
+          result.address = email.email;
+        }
+
+        if (user.profile.name) {
+          result.name = user.profile.name;
+        }
     }
 
     return result;


### PR DESCRIPTION
I'm using Sandstorm's ability to send and receive emails in custom apps (to do some task automation). When sharing a grain with other people however, it's only possible for the grain to send mails to the grain owner, instead of the currently logged in user.

This PR changes this, and looks up the email address of the currently logged in user of the session.

This is also respected from the mail sending code: 
https://github.com/rs22/sandstorm/blob/send_mails_to_current_user/shell/imports/server/drivers/mail.js#L240
(Another useful addition would be to allow sending emails to other people who have access to the same grain.)