### PR TITLE
Fix #3688

### DIFF
--- a/shell/imports/client/apps/app-details-client.js
+++ b/shell/imports/client/apps/app-details-client.js
@@ -138,11 +138,12 @@ Template.sandstormAppDetails.helpers({
   },
 
   appMarketHost: function() {
-    let host = "https://apps.sandstorm.io/";
+    let host = "https://apps.sandstorm.io";
     const ref = Template.instance().data;
-    const db = ref._db;
+    // Pull the database from our parent context:
+    const db = Template.parentData(1)._db;
     const appMarket = db.collections.settings.findOne({ _id: "appMarketUrl" });
-    if (!appMarket) {
+    if (appMarket) {
       host = appMarket.value;
     }
     return host;


### PR DESCRIPTION
There were three problems:

- The database property wasn't actually available here, so the query crashed when run, meaning appMarketHost was being filled in with an empty string.
- The conditional was backwards, and so if the setting was absent this would then crash on the following line.
- There was an extra trailing slash on the default URL -- which apps.sandstorm.io doesn't seem to canonicalize away, so even after fixing the above we were greeted with a blank page.