### PR TITLE
I18n for grain renaming and grain deletion prompt

### DIFF
--- a/shell/i18n/en.i18n.json
+++ b/shell/i18n/en.i18n.json
@@ -177,9 +177,16 @@
       "was": "was: %s",
       "renamedFrom": "renamed from: %s"
     },
+    "grainTitlePopup": {
+      "prompt": "Set new title:",
+      "promptNotOwner": "Set a new personal title: (does not change the owner's title for this grain)"
+    },
     "grainDeleteButton": {
       "hint": "Move to trash",
       "text": "Move to trash"
+    },
+    "grainDeletePopup": {
+      "confirmationMessage": "Really move this grain to your trash?"
     },
     "grainDebugLogButton": {
       "hint": "Show Debug Log",

--- a/shell/imports/client/grain-client.js
+++ b/shell/imports/client/grain-client.js
@@ -51,9 +51,9 @@ GrainLog = new Mongo.Collection("grainLog");
 
 const promptNewTitle = function (grain) {
   if (grain) {
-    let prompt = "Set new title:";
+    let prompt = TAPi18n.__('grains.grainTitlePopup.prompt');
     if (!grain.isOwner()) {
-      prompt = "Set a new personal title: (does not change the owner's title for this grain)";
+      prompt = TAPi18n.__('grains.grainTitlePopup.promptNotOwner');
     }
 
     const title = window.prompt(prompt, grain.title());
@@ -159,7 +159,7 @@ Template.grainDeleteButton.events({
   "click button": function (event) {
     const activeGrain = globalGrains.getActive();
     const grainId = activeGrain.grainId();
-    let confirmationMessage = "Really move this grain to your trash?";
+    let confirmationMessage = TAPi18n.__("grains.grainDeletePopup.confirmationMessage");
     if (window.confirm(confirmationMessage)) {
       Meteor.call("moveGrainsToTrash", [grainId]);
       globalGrains.remove(grainId, true);


### PR DESCRIPTION
I found several prompts that are not internationalized.  With this change (and a coming related PR to add the Russian localization,) we can localize additional prompts:
![Renaming a grain in English](https://user-images.githubusercontent.com/208646/228141656-258458c2-8fed-4148-a0b0-9e558d4ffc3e.png)
![Renaming a grain in Russian](https://user-images.githubusercontent.com/208646/228141724-8b411ee3-0bc3-4f71-b547-22a5c00ee615.png)
![Deleting a grain in English](https://user-images.githubusercontent.com/208646/228141774-85d9081c-04e5-464e-9c26-555750bb4160.png)
![Deleting a grain in Russian](https://user-images.githubusercontent.com/208646/228141850-32f67461-d13d-4a1d-ba45-4fa4ab933100.png)

I will submit the Russian PR once #3697 is merged.