### PR TITLE
Update github actions to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: |
             export DEBIAN_FRONTEND=noninteractive
@@ -21,7 +21,7 @@ jobs:
         run: |
             curl https://install.meteor.com/ | sh
       - name: cache ccache files
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v3
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ github.run_number }}
@@ -57,7 +57,7 @@ jobs:
       #    path: ccache-debug.tar.gz
       - name: upload sandstorm tarball
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sandstorm-0-fast.tar.xz
           path: sandstorm-0-fast.tar.xz
@@ -78,13 +78,13 @@ jobs:
           (make test |& tee testlog.txt; echo "Result: $?")
       - name: upload test log
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: testlog.txt
           path: testlog.txt
       - name: upload screenshots
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: screenshots
           path: tests/screenshots

--- a/.github/workflows/doc-ci.yml
+++ b/.github/workflows/doc-ci.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: install dependencies
       run: |
         sudo apt-get update
@@ -29,7 +29,7 @@ jobs:
         tar cvf docbuild.tar docbuild
     - name: upload docbuild.tar
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: docbuild.tar
         path: docbuild.tar

--- a/.github/workflows/doc-prod.yml
+++ b/.github/workflows/doc-prod.yml
@@ -13,5 +13,5 @@ jobs:
     env:
       SANDSTORM_DOC_URL: ${{ secrets.doc_url_prod }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: bash -x docs/generate.sh -s -p


### PR DESCRIPTION
The Github actions used by Sandstorm are quite out of a date. Some of the versions are being deprecated; it's generally good practice to update them as appropriate.