### PR TITLE
Build on Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ env:
   CCACHE_DIR: ${{ github.workspace }}/.ccache"
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies


### PR DESCRIPTION
It doesn't seem possible for the github actions to build Sandstorm on Ubuntu 22.04.  This adjusts the build machine to use Ubuntu 20.04 so that the build succeeds/ gets further along.