### PR TITLE
Add workflow-dispatch to doc-ci to run manually

### DIFF
--- a/.github/workflows/doc-ci.yml
+++ b/.github/workflows/doc-ci.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'mkdocs.yml'
       - 'docs/**'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
It's kind of difficult to test whether doc-ci works on Ubuntu 22.04 (quick answer: it does!) without a workflow-dispatch event trigger. This adds workflow-dispatch so it can manually be run by a repo owner.