### PR TITLE
Add skipLibCheck so we stop checking node_modules package definitions

### DIFF
--- a/shell/tsconfig.json
+++ b/shell/tsconfig.json
@@ -30,7 +30,8 @@
     "resolveJsonModule": true,
     "types": ["node"],
     "esModuleInterop": true,
-    "preserveSymlinks": true
+    "preserveSymlinks": true,
+    "skipLibCheck": true
   },
   "exclude": [
     "./node_modules/**",


### PR DESCRIPTION
skipLibCheck skips checking type declaration files. This should fix typescript type checking in the build