### PR TITLE
Ignore .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ tests/tmp-sandstorm
 app-index.spk
 test-app.spk
 deps/llvm-build
+
+.vscode


### PR DESCRIPTION
Anyone using VSCode with the project will have their local VSCode config settings added at `.vscode/`. Since these are generally unique to the individual and customized, it's easy to unintentionally add these to a commit unless they're gitignored. So we're doing that here.
