### PR TITLE
Update actions/cache to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
             curl https://install.meteor.com/ | sh
       - name: cache ccache files
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ github.run_number }}


### PR DESCRIPTION
Github's official cache action is now on major version 4. Seems like it's wise to update it since the old one uses a deprecated Node version.