### PR TITLE
Add funding-manifest-urls check

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://sandstorm.org/funding.json


### PR DESCRIPTION
This is a non-code change to indicate we have provenance and authority to submit funding requests for the project. To be clear, this refers to funding for the Sandstorm Community project, and will be implemented as a fork, not as a direct update to the original repository.