### PR TITLE
Docs: Add Ubuntu 24.04 fix instructions

### DIFF
--- a/docs/administering/install-troubleshooting.md
+++ b/docs/administering/install-troubleshooting.md
@@ -132,7 +132,7 @@ This should resolve your problems. If not, please get in touch.
 ## Are grains not starting on Ubuntu 24.04 or later?
 
 If your wildcard DNS is configured correctly, you should see the app icons correctly on the apps tab. If
-grains are not starting, and you are on Ubuntu 24.04 or later, AppArmor may be restricting unpriviliged
+grains are not starting, and you are on Ubuntu 24.04 or later, AppArmor may be restricting unprivileged
 user namespaces. You can run the following commands to correct this:
 
 ```bash
@@ -140,6 +140,9 @@ sudo sh -c 'echo "kernel.apparmor_restrict_unprivileged_userns = 0" > /etc/sysct
 sudo sysctl --system
 sudo service sandstorm restart
 ```
+
+As of this writing, this restriction is very uncommon in Linux distributions, but you may wish to consult
+updated guidance. An AppArmor profile for Sandstorm would be a welcome contribution.
 
 ## Did you disable outside collaborators before attempting to configure Google or GitHub login methods?
 

--- a/docs/administering/install-troubleshooting.md
+++ b/docs/administering/install-troubleshooting.md
@@ -129,6 +129,18 @@ sudo service sandstorm restart
 
 This should resolve your problems. If not, please get in touch.
 
+## Are grains not starting on Ubuntu 24.04 or later?
+
+If your wildcard DNS is configured correctly, you should see the app icons correctly on the apps tab. If
+grains are not starting, and you are on Ubuntu 24.04 or later, AppArmor may be restricting unpriviliged
+user namespaces. You can run the following commands to correct this:
+
+```bash
+sudo sh -c 'echo "kernel.apparmor_restrict_unprivileged_userns = 0" > /etc/sysctl.d/sandstorm-userns.conf'
+sudo sysctl --system
+sudo service sandstorm restart
+```
+
 ## Did you disable outside collaborators before attempting to configure Google or GitHub login methods?
 
 The setting "Disallow collaboration with users outside the organization" is intended for servers using


### PR DESCRIPTION
We've had a bunch of people have weird reports of issues with Ubuntu 24.04, and so far this has been the solution to all of them. I think we should codify it in the documentation page.

@Michael-S found this solution, and deserves all the credit.