### PR TITLE
Docs: Note experimental app market

### DIFF
--- a/docs/developing/publishing-apps.md
+++ b/docs/developing/publishing-apps.md
@@ -207,4 +207,6 @@ You can run `spk verify mypackage.spk` on your app package to see the details of
 
 In order to submit your app to the market, you need to run one of the following commands, depending on your build tool: `spk publish mypackage.spk` or `vagrant-spk publish mypackage.spk`.
 
-It will then go into the queue for us to review. We'll check that everything looks right. If it does, we'll publish the app, otherwise we'll email you to let you know what needs fixing.
+It will then go into the queue for us to review. Apps which are submitted but not yet approved can be found on the [experimental app market](https://apps.sandstorm.io/?experimental=true).
+
+We'll check that everything looks right. If it does, we'll publish the app, otherwise we'll email you to let you know what needs fixing.


### PR DESCRIPTION
@neuroradiology pointed out this was not documented well. Considering we recommend people try apps in experimental before we publish them, and developers may want to make sure their app looks good on the market view, I think this would be a good place to point it out as well.