### PR TITLE
Docs: Fix how to install latest Go version

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -154,7 +154,7 @@ On Debian or Ubuntu, you should be able to get all these with:
     sudo apt-get install build-essential libcap-dev xz-utils zip \
         unzip strace curl discount git python3 zlib1g-dev \
         cmake flex bison locales
-    GO_VERSION=$(curl 'https://go.dev/VERSION?m=text')
+    GO_VERSION=$(curl 'https://go.dev/VERSION?m=text' | head -n 1)
     curl -L "https://go.dev/dl/$GO_VERSION.linux-amd64.tar.gz" -o go.tar.gz \
         && sudo tar -C /usr/local -xvf go.tar.gz \
         && rm go.tar.gz


### PR DESCRIPTION
This is a mirror of the changes in https://github.com/sandstorm-io/vagrant-spk/pull/355 but to build Sandstorm.

@orblivion Can you review?