### PR TITLE
Docs: Clone with submodules

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -194,7 +194,7 @@ machine running the latest stable Debian release. This is easy to set up using V
 
 Get the source code from the git repository:
 
-    git clone https://github.com/sandstorm-io/sandstorm.git
+    git clone https://github.com/sandstorm-io/sandstorm.git --recurse-submodules
 
 ### Building / installing the binaries
 


### PR DESCRIPTION
Sandstorm uses submodules so when installing from source we should make sure people clone the repo with them correctly.