### PR TITLE
Update vagrant-spk stacks list

### DIFF
--- a/docs/vagrant-spk/platform-stacks.md
+++ b/docs/vagrant-spk/platform-stacks.md
@@ -12,8 +12,8 @@ The following stacks exist:
 * `lemp`: a PHP-oriented software collection including nginx, MySQL, and PHP.
 * `lesp`: a similar take on the PHP stack using SQLite as the database.
 * `meteor`: a stack for [Meteor](https://meteor.com) apps, including MongoDB.
-* `node`: a Node stack using the current LTS release, for modern Node apps.
-* `node6`: a Node stack on version 6.x, for legacy Node apps.
+* `node`: a stack for Node apps.
+* `python`: a basic Python stack for apps which bring their own server.
 * `static`: `nginx` configured to serve static files from `/opt/app`.
 * `uwsgi`: a Python-oriented stack including nginx and uwsgi.
 * `diy`: Create your own.


### PR DESCRIPTION
We got rid of the node6 stack a long time ago, and I merged a new python stack, so we should update this list.