### PR TITLE
Proposal: relax csp to allow web workers

### DIFF
--- a/shell/imports/server/pre-meteor.js
+++ b/shell/imports/server/pre-meteor.js
@@ -56,6 +56,14 @@ function writeErrorResponse(res, err) {
   res.end(err.htmlMessage || err.message);
 }
 
+function isServiceWorkerScriptRequest(req) {
+  // Service worker registrations fetch script URLs with a dedicated header.
+  if ((req.headers["service-worker"] || "").toLowerCase().trim() === "script") return true;
+
+  // Fetch Metadata also marks service worker script requests.
+  return (req.headers["sec-fetch-dest"] || "").toLowerCase().trim() === "serviceworker";
+}
+
 const PNG_MAGIC = new Buffer([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
 const JPEG_MAGIC = new Buffer([0xFF, 0xD8, 0xFF]);
 
@@ -287,6 +295,12 @@ Meteor.startup(() => {
   WebApp.httpServer.removeAllListeners("request");
   WebApp.httpServer.on("request", (req, res) => {
     Promise.resolve(undefined).then(() => {
+      if (isServiceWorkerScriptRequest(req)) {
+        res.writeHead(403, { "Content-Type": "text/plain" });
+        res.end("Service worker script requests are not allowed.");
+        return;
+      }
+
       if (!req.headers.host) {
         res.writeHead(400, { "Content-Type": "text/plain" });
         res.end("Missing Host header");

--- a/src/sandstorm/web-session-bridge.c++
+++ b/src/sandstorm/web-session-bridge.c++
@@ -1297,6 +1297,7 @@ kj::Promise<void> WebSessionBridge::handleResponse(
             "script-src 'self' " UNSAFE
             "style-src 'self' " UNSAFE
             "child-src 'self' " UNSAFE
+            "worker-src 'self' " UNSAFE
             "font-src 'self' " UNSAFE
 
             // frame-src needs to allow references to BASE_URL, because
@@ -1304,11 +1305,6 @@ kj::Promise<void> WebSessionBridge::handleResponse(
             // there:
             "frame-src 'self' ", baseHttpHost, " ", UNSAFE
 #undef UNSAFE
-
-            // Service workers can intercept http requests and muck with
-            // response headers, possibly overriding our security settings,
-            // so we need to disable them.
-            "worker-src 'none';"
 
             // 'self' alone does not allow websocket connections; see:
             // https://github.com/w3c/webappsec-csp/issues/7


### PR DESCRIPTION
This is opened as a draft for discussion only.

Back in 2020 it came to light that allowing Service Workers would allow them to modify response headers and potentially allow external requests to leak. The [fix](https://github.com/sandstorm-io/sandstorm/issues/3538) was `worker-src 'none'`. Unfortunately this had the side effect of also disallowing Web Workers.

Web Workers can be really useful for a lot of applications that need to do anything moderately complex on the front end. In my case, I'm trying to get a LibreOffice app to work but it requires a web worker. I could disable CSP at the server level but that doesn't feel like the right solution.

Web Workers (to my knowledge) don't have the same potential security issues as Service Workers, but there is no way to target just Service Workers. [(link)](https://lists.w3.org/Archives/Public/public-webrtc-logs/2021Jun/0298.html) [(link)](https://github.com/w3c/webappsec-csp/issues/638)

In the meantime, I think we should be able to protect against Service Workers by instead limiting all worker loads to `'self'` and then rejecting the actual Service Worker http requests. I'm not 100% sure of this solution, but it seems to work from what I can tell?