### PR TITLE
Update productivity suite

### DIFF
--- a/shell/imports/sandstorm-db/db.js
+++ b/shell/imports/sandstorm-db/db.js
@@ -2087,7 +2087,7 @@ _.extend(SandstormDb.prototype, {
     return [
       "8aspz4sfjnp8u89000mh2v1xrdyx97ytn8hq71mdzv4p4d8n0n3h", // Davros
       "h37dm17aa89yrd8zuqpdn36p6zntumtv08fjpu8a8zrte7q1cn60", // Etherpad
-      "vfnwptfn02ty21w715snyyczw0nqxkv3jvawcah10c6z7hj1hnu0", // Rocket.Chat
+      "a0n6hwm32zjsrzes8gnjg734dh6jwt7x83xdgytspe761pe2asw0", // EtherCalc
       "m86q05rdvj14yvn78ghaxynqz7u2svw6rnttptxx49g1785cdv1h", // Wekan
     ];
   },


### PR DESCRIPTION
Fixes #3237.

I don't believe this will affect existing servers at all (because no migration would occur to actually make this change), but we should definitely think about what apps we "recommend" on a fresh install. Rocket.Chat is not a good reflection of either the state of chat today, Rocket.Chat itself as it is today, or a top notch Sandstorm package. Meanwhile, EtherCalc at least delivers a core spreadsheet experience, and it's one of the apps I most regularly still use today. The file previewer/LibreOffice viewer app probably makes sense to default-install once it and the new Davros ships.