### PR TITLE
Replace MediaWiki app key

### DIFF
--- a/src/sandstorm/appid-replacements.capnp
+++ b/src/sandstorm/appid-replacements.capnp
@@ -121,5 +121,14 @@ const appIdReplacementList :List(AppIdReplacement) = [
 
   # ---- end WordPress entry ----
 
+  # ---- MediaWiki entry ----
+
+  (original = "p04q48xd2kgkystkrda5n77kdns6u569wnactgh904tf7s3vev70",
+   replacement = "yzsw82ka30zwtv4xvq6pkm71zdz19rwx7dgm5qvm5hvjudq8g0a0"),
+  # The original key was held by Ian Denhardt who passed away in 2023. This replacement key is held
+  # by Jacob Weisz in order to fix a bug in this release.
+
+  # ---- end MediaWiki entry ----
+
   # Add your entry here!
 ];


### PR DESCRIPTION
In particular, I really want to fix the issue this app has with resizing GIF images. As nobody but Ian Denhardt held this key, I wanted to go ahead and get an app key replacement in place so that I can eventually fix this and update the package for existing users.