### PR TITLE
Update README community link to sandstorm.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ See [the developer hub in the Sandstorm documentation](https://docs.sandstorm.io
 
 ## Contribute
 
-Want to help? Check out [CONTRIBUTING.md](https://github.com/sandstorm-io/sandstorm/blob/master/CONTRIBUTING.md). Also see our [community page](https://sandstorm.io/community) or get on our [discussion group](https://groups.google.com/group/sandstorm-dev) and let us know!
+Want to help? Check out [CONTRIBUTING.md](https://github.com/sandstorm-io/sandstorm/blob/master/CONTRIBUTING.md). Also see our [community page](https://sandstorm.org/community) or get on our [discussion group](https://groups.google.com/group/sandstorm-dev) and let us know!


### PR DESCRIPTION
## Summary
Updated the README community link from sandstorm.io/community to sandstorm.org/community.

## Why
This fixes the outdated community link referenced in issue #3724.

## Changes Made
- Replaced old community link in README.md
- Updated URL to sandstorm.org/community

## Testing
Verified the README now points to the correct community URL.