### PR TITLE
Remove wizard and walkthrough from development server accounts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,10 @@ jobs:
             export DEBIAN_FRONTEND=noninteractive
             echo "The build of boringssl requires golang."
             echo "The github runner seems to have some version of golang already; installing golang-go breaks."
-            which go || sudo apt-get install golang-go
+            which go || (sudo apt-get update && sudo apt-get install golang-go)
 
-            sudo apt-get install -y build-essential libcap-dev xz-utils zip unzip strace curl discount git python3 zlib1g-dev cmake ccache
+            sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+                build-essential libcap-dev xz-utils zip unzip strace curl discount git python3 zlib1g-dev cmake ccache
 
             # Install OpenSSL 1.1 (required for Meteor/Node compatibility)
             # Ubuntu 24.04 only ships OpenSSL 3.x, so we need to install 1.1 from older release

--- a/shell/imports/client/apps/applist-client.js
+++ b/shell/imports/client/apps/applist-client.js
@@ -7,6 +7,7 @@ import { _ } from "meteor/underscore";
 import { TAPi18n } from "meteor/tap:i18n";
 
 import { introJs } from "intro.js";
+import { isDevelopmentServer } from "/imports/client/dev-mode";
 import { SandstormDb } from "/imports/sandstorm-db/db";
 
 SandstormAppList = function (db, quotaEnforcer) {
@@ -269,7 +270,8 @@ Template.sandstormAppListPage.onRendered(() => {
   const db = instance.data._db;
   // Set up automatically-opening hint explaining what installing is, if zero apps installed.
   // Only show it if the user is allowed to install apps.
-  if (!db.collections.userActions.find().count() &&
+  if (!isDevelopmentServer() &&
+          !db.collections.userActions.find().count() &&
           !Session.get("dismissedInstallHint") &&
           isSignedUpOrDemo()) {
     // If the user had 0 grains (including in the trash) at the time they see this message, then

--- a/shell/imports/client/dev-mode.js
+++ b/shell/imports/client/dev-mode.js
@@ -1,0 +1,5 @@
+import { Meteor } from "meteor/meteor";
+
+export function isDevelopmentServer() {
+  return !!(Meteor.settings && Meteor.settings.public && Meteor.settings.public.allowDevAccounts);
+}

--- a/shell/imports/client/grain-client.js
+++ b/shell/imports/client/grain-client.js
@@ -35,6 +35,7 @@ import { introJs } from "intro.js";
 import downloadFile from "/imports/client/download-file";
 import { makeAndDownloadBackup } from "/imports/client/backups";
 import { ContactProfiles } from "/imports/client/contacts";
+import { isDevelopmentServer } from "/imports/client/dev-mode";
 import { isStandalone } from "/imports/client/standalone";
 import { GrainView } from "/imports/client/grain/grainview";
 import { SandstormDb } from "/imports/sandstorm-db/db";
@@ -554,6 +555,10 @@ Template.shareableLinkTab.events({
 });
 
 Template.grainShareButton.onRendered(() => {
+  if (isDevelopmentServer()) {
+    return;
+  }
+
   if (!Meteor._localStorage.getItem("userNeedsShareAccessHint")) {
     return;
   }

--- a/shell/imports/client/grain/grainlist-client.js
+++ b/shell/imports/client/grain/grainlist-client.js
@@ -9,6 +9,7 @@ import { _ } from "meteor/underscore";
 import { TAPi18n } from "meteor/tap:i18n";
 
 import { introJs } from "intro.js";
+import { isDevelopmentServer } from "/imports/client/dev-mode";
 import { identiconForApp } from "/imports/sandstorm-identicons/helpers";
 import { SandstormDb } from "/imports/sandstorm-db/db";
 import { makeAndDownloadBackup } from "/imports/client/backups";
@@ -751,6 +752,10 @@ Template.sandstormGrainTable.events({
 
 Template.sandstormGrainTable.onRendered(function () {
   // Set up the guided tour box, via introJs, if desired.
+  if (isDevelopmentServer()) {
+    return;
+  }
+
   if (!Template.instance().data.showHintIfEmpty) {
     return;
   }

--- a/shell/imports/client/setup-wizard/wizard.js
+++ b/shell/imports/client/setup-wizard/wizard.js
@@ -9,6 +9,7 @@ import { Iron } from "meteor/iron:core";
 
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui";
 import AccountsUi from "/imports/client/accounts/accounts-ui";
+import { isDevelopmentServer } from "/imports/client/dev-mode";
 import downloadFile from "/imports/client/download-file";
 import { globalDb } from "/imports/db-deprecated";
 
@@ -805,7 +806,8 @@ Template.setupWizardLoginUser.helpers({
   },
 
   currentUserFirstLogin() {
-    return !Meteor.loggingIn() && Meteor.user() && !Meteor.user().hasCompletedSignup;
+    return !isDevelopmentServer() && !Meteor.loggingIn() && Meteor.user() &&
+        !Meteor.user().hasCompletedSignup;
   },
 
   credentialUser() {
@@ -879,7 +881,8 @@ Template.setupWizardLoginUser.events({
 
   "click .setup-next-button"() {
     const instance = Template.instance();
-    const isFirstLogin = Meteor.user() && !Meteor.user().hasCompletedSignup;
+    const isFirstLogin = !isDevelopmentServer() && Meteor.user() &&
+        !Meteor.user().hasCompletedSignup;
     if (isFirstLogin) {
       // If your profile is unconfirmed, attempt to save it.
       const form = instance.find("form");

--- a/shell/imports/client/shell-client.js
+++ b/shell/imports/client/shell-client.js
@@ -29,6 +29,7 @@ import { TAPi18n } from "meteor/tap:i18n";
 
 import getBuildInfo from "/imports/client/build-info";
 import SandstormAccountSettingsUi from "/imports/client/accounts/account-settings-ui";
+import { isDevelopmentServer } from "/imports/client/dev-mode";
 import { isStandalone } from "/imports/client/standalone";
 import { SandstormDb } from "/imports/sandstorm-db/db";
 import { globalDb } from "/imports/db-deprecated";
@@ -635,7 +636,8 @@ Template.layout.helpers({
   },
 
   firstLogin: function () {
-    return credentialsSubscription.ready() && !isDemoUser() && !Meteor.loggingIn()
+    return !isDevelopmentServer() && credentialsSubscription.ready() &&
+        !isDemoUser() && !Meteor.loggingIn()
         && Meteor.user() && !Meteor.user().hasCompletedSignup &&
         !isStandalone();
   },

--- a/tests/tests/account-settings.js
+++ b/tests/tests/account-settings.js
@@ -31,8 +31,7 @@ var devName2 = "A" + crypto.randomBytes(10).toString("hex");
 module.exports["Test profile changes passing to testapp"] = function (browser) {
   browser
     .loginDevAccount()
-    .click("a.introjs-skipbutton")
-    .waitForElementNotPresent("div.introjs-overlay", short_wait)
+    .disableGuidedTour()
     // Click dropdown menu, go to account settings link
     .waitForElementVisible("button.has-picture", medium_wait)
     .pause(500)


### PR DESCRIPTION
The most common use case for `ALLOW_DEV_ACCOUNTS` is app development with vagrant-spk. Every time you set up a new vm and hit http://local.sandstorm.io:6090/ you log in as Alice, then have to configure her account. Then you have to dismiss each step of the walkthrough meant for teaching you how sandstorm works.

This removes both when `ALLOW_DEV_ACCOUNTS` is on:

https://github.com/user-attachments/assets/c9d46541-cac5-4f56-a1ff-e69588086b0e