### PR TITLE
Add SERVER_RUNTIME environment variable

### DIFF
--- a/meteor-testapp/client/main.html
+++ b/meteor-testapp/client/main.html
@@ -12,4 +12,5 @@
   <p id="picture">picture: {{picture}}</p>
   <p id="preferredHandle">preferredHandle: {{preferredHandle}}</p>
   <p id="pronouns">pronouns: {{pronouns}}</p>
+  <p id="serverRuntime">serverRuntime: {{serverRuntime}}</p>
 </template>

--- a/meteor-testapp/client/main.js
+++ b/meteor-testapp/client/main.js
@@ -1,6 +1,19 @@
+import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
+import { ReactiveVar } from 'meteor/reactive-var';
 
 import './main.html';
+
+const serverRuntime = new ReactiveVar("");
+
+Meteor.call("getServerRuntime", (err, result) => {
+  if (err) {
+    console.error("getServerRuntime failed:", err);
+    serverRuntime.set("ERROR");
+  } else {
+    serverRuntime.set(result);
+  }
+});
 
 Template.hello.helpers({
   id() {
@@ -17,5 +30,8 @@ Template.hello.helpers({
   },
   pronouns() {
     return Meteor.sandstormUser().pronouns;
+  },
+  serverRuntime() {
+    return serverRuntime.get();
   },
 });

--- a/meteor-testapp/server/main.js
+++ b/meteor-testapp/server/main.js
@@ -36,6 +36,9 @@ const bridge = conn.restore(null, SandstormHttpBridge);
 
 Meteor.startup(() => {
   Meteor.methods({
+    getServerRuntime() {
+      return process.env.SERVER_RUNTIME;
+    },
     schedule(objectId) {
       bridge.getSandstormApi().api.schedule(
         { defaultText: 'test job' },

--- a/src/sandstorm/backend.c++
+++ b/src/sandstorm/backend.c++
@@ -24,6 +24,8 @@
 
 namespace sandstorm {
 
+static constexpr kj::StringPtr SERVER_RUNTIME = "classic"_kj;
+
 static kj::StringPtr validateId(kj::StringPtr id) {
   KJ_REQUIRE(id.size() >= 8 && !id.startsWith(".") && id.findFirst('/') == nullptr, id);
   return id;
@@ -152,6 +154,7 @@ kj::Promise<Supervisor::Client> BackendImpl::bootGrain(
   for (auto env: command.getEnviron()) {
     argv.add(kj::str("-e", env.getKey(), "=", env.getValue()));
   }
+  argv.add(kj::str("-eSERVER_RUNTIME=", SERVER_RUNTIME));
 
   argv.add(kj::heapString(packageId));
   argv.add(kj::heapString(grainId));

--- a/tests/tests/account-settings.js
+++ b/tests/tests/account-settings.js
@@ -102,6 +102,7 @@ module.exports["Test profile changes passing to testapp"] = function (browser) {
     .assert.textContains('#picture', 'sandstorm.io')
     .assert.textContains('#preferredHandle', devName2.toLowerCase())
     .assert.textContains('#pronouns', 'robot')
+    .assert.textContains('#serverRuntime', 'classic')
 
     .frameParent()
     .execute("window.Meteor.logout()")


### PR DESCRIPTION
This defaults to `classic` and is readable by Sandstorm grains as `SERVER_RUNTIME=classic`. It can only be modified by changing the constant in the source.