### PR TITLE
Get test apps from sandstorm.org

### DIFF
--- a/tests/apps/backgrounding.js
+++ b/tests/apps/backgrounding.js
@@ -33,7 +33,7 @@ module.exports["Install"] = function (browser) {
   browser
     .init()
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/jparyani/background-test-0.spk", "dbed78d1ef5ed4a4f8193e829672623e", "duvq9t519fdcpetkk2s1axe1hdy91zc5svhzas2yfqpn8df9cd40")
+    .installApp("https://dl.sandstorm.org/testapps/background-test-0.spk", "dbed78d1ef5ed4a4f8193e829672623e", "duvq9t519fdcpetkk2s1axe1hdy91zc5svhzas2yfqpn8df9cd40")
     .assert.textContains("#grainTitle", "Untitled SandstormTest");
 };
 
@@ -62,7 +62,7 @@ module.exports["Install Wakelock Dropper"] = function (browser) {
   browser
     .init()
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/jparyani/background-test-drop-wakelock-1.spk", "963745fa41d602dfc7467cac2e1597b5", "duvq9t519fdcpetkk2s1axe1hdy91zc5svhzas2yfqpn8df9cd40")
+    .installApp("https://dl.sandstorm.org/testapps/background-test-drop-wakelock-1.spk", "963745fa41d602dfc7467cac2e1597b5", "duvq9t519fdcpetkk2s1axe1hdy91zc5svhzas2yfqpn8df9cd40")
     .assert.textContains("#grainTitle", "Untitled SandstormTest");
 };
 

--- a/tests/apps/collections.js
+++ b/tests/apps/collections.js
@@ -24,7 +24,7 @@ var utils = require("../utils"),
 
 var COLLECTIONS_APP_ID = "s3u2xgmqwznz2n3apf30sm3gw1d85y029enw5pymx734cnk5n78h";
 var COLLECTIONS_PACKAGE_ID = "e9408a7c077f7a9baeb9c02f0437ae40";
-var COLLECTIONS_PACKAGE_URL = "https://sandstorm.io/apps/david/collections3.spk";
+var COLLECTIONS_PACKAGE_URL = "https://dl.sandstorm.org/testapps/collections3.spk";
 
 module.exports = {};
 

--- a/tests/apps/ip-networking.js
+++ b/tests/apps/ip-networking.js
@@ -31,7 +31,7 @@ var IP_INTERFACE_TEST_PORT = parseInt(process.env.IP_INTERFACE_TEST_PORT, 10) ||
 module.exports["Test Ip Networking"] = function (browser) {
   browser
     .loginDevAccount(null, true)
-    .installApp("https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-11.spk",
+    .installApp("https://dl.sandstorm.org/testapps/test-11.spk",
                 "9e431ec70f1ee66901bb73f48687f485",
                 "rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh")
     .assert.textContains("#grainTitle", "Untitled Test App test page")
@@ -55,7 +55,7 @@ module.exports["Test Ip Networking"] = function (browser) {
 module.exports["Test Ip Interface"] = function (browser) {
   browser
     .loginDevAccount(null, true)
-    .installApp("https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-11.spk",
+    .installApp("https://dl.sandstorm.org/testapps/test-11.spk",
                 "9e431ec70f1ee66901bb73f48687f485",
                 "rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh")
     .assert.textContains("#grainTitle", "Untitled Test App test page")

--- a/tests/apps/powerbox.js
+++ b/tests/apps/powerbox.js
@@ -35,7 +35,7 @@ module.exports["Test Powerbox"] = function (browser) {
   browser
     .init()
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app4.spk",
+    .installApp("https://dl.sandstorm.org/testapps/sandstorm-powerbox-test-app4.spk",
                 "f855d3c96e18e785a3a734a49919ef18",
                 "ygpudg61w49gg0x1t2gw4p7q2q7us24gxsyr1as1hf0ezn2uycth")
     .assert.textContains("#grainTitle", "Untitled PowerboxTest")
@@ -68,7 +68,7 @@ module.exports["Test PowerboxSave"] = function (browser) {
     browser
     .init()
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app4.spk",
+    .installApp("https://dl.sandstorm.org/testapps/sandstorm-powerbox-test-app4.spk",
                 "f855d3c96e18e785a3a734a49919ef18",
                 "ygpudg61w49gg0x1t2gw4p7q2q7us24gxsyr1as1hf0ezn2uycth")
     .assert.textContains("#grainTitle", "Untitled PowerboxTest")
@@ -101,7 +101,7 @@ module.exports["Test Powerbox with failing requirements"] = function (browser) {
   browser
     .init()
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app4.spk",
+    .installApp("https://dl.sandstorm.org/testapps/sandstorm-powerbox-test-app4.spk",
                 "f855d3c96e18e785a3a734a49919ef18",
                 "ygpudg61w49gg0x1t2gw4p7q2q7us24gxsyr1as1hf0ezn2uycth")
     .assert.textContains("#grainTitle", "Untitled PowerboxTest")
@@ -181,7 +181,7 @@ module.exports["Test Powerbox query"] = function (browser) {
     // Install another app that we can match against. This can be any app other than
     // test-app.spk -- I'm only using the old test app here because it's probably already
     // downloaded.
-    .installApp("http://sandstorm.io/apps/david/sandstorm-powerbox-test-app4.spk",
+    .installApp("https://dl.sandstorm.org/testapps/sandstorm-powerbox-test-app4.spk",
                 "f855d3c96e18e785a3a734a49919ef18",
                 "ygpudg61w49gg0x1t2gw4p7q2q7us24gxsyr1as1hf0ezn2uycth")
     .url(function (otherGrainUrl) {

--- a/tests/apps/roundcube.js
+++ b/tests/apps/roundcube.js
@@ -27,7 +27,7 @@ module.exports = {};
 module.exports["Install"] = function (browser) {
   browser
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/jparyani/roundcube-6.spk", "373a821a7a9cde5b13258922046fe217", "0qhha1v9ne1p42s5jw7r6qq6rt5tcx80zpg1f5ptsg7ryr4hws1h")
+    .installApp("https://dl.sandstorm.org/testapps/roundcube-6.spk", "373a821a7a9cde5b13258922046fe217", "0qhha1v9ne1p42s5jw7r6qq6rt5tcx80zpg1f5ptsg7ryr4hws1h")
     .assert.textContains("#grainTitle", "Untitled Roundcube mailbox");
 };
 

--- a/tests/tests/apihost.js
+++ b/tests/tests/apihost.js
@@ -32,7 +32,7 @@ module.exports['Install and launch test app'] = function (browser) {
     .init()
     .loginDevAccount()
     // Test app code: https://github.com/kentonv/apihost-testapp
-    .installApp("https://alpha-qkhxczi7kki1x49pfakw.sandstorm.io/apihost-testapp.spk", "1c3b4825b0f383c0641c01fdbc47dc07", "w304h9n5rjx1pzfa8e4guheue5mq3dkwv63aajy1rscupw6e38mh")
+    .installApp("https://dl.sandstorm.org/testapps/apihost-testapp.spk", "1c3b4825b0f383c0641c01fdbc47dc07", "w304h9n5rjx1pzfa8e4guheue5mq3dkwv63aajy1rscupw6e38mh")
     .assert.textContains('#grainTitle', 'Untitled ApiHost test app instance')
     .grainFrame()
     .waitForElementPresent('iframe', medium_wait)

--- a/tests/tests/appdemo.js
+++ b/tests/tests/appdemo.js
@@ -28,7 +28,7 @@ module.exports = {};
 module.exports["Test appdemo link"] = function (browser) {
   browser
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/ssjekyll8.spk",
+    .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk",
                 "ca690ad886bf920026f8b876c19539c1",
                 "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh",
                 true)

--- a/tests/tests/autoupdate.js
+++ b/tests/tests/autoupdate.js
@@ -29,7 +29,7 @@ module.exports["Test autoupdates"] = function (browser) {
   var appId = "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh";
   browser
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/ssjekyll8.spk",
+    .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk",
                 "ca690ad886bf920026f8b876c19539c1",
                 appId,
                 true)

--- a/tests/tests/backup-restore.js
+++ b/tests/tests/backup-restore.js
@@ -101,7 +101,7 @@ module.exports["Test backup and restore"] = function(browser) {
   browser
     .loginDevAccount()
     // sandstorm-test-python, v0
-    .installApp("https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-0.spk", "9111a8c70938276d28a00468a18a25c7", "rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh")
+    .installApp("https://dl.sandstorm.org/testapps/test-0.spk", "9111a8c70938276d28a00468a18a25c7", "rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh")
     .assert.textContains('#grainTitle', 'Untitled Test App test page')
     .waitForElementVisible('.grain-frame', short_wait)
     .grainFrame()

--- a/tests/tests/grain.js
+++ b/tests/tests/grain.js
@@ -109,7 +109,7 @@ module.exports = utils.testAllLogins({
 
   "Test remote install" : function (browser) {
     browser
-      .url(browser.launch_url + "/install/ca690ad886bf920026f8b876c19539c1?url=http://sandstorm.io/apps/ssjekyll8.spk")
+      .url(browser.launch_url + "/install/ca690ad886bf920026f8b876c19539c1?url=https://dl.sandstorm.org/testapps/ssjekyll8.spk")
       .disableGuidedTour()
       .waitForElementVisible('#step-confirm', very_long_wait)
       .click('#confirmInstall')
@@ -173,7 +173,7 @@ module.exports["Test grain not found"] = function (browser) {
 module.exports["Sign in at grain URL"] = function (browser) {
   browser
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
+    .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
     .waitForElementVisible("#grainTitle", medium_wait)
     .assert.textContains("#grainTitle", expectedHackerCMSGrainTitle)
     .getDevName(function (devName) {
@@ -260,7 +260,7 @@ module.exports["Sign in at grain URL"] = function (browser) {
 module.exports["Logging out closes grain"] = function (browser) {
   browser
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
+    .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
     .waitForElementVisible("#grainTitle", medium_wait)
     .assert.textContains("#grainTitle", expectedHackerCMSGrainTitle)
     .execute("window.Meteor.logout()")
@@ -279,7 +279,7 @@ module.exports["Test grain anonymous user"] = function (browser) {
   browser
     // Upload app as normal user
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
+    .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
     .waitForElementVisible('#grainTitle', medium_wait)
     .assert.textContains('#grainTitle', expectedHackerCMSGrainTitle)
     .click('.topbar .share > .show-popup')
@@ -323,7 +323,7 @@ module.exports["Test roleless sharing"] = function (browser) {
   browser
   // Upload app as 1st user
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
+    .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
     .getDevName(function (result) {
       firstUserName = result.value;
     })
@@ -400,7 +400,7 @@ module.exports["Test role sharing"] = function (browser) {
   browser
     // Upload app as 1st user
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/david/gitweb5.spk",
+    .installApp("https://dl.sandstorm.org/testapps/gitweb5.spk",
                 "26eb486a44085512a678c543fc7c1fdd",
                 "6va4cjamc21j0znf5h5rrgnv0rpyvh1vaxurkrgknefvj0x63ash")
     .waitForElementVisible('.grain-frame', medium_wait)
@@ -461,7 +461,7 @@ module.exports["Test grain reveal identity interstitial"] = function (browser) {
   browser
      // Upload app as normal user
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
+    .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1", "nqmcqs9spcdpmqyuxemf0tsgwn8awfvswc58wgk375g4u25xv6yh")
     .waitForElementVisible('.grain-frame', medium_wait)
     .assert.textContains('#grainTitle', expectedHackerCMSGrainTitle)
     .click('.topbar .share > .show-popup')

--- a/tests/tests/postmessage-api.js
+++ b/tests/tests/postmessage-api.js
@@ -32,7 +32,7 @@ module.exports['Install and launch test app'] = function (browser) {
     .init()
     // test-3 introduces the JSON-formatted renderTemplate output
     .loginDevAccount()
-    .installApp("https://alpha-hlngxit86q1mrs2iplnx.sandstorm.io/test-7.spk", "281d3ffbc93933001d6b28e44ffac615", "rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh")
+    .installApp("https://dl.sandstorm.org/testapps/test-7.spk", "281d3ffbc93933001d6b28e44ffac615", "rwyva77wj1pnj01cjdj2kvap7c059n9ephyyg5k4s5enh5yw9rxh")
 
     .assert.textContains('#grainTitle', 'Untitled Test App test page')
     .grainFrame()

--- a/tests/tests/powerbox-contacts.js
+++ b/tests/tests/powerbox-contacts.js
@@ -37,7 +37,7 @@ module.exports["Test powerbox request contact"] = function (browser) {
 
   browser
     .loginDevAccount(aliceName)
-    .installApp("http://sandstorm.io/apps/david/sandstorm-test-python7.spk",
+    .installApp("https://dl.sandstorm.org/testapps/sandstorm-test-python7.spk",
                 "b06dc34b21ba3e8dcedc6d8bab351eac",
                 APP_ID)
     .assert.textContains("#grainTitle", "Untitled Test App test page")

--- a/tests/tests/restore-open-grains.js
+++ b/tests/tests/restore-open-grains.js
@@ -36,7 +36,7 @@ module.exports["Test restore open grains"] = function (browser) {
   browser
     .loginDevAccount()
     // Create three Hacker CMS grains.
-    .installApp("http://sandstorm.io/apps/ssjekyll8.spk",
+    .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk",
                 "ca690ad886bf920026f8b876c19539c1",
                 hackerCmsAppId)
     .waitForElementVisible("#grainTitle", medium_wait)

--- a/tests/tests/sharing.js
+++ b/tests/tests/sharing.js
@@ -38,7 +38,7 @@ module.exports["Test open direct share link"] = function (browser) {
       var devAccountId2 = result.value;
       browser.execute("window.Meteor.logout()")
         .loginDevAccount()
-        .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
+        .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
                     hackerCmsAppId)
         .waitForElementVisible("#grainTitle", medium_wait)
         .assert.textContains("#grainTitle", expectedHackerCMSGrainTitle)
@@ -112,7 +112,7 @@ module.exports["Test open direct share link"] = function (browser) {
 module.exports["Test revoked share link"] = function (browser) {
   browser
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
+    .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
                 hackerCmsAppId)
     .waitForElementVisible("#grainTitle", medium_wait)
     .assert.textContains("#grainTitle", expectedHackerCMSGrainTitle)
@@ -149,7 +149,7 @@ module.exports["Test share popup no permission"] = function (browser) {
   var sharePopupSelector = ".topbar .share > .show-popup";
   browser
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
+    .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
                 hackerCmsAppId)
     .waitForElementVisible("#grainTitle", medium_wait)
     .assert.textContains("#grainTitle", expectedHackerCMSGrainTitle)

--- a/tests/tests/trash.js
+++ b/tests/tests/trash.js
@@ -36,7 +36,7 @@ module.exports["Test grain trash"] = function (browser) {
 
   browser
     .loginDevAccount()
-    .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
+    .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
                 hackerCmsAppId)
     .getDevName(function (result) {
       firstUserName = result.value;
@@ -167,7 +167,7 @@ module.exports["Test topbar trash button"] = function (browser) {
       browser.execute("window.Meteor.logout()")
       browser
         .loginDevAccount(devName1)
-        .installApp("http://sandstorm.io/apps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
+        .installApp("https://dl.sandstorm.org/testapps/ssjekyll8.spk", "ca690ad886bf920026f8b876c19539c1",
                     hackerCmsAppId)
         .waitForElementVisible("#grainTitle", medium_wait)
         .assert.textContains("#grainTitle", expectedHackerCMSGrainTitle)


### PR DESCRIPTION
I think this will have tests pull all test apps from dl.sandstorm.org (hosted on Cloudflare R2) instead of depending on either the Sandstorm.io website or Sandstorm Alpha. This means tests should not break in a way we need Kenton to fix.