### PR TITLE
Fix #3699: powerbox dialog: allow long URLs to wrap instead of trunca…

### DIFF
--- a/shell/client/styles/_powerbox.scss
+++ b/shell/client/styles/_powerbox.scss
@@ -64,12 +64,14 @@ body>.popup.request>.frame-container>.frame {
       display: block;
       vertical-align: middle;
       width: 100%;
-      height: 32px;
-      line-height: 32px;
+      min-height: 32px;
+      line-height: 1.4;
       background-size: 24px 24px;
       background-position: 4px 4px;
       background-repeat: no-repeat;
-      padding-left: 32px;
+      padding: 4px 4px 4px 32px;
+      word-break: break-all;
+      overflow-wrap: break-word;
     }
     >form {
       margin-top: 10px;
@@ -143,15 +145,17 @@ body>.popup.request>.frame-container>.frame {
   background-color: #eeeeee;
   display: block;
   vertical-align: middle;
-  height: 32px;
+  min-height: 32px;
   >button.card-button {
     @include unstyled-button();
-    @include overflow-ellipsis();
+    white-space: normal;
+    word-break: break-all;
+    overflow-wrap: break-word;
     width: 100%;
     background-size: 24px 24px;
     background-position: 4px 4px;
     background-repeat: no-repeat;
-    padding-left: 32px;
-    height: 31px;
+    padding: 4px 4px 4px 32px;
+    min-height: 31px;
   }
 }


### PR DESCRIPTION
Long URLs in the Powerbox request dialog were being truncated with an ellipsis. This CSS change allows them to wrap onto multiple lines so the full URL is visible.
Fixes #3699