### PR TITLE
Default to mongo 7 on new installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1431,6 +1431,12 @@ make_runtime_directories() {
   # Make var directories.
   mkdir -p var/{log,pid,mongo} var/sandstorm/{apps,grains,downloads}
 
+  # Fresh installs should initialize directly on MongoDB 7. Existing installs are rejected by
+  # choose_install_dir(), so this does not mark an old MongoDB 2.6 database as migrated.
+  if [ ! -e var/mongo/version ]; then
+    echo "7" > var/mongo/version
+  fi
+
   # Create useful symlinks.
   ln -sfT $BUILD_DIR latest
   ln -sfT latest/sandstorm sandstorm

--- a/tests/run-local.sh
+++ b/tests/run-local.sh
@@ -122,11 +122,6 @@ MAIL_URL=smtp://127.0.0.1:${SMTP_OUTGOING_PORT}
 UPDATE_CHANNEL=none
 " >> "$SANDSTORM_DIR/sandstorm.conf"
 
-# For fresh installs, configure MongoDB 7 directly (no migration needed)
-# The version file tells Sandstorm which MongoDB to use
-mkdir -p "$SANDSTORM_DIR/var/mongo"
-echo "7" > "$SANDSTORM_DIR/var/mongo/version"
-
 "$SANDSTORM_DIR/sandstorm" start
 
 echo -n "Waiting for sandstorm to start."


### PR DESCRIPTION
I spent so much time testing upgrading an existing install I had an oversight in new installs not starting on MongoDB 7 by default.

The installer already has a check to make sure it isn't installing over an existing installation and we rely on that to not accidentally have it mark an existing install as upgraded.