### PR TITLE
installer adds apparmor profile on ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
             which go || (sudo apt-get update && sudo apt-get install golang-go)
 
             sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-                build-essential libcap-dev xz-utils zip unzip strace curl discount git python3 zlib1g-dev cmake ccache
+                build-essential libcap-dev xz-utils zip unzip strace curl discount git python3 zlib1g-dev cmake ccache apparmor
 
             # Install OpenSSL 1.1 (required for Meteor/Node compatibility)
             # Ubuntu 24.04 only ships OpenSSL 3.x, so we need to install 1.1 from older release
@@ -48,10 +48,40 @@ jobs:
             sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
             rm libssl1.1_1.1.1f-1ubuntu2_amd64.deb
 
-            # Ubuntu 24.04 restricts unprivileged user namespaces by default via AppArmor
-            # Sandstorm requires user namespaces for sandboxing, so disable this restriction
-            echo "kernel.apparmor_restrict_unprivileged_userns = 0" | sudo tee /etc/sysctl.d/99-userns.conf
-            sudo sysctl --system
+            # Ubuntu 24.04 restricts unprivileged user namespaces by default via AppArmor.
+            # Sandstorm requires user namespaces for sandboxing, so grant that permission
+            # to the binaries used by this CI run.
+            cat > /tmp/sandstorm-ci-apparmor <<EOF
+            profile sandstorm-ci-bin $GITHUB_WORKSPACE/bin/sandstorm flags=(unconfined) {
+              userns,
+            }
+
+            profile spk-ci-bin $GITHUB_WORKSPACE/bin/spk flags=(unconfined) {
+              userns,
+            }
+
+            profile sandstorm-ci-bundle $GITHUB_WORKSPACE/bundle/sandstorm flags=(unconfined) {
+              userns,
+            }
+
+            profile sandstorm-ci-test $GITHUB_WORKSPACE/tests/tmp-sandstorm/sandstorm flags=(unconfined) {
+              userns,
+            }
+
+            profile sandstorm-ci-test-latest $GITHUB_WORKSPACE/tests/tmp-sandstorm/latest/sandstorm flags=(unconfined) {
+              userns,
+            }
+
+            profile sandstorm-ci-test-build $GITHUB_WORKSPACE/tests/tmp-sandstorm/sandstorm-*/sandstorm flags=(unconfined) {
+              userns,
+            }
+
+            profile sandstorm-ci-test-custom-build $GITHUB_WORKSPACE/tests/tmp-sandstorm/sandstorm-custom.*/sandstorm flags=(unconfined) {
+              userns,
+            }
+            EOF
+            sudo mv /tmp/sandstorm-ci-apparmor /etc/apparmor.d/sandstorm-ci
+            sudo apparmor_parser -r /etc/apparmor.d/sandstorm-ci
       - name: install meteor
         run: |
             curl https://install.meteor.com/ | sh

--- a/install.sh
+++ b/install.sh
@@ -535,6 +535,64 @@ __EOF__
   fi
 }
 
+maybe_install_apparmor_userns_profile() {
+  # Ubuntu 24.04 restricts unprivileged user namespaces through AppArmor by
+  # default. Give Sandstorm the userns permission.
+
+  if [ "yes" != "$CURRENTLY_UID_ZERO" ]; then
+    return
+  fi
+
+  if [ ! -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+    return
+  fi
+
+  if [ ! -d /etc/apparmor.d ]; then
+    return
+  fi
+
+  if ! which apparmor_parser > /dev/null; then
+    echo "NOTE: AppArmor restricts unprivileged user namespaces, but apparmor_parser was not found."
+    return
+  fi
+
+  local PROFILE_PATH="/etc/apparmor.d/sandstorm"
+  if ! cat > "$PROFILE_PATH" << __EOF__
+# Allow Sandstorm to create user namespaces on systems that restrict
+# unprivileged user namespaces through AppArmor.
+profile sandstorm ${DIR}/sandstorm flags=(unconfined) {
+  userns,
+}
+
+profile sandstorm-latest ${DIR}/latest/sandstorm flags=(unconfined) {
+  userns,
+}
+
+profile sandstorm-build ${DIR}/sandstorm-*/sandstorm flags=(unconfined) {
+  userns,
+}
+
+profile sandstorm-custom-build ${DIR}/sandstorm-custom.*/sandstorm flags=(unconfined) {
+  userns,
+}
+
+profile sandstorm-usr-local-bin /usr/local/bin/sandstorm flags=(unconfined) {
+  userns,
+}
+
+profile spk-usr-local-bin /usr/local/bin/spk flags=(unconfined) {
+  userns,
+}
+__EOF__
+  then
+    echo "NOTE: Could not install AppArmor profile for Sandstorm."
+    return
+  fi
+
+  apparmor_parser -r "$PROFILE_PATH" 2>/dev/null ||
+    echo "NOTE: Installed AppArmor profile for Sandstorm, but could not load it."
+}
+
 test_if_dev_tcp_works() {
   # In is_port_bound(), we prefer to use bash /dev/tcp to check if the port is bound. This is
   # available on most Linux distributions, but it is a compile-time flag for bash and at least
@@ -818,6 +876,9 @@ full_server_install() {
       echo "*** WARNING: Could not detect how to run Sandstorm at startup on your system. ***"
     else
       echo "* Configure Sandstorm to start on system boot (with $INIT_SYSTEM)"
+    fi
+    if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+      echo "* Configure AppArmor to allow Sandstorm to create unprivileged user namespaces."
     fi
     echo "* Listen for inbound email on port ${PLANNED_SMTP_PORT}."
     echo ""
@@ -2129,6 +2190,7 @@ make_runtime_directories
 generate_admin_token
 set_permissions
 install_sandstorm_symlinks
+maybe_install_apparmor_userns_profile
 ask_about_starting_at_boot
 configure_start_at_boot_if_desired
 wait_for_server_bind_to_its_port


### PR DESCRIPTION
I tried this out in a Ubuntu 24.04 vm and it seemed to work fine, allowing me to start grains with userns. I can confirm that it installs and loads the apparmor profile, which is the same one we manually install in the CI build.