### PR TITLE
Update changelog for build 0.309

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### v0.309 (pending)
+- This is the first community release of Sandstorm. Thanks @kentonv for creating this project and the excellent stewardship of it over the years.
+- Most references to sandstorm.io have been changed to new infrastructure at sandstorm.org.
+- Meteor has been upgraded to 2.16, MongoDB has been upgraded to 7.0, and many other dependencies have been updated. The database migration must be run manually. (Thanks @mnutt.)
+- Sandstorm will now create an AppArmor profile when installing on servers which restrict userns by default, particularly modern versions of Ubuntu. (Thanks @mnutt.)
+- Long domains will now display in full in Powerbox requests, rather than being truncated. (Thanks @berbad.)
+- The signing key for the MediaWiki app has been replaced to transfer maintainership to @ocdtrekkie, as @zenhack was the sole holder of the previous key.
+- The Productivity Suite now includes EtherCalc instead of Rocket.Chat for new installations.
+- Sandstorm will suppress the user setup and guided tour when in development mode. (Thanks @mnutt.)
+- A new `SERVER_RUNTIME` environment variable is available to apps to determine which flavor of Sandstorm they are running on. (Thanks @mnutt.)
+
 ### v0.308 (2023-08-06)
 - Added Russian-language localization. (Thanks @troyjfarrell.)
 - Fixed broken links to the app market. (Thanks @zenhack. RIP.)


### PR DESCRIPTION
I think we are feature-locked for this release, so here is the changelog I expect to ship with release 309. The only outstanding changes to come are the update and signature checks and the migration script. The date will need to be updated on release day.

@mnutt and @berbad are particularly cited for contributions in this release, please let me know if there are any noteworthy or substantial changes we should yet mention here. (Obviously more detail on migration, trustworthiness of the upgrade, testing, etc. will go into the blog post, so this is much more succinct.)