### PR TITLE
docs: align inbound SMTP port documentation with installer behavior

### DIFF
--- a/docs/administering/config-file.md
+++ b/docs/administering/config-file.md
@@ -71,7 +71,8 @@ A HTTPS_PORT is automatically treated as the first port, in the context of "firs
 
 ### SMTP_LISTEN_PORT
 
-A port number on which Sandstorm will bind, listening for inbound email. By default, 30025; if
+A port number on which Sandstorm will bind, listening for inbound email. The installer
+writes 25 when that port is available on the host and 30025 otherwise; if the setting is
 missing, the Sandstorm shell uses 30025. You can choose port 25 if you like.
 
 If Sandstorm is started as root, Sandstorm binds to this port as root, allowing it to use

--- a/docs/administering/email.md
+++ b/docs/administering/email.md
@@ -3,7 +3,8 @@
 This tutorial will show you how to setup your personal sandstorm instance with support for e-mail.
 
 First, a quick rundown of how email works in sandstorm. Sandstorm is
-running an SMTP server on port 30025 that will accept email of the
+running an SMTP server (on port 25 when that port was available at install
+time, otherwise 30025) that will accept email of the
 form `publicId`@`hostname`. `publicId` is randomly generated for every
 grain that handles e-mail, and `hostname` is extracted from the
 `BASE_URL` parameter in sandstorm.conf (which is initially created by
@@ -86,7 +87,10 @@ as the MX priority, for example, `10`.
 
 ### Configure port 25, the easy way: Sandstorm can listen on port 25
 
-By default, Sandstorm's SMTP server runs on port 30025. You can adjust it to listen on port 25.
+The installer configures port 25 for inbound SMTP when that port is
+available on the host, and falls back to port 30025 otherwise. You can
+always switch the port after installation by editing
+`/opt/sandstorm/sandstorm.conf` as described below.
 This is the easiest way to configure inbound email; however, note that Sandstorm's SMTP server does
 not support inbound STARTTLS at this time.
 

--- a/docs/administering/faq.md
+++ b/docs/administering/faq.md
@@ -119,7 +119,7 @@ traffic.
 _Default configuration_
 
 * **TCP port 6080**
-* **TCP port 30025**
+* **TCP port 25 or 30025** — inbound SMTP; the installer writes port 25 when it is available on the host, otherwise 30025
 
 _Optionally_
 


### PR DESCRIPTION
The installer (`install.sh`) prefers inbound SMTP on **port 25** when that port is available on the host and only falls back to **30025** when port 25 is unavailable (`PLANNED_SMTP_PORT="25"` when `PORT_25_AVAILABLE=yes`, `30025` otherwise). The docs only mentioned port 30025, so a default install often ends up on port 25 while the documentation said 30025.

Updated:
- `docs/administering/email.md` — intro and "configure port 25" section now describe the installer's port-25-when-available / 30025-fallback behavior instead of claiming 30025 is always the default.
- `docs/administering/config-file.md` — `SMTP_LISTEN_PORT` description matches installer choices (25 when available, else 30025; 30025 fallback in config if unset).
- `docs/administering/faq.md` — firewall port list now includes port 25 or 30025.

Closes #3680
